### PR TITLE
Synthesize Accept header based on response media types

### DIFF
--- a/modelerfour/test/scenarios/a-playground/flattened.yaml
+++ b/modelerfour/test/scenarios/a-playground/flattened.yaml
@@ -80,7 +80,7 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_73
+    - !<!StringSchema> &ref_74
       type: string
       language: !<!Languages> 
         default:
@@ -374,6 +374,16 @@ schemas: !<!Schemas>
           description: Colors possible
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_70
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_68
       type: constant
       value: !<!ConstantValue> 
@@ -521,7 +531,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_70
+    - !<!ObjectSchema> &ref_71
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -562,7 +572,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_71
+    - !<!ObjectSchema> &ref_72
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -594,13 +604,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_76
+    - !<!ObjectSchema> &ref_77
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_78
+        - !<!Property> &ref_79
           schema: *ref_6
           serializedName: field1
           language: !<!Languages> 
@@ -608,7 +618,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_79
+        - !<!Property> &ref_80
           schema: *ref_6
           serializedName: field2
           language: !<!Languages> 
@@ -627,13 +637,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_82
+    - !<!ObjectSchema> &ref_83
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_84
+        - !<!Property> &ref_85
           schema: *ref_8
           serializedName: field1
           language: !<!Languages> 
@@ -641,7 +651,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_85
+        - !<!Property> &ref_86
           schema: *ref_8
           serializedName: field2
           language: !<!Languages> 
@@ -660,13 +670,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_88
+    - !<!ObjectSchema> &ref_89
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_90
+        - !<!Property> &ref_91
           schema: *ref_9
           serializedName: field1
           language: !<!Languages> 
@@ -674,7 +684,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_91
+        - !<!Property> &ref_92
           schema: *ref_9
           serializedName: field2
           language: !<!Languages> 
@@ -693,13 +703,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_94
+    - !<!ObjectSchema> &ref_95
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_96
+        - !<!Property> &ref_97
           schema: *ref_10
           serializedName: field1
           language: !<!Languages> 
@@ -707,7 +717,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_97
+        - !<!Property> &ref_98
           schema: *ref_10
           serializedName: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
           language: !<!Languages> 
@@ -726,13 +736,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_100
+    - !<!ObjectSchema> &ref_101
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_102
+        - !<!Property> &ref_103
           schema: *ref_11
           serializedName: field_true
           language: !<!Languages> 
@@ -740,7 +750,7 @@ schemas: !<!Schemas>
               name: field_true
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_103
+        - !<!Property> &ref_104
           schema: *ref_11
           serializedName: field_false
           language: !<!Languages> 
@@ -759,7 +769,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_106
+    - !<!ObjectSchema> &ref_107
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -800,13 +810,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_108
+    - !<!ObjectSchema> &ref_109
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_110
+        - !<!Property> &ref_111
           schema: *ref_15
           serializedName: field
           language: !<!Languages> 
@@ -814,7 +824,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_111
+        - !<!Property> &ref_112
           schema: *ref_16
           serializedName: leap
           language: !<!Languages> 
@@ -833,13 +843,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_114
+    - !<!ObjectSchema> &ref_115
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_116
+        - !<!Property> &ref_117
           schema: *ref_17
           serializedName: field
           language: !<!Languages> 
@@ -847,7 +857,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_117
+        - !<!Property> &ref_118
           schema: *ref_18
           serializedName: now
           language: !<!Languages> 
@@ -866,13 +876,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_120
+    - !<!ObjectSchema> &ref_121
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_122
+        - !<!Property> &ref_123
           schema: *ref_19
           serializedName: field
           language: !<!Languages> 
@@ -880,7 +890,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_123
+        - !<!Property> &ref_124
           schema: *ref_20
           serializedName: now
           language: !<!Languages> 
@@ -899,13 +909,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_126
+    - !<!ObjectSchema> &ref_127
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_128
+        - !<!Property> &ref_129
           schema: *ref_21
           serializedName: field
           language: !<!Languages> 
@@ -924,13 +934,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_130
+    - !<!ObjectSchema> &ref_131
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_132
+        - !<!Property> &ref_133
           schema: *ref_22
           serializedName: field
           language: !<!Languages> 
@@ -949,13 +959,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_134
+    - !<!ObjectSchema> &ref_135
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_136
+        - !<!Property> &ref_137
           schema: !<!ArraySchema> &ref_63
             type: array
             apiVersions:
@@ -984,13 +994,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_140
+    - !<!ObjectSchema> &ref_141
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_142
+        - !<!Property> &ref_143
           schema: *ref_24
           serializedName: defaultProgram
           language: !<!Languages> 
@@ -1569,7 +1579,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_148
+    - !<!ObjectSchema> &ref_149
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1639,7 +1649,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_51
     - *ref_33
-    - !<!ObjectSchema> &ref_153
+    - !<!ObjectSchema> &ref_154
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1654,7 +1664,7 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_155
+        - !<!Property> &ref_156
           schema: *ref_6
           serializedName: size
           language: !<!Languages> 
@@ -1791,7 +1801,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_72
+  - !<!Parameter> &ref_73
     schema: *ref_68
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -1816,6 +1826,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1828,7 +1853,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1842,7 +1867,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1865,9 +1890,9 @@ operationGroups:
             version: '2016-02-29'
         parameters:
           - *ref_69
-          - *ref_72
-          - !<!Parameter> &ref_75
-            schema: *ref_73
+          - *ref_73
+          - !<!Parameter> &ref_76
+            schema: *ref_74
             clientDefaultValue: garrett
             implementation: Method
             required: true
@@ -1884,8 +1909,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_74
-                schema: *ref_70
+              - !<!Parameter> &ref_75
+                schema: *ref_71
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1896,8 +1921,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_74
+              - *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -1911,7 +1949,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_75
+          - *ref_76
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1924,7 +1962,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1949,6 +1987,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1961,7 +2014,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1975,7 +2028,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2000,6 +2053,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2012,7 +2080,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2026,7 +2094,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2051,6 +2119,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2063,7 +2146,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2077,7 +2160,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2102,6 +2185,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2114,7 +2212,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2128,7 +2226,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2161,6 +2259,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2173,7 +2286,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_76
+            schema: *ref_77
             language: !<!Languages> 
               default:
                 name: ''
@@ -2187,7 +2300,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2213,8 +2326,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_77
-                schema: *ref_76
+              - !<!Parameter> &ref_78
+                schema: *ref_77
                 flattened: true
                 implementation: Method
                 required: true
@@ -2226,31 +2339,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_80
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_81
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_77
+                originalParameter: *ref_78
                 pathToProperty: []
-                targetProperty: *ref_78
+                targetProperty: *ref_79
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_81
+              - !<!VirtualParameter> &ref_82
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_77
+                originalParameter: *ref_78
                 pathToProperty: []
-                targetProperty: *ref_79
+                targetProperty: *ref_80
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_80
               - *ref_81
+              - *ref_82
             language: !<!Languages> 
               default:
                 name: ''
@@ -2276,7 +2402,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2301,6 +2427,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2313,7 +2454,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_82
+            schema: *ref_83
             language: !<!Languages> 
               default:
                 name: ''
@@ -2327,7 +2468,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2353,8 +2494,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_83
-                schema: *ref_82
+              - !<!Parameter> &ref_84
+                schema: *ref_83
                 flattened: true
                 implementation: Method
                 required: true
@@ -2366,31 +2507,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_86
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_87
                 schema: *ref_8
                 implementation: Method
-                originalParameter: *ref_83
+                originalParameter: *ref_84
                 pathToProperty: []
-                targetProperty: *ref_84
+                targetProperty: *ref_85
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_87
+              - !<!VirtualParameter> &ref_88
                 schema: *ref_8
                 implementation: Method
-                originalParameter: *ref_83
+                originalParameter: *ref_84
                 pathToProperty: []
-                targetProperty: *ref_85
+                targetProperty: *ref_86
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_86
               - *ref_87
+              - *ref_88
             language: !<!Languages> 
               default:
                 name: ''
@@ -2416,7 +2570,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2441,6 +2595,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2453,7 +2622,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_88
+            schema: *ref_89
             language: !<!Languages> 
               default:
                 name: ''
@@ -2467,7 +2636,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2493,8 +2662,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_89
-                schema: *ref_88
+              - !<!Parameter> &ref_90
+                schema: *ref_89
                 flattened: true
                 implementation: Method
                 required: true
@@ -2506,31 +2675,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_92
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_93
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_89
+                originalParameter: *ref_90
                 pathToProperty: []
-                targetProperty: *ref_90
+                targetProperty: *ref_91
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_93
+              - !<!VirtualParameter> &ref_94
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_89
+                originalParameter: *ref_90
                 pathToProperty: []
-                targetProperty: *ref_91
+                targetProperty: *ref_92
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_92
               - *ref_93
+              - *ref_94
             language: !<!Languages> 
               default:
                 name: ''
@@ -2556,7 +2738,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2581,6 +2763,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2593,7 +2790,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_94
+            schema: *ref_95
             language: !<!Languages> 
               default:
                 name: ''
@@ -2607,7 +2804,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2633,8 +2830,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_95
-                schema: *ref_94
+              - !<!Parameter> &ref_96
+                schema: *ref_95
                 flattened: true
                 implementation: Method
                 required: true
@@ -2646,31 +2843,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_98
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_99
                 schema: *ref_10
                 implementation: Method
-                originalParameter: *ref_95
+                originalParameter: *ref_96
                 pathToProperty: []
-                targetProperty: *ref_96
+                targetProperty: *ref_97
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_99
+              - !<!VirtualParameter> &ref_100
                 schema: *ref_10
                 implementation: Method
-                originalParameter: *ref_95
+                originalParameter: *ref_96
                 pathToProperty: []
-                targetProperty: *ref_97
+                targetProperty: *ref_98
                 language: !<!Languages> 
                   default:
                     name: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_98
               - *ref_99
+              - *ref_100
             language: !<!Languages> 
               default:
                 name: ''
@@ -2696,7 +2906,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2721,6 +2931,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2733,7 +2958,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_100
+            schema: *ref_101
             language: !<!Languages> 
               default:
                 name: ''
@@ -2747,7 +2972,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2773,8 +2998,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_101
-                schema: *ref_100
+              - !<!Parameter> &ref_102
+                schema: *ref_101
                 flattened: true
                 implementation: Method
                 required: true
@@ -2786,31 +3011,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_104
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_105
                 schema: *ref_11
                 implementation: Method
-                originalParameter: *ref_101
+                originalParameter: *ref_102
                 pathToProperty: []
-                targetProperty: *ref_102
+                targetProperty: *ref_103
                 language: !<!Languages> 
                   default:
                     name: field_true
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_105
+              - !<!VirtualParameter> &ref_106
                 schema: *ref_11
                 implementation: Method
-                originalParameter: *ref_101
+                originalParameter: *ref_102
                 pathToProperty: []
-                targetProperty: *ref_103
+                targetProperty: *ref_104
                 language: !<!Languages> 
                   default:
                     name: field_false
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_104
               - *ref_105
+              - *ref_106
             language: !<!Languages> 
               default:
                 name: ''
@@ -2836,7 +3074,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2861,6 +3099,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2873,7 +3126,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_106
+            schema: *ref_107
             language: !<!Languages> 
               default:
                 name: ''
@@ -2887,7 +3140,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2913,8 +3166,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_107
-                schema: *ref_106
+              - !<!Parameter> &ref_108
+                schema: *ref_107
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2925,8 +3178,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_107
+              - *ref_108
             language: !<!Languages> 
               default:
                 name: ''
@@ -2952,7 +3218,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2977,6 +3243,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2989,7 +3270,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_108
+            schema: *ref_109
             language: !<!Languages> 
               default:
                 name: ''
@@ -3003,7 +3284,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3029,8 +3310,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_109
-                schema: *ref_108
+              - !<!Parameter> &ref_110
+                schema: *ref_109
                 flattened: true
                 implementation: Method
                 required: true
@@ -3042,31 +3323,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_112
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_113
                 schema: *ref_15
                 implementation: Method
-                originalParameter: *ref_109
+                originalParameter: *ref_110
                 pathToProperty: []
-                targetProperty: *ref_110
+                targetProperty: *ref_111
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_113
+              - !<!VirtualParameter> &ref_114
                 schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_109
+                originalParameter: *ref_110
                 pathToProperty: []
-                targetProperty: *ref_111
+                targetProperty: *ref_112
                 language: !<!Languages> 
                   default:
                     name: leap
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_112
               - *ref_113
+              - *ref_114
             language: !<!Languages> 
               default:
                 name: ''
@@ -3092,7 +3386,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3117,6 +3411,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3129,7 +3438,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_114
+            schema: *ref_115
             language: !<!Languages> 
               default:
                 name: ''
@@ -3143,7 +3452,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3169,8 +3478,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_115
-                schema: *ref_114
+              - !<!Parameter> &ref_116
+                schema: *ref_115
                 flattened: true
                 implementation: Method
                 required: true
@@ -3182,31 +3491,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_118
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_119
                 schema: *ref_17
                 implementation: Method
-                originalParameter: *ref_115
+                originalParameter: *ref_116
                 pathToProperty: []
-                targetProperty: *ref_116
+                targetProperty: *ref_117
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_119
+              - !<!VirtualParameter> &ref_120
                 schema: *ref_18
                 implementation: Method
-                originalParameter: *ref_115
+                originalParameter: *ref_116
                 pathToProperty: []
-                targetProperty: *ref_117
+                targetProperty: *ref_118
                 language: !<!Languages> 
                   default:
                     name: now
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_118
               - *ref_119
+              - *ref_120
             language: !<!Languages> 
               default:
                 name: ''
@@ -3232,7 +3554,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3257,6 +3579,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3269,7 +3606,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_120
+            schema: *ref_121
             language: !<!Languages> 
               default:
                 name: ''
@@ -3283,7 +3620,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3309,8 +3646,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_121
-                schema: *ref_120
+              - !<!Parameter> &ref_122
+                schema: *ref_121
                 flattened: true
                 implementation: Method
                 required: true
@@ -3322,31 +3659,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_124
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_125
                 schema: *ref_19
                 implementation: Method
-                originalParameter: *ref_121
+                originalParameter: *ref_122
                 pathToProperty: []
-                targetProperty: *ref_122
+                targetProperty: *ref_123
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_125
+              - !<!VirtualParameter> &ref_126
                 schema: *ref_20
                 implementation: Method
-                originalParameter: *ref_121
+                originalParameter: *ref_122
                 pathToProperty: []
-                targetProperty: *ref_123
+                targetProperty: *ref_124
                 language: !<!Languages> 
                   default:
                     name: now
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_124
               - *ref_125
+              - *ref_126
             language: !<!Languages> 
               default:
                 name: ''
@@ -3372,7 +3722,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3397,6 +3747,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3409,7 +3774,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_126
+            schema: *ref_127
             language: !<!Languages> 
               default:
                 name: ''
@@ -3423,7 +3788,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3449,8 +3814,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_127
-                schema: *ref_126
+              - !<!Parameter> &ref_128
+                schema: *ref_127
                 flattened: true
                 implementation: Method
                 required: true
@@ -3462,19 +3827,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_129
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_130
                 schema: *ref_21
                 implementation: Method
-                originalParameter: *ref_127
+                originalParameter: *ref_128
                 pathToProperty: []
-                targetProperty: *ref_128
+                targetProperty: *ref_129
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_129
+              - *ref_130
             language: !<!Languages> 
               default:
                 name: ''
@@ -3500,7 +3878,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3525,6 +3903,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3537,7 +3930,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_130
+            schema: *ref_131
             language: !<!Languages> 
               default:
                 name: ''
@@ -3551,7 +3944,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3577,8 +3970,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_131
-                schema: *ref_130
+              - !<!Parameter> &ref_132
+                schema: *ref_131
                 flattened: true
                 implementation: Method
                 required: true
@@ -3590,19 +3983,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_133
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_134
                 schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_131
+                originalParameter: *ref_132
                 pathToProperty: []
-                targetProperty: *ref_132
+                targetProperty: *ref_133
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_133
+              - *ref_134
             language: !<!Languages> 
               default:
                 name: ''
@@ -3628,7 +4034,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3661,6 +4067,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3673,7 +4094,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_134
+            schema: *ref_135
             language: !<!Languages> 
               default:
                 name: ''
@@ -3687,7 +4108,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3713,8 +4134,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_135
-                schema: *ref_134
+              - !<!Parameter> &ref_136
+                schema: *ref_135
                 flattened: true
                 implementation: Method
                 required: true
@@ -3726,19 +4147,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_137
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_138
                 schema: *ref_63
                 implementation: Method
-                originalParameter: *ref_135
+                originalParameter: *ref_136
                 pathToProperty: []
-                targetProperty: *ref_136
+                targetProperty: *ref_137
                 language: !<!Languages> 
                   default:
                     name: array
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_137
+              - *ref_138
             language: !<!Languages> 
               default:
                 name: ''
@@ -3764,7 +4198,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3789,6 +4223,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3801,7 +4250,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_134
+            schema: *ref_135
             language: !<!Languages> 
               default:
                 name: ''
@@ -3815,7 +4264,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3841,8 +4290,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_138
-                schema: *ref_134
+              - !<!Parameter> &ref_139
+                schema: *ref_135
                 flattened: true
                 implementation: Method
                 required: true
@@ -3854,19 +4303,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_139
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_140
                 schema: *ref_63
                 implementation: Method
-                originalParameter: *ref_138
+                originalParameter: *ref_139
                 pathToProperty: []
-                targetProperty: *ref_136
+                targetProperty: *ref_137
                 language: !<!Languages> 
                   default:
                     name: array
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_139
+              - *ref_140
             language: !<!Languages> 
               default:
                 name: ''
@@ -3892,7 +4354,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3917,6 +4379,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3929,7 +4406,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_134
+            schema: *ref_135
             language: !<!Languages> 
               default:
                 name: ''
@@ -3943,7 +4420,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3976,6 +4453,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3988,7 +4480,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_140
+            schema: *ref_141
             language: !<!Languages> 
               default:
                 name: ''
@@ -4002,7 +4494,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4028,8 +4520,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_141
-                schema: *ref_140
+              - !<!Parameter> &ref_142
+                schema: *ref_141
                 flattened: true
                 implementation: Method
                 required: true
@@ -4041,19 +4533,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_143
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_144
                 schema: *ref_24
                 implementation: Method
-                originalParameter: *ref_141
+                originalParameter: *ref_142
                 pathToProperty: []
-                targetProperty: *ref_142
+                targetProperty: *ref_143
                 language: !<!Languages> 
                   default:
                     name: defaultProgram
                     description: Dictionary of <string>
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_143
+              - *ref_144
             language: !<!Languages> 
               default:
                 name: ''
@@ -4079,7 +4584,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4104,6 +4609,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4116,7 +4636,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_140
+            schema: *ref_141
             language: !<!Languages> 
               default:
                 name: ''
@@ -4130,7 +4650,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4156,8 +4676,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_144
-                schema: *ref_140
+              - !<!Parameter> &ref_145
+                schema: *ref_141
                 flattened: true
                 implementation: Method
                 required: true
@@ -4169,19 +4689,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_145
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_146
                 schema: *ref_24
                 implementation: Method
-                originalParameter: *ref_144
+                originalParameter: *ref_145
                 pathToProperty: []
-                targetProperty: *ref_142
+                targetProperty: *ref_143
                 language: !<!Languages> 
                   default:
                     name: defaultProgram
                     description: Dictionary of <string>
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_145
+              - *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -4207,7 +4740,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4232,6 +4765,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4244,7 +4792,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_140
+            schema: *ref_141
             language: !<!Languages> 
               default:
                 name: ''
@@ -4258,7 +4806,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4283,6 +4831,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4295,7 +4858,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_140
+            schema: *ref_141
             language: !<!Languages> 
               default:
                 name: ''
@@ -4309,7 +4872,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4342,6 +4905,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4368,7 +4946,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4394,7 +4972,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_146
+              - !<!Parameter> &ref_147
                 schema: *ref_25
                 implementation: Method
                 required: true
@@ -4406,8 +4984,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_146
+              - *ref_147
             language: !<!Languages> 
               default:
                 name: ''
@@ -4433,7 +5024,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4466,6 +5057,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4492,7 +5098,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4518,7 +5124,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_147
+              - !<!Parameter> &ref_148
                 schema: *ref_35
                 implementation: Method
                 required: true
@@ -4563,8 +5169,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_147
+              - *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -4590,7 +5209,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4615,6 +5234,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4641,7 +5275,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4666,6 +5300,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4678,7 +5327,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_148
+            schema: *ref_149
             language: !<!Languages> 
               default:
                 name: ''
@@ -4692,7 +5341,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4717,6 +5366,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4729,7 +5393,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_148
+            schema: *ref_149
             language: !<!Languages> 
               default:
                 name: ''
@@ -4743,7 +5407,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4768,6 +5432,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4794,7 +5473,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4820,7 +5499,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_149
+              - !<!Parameter> &ref_150
                 schema: *ref_33
                 implementation: Method
                 required: true
@@ -4832,8 +5511,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_149
+              - *ref_150
             language: !<!Languages> 
               default:
                 name: ''
@@ -4859,7 +5551,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4885,7 +5577,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_150
+              - !<!Parameter> &ref_151
                 schema: *ref_33
                 implementation: Method
                 required: true
@@ -4897,8 +5589,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_150
+              - *ref_151
             language: !<!Languages> 
               default:
                 name: ''
@@ -4928,7 +5633,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4944,163 +5649,6 @@ operationGroups:
           default:
             name: putMissingDiscriminator
             description: 'Put complex types that are polymorphic, omitting the discriminator'
-        protocol: !<!Protocols> {}
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: '2016-02-29'
-        parameters:
-          - *ref_69
-        requests:
-          - !<!Request> 
-            parameters:
-              - !<!Parameter> &ref_151
-                schema: *ref_35
-                implementation: Method
-                required: true
-                language: !<!Languages> 
-                  default:
-                    name: complexBody
-                    description: |-
-                      Please put a salmon that looks like this:
-                      {
-                              'fishtype':'Salmon',
-                              'location':'alaska',
-                              'iswild':true,
-                              'species':'king',
-                              'length':1.0,
-                              'siblings':[
-                                {
-                                  'fishtype':'Shark',
-                                  'age':6,
-                                  'birthday': '2012-01-05T01:00:00Z',
-                                  'length':20.0,
-                                  'species':'predator',
-                                },
-                                {
-                                  'fishtype':'Sawshark',
-                                  'age':105,
-                                  'birthday': '1900-01-05T01:00:00Z',
-                                  'length':10.0,
-                                  'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-                                  'species':'dangerous',
-                                },
-                                {
-                                  'fishtype': 'goblin',
-                                  'age': 1,
-                                  'birthday': '2015-08-08T00:00:00Z',
-                                  'length': 30.0,
-                                  'species': 'scary',
-                                  'jawsize': 5
-                                }
-                              ]
-                            };
-                protocol: !<!Protocols> 
-                  http: !<!HttpParameter> 
-                    in: body
-                    style: json
-            signatureParameters:
-              - *ref_151
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpWithBodyRequest> 
-                path: /complex/polymorphism/missingrequired/invalid
-                method: put
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_71
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: putValidMissingRequired
-            description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
-        protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: polymorphism
-        description: ''
-    protocol: !<!Protocols> {}
-  - !<!OperationGroup> 
-    $key: polymorphicrecursive
-    operations:
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: '2016-02-29'
-        parameters:
-          - *ref_69
-        requests:
-          - !<!Request> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpRequest> 
-                path: /complex/polymorphicrecursive/valid
-                method: get
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!SchemaResponse> 
-            schema: *ref_35
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_71
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: getValid
-            description: Get complex types that are polymorphic and have recursive references
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
@@ -5156,8 +5704,206 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
               - *ref_152
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpWithBodyRequest> 
+                path: /complex/polymorphism/missingrequired/invalid
+                method: put
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_72
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: putValidMissingRequired
+            description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
+        protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: polymorphism
+        description: ''
+    protocol: !<!Protocols> {}
+  - !<!OperationGroup> 
+    $key: polymorphicrecursive
+    operations:
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: '2016-02-29'
+        parameters:
+          - *ref_69
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpRequest> 
+                path: /complex/polymorphicrecursive/valid
+                method: get
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!SchemaResponse> 
+            schema: *ref_35
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_72
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: getValid
+            description: Get complex types that are polymorphic and have recursive references
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: '2016-02-29'
+        parameters:
+          - *ref_69
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_153
+                schema: *ref_35
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: complexBody
+                    description: |-
+                      Please put a salmon that looks like this:
+                      {
+                              'fishtype':'Salmon',
+                              'location':'alaska',
+                              'iswild':true,
+                              'species':'king',
+                              'length':1.0,
+                              'siblings':[
+                                {
+                                  'fishtype':'Shark',
+                                  'age':6,
+                                  'birthday': '2012-01-05T01:00:00Z',
+                                  'length':20.0,
+                                  'species':'predator',
+                                },
+                                {
+                                  'fishtype':'Sawshark',
+                                  'age':105,
+                                  'birthday': '1900-01-05T01:00:00Z',
+                                  'length':10.0,
+                                  'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                                  'species':'dangerous',
+                                },
+                                {
+                                  'fishtype': 'goblin',
+                                  'age': 1,
+                                  'birthday': '2015-08-08T00:00:00Z',
+                                  'length': 30.0,
+                                  'species': 'scary',
+                                  'jawsize': 5
+                                }
+                              ]
+                            };
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters:
+              - *ref_153
             language: !<!Languages> 
               default:
                 name: ''
@@ -5183,7 +5929,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5216,6 +5962,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5228,7 +5989,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_153
+            schema: *ref_154
             language: !<!Languages> 
               default:
                 name: ''
@@ -5242,7 +6003,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5268,8 +6029,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_154
-                schema: *ref_153
+              - !<!Parameter> &ref_155
+                schema: *ref_154
                 flattened: true
                 implementation: Method
                 required: true
@@ -5281,19 +6042,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_156
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_157
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_154
+                originalParameter: *ref_155
                 pathToProperty: []
-                targetProperty: *ref_155
+                targetProperty: *ref_156
                 language: !<!Languages> 
                   default:
                     name: size
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_156
+              - *ref_157
             language: !<!Languages> 
               default:
                 name: ''
@@ -5319,7 +6093,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5352,6 +6126,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/a-playground/grouped.yaml
+++ b/modelerfour/test/scenarios/a-playground/grouped.yaml
@@ -80,7 +80,7 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_73
+    - !<!StringSchema> &ref_74
       type: string
       language: !<!Languages> 
         default:
@@ -374,6 +374,16 @@ schemas: !<!Schemas>
           description: Colors possible
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_70
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_68
       type: constant
       value: !<!ConstantValue> 
@@ -521,7 +531,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_70
+    - !<!ObjectSchema> &ref_71
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -562,7 +572,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_71
+    - !<!ObjectSchema> &ref_72
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -594,13 +604,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_76
+    - !<!ObjectSchema> &ref_77
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_78
+        - !<!Property> &ref_79
           schema: *ref_6
           serializedName: field1
           language: !<!Languages> 
@@ -608,7 +618,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_79
+        - !<!Property> &ref_80
           schema: *ref_6
           serializedName: field2
           language: !<!Languages> 
@@ -627,13 +637,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_82
+    - !<!ObjectSchema> &ref_83
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_84
+        - !<!Property> &ref_85
           schema: *ref_8
           serializedName: field1
           language: !<!Languages> 
@@ -641,7 +651,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_85
+        - !<!Property> &ref_86
           schema: *ref_8
           serializedName: field2
           language: !<!Languages> 
@@ -660,13 +670,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_88
+    - !<!ObjectSchema> &ref_89
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_90
+        - !<!Property> &ref_91
           schema: *ref_9
           serializedName: field1
           language: !<!Languages> 
@@ -674,7 +684,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_91
+        - !<!Property> &ref_92
           schema: *ref_9
           serializedName: field2
           language: !<!Languages> 
@@ -693,13 +703,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_94
+    - !<!ObjectSchema> &ref_95
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_96
+        - !<!Property> &ref_97
           schema: *ref_10
           serializedName: field1
           language: !<!Languages> 
@@ -707,7 +717,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_97
+        - !<!Property> &ref_98
           schema: *ref_10
           serializedName: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
           language: !<!Languages> 
@@ -726,13 +736,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_100
+    - !<!ObjectSchema> &ref_101
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_102
+        - !<!Property> &ref_103
           schema: *ref_11
           serializedName: field_true
           language: !<!Languages> 
@@ -740,7 +750,7 @@ schemas: !<!Schemas>
               name: field_true
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_103
+        - !<!Property> &ref_104
           schema: *ref_11
           serializedName: field_false
           language: !<!Languages> 
@@ -759,7 +769,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_106
+    - !<!ObjectSchema> &ref_107
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -800,13 +810,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_108
+    - !<!ObjectSchema> &ref_109
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_110
+        - !<!Property> &ref_111
           schema: *ref_15
           serializedName: field
           language: !<!Languages> 
@@ -814,7 +824,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_111
+        - !<!Property> &ref_112
           schema: *ref_16
           serializedName: leap
           language: !<!Languages> 
@@ -833,13 +843,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_114
+    - !<!ObjectSchema> &ref_115
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_116
+        - !<!Property> &ref_117
           schema: *ref_17
           serializedName: field
           language: !<!Languages> 
@@ -847,7 +857,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_117
+        - !<!Property> &ref_118
           schema: *ref_18
           serializedName: now
           language: !<!Languages> 
@@ -866,13 +876,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_120
+    - !<!ObjectSchema> &ref_121
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_122
+        - !<!Property> &ref_123
           schema: *ref_19
           serializedName: field
           language: !<!Languages> 
@@ -880,7 +890,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_123
+        - !<!Property> &ref_124
           schema: *ref_20
           serializedName: now
           language: !<!Languages> 
@@ -899,13 +909,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_126
+    - !<!ObjectSchema> &ref_127
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_128
+        - !<!Property> &ref_129
           schema: *ref_21
           serializedName: field
           language: !<!Languages> 
@@ -924,13 +934,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_130
+    - !<!ObjectSchema> &ref_131
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_132
+        - !<!Property> &ref_133
           schema: *ref_22
           serializedName: field
           language: !<!Languages> 
@@ -949,13 +959,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_134
+    - !<!ObjectSchema> &ref_135
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_136
+        - !<!Property> &ref_137
           schema: !<!ArraySchema> &ref_63
             type: array
             apiVersions:
@@ -984,13 +994,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_140
+    - !<!ObjectSchema> &ref_141
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_142
+        - !<!Property> &ref_143
           schema: *ref_24
           serializedName: defaultProgram
           language: !<!Languages> 
@@ -1569,7 +1579,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_148
+    - !<!ObjectSchema> &ref_149
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1639,7 +1649,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_51
     - *ref_33
-    - !<!ObjectSchema> &ref_153
+    - !<!ObjectSchema> &ref_154
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1654,7 +1664,7 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_155
+        - !<!Property> &ref_156
           schema: *ref_6
           serializedName: size
           language: !<!Languages> 
@@ -1791,7 +1801,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_72
+  - !<!Parameter> &ref_73
     schema: *ref_68
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -1816,6 +1826,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1828,7 +1853,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1842,7 +1867,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1865,9 +1890,9 @@ operationGroups:
             version: '2016-02-29'
         parameters:
           - *ref_69
-          - *ref_72
-          - !<!Parameter> &ref_75
-            schema: *ref_73
+          - *ref_73
+          - !<!Parameter> &ref_76
+            schema: *ref_74
             clientDefaultValue: garrett
             implementation: Method
             required: true
@@ -1884,8 +1909,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_74
-                schema: *ref_70
+              - !<!Parameter> &ref_75
+                schema: *ref_71
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1896,8 +1921,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_74
+              - *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -1911,7 +1949,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_75
+          - *ref_76
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1924,7 +1962,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1949,6 +1987,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1961,7 +2014,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1975,7 +2028,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2000,6 +2053,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2012,7 +2080,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2026,7 +2094,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2051,6 +2119,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2063,7 +2146,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2077,7 +2160,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2102,6 +2185,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2114,7 +2212,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2128,7 +2226,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2161,6 +2259,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2173,7 +2286,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_76
+            schema: *ref_77
             language: !<!Languages> 
               default:
                 name: ''
@@ -2187,7 +2300,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2213,8 +2326,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_77
-                schema: *ref_76
+              - !<!Parameter> &ref_78
+                schema: *ref_77
                 flattened: true
                 implementation: Method
                 required: true
@@ -2226,31 +2339,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_80
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_81
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_77
+                originalParameter: *ref_78
                 pathToProperty: []
-                targetProperty: *ref_78
+                targetProperty: *ref_79
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_81
+              - !<!VirtualParameter> &ref_82
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_77
+                originalParameter: *ref_78
                 pathToProperty: []
-                targetProperty: *ref_79
+                targetProperty: *ref_80
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_80
               - *ref_81
+              - *ref_82
             language: !<!Languages> 
               default:
                 name: ''
@@ -2276,7 +2402,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2301,6 +2427,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2313,7 +2454,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_82
+            schema: *ref_83
             language: !<!Languages> 
               default:
                 name: ''
@@ -2327,7 +2468,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2353,8 +2494,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_83
-                schema: *ref_82
+              - !<!Parameter> &ref_84
+                schema: *ref_83
                 flattened: true
                 implementation: Method
                 required: true
@@ -2366,31 +2507,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_86
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_87
                 schema: *ref_8
                 implementation: Method
-                originalParameter: *ref_83
+                originalParameter: *ref_84
                 pathToProperty: []
-                targetProperty: *ref_84
+                targetProperty: *ref_85
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_87
+              - !<!VirtualParameter> &ref_88
                 schema: *ref_8
                 implementation: Method
-                originalParameter: *ref_83
+                originalParameter: *ref_84
                 pathToProperty: []
-                targetProperty: *ref_85
+                targetProperty: *ref_86
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_86
               - *ref_87
+              - *ref_88
             language: !<!Languages> 
               default:
                 name: ''
@@ -2416,7 +2570,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2441,6 +2595,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2453,7 +2622,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_88
+            schema: *ref_89
             language: !<!Languages> 
               default:
                 name: ''
@@ -2467,7 +2636,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2493,8 +2662,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_89
-                schema: *ref_88
+              - !<!Parameter> &ref_90
+                schema: *ref_89
                 flattened: true
                 implementation: Method
                 required: true
@@ -2506,31 +2675,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_92
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_93
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_89
+                originalParameter: *ref_90
                 pathToProperty: []
-                targetProperty: *ref_90
+                targetProperty: *ref_91
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_93
+              - !<!VirtualParameter> &ref_94
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_89
+                originalParameter: *ref_90
                 pathToProperty: []
-                targetProperty: *ref_91
+                targetProperty: *ref_92
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_92
               - *ref_93
+              - *ref_94
             language: !<!Languages> 
               default:
                 name: ''
@@ -2556,7 +2738,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2581,6 +2763,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2593,7 +2790,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_94
+            schema: *ref_95
             language: !<!Languages> 
               default:
                 name: ''
@@ -2607,7 +2804,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2633,8 +2830,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_95
-                schema: *ref_94
+              - !<!Parameter> &ref_96
+                schema: *ref_95
                 flattened: true
                 implementation: Method
                 required: true
@@ -2646,31 +2843,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_98
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_99
                 schema: *ref_10
                 implementation: Method
-                originalParameter: *ref_95
+                originalParameter: *ref_96
                 pathToProperty: []
-                targetProperty: *ref_96
+                targetProperty: *ref_97
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_99
+              - !<!VirtualParameter> &ref_100
                 schema: *ref_10
                 implementation: Method
-                originalParameter: *ref_95
+                originalParameter: *ref_96
                 pathToProperty: []
-                targetProperty: *ref_97
+                targetProperty: *ref_98
                 language: !<!Languages> 
                   default:
                     name: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_98
               - *ref_99
+              - *ref_100
             language: !<!Languages> 
               default:
                 name: ''
@@ -2696,7 +2906,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2721,6 +2931,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2733,7 +2958,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_100
+            schema: *ref_101
             language: !<!Languages> 
               default:
                 name: ''
@@ -2747,7 +2972,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2773,8 +2998,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_101
-                schema: *ref_100
+              - !<!Parameter> &ref_102
+                schema: *ref_101
                 flattened: true
                 implementation: Method
                 required: true
@@ -2786,31 +3011,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_104
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_105
                 schema: *ref_11
                 implementation: Method
-                originalParameter: *ref_101
+                originalParameter: *ref_102
                 pathToProperty: []
-                targetProperty: *ref_102
+                targetProperty: *ref_103
                 language: !<!Languages> 
                   default:
                     name: field_true
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_105
+              - !<!VirtualParameter> &ref_106
                 schema: *ref_11
                 implementation: Method
-                originalParameter: *ref_101
+                originalParameter: *ref_102
                 pathToProperty: []
-                targetProperty: *ref_103
+                targetProperty: *ref_104
                 language: !<!Languages> 
                   default:
                     name: field_false
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_104
               - *ref_105
+              - *ref_106
             language: !<!Languages> 
               default:
                 name: ''
@@ -2836,7 +3074,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2861,6 +3099,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2873,7 +3126,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_106
+            schema: *ref_107
             language: !<!Languages> 
               default:
                 name: ''
@@ -2887,7 +3140,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2913,8 +3166,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_107
-                schema: *ref_106
+              - !<!Parameter> &ref_108
+                schema: *ref_107
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2925,8 +3178,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_107
+              - *ref_108
             language: !<!Languages> 
               default:
                 name: ''
@@ -2952,7 +3218,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2977,6 +3243,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2989,7 +3270,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_108
+            schema: *ref_109
             language: !<!Languages> 
               default:
                 name: ''
@@ -3003,7 +3284,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3029,8 +3310,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_109
-                schema: *ref_108
+              - !<!Parameter> &ref_110
+                schema: *ref_109
                 flattened: true
                 implementation: Method
                 required: true
@@ -3042,31 +3323,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_112
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_113
                 schema: *ref_15
                 implementation: Method
-                originalParameter: *ref_109
+                originalParameter: *ref_110
                 pathToProperty: []
-                targetProperty: *ref_110
+                targetProperty: *ref_111
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_113
+              - !<!VirtualParameter> &ref_114
                 schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_109
+                originalParameter: *ref_110
                 pathToProperty: []
-                targetProperty: *ref_111
+                targetProperty: *ref_112
                 language: !<!Languages> 
                   default:
                     name: leap
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_112
               - *ref_113
+              - *ref_114
             language: !<!Languages> 
               default:
                 name: ''
@@ -3092,7 +3386,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3117,6 +3411,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3129,7 +3438,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_114
+            schema: *ref_115
             language: !<!Languages> 
               default:
                 name: ''
@@ -3143,7 +3452,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3169,8 +3478,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_115
-                schema: *ref_114
+              - !<!Parameter> &ref_116
+                schema: *ref_115
                 flattened: true
                 implementation: Method
                 required: true
@@ -3182,31 +3491,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_118
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_119
                 schema: *ref_17
                 implementation: Method
-                originalParameter: *ref_115
+                originalParameter: *ref_116
                 pathToProperty: []
-                targetProperty: *ref_116
+                targetProperty: *ref_117
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_119
+              - !<!VirtualParameter> &ref_120
                 schema: *ref_18
                 implementation: Method
-                originalParameter: *ref_115
+                originalParameter: *ref_116
                 pathToProperty: []
-                targetProperty: *ref_117
+                targetProperty: *ref_118
                 language: !<!Languages> 
                   default:
                     name: now
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_118
               - *ref_119
+              - *ref_120
             language: !<!Languages> 
               default:
                 name: ''
@@ -3232,7 +3554,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3257,6 +3579,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3269,7 +3606,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_120
+            schema: *ref_121
             language: !<!Languages> 
               default:
                 name: ''
@@ -3283,7 +3620,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3309,8 +3646,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_121
-                schema: *ref_120
+              - !<!Parameter> &ref_122
+                schema: *ref_121
                 flattened: true
                 implementation: Method
                 required: true
@@ -3322,31 +3659,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_124
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_125
                 schema: *ref_19
                 implementation: Method
-                originalParameter: *ref_121
+                originalParameter: *ref_122
                 pathToProperty: []
-                targetProperty: *ref_122
+                targetProperty: *ref_123
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_125
+              - !<!VirtualParameter> &ref_126
                 schema: *ref_20
                 implementation: Method
-                originalParameter: *ref_121
+                originalParameter: *ref_122
                 pathToProperty: []
-                targetProperty: *ref_123
+                targetProperty: *ref_124
                 language: !<!Languages> 
                   default:
                     name: now
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_124
               - *ref_125
+              - *ref_126
             language: !<!Languages> 
               default:
                 name: ''
@@ -3372,7 +3722,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3397,6 +3747,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3409,7 +3774,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_126
+            schema: *ref_127
             language: !<!Languages> 
               default:
                 name: ''
@@ -3423,7 +3788,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3449,8 +3814,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_127
-                schema: *ref_126
+              - !<!Parameter> &ref_128
+                schema: *ref_127
                 flattened: true
                 implementation: Method
                 required: true
@@ -3462,19 +3827,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_129
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_130
                 schema: *ref_21
                 implementation: Method
-                originalParameter: *ref_127
+                originalParameter: *ref_128
                 pathToProperty: []
-                targetProperty: *ref_128
+                targetProperty: *ref_129
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_129
+              - *ref_130
             language: !<!Languages> 
               default:
                 name: ''
@@ -3500,7 +3878,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3525,6 +3903,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3537,7 +3930,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_130
+            schema: *ref_131
             language: !<!Languages> 
               default:
                 name: ''
@@ -3551,7 +3944,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3577,8 +3970,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_131
-                schema: *ref_130
+              - !<!Parameter> &ref_132
+                schema: *ref_131
                 flattened: true
                 implementation: Method
                 required: true
@@ -3590,19 +3983,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_133
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_134
                 schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_131
+                originalParameter: *ref_132
                 pathToProperty: []
-                targetProperty: *ref_132
+                targetProperty: *ref_133
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_133
+              - *ref_134
             language: !<!Languages> 
               default:
                 name: ''
@@ -3628,7 +4034,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3661,6 +4067,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3673,7 +4094,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_134
+            schema: *ref_135
             language: !<!Languages> 
               default:
                 name: ''
@@ -3687,7 +4108,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3713,8 +4134,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_135
-                schema: *ref_134
+              - !<!Parameter> &ref_136
+                schema: *ref_135
                 flattened: true
                 implementation: Method
                 required: true
@@ -3726,19 +4147,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_137
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_138
                 schema: *ref_63
                 implementation: Method
-                originalParameter: *ref_135
+                originalParameter: *ref_136
                 pathToProperty: []
-                targetProperty: *ref_136
+                targetProperty: *ref_137
                 language: !<!Languages> 
                   default:
                     name: array
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_137
+              - *ref_138
             language: !<!Languages> 
               default:
                 name: ''
@@ -3764,7 +4198,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3789,6 +4223,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3801,7 +4250,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_134
+            schema: *ref_135
             language: !<!Languages> 
               default:
                 name: ''
@@ -3815,7 +4264,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3841,8 +4290,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_138
-                schema: *ref_134
+              - !<!Parameter> &ref_139
+                schema: *ref_135
                 flattened: true
                 implementation: Method
                 required: true
@@ -3854,19 +4303,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_139
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_140
                 schema: *ref_63
                 implementation: Method
-                originalParameter: *ref_138
+                originalParameter: *ref_139
                 pathToProperty: []
-                targetProperty: *ref_136
+                targetProperty: *ref_137
                 language: !<!Languages> 
                   default:
                     name: array
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_139
+              - *ref_140
             language: !<!Languages> 
               default:
                 name: ''
@@ -3892,7 +4354,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3917,6 +4379,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3929,7 +4406,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_134
+            schema: *ref_135
             language: !<!Languages> 
               default:
                 name: ''
@@ -3943,7 +4420,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3976,6 +4453,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3988,7 +4480,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_140
+            schema: *ref_141
             language: !<!Languages> 
               default:
                 name: ''
@@ -4002,7 +4494,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4028,8 +4520,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_141
-                schema: *ref_140
+              - !<!Parameter> &ref_142
+                schema: *ref_141
                 flattened: true
                 implementation: Method
                 required: true
@@ -4041,19 +4533,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_143
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_144
                 schema: *ref_24
                 implementation: Method
-                originalParameter: *ref_141
+                originalParameter: *ref_142
                 pathToProperty: []
-                targetProperty: *ref_142
+                targetProperty: *ref_143
                 language: !<!Languages> 
                   default:
                     name: defaultProgram
                     description: Dictionary of <string>
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_143
+              - *ref_144
             language: !<!Languages> 
               default:
                 name: ''
@@ -4079,7 +4584,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4104,6 +4609,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4116,7 +4636,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_140
+            schema: *ref_141
             language: !<!Languages> 
               default:
                 name: ''
@@ -4130,7 +4650,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4156,8 +4676,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_144
-                schema: *ref_140
+              - !<!Parameter> &ref_145
+                schema: *ref_141
                 flattened: true
                 implementation: Method
                 required: true
@@ -4169,19 +4689,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_145
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_146
                 schema: *ref_24
                 implementation: Method
-                originalParameter: *ref_144
+                originalParameter: *ref_145
                 pathToProperty: []
-                targetProperty: *ref_142
+                targetProperty: *ref_143
                 language: !<!Languages> 
                   default:
                     name: defaultProgram
                     description: Dictionary of <string>
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_145
+              - *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -4207,7 +4740,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4232,6 +4765,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4244,7 +4792,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_140
+            schema: *ref_141
             language: !<!Languages> 
               default:
                 name: ''
@@ -4258,7 +4806,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4283,6 +4831,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4295,7 +4858,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_140
+            schema: *ref_141
             language: !<!Languages> 
               default:
                 name: ''
@@ -4309,7 +4872,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4342,6 +4905,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4368,7 +4946,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4394,7 +4972,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_146
+              - !<!Parameter> &ref_147
                 schema: *ref_25
                 implementation: Method
                 required: true
@@ -4406,8 +4984,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_146
+              - *ref_147
             language: !<!Languages> 
               default:
                 name: ''
@@ -4433,7 +5024,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4466,6 +5057,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4492,7 +5098,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4518,7 +5124,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_147
+              - !<!Parameter> &ref_148
                 schema: *ref_35
                 implementation: Method
                 required: true
@@ -4563,8 +5169,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_147
+              - *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -4590,7 +5209,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4615,6 +5234,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4641,7 +5275,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4666,6 +5300,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4678,7 +5327,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_148
+            schema: *ref_149
             language: !<!Languages> 
               default:
                 name: ''
@@ -4692,7 +5341,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4717,6 +5366,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4729,7 +5393,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_148
+            schema: *ref_149
             language: !<!Languages> 
               default:
                 name: ''
@@ -4743,7 +5407,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4768,6 +5432,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4794,7 +5473,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4820,7 +5499,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_149
+              - !<!Parameter> &ref_150
                 schema: *ref_33
                 implementation: Method
                 required: true
@@ -4832,8 +5511,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_149
+              - *ref_150
             language: !<!Languages> 
               default:
                 name: ''
@@ -4859,7 +5551,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4885,7 +5577,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_150
+              - !<!Parameter> &ref_151
                 schema: *ref_33
                 implementation: Method
                 required: true
@@ -4897,8 +5589,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_150
+              - *ref_151
             language: !<!Languages> 
               default:
                 name: ''
@@ -4928,7 +5633,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4944,163 +5649,6 @@ operationGroups:
           default:
             name: putMissingDiscriminator
             description: 'Put complex types that are polymorphic, omitting the discriminator'
-        protocol: !<!Protocols> {}
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: '2016-02-29'
-        parameters:
-          - *ref_69
-        requests:
-          - !<!Request> 
-            parameters:
-              - !<!Parameter> &ref_151
-                schema: *ref_35
-                implementation: Method
-                required: true
-                language: !<!Languages> 
-                  default:
-                    name: complexBody
-                    description: |-
-                      Please put a salmon that looks like this:
-                      {
-                              'fishtype':'Salmon',
-                              'location':'alaska',
-                              'iswild':true,
-                              'species':'king',
-                              'length':1.0,
-                              'siblings':[
-                                {
-                                  'fishtype':'Shark',
-                                  'age':6,
-                                  'birthday': '2012-01-05T01:00:00Z',
-                                  'length':20.0,
-                                  'species':'predator',
-                                },
-                                {
-                                  'fishtype':'Sawshark',
-                                  'age':105,
-                                  'birthday': '1900-01-05T01:00:00Z',
-                                  'length':10.0,
-                                  'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-                                  'species':'dangerous',
-                                },
-                                {
-                                  'fishtype': 'goblin',
-                                  'age': 1,
-                                  'birthday': '2015-08-08T00:00:00Z',
-                                  'length': 30.0,
-                                  'species': 'scary',
-                                  'jawsize': 5
-                                }
-                              ]
-                            };
-                protocol: !<!Protocols> 
-                  http: !<!HttpParameter> 
-                    in: body
-                    style: json
-            signatureParameters:
-              - *ref_151
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpWithBodyRequest> 
-                path: /complex/polymorphism/missingrequired/invalid
-                method: put
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_71
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: putValidMissingRequired
-            description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
-        protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: polymorphism
-        description: ''
-    protocol: !<!Protocols> {}
-  - !<!OperationGroup> 
-    $key: polymorphicrecursive
-    operations:
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: '2016-02-29'
-        parameters:
-          - *ref_69
-        requests:
-          - !<!Request> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpRequest> 
-                path: /complex/polymorphicrecursive/valid
-                method: get
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!SchemaResponse> 
-            schema: *ref_35
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_71
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: getValid
-            description: Get complex types that are polymorphic and have recursive references
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
@@ -5156,8 +5704,206 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
               - *ref_152
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpWithBodyRequest> 
+                path: /complex/polymorphism/missingrequired/invalid
+                method: put
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_72
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: putValidMissingRequired
+            description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
+        protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: polymorphism
+        description: ''
+    protocol: !<!Protocols> {}
+  - !<!OperationGroup> 
+    $key: polymorphicrecursive
+    operations:
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: '2016-02-29'
+        parameters:
+          - *ref_69
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpRequest> 
+                path: /complex/polymorphicrecursive/valid
+                method: get
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!SchemaResponse> 
+            schema: *ref_35
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_72
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: getValid
+            description: Get complex types that are polymorphic and have recursive references
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: '2016-02-29'
+        parameters:
+          - *ref_69
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_153
+                schema: *ref_35
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: complexBody
+                    description: |-
+                      Please put a salmon that looks like this:
+                      {
+                              'fishtype':'Salmon',
+                              'location':'alaska',
+                              'iswild':true,
+                              'species':'king',
+                              'length':1.0,
+                              'siblings':[
+                                {
+                                  'fishtype':'Shark',
+                                  'age':6,
+                                  'birthday': '2012-01-05T01:00:00Z',
+                                  'length':20.0,
+                                  'species':'predator',
+                                },
+                                {
+                                  'fishtype':'Sawshark',
+                                  'age':105,
+                                  'birthday': '1900-01-05T01:00:00Z',
+                                  'length':10.0,
+                                  'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                                  'species':'dangerous',
+                                },
+                                {
+                                  'fishtype': 'goblin',
+                                  'age': 1,
+                                  'birthday': '2015-08-08T00:00:00Z',
+                                  'length': 30.0,
+                                  'species': 'scary',
+                                  'jawsize': 5
+                                }
+                              ]
+                            };
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters:
+              - *ref_153
             language: !<!Languages> 
               default:
                 name: ''
@@ -5183,7 +5929,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5216,6 +5962,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5228,7 +5989,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_153
+            schema: *ref_154
             language: !<!Languages> 
               default:
                 name: ''
@@ -5242,7 +6003,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5268,8 +6029,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_154
-                schema: *ref_153
+              - !<!Parameter> &ref_155
+                schema: *ref_154
                 flattened: true
                 implementation: Method
                 required: true
@@ -5281,19 +6042,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_156
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_157
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_154
+                originalParameter: *ref_155
                 pathToProperty: []
-                targetProperty: *ref_155
+                targetProperty: *ref_156
                 language: !<!Languages> 
                   default:
                     name: size
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_156
+              - *ref_157
             language: !<!Languages> 
               default:
                 name: ''
@@ -5319,7 +6093,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5352,6 +6126,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/a-playground/modeler.yaml
+++ b/modelerfour/test/scenarios/a-playground/modeler.yaml
@@ -80,7 +80,7 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_73
+    - !<!StringSchema> &ref_74
       type: string
       language: !<!Languages> 
         default:
@@ -374,7 +374,17 @@ schemas: !<!Schemas>
           description: Colors possible
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_72
+    - !<!ConstantSchema> &ref_69
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_73
       type: constant
       value: !<!ConstantValue> 
         value: '2016-02-29'
@@ -521,7 +531,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_69
+    - !<!ObjectSchema> &ref_70
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -562,7 +572,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_70
+    - !<!ObjectSchema> &ref_71
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -594,7 +604,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_76
+    - !<!ObjectSchema> &ref_77
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -627,7 +637,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_78
+    - !<!ObjectSchema> &ref_79
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -660,7 +670,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_80
+    - !<!ObjectSchema> &ref_81
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -693,7 +703,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_82
+    - !<!ObjectSchema> &ref_83
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -726,7 +736,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_84
+    - !<!ObjectSchema> &ref_85
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -759,7 +769,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_86
+    - !<!ObjectSchema> &ref_87
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -800,7 +810,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_88
+    - !<!ObjectSchema> &ref_89
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -833,7 +843,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_90
+    - !<!ObjectSchema> &ref_91
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -866,7 +876,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_92
+    - !<!ObjectSchema> &ref_93
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -899,7 +909,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_94
+    - !<!ObjectSchema> &ref_95
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -924,7 +934,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_96
+    - !<!ObjectSchema> &ref_97
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -949,7 +959,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_98
+    - !<!ObjectSchema> &ref_99
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -984,7 +994,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_101
+    - !<!ObjectSchema> &ref_102
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1569,7 +1579,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_106
+    - !<!ObjectSchema> &ref_107
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1639,7 +1649,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_39
     - *ref_27
-    - !<!ObjectSchema> &ref_111
+    - !<!ObjectSchema> &ref_112
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1798,7 +1808,7 @@ schemas: !<!Schemas>
     - *ref_65
     - *ref_66
 globalParameters:
-  - !<!Parameter> &ref_71
+  - !<!Parameter> &ref_72
     schema: *ref_1
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -1814,8 +1824,8 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_113
-    schema: *ref_72
+  - !<!Parameter> &ref_114
+    schema: *ref_73
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
     required: true
@@ -1836,9 +1846,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1851,7 +1876,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_69
+            schema: *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -1865,7 +1890,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1887,10 +1912,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
-          - *ref_113
-          - !<!Parameter> &ref_74
-            schema: *ref_73
+          - *ref_72
+          - *ref_114
+          - !<!Parameter> &ref_75
+            schema: *ref_74
             clientDefaultValue: garrett
             implementation: Method
             required: true
@@ -1907,8 +1932,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_75
-                schema: *ref_69
+              - !<!Parameter> &ref_76
+                schema: *ref_70
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1919,8 +1944,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_75
+              - *ref_76
             language: !<!Languages> 
               default:
                 name: ''
@@ -1934,7 +1972,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_74
+          - *ref_75
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1947,7 +1985,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1969,9 +2007,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1984,7 +2037,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_69
+            schema: *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -1998,7 +2051,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2020,9 +2073,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2035,7 +2103,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_69
+            schema: *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -2049,7 +2117,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2071,9 +2139,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2086,7 +2169,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_69
+            schema: *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -2100,7 +2183,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2122,9 +2205,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2137,7 +2235,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_69
+            schema: *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -2151,7 +2249,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2181,9 +2279,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2196,7 +2309,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_76
+            schema: *ref_77
             language: !<!Languages> 
               default:
                 name: ''
@@ -2210,7 +2323,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2232,12 +2345,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_77
-                schema: *ref_76
+              - !<!Parameter> &ref_78
+                schema: *ref_77
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2248,8 +2361,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_77
+              - *ref_78
             language: !<!Languages> 
               default:
                 name: ''
@@ -2275,7 +2401,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2297,9 +2423,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2312,7 +2453,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_78
+            schema: *ref_79
             language: !<!Languages> 
               default:
                 name: ''
@@ -2326,7 +2467,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2348,12 +2489,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_79
-                schema: *ref_78
+              - !<!Parameter> &ref_80
+                schema: *ref_79
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2364,8 +2505,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_79
+              - *ref_80
             language: !<!Languages> 
               default:
                 name: ''
@@ -2391,7 +2545,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2413,9 +2567,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2428,7 +2597,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_80
+            schema: *ref_81
             language: !<!Languages> 
               default:
                 name: ''
@@ -2442,7 +2611,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2464,12 +2633,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_81
-                schema: *ref_80
+              - !<!Parameter> &ref_82
+                schema: *ref_81
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2480,8 +2649,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_81
+              - *ref_82
             language: !<!Languages> 
               default:
                 name: ''
@@ -2507,7 +2689,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2529,9 +2711,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2544,7 +2741,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_82
+            schema: *ref_83
             language: !<!Languages> 
               default:
                 name: ''
@@ -2558,7 +2755,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2580,12 +2777,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_83
-                schema: *ref_82
+              - !<!Parameter> &ref_84
+                schema: *ref_83
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2596,8 +2793,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_83
+              - *ref_84
             language: !<!Languages> 
               default:
                 name: ''
@@ -2623,7 +2833,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2645,9 +2855,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2660,7 +2885,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_84
+            schema: *ref_85
             language: !<!Languages> 
               default:
                 name: ''
@@ -2674,7 +2899,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2696,12 +2921,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_85
-                schema: *ref_84
+              - !<!Parameter> &ref_86
+                schema: *ref_85
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2712,8 +2937,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_85
+              - *ref_86
             language: !<!Languages> 
               default:
                 name: ''
@@ -2739,7 +2977,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2761,9 +2999,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2776,7 +3029,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_86
+            schema: *ref_87
             language: !<!Languages> 
               default:
                 name: ''
@@ -2790,7 +3043,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2812,12 +3065,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_87
-                schema: *ref_86
+              - !<!Parameter> &ref_88
+                schema: *ref_87
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2828,8 +3081,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_87
+              - *ref_88
             language: !<!Languages> 
               default:
                 name: ''
@@ -2855,7 +3121,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2877,9 +3143,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2892,7 +3173,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_88
+            schema: *ref_89
             language: !<!Languages> 
               default:
                 name: ''
@@ -2906,7 +3187,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2928,12 +3209,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_89
-                schema: *ref_88
+              - !<!Parameter> &ref_90
+                schema: *ref_89
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2944,8 +3225,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_89
+              - *ref_90
             language: !<!Languages> 
               default:
                 name: ''
@@ -2971,7 +3265,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2993,9 +3287,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3008,7 +3317,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_90
+            schema: *ref_91
             language: !<!Languages> 
               default:
                 name: ''
@@ -3022,7 +3331,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3044,12 +3353,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_91
-                schema: *ref_90
+              - !<!Parameter> &ref_92
+                schema: *ref_91
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3060,8 +3369,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_91
+              - *ref_92
             language: !<!Languages> 
               default:
                 name: ''
@@ -3087,7 +3409,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3109,9 +3431,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3124,7 +3461,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_92
+            schema: *ref_93
             language: !<!Languages> 
               default:
                 name: ''
@@ -3138,7 +3475,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3160,12 +3497,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_93
-                schema: *ref_92
+              - !<!Parameter> &ref_94
+                schema: *ref_93
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3176,8 +3513,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_93
+              - *ref_94
             language: !<!Languages> 
               default:
                 name: ''
@@ -3203,7 +3553,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3225,9 +3575,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3240,7 +3605,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_94
+            schema: *ref_95
             language: !<!Languages> 
               default:
                 name: ''
@@ -3254,7 +3619,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3276,12 +3641,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_95
-                schema: *ref_94
+              - !<!Parameter> &ref_96
+                schema: *ref_95
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3292,8 +3657,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_95
+              - *ref_96
             language: !<!Languages> 
               default:
                 name: ''
@@ -3319,7 +3697,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3341,9 +3719,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3356,7 +3749,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_96
+            schema: *ref_97
             language: !<!Languages> 
               default:
                 name: ''
@@ -3370,7 +3763,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3392,12 +3785,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_97
-                schema: *ref_96
+              - !<!Parameter> &ref_98
+                schema: *ref_97
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3408,8 +3801,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_97
+              - *ref_98
             language: !<!Languages> 
               default:
                 name: ''
@@ -3435,7 +3841,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3465,9 +3871,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3480,7 +3901,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_98
+            schema: *ref_99
             language: !<!Languages> 
               default:
                 name: ''
@@ -3494,7 +3915,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3516,12 +3937,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_99
-                schema: *ref_98
+              - !<!Parameter> &ref_100
+                schema: *ref_99
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3532,8 +3953,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_99
+              - *ref_100
             language: !<!Languages> 
               default:
                 name: ''
@@ -3559,7 +3993,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3581,9 +4015,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3596,7 +4045,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_98
+            schema: *ref_99
             language: !<!Languages> 
               default:
                 name: ''
@@ -3610,7 +4059,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3632,12 +4081,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_100
-                schema: *ref_98
+              - !<!Parameter> &ref_101
+                schema: *ref_99
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3648,8 +4097,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_100
+              - *ref_101
             language: !<!Languages> 
               default:
                 name: ''
@@ -3675,7 +4137,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3697,9 +4159,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3712,7 +4189,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_98
+            schema: *ref_99
             language: !<!Languages> 
               default:
                 name: ''
@@ -3726,7 +4203,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3756,9 +4233,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3771,7 +4263,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_101
+            schema: *ref_102
             language: !<!Languages> 
               default:
                 name: ''
@@ -3785,7 +4277,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3807,12 +4299,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_102
-                schema: *ref_101
+              - !<!Parameter> &ref_103
+                schema: *ref_102
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3823,8 +4315,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_102
+              - *ref_103
             language: !<!Languages> 
               default:
                 name: ''
@@ -3850,7 +4355,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3872,9 +4377,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3887,7 +4407,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_101
+            schema: *ref_102
             language: !<!Languages> 
               default:
                 name: ''
@@ -3901,7 +4421,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3923,12 +4443,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_103
-                schema: *ref_101
+              - !<!Parameter> &ref_104
+                schema: *ref_102
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3939,8 +4459,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_103
+              - *ref_104
             language: !<!Languages> 
               default:
                 name: ''
@@ -3966,7 +4499,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3988,9 +4521,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4003,7 +4551,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_101
+            schema: *ref_102
             language: !<!Languages> 
               default:
                 name: ''
@@ -4017,7 +4565,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4039,9 +4587,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4054,7 +4617,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_101
+            schema: *ref_102
             language: !<!Languages> 
               default:
                 name: ''
@@ -4068,7 +4631,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4098,9 +4661,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4127,7 +4705,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4149,11 +4727,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_104
+              - !<!Parameter> &ref_105
                 schema: *ref_19
                 implementation: Method
                 required: true
@@ -4165,8 +4743,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_104
+              - *ref_105
             language: !<!Languages> 
               default:
                 name: ''
@@ -4192,7 +4783,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4222,9 +4813,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4251,7 +4857,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4273,11 +4879,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_105
+              - !<!Parameter> &ref_106
                 schema: *ref_23
                 implementation: Method
                 required: true
@@ -4322,8 +4928,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_105
+              - *ref_106
             language: !<!Languages> 
               default:
                 name: ''
@@ -4349,7 +4968,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4371,9 +4990,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4400,7 +5034,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4422,9 +5056,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4437,7 +5086,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_106
+            schema: *ref_107
             language: !<!Languages> 
               default:
                 name: ''
@@ -4451,7 +5100,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4473,9 +5122,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4488,7 +5152,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_106
+            schema: *ref_107
             language: !<!Languages> 
               default:
                 name: ''
@@ -4502,7 +5166,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4524,9 +5188,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4553,7 +5232,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4575,11 +5254,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_107
+              - !<!Parameter> &ref_108
                 schema: *ref_27
                 implementation: Method
                 required: true
@@ -4591,8 +5270,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_107
+              - *ref_108
             language: !<!Languages> 
               default:
                 name: ''
@@ -4618,7 +5310,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4640,11 +5332,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_108
+              - !<!Parameter> &ref_109
                 schema: *ref_27
                 implementation: Method
                 required: true
@@ -4656,8 +5348,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_108
+              - *ref_109
             language: !<!Languages> 
               default:
                 name: ''
@@ -4687,7 +5392,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4709,164 +5414,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
-        requests:
-          - !<!Request> 
-            parameters:
-              - !<!Parameter> &ref_109
-                schema: *ref_23
-                implementation: Method
-                required: true
-                language: !<!Languages> 
-                  default:
-                    name: complexBody
-                    description: |-
-                      Please put a salmon that looks like this:
-                      {
-                              'fishtype':'Salmon',
-                              'location':'alaska',
-                              'iswild':true,
-                              'species':'king',
-                              'length':1.0,
-                              'siblings':[
-                                {
-                                  'fishtype':'Shark',
-                                  'age':6,
-                                  'birthday': '2012-01-05T01:00:00Z',
-                                  'length':20.0,
-                                  'species':'predator',
-                                },
-                                {
-                                  'fishtype':'Sawshark',
-                                  'age':105,
-                                  'birthday': '1900-01-05T01:00:00Z',
-                                  'length':10.0,
-                                  'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-                                  'species':'dangerous',
-                                },
-                                {
-                                  'fishtype': 'goblin',
-                                  'age': 1,
-                                  'birthday': '2015-08-08T00:00:00Z',
-                                  'length': 30.0,
-                                  'species': 'scary',
-                                  'jawsize': 5
-                                }
-                              ]
-                            };
-                protocol: !<!Protocols> 
-                  http: !<!HttpParameter> 
-                    in: body
-                    style: json
-            signatureParameters:
-              - *ref_109
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpWithBodyRequest> 
-                path: /complex/polymorphism/missingrequired/invalid
-                method: put
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_70
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: putValidMissingRequired
-            description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
-        protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: polymorphism
-        description: ''
-    protocol: !<!Protocols> {}
-  - !<!OperationGroup> 
-    $key: polymorphicrecursive
-    operations:
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: '2016-02-29'
-        parameters:
-          - *ref_71
-        requests:
-          - !<!Request> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpRequest> 
-                path: /complex/polymorphicrecursive/valid
-                method: get
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!SchemaResponse> 
-            schema: *ref_23
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_70
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: getValid
-            description: Get complex types that are polymorphic and have recursive references
-        protocol: !<!Protocols> {}
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: '2016-02-29'
-        parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
@@ -4915,8 +5463,206 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
               - *ref_110
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpWithBodyRequest> 
+                path: /complex/polymorphism/missingrequired/invalid
+                method: put
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_71
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: putValidMissingRequired
+            description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
+        protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: polymorphism
+        description: ''
+    protocol: !<!Protocols> {}
+  - !<!OperationGroup> 
+    $key: polymorphicrecursive
+    operations:
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: '2016-02-29'
+        parameters:
+          - *ref_72
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpRequest> 
+                path: /complex/polymorphicrecursive/valid
+                method: get
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!SchemaResponse> 
+            schema: *ref_23
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_71
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: getValid
+            description: Get complex types that are polymorphic and have recursive references
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: '2016-02-29'
+        parameters:
+          - *ref_72
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_111
+                schema: *ref_23
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: complexBody
+                    description: |-
+                      Please put a salmon that looks like this:
+                      {
+                              'fishtype':'Salmon',
+                              'location':'alaska',
+                              'iswild':true,
+                              'species':'king',
+                              'length':1.0,
+                              'siblings':[
+                                {
+                                  'fishtype':'Shark',
+                                  'age':6,
+                                  'birthday': '2012-01-05T01:00:00Z',
+                                  'length':20.0,
+                                  'species':'predator',
+                                },
+                                {
+                                  'fishtype':'Sawshark',
+                                  'age':105,
+                                  'birthday': '1900-01-05T01:00:00Z',
+                                  'length':10.0,
+                                  'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                                  'species':'dangerous',
+                                },
+                                {
+                                  'fishtype': 'goblin',
+                                  'age': 1,
+                                  'birthday': '2015-08-08T00:00:00Z',
+                                  'length': 30.0,
+                                  'species': 'scary',
+                                  'jawsize': 5
+                                }
+                              ]
+                            };
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters:
+              - *ref_111
             language: !<!Languages> 
               default:
                 name: ''
@@ -4942,7 +5688,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4972,9 +5718,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4987,7 +5748,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_111
+            schema: *ref_112
             language: !<!Languages> 
               default:
                 name: ''
@@ -5001,7 +5762,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -5023,12 +5784,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_112
-                schema: *ref_111
+              - !<!Parameter> &ref_113
+                schema: *ref_112
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -5039,8 +5800,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_112
+              - *ref_113
             language: !<!Languages> 
               default:
                 name: ''
@@ -5066,7 +5840,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -5096,9 +5870,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/a-playground/namer.yaml
+++ b/modelerfour/test/scenarios/a-playground/namer.yaml
@@ -80,7 +80,7 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_73
+    - !<!StringSchema> &ref_74
       type: string
       language: !<!Languages> 
         default:
@@ -374,6 +374,16 @@ schemas: !<!Schemas>
           description: Colors possible
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_70
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_68
       type: constant
       value: !<!ConstantValue> 
@@ -521,7 +531,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_70
+    - !<!ObjectSchema> &ref_71
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -562,7 +572,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_71
+    - !<!ObjectSchema> &ref_72
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -594,13 +604,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_76
+    - !<!ObjectSchema> &ref_77
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_78
+        - !<!Property> &ref_79
           schema: *ref_6
           serializedName: field1
           language: !<!Languages> 
@@ -608,7 +618,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_79
+        - !<!Property> &ref_80
           schema: *ref_6
           serializedName: field2
           language: !<!Languages> 
@@ -627,13 +637,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_82
+    - !<!ObjectSchema> &ref_83
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_84
+        - !<!Property> &ref_85
           schema: *ref_8
           serializedName: field1
           language: !<!Languages> 
@@ -641,7 +651,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_85
+        - !<!Property> &ref_86
           schema: *ref_8
           serializedName: field2
           language: !<!Languages> 
@@ -660,13 +670,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_88
+    - !<!ObjectSchema> &ref_89
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_90
+        - !<!Property> &ref_91
           schema: *ref_9
           serializedName: field1
           language: !<!Languages> 
@@ -674,7 +684,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_91
+        - !<!Property> &ref_92
           schema: *ref_9
           serializedName: field2
           language: !<!Languages> 
@@ -693,13 +703,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_94
+    - !<!ObjectSchema> &ref_95
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_96
+        - !<!Property> &ref_97
           schema: *ref_10
           serializedName: field1
           language: !<!Languages> 
@@ -707,7 +717,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_97
+        - !<!Property> &ref_98
           schema: *ref_10
           serializedName: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
           language: !<!Languages> 
@@ -726,13 +736,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_100
+    - !<!ObjectSchema> &ref_101
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_102
+        - !<!Property> &ref_103
           schema: *ref_11
           serializedName: field_true
           language: !<!Languages> 
@@ -740,7 +750,7 @@ schemas: !<!Schemas>
               name: fieldTrue
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_103
+        - !<!Property> &ref_104
           schema: *ref_11
           serializedName: field_false
           language: !<!Languages> 
@@ -759,7 +769,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_106
+    - !<!ObjectSchema> &ref_107
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -800,13 +810,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_108
+    - !<!ObjectSchema> &ref_109
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_110
+        - !<!Property> &ref_111
           schema: *ref_15
           serializedName: field
           language: !<!Languages> 
@@ -814,7 +824,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_111
+        - !<!Property> &ref_112
           schema: *ref_16
           serializedName: leap
           language: !<!Languages> 
@@ -833,13 +843,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_114
+    - !<!ObjectSchema> &ref_115
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_116
+        - !<!Property> &ref_117
           schema: *ref_17
           serializedName: field
           language: !<!Languages> 
@@ -847,7 +857,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_117
+        - !<!Property> &ref_118
           schema: *ref_18
           serializedName: now
           language: !<!Languages> 
@@ -866,13 +876,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_120
+    - !<!ObjectSchema> &ref_121
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_122
+        - !<!Property> &ref_123
           schema: *ref_19
           serializedName: field
           language: !<!Languages> 
@@ -880,7 +890,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_123
+        - !<!Property> &ref_124
           schema: *ref_20
           serializedName: now
           language: !<!Languages> 
@@ -899,13 +909,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_126
+    - !<!ObjectSchema> &ref_127
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_128
+        - !<!Property> &ref_129
           schema: *ref_21
           serializedName: field
           language: !<!Languages> 
@@ -924,13 +934,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_130
+    - !<!ObjectSchema> &ref_131
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_132
+        - !<!Property> &ref_133
           schema: *ref_22
           serializedName: field
           language: !<!Languages> 
@@ -949,13 +959,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_134
+    - !<!ObjectSchema> &ref_135
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_136
+        - !<!Property> &ref_137
           schema: !<!ArraySchema> &ref_63
             type: array
             apiVersions:
@@ -984,13 +994,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_140
+    - !<!ObjectSchema> &ref_141
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_142
+        - !<!Property> &ref_143
           schema: *ref_24
           serializedName: defaultProgram
           language: !<!Languages> 
@@ -1569,7 +1579,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_148
+    - !<!ObjectSchema> &ref_149
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1639,7 +1649,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_51
     - *ref_33
-    - !<!ObjectSchema> &ref_153
+    - !<!ObjectSchema> &ref_154
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1654,7 +1664,7 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_155
+        - !<!Property> &ref_156
           schema: *ref_6
           serializedName: size
           language: !<!Languages> 
@@ -1791,7 +1801,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_72
+  - !<!Parameter> &ref_73
     schema: *ref_68
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -1816,6 +1826,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1828,7 +1853,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1842,7 +1867,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1865,9 +1890,9 @@ operationGroups:
             version: '2016-02-29'
         parameters:
           - *ref_69
-          - *ref_72
-          - !<!Parameter> &ref_75
-            schema: *ref_73
+          - *ref_73
+          - !<!Parameter> &ref_76
+            schema: *ref_74
             clientDefaultValue: garrett
             implementation: Method
             required: true
@@ -1884,8 +1909,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_74
-                schema: *ref_70
+              - !<!Parameter> &ref_75
+                schema: *ref_71
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1896,8 +1921,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_74
+              - *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -1911,7 +1949,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_75
+          - *ref_76
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1924,7 +1962,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1949,6 +1987,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1961,7 +2014,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1975,7 +2028,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2000,6 +2053,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2012,7 +2080,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2026,7 +2094,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2051,6 +2119,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2063,7 +2146,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2077,7 +2160,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2102,6 +2185,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2114,7 +2212,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2128,7 +2226,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2161,6 +2259,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2173,7 +2286,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_76
+            schema: *ref_77
             language: !<!Languages> 
               default:
                 name: ''
@@ -2187,7 +2300,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2213,8 +2326,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_77
-                schema: *ref_76
+              - !<!Parameter> &ref_78
+                schema: *ref_77
                 flattened: true
                 implementation: Method
                 required: true
@@ -2226,31 +2339,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_80
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_81
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_77
+                originalParameter: *ref_78
                 pathToProperty: []
-                targetProperty: *ref_78
+                targetProperty: *ref_79
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_81
+              - !<!VirtualParameter> &ref_82
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_77
+                originalParameter: *ref_78
                 pathToProperty: []
-                targetProperty: *ref_79
+                targetProperty: *ref_80
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_80
               - *ref_81
+              - *ref_82
             language: !<!Languages> 
               default:
                 name: ''
@@ -2276,7 +2402,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2301,6 +2427,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2313,7 +2454,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_82
+            schema: *ref_83
             language: !<!Languages> 
               default:
                 name: ''
@@ -2327,7 +2468,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2353,8 +2494,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_83
-                schema: *ref_82
+              - !<!Parameter> &ref_84
+                schema: *ref_83
                 flattened: true
                 implementation: Method
                 required: true
@@ -2366,31 +2507,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_86
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_87
                 schema: *ref_8
                 implementation: Method
-                originalParameter: *ref_83
+                originalParameter: *ref_84
                 pathToProperty: []
-                targetProperty: *ref_84
+                targetProperty: *ref_85
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_87
+              - !<!VirtualParameter> &ref_88
                 schema: *ref_8
                 implementation: Method
-                originalParameter: *ref_83
+                originalParameter: *ref_84
                 pathToProperty: []
-                targetProperty: *ref_85
+                targetProperty: *ref_86
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_86
               - *ref_87
+              - *ref_88
             language: !<!Languages> 
               default:
                 name: ''
@@ -2416,7 +2570,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2441,6 +2595,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2453,7 +2622,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_88
+            schema: *ref_89
             language: !<!Languages> 
               default:
                 name: ''
@@ -2467,7 +2636,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2493,8 +2662,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_89
-                schema: *ref_88
+              - !<!Parameter> &ref_90
+                schema: *ref_89
                 flattened: true
                 implementation: Method
                 required: true
@@ -2506,31 +2675,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_92
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_93
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_89
+                originalParameter: *ref_90
                 pathToProperty: []
-                targetProperty: *ref_90
+                targetProperty: *ref_91
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_93
+              - !<!VirtualParameter> &ref_94
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_89
+                originalParameter: *ref_90
                 pathToProperty: []
-                targetProperty: *ref_91
+                targetProperty: *ref_92
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_92
               - *ref_93
+              - *ref_94
             language: !<!Languages> 
               default:
                 name: ''
@@ -2556,7 +2738,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2581,6 +2763,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2593,7 +2790,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_94
+            schema: *ref_95
             language: !<!Languages> 
               default:
                 name: ''
@@ -2607,7 +2804,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2633,8 +2830,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_95
-                schema: *ref_94
+              - !<!Parameter> &ref_96
+                schema: *ref_95
                 flattened: true
                 implementation: Method
                 required: true
@@ -2646,31 +2843,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_98
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_99
                 schema: *ref_10
                 implementation: Method
-                originalParameter: *ref_95
+                originalParameter: *ref_96
                 pathToProperty: []
-                targetProperty: *ref_96
+                targetProperty: *ref_97
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_99
+              - !<!VirtualParameter> &ref_100
                 schema: *ref_10
                 implementation: Method
-                originalParameter: *ref_95
+                originalParameter: *ref_96
                 pathToProperty: []
-                targetProperty: *ref_97
+                targetProperty: *ref_98
                 language: !<!Languages> 
                   default:
                     name: field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_98
               - *ref_99
+              - *ref_100
             language: !<!Languages> 
               default:
                 name: ''
@@ -2696,7 +2906,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2721,6 +2931,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2733,7 +2958,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_100
+            schema: *ref_101
             language: !<!Languages> 
               default:
                 name: ''
@@ -2747,7 +2972,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2773,8 +2998,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_101
-                schema: *ref_100
+              - !<!Parameter> &ref_102
+                schema: *ref_101
                 flattened: true
                 implementation: Method
                 required: true
@@ -2786,31 +3011,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_104
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_105
                 schema: *ref_11
                 implementation: Method
-                originalParameter: *ref_101
+                originalParameter: *ref_102
                 pathToProperty: []
-                targetProperty: *ref_102
+                targetProperty: *ref_103
                 language: !<!Languages> 
                   default:
                     name: fieldTrue
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_105
+              - !<!VirtualParameter> &ref_106
                 schema: *ref_11
                 implementation: Method
-                originalParameter: *ref_101
+                originalParameter: *ref_102
                 pathToProperty: []
-                targetProperty: *ref_103
+                targetProperty: *ref_104
                 language: !<!Languages> 
                   default:
                     name: fieldFalse
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_104
               - *ref_105
+              - *ref_106
             language: !<!Languages> 
               default:
                 name: ''
@@ -2836,7 +3074,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2861,6 +3099,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2873,7 +3126,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_106
+            schema: *ref_107
             language: !<!Languages> 
               default:
                 name: ''
@@ -2887,7 +3140,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2913,8 +3166,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_107
-                schema: *ref_106
+              - !<!Parameter> &ref_108
+                schema: *ref_107
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2925,8 +3178,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_107
+              - *ref_108
             language: !<!Languages> 
               default:
                 name: ''
@@ -2952,7 +3218,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2977,6 +3243,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2989,7 +3270,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_108
+            schema: *ref_109
             language: !<!Languages> 
               default:
                 name: ''
@@ -3003,7 +3284,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3029,8 +3310,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_109
-                schema: *ref_108
+              - !<!Parameter> &ref_110
+                schema: *ref_109
                 flattened: true
                 implementation: Method
                 required: true
@@ -3042,31 +3323,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_112
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_113
                 schema: *ref_15
                 implementation: Method
-                originalParameter: *ref_109
+                originalParameter: *ref_110
                 pathToProperty: []
-                targetProperty: *ref_110
+                targetProperty: *ref_111
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_113
+              - !<!VirtualParameter> &ref_114
                 schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_109
+                originalParameter: *ref_110
                 pathToProperty: []
-                targetProperty: *ref_111
+                targetProperty: *ref_112
                 language: !<!Languages> 
                   default:
                     name: leap
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_112
               - *ref_113
+              - *ref_114
             language: !<!Languages> 
               default:
                 name: ''
@@ -3092,7 +3386,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3117,6 +3411,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3129,7 +3438,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_114
+            schema: *ref_115
             language: !<!Languages> 
               default:
                 name: ''
@@ -3143,7 +3452,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3169,8 +3478,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_115
-                schema: *ref_114
+              - !<!Parameter> &ref_116
+                schema: *ref_115
                 flattened: true
                 implementation: Method
                 required: true
@@ -3182,31 +3491,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_118
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_119
                 schema: *ref_17
                 implementation: Method
-                originalParameter: *ref_115
+                originalParameter: *ref_116
                 pathToProperty: []
-                targetProperty: *ref_116
+                targetProperty: *ref_117
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_119
+              - !<!VirtualParameter> &ref_120
                 schema: *ref_18
                 implementation: Method
-                originalParameter: *ref_115
+                originalParameter: *ref_116
                 pathToProperty: []
-                targetProperty: *ref_117
+                targetProperty: *ref_118
                 language: !<!Languages> 
                   default:
                     name: now
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_118
               - *ref_119
+              - *ref_120
             language: !<!Languages> 
               default:
                 name: ''
@@ -3232,7 +3554,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3257,6 +3579,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3269,7 +3606,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_120
+            schema: *ref_121
             language: !<!Languages> 
               default:
                 name: ''
@@ -3283,7 +3620,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3309,8 +3646,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_121
-                schema: *ref_120
+              - !<!Parameter> &ref_122
+                schema: *ref_121
                 flattened: true
                 implementation: Method
                 required: true
@@ -3322,31 +3659,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_124
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_125
                 schema: *ref_19
                 implementation: Method
-                originalParameter: *ref_121
+                originalParameter: *ref_122
                 pathToProperty: []
-                targetProperty: *ref_122
+                targetProperty: *ref_123
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_125
+              - !<!VirtualParameter> &ref_126
                 schema: *ref_20
                 implementation: Method
-                originalParameter: *ref_121
+                originalParameter: *ref_122
                 pathToProperty: []
-                targetProperty: *ref_123
+                targetProperty: *ref_124
                 language: !<!Languages> 
                   default:
                     name: now
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_124
               - *ref_125
+              - *ref_126
             language: !<!Languages> 
               default:
                 name: ''
@@ -3372,7 +3722,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3397,6 +3747,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3409,7 +3774,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_126
+            schema: *ref_127
             language: !<!Languages> 
               default:
                 name: ''
@@ -3423,7 +3788,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3449,8 +3814,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_127
-                schema: *ref_126
+              - !<!Parameter> &ref_128
+                schema: *ref_127
                 flattened: true
                 implementation: Method
                 required: true
@@ -3462,19 +3827,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_129
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_130
                 schema: *ref_21
                 implementation: Method
-                originalParameter: *ref_127
+                originalParameter: *ref_128
                 pathToProperty: []
-                targetProperty: *ref_128
+                targetProperty: *ref_129
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_129
+              - *ref_130
             language: !<!Languages> 
               default:
                 name: ''
@@ -3500,7 +3878,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3525,6 +3903,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3537,7 +3930,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_130
+            schema: *ref_131
             language: !<!Languages> 
               default:
                 name: ''
@@ -3551,7 +3944,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3577,8 +3970,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_131
-                schema: *ref_130
+              - !<!Parameter> &ref_132
+                schema: *ref_131
                 flattened: true
                 implementation: Method
                 required: true
@@ -3590,19 +3983,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_133
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_134
                 schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_131
+                originalParameter: *ref_132
                 pathToProperty: []
-                targetProperty: *ref_132
+                targetProperty: *ref_133
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_133
+              - *ref_134
             language: !<!Languages> 
               default:
                 name: ''
@@ -3628,7 +4034,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3661,6 +4067,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3673,7 +4094,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_134
+            schema: *ref_135
             language: !<!Languages> 
               default:
                 name: ''
@@ -3687,7 +4108,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3713,8 +4134,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_135
-                schema: *ref_134
+              - !<!Parameter> &ref_136
+                schema: *ref_135
                 flattened: true
                 implementation: Method
                 required: true
@@ -3726,19 +4147,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_137
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_138
                 schema: *ref_63
                 implementation: Method
-                originalParameter: *ref_135
+                originalParameter: *ref_136
                 pathToProperty: []
-                targetProperty: *ref_136
+                targetProperty: *ref_137
                 language: !<!Languages> 
                   default:
                     name: array
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_137
+              - *ref_138
             language: !<!Languages> 
               default:
                 name: ''
@@ -3764,7 +4198,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3789,6 +4223,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3801,7 +4250,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_134
+            schema: *ref_135
             language: !<!Languages> 
               default:
                 name: ''
@@ -3815,7 +4264,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3841,8 +4290,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_138
-                schema: *ref_134
+              - !<!Parameter> &ref_139
+                schema: *ref_135
                 flattened: true
                 implementation: Method
                 required: true
@@ -3854,19 +4303,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_139
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_140
                 schema: *ref_63
                 implementation: Method
-                originalParameter: *ref_138
+                originalParameter: *ref_139
                 pathToProperty: []
-                targetProperty: *ref_136
+                targetProperty: *ref_137
                 language: !<!Languages> 
                   default:
                     name: array
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_139
+              - *ref_140
             language: !<!Languages> 
               default:
                 name: ''
@@ -3892,7 +4354,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3917,6 +4379,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3929,7 +4406,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_134
+            schema: *ref_135
             language: !<!Languages> 
               default:
                 name: ''
@@ -3943,7 +4420,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3976,6 +4453,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3988,7 +4480,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_140
+            schema: *ref_141
             language: !<!Languages> 
               default:
                 name: ''
@@ -4002,7 +4494,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4028,8 +4520,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_141
-                schema: *ref_140
+              - !<!Parameter> &ref_142
+                schema: *ref_141
                 flattened: true
                 implementation: Method
                 required: true
@@ -4041,19 +4533,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_143
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_144
                 schema: *ref_24
                 implementation: Method
-                originalParameter: *ref_141
+                originalParameter: *ref_142
                 pathToProperty: []
-                targetProperty: *ref_142
+                targetProperty: *ref_143
                 language: !<!Languages> 
                   default:
                     name: defaultProgram
                     description: Dictionary of <string>
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_143
+              - *ref_144
             language: !<!Languages> 
               default:
                 name: ''
@@ -4079,7 +4584,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4104,6 +4609,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4116,7 +4636,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_140
+            schema: *ref_141
             language: !<!Languages> 
               default:
                 name: ''
@@ -4130,7 +4650,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4156,8 +4676,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_144
-                schema: *ref_140
+              - !<!Parameter> &ref_145
+                schema: *ref_141
                 flattened: true
                 implementation: Method
                 required: true
@@ -4169,19 +4689,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_145
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_146
                 schema: *ref_24
                 implementation: Method
-                originalParameter: *ref_144
+                originalParameter: *ref_145
                 pathToProperty: []
-                targetProperty: *ref_142
+                targetProperty: *ref_143
                 language: !<!Languages> 
                   default:
                     name: defaultProgram
                     description: Dictionary of <string>
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_145
+              - *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -4207,7 +4740,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4232,6 +4765,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4244,7 +4792,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_140
+            schema: *ref_141
             language: !<!Languages> 
               default:
                 name: ''
@@ -4258,7 +4806,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4283,6 +4831,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4295,7 +4858,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_140
+            schema: *ref_141
             language: !<!Languages> 
               default:
                 name: ''
@@ -4309,7 +4872,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4342,6 +4905,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4368,7 +4946,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4394,7 +4972,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_146
+              - !<!Parameter> &ref_147
                 schema: *ref_25
                 implementation: Method
                 required: true
@@ -4406,8 +4984,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_146
+              - *ref_147
             language: !<!Languages> 
               default:
                 name: ''
@@ -4433,7 +5024,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4466,6 +5057,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4492,7 +5098,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4518,7 +5124,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_147
+              - !<!Parameter> &ref_148
                 schema: *ref_35
                 implementation: Method
                 required: true
@@ -4563,8 +5169,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_147
+              - *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -4590,7 +5209,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4615,6 +5234,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4641,7 +5275,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4666,6 +5300,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4678,7 +5327,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_148
+            schema: *ref_149
             language: !<!Languages> 
               default:
                 name: ''
@@ -4692,7 +5341,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4717,6 +5366,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4729,7 +5393,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_148
+            schema: *ref_149
             language: !<!Languages> 
               default:
                 name: ''
@@ -4743,7 +5407,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4768,6 +5432,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4794,7 +5473,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4820,7 +5499,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_149
+              - !<!Parameter> &ref_150
                 schema: *ref_33
                 implementation: Method
                 required: true
@@ -4832,8 +5511,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_149
+              - *ref_150
             language: !<!Languages> 
               default:
                 name: ''
@@ -4859,7 +5551,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4885,7 +5577,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_150
+              - !<!Parameter> &ref_151
                 schema: *ref_33
                 implementation: Method
                 required: true
@@ -4897,8 +5589,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_150
+              - *ref_151
             language: !<!Languages> 
               default:
                 name: ''
@@ -4928,7 +5633,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4944,163 +5649,6 @@ operationGroups:
           default:
             name: PutMissingDiscriminator
             description: 'Put complex types that are polymorphic, omitting the discriminator'
-        protocol: !<!Protocols> {}
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: '2016-02-29'
-        parameters:
-          - *ref_69
-        requests:
-          - !<!Request> 
-            parameters:
-              - !<!Parameter> &ref_151
-                schema: *ref_35
-                implementation: Method
-                required: true
-                language: !<!Languages> 
-                  default:
-                    name: complexBody
-                    description: |-
-                      Please put a salmon that looks like this:
-                      {
-                              'fishtype':'Salmon',
-                              'location':'alaska',
-                              'iswild':true,
-                              'species':'king',
-                              'length':1.0,
-                              'siblings':[
-                                {
-                                  'fishtype':'Shark',
-                                  'age':6,
-                                  'birthday': '2012-01-05T01:00:00Z',
-                                  'length':20.0,
-                                  'species':'predator',
-                                },
-                                {
-                                  'fishtype':'Sawshark',
-                                  'age':105,
-                                  'birthday': '1900-01-05T01:00:00Z',
-                                  'length':10.0,
-                                  'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-                                  'species':'dangerous',
-                                },
-                                {
-                                  'fishtype': 'goblin',
-                                  'age': 1,
-                                  'birthday': '2015-08-08T00:00:00Z',
-                                  'length': 30.0,
-                                  'species': 'scary',
-                                  'jawsize': 5
-                                }
-                              ]
-                            };
-                protocol: !<!Protocols> 
-                  http: !<!HttpParameter> 
-                    in: body
-                    style: json
-            signatureParameters:
-              - *ref_151
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpWithBodyRequest> 
-                path: /complex/polymorphism/missingrequired/invalid
-                method: put
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_71
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: PutValidMissingRequired
-            description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
-        protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Polymorphism
-        description: ''
-    protocol: !<!Protocols> {}
-  - !<!OperationGroup> 
-    $key: polymorphicrecursive
-    operations:
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: '2016-02-29'
-        parameters:
-          - *ref_69
-        requests:
-          - !<!Request> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpRequest> 
-                path: /complex/polymorphicrecursive/valid
-                method: get
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!SchemaResponse> 
-            schema: *ref_35
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_71
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: GetValid
-            description: Get complex types that are polymorphic and have recursive references
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
@@ -5156,8 +5704,206 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
               - *ref_152
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpWithBodyRequest> 
+                path: /complex/polymorphism/missingrequired/invalid
+                method: put
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_72
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: PutValidMissingRequired
+            description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
+        protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: Polymorphism
+        description: ''
+    protocol: !<!Protocols> {}
+  - !<!OperationGroup> 
+    $key: polymorphicrecursive
+    operations:
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: '2016-02-29'
+        parameters:
+          - *ref_69
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpRequest> 
+                path: /complex/polymorphicrecursive/valid
+                method: get
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!SchemaResponse> 
+            schema: *ref_35
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_72
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: GetValid
+            description: Get complex types that are polymorphic and have recursive references
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: '2016-02-29'
+        parameters:
+          - *ref_69
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_153
+                schema: *ref_35
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: complexBody
+                    description: |-
+                      Please put a salmon that looks like this:
+                      {
+                              'fishtype':'Salmon',
+                              'location':'alaska',
+                              'iswild':true,
+                              'species':'king',
+                              'length':1.0,
+                              'siblings':[
+                                {
+                                  'fishtype':'Shark',
+                                  'age':6,
+                                  'birthday': '2012-01-05T01:00:00Z',
+                                  'length':20.0,
+                                  'species':'predator',
+                                },
+                                {
+                                  'fishtype':'Sawshark',
+                                  'age':105,
+                                  'birthday': '1900-01-05T01:00:00Z',
+                                  'length':10.0,
+                                  'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                                  'species':'dangerous',
+                                },
+                                {
+                                  'fishtype': 'goblin',
+                                  'age': 1,
+                                  'birthday': '2015-08-08T00:00:00Z',
+                                  'length': 30.0,
+                                  'species': 'scary',
+                                  'jawsize': 5
+                                }
+                              ]
+                            };
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters:
+              - *ref_153
             language: !<!Languages> 
               default:
                 name: ''
@@ -5183,7 +5929,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5216,6 +5962,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5228,7 +5989,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_153
+            schema: *ref_154
             language: !<!Languages> 
               default:
                 name: ''
@@ -5242,7 +6003,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5268,8 +6029,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_154
-                schema: *ref_153
+              - !<!Parameter> &ref_155
+                schema: *ref_154
                 flattened: true
                 implementation: Method
                 required: true
@@ -5281,19 +6042,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_156
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_157
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_154
+                originalParameter: *ref_155
                 pathToProperty: []
-                targetProperty: *ref_155
+                targetProperty: *ref_156
                 language: !<!Languages> 
                   default:
                     name: size
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_156
+              - *ref_157
             language: !<!Languages> 
               default:
                 name: ''
@@ -5319,7 +6093,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5352,6 +6126,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/additionalProperties/flattened.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: additionalProperties
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_5
+    - !<!BooleanSchema> &ref_6
       type: boolean
       language: !<!Languages> 
         default:
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_7
+    - !<!NumberSchema> &ref_8
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -20,7 +20,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_2
+    - !<!NumberSchema> &ref_3
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -32,14 +32,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_20
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -49,7 +49,7 @@ schemas: !<!Schemas>
           name: PetAPTrue-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_9
+    - !<!StringSchema> &ref_10
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -59,7 +59,7 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -69,7 +69,7 @@ schemas: !<!Schemas>
           name: PetAPObject-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -79,7 +79,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_13
+    - !<!StringSchema> &ref_14
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -89,7 +89,7 @@ schemas: !<!Schemas>
           name: PetAPString-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_15
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -99,7 +99,7 @@ schemas: !<!Schemas>
           name: PetAPInProperties-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_17
+    - !<!StringSchema> &ref_18
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -109,7 +109,7 @@ schemas: !<!Schemas>
           name: PetAPInPropertiesWithAPString-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_18
+    - !<!StringSchema> &ref_19
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -119,10 +119,21 @@ schemas: !<!Schemas>
           name: PetAPInPropertiesWithAPString-@odata.location
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_22
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_4
+    - !<!DictionarySchema> &ref_5
       type: dictionary
-      elementType: !<!AnySchema> &ref_0
+      elementType: !<!AnySchema> &ref_1
         type: any
         language: !<!Languages> 
           default:
@@ -134,70 +145,70 @@ schemas: !<!Schemas>
           name: PetAPTrue
           description: Dictionary of <any>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_10
+    - !<!DictionarySchema> &ref_11
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: PetAPObject
           description: Dictionary of <any>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_12
+    - !<!DictionarySchema> &ref_13
       type: dictionary
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: PetAPString
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_15
+    - !<!DictionarySchema> &ref_16
       type: dictionary
-      elementType: *ref_2
+      elementType: *ref_3
       language: !<!Languages> 
         default:
           name: PetAPInProperties-additionalProperties
           description: Dictionary of <number>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_16
+    - !<!DictionarySchema> &ref_17
       type: dictionary
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_19
+    - !<!DictionarySchema> &ref_20
       type: dictionary
-      elementType: *ref_2
+      elementType: *ref_3
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString-additionalProperties
           description: Dictionary of <number>
       protocol: !<!Protocols> {}
   any:
-    - *ref_0
+    - *ref_1
   objects:
-    - !<!ObjectSchema> &ref_3
+    - !<!ObjectSchema> &ref_4
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       children: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_6
+          - !<!ObjectSchema> &ref_7
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
             parents: !<!Relations> 
               all:
-                - *ref_3
                 - *ref_4
+                - *ref_5
               immediate:
-                - *ref_3
+                - *ref_4
             properties:
               - !<!Property> 
-                schema: *ref_5
+                schema: *ref_6
                 serializedName: friendly
                 language: !<!Languages> 
                   default:
@@ -216,15 +227,15 @@ schemas: !<!Schemas>
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_6
+          - *ref_7
       parents: !<!Relations> 
         all:
-          - *ref_4
+          - *ref_5
         immediate:
-          - *ref_4
+          - *ref_5
       properties:
-        - !<!Property> &ref_23
-          schema: *ref_7
+        - !<!Property> &ref_24
+          schema: *ref_8
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -232,8 +243,8 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_24
-          schema: *ref_8
+        - !<!Property> &ref_25
+          schema: *ref_9
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -242,7 +253,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           readOnly: true
           required: false
           serializedName: status
@@ -262,14 +273,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_27
+    - !<!ObjectSchema> &ref_28
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_7
+          schema: *ref_8
           serializedName: status
           language: !<!Languages> 
             default:
@@ -277,7 +288,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_9
+          schema: *ref_10
           serializedName: message
           language: !<!Languages> 
             default:
@@ -294,20 +305,20 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_6
-    - !<!ObjectSchema> &ref_29
+    - *ref_7
+    - !<!ObjectSchema> &ref_30
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       parents: !<!Relations> 
         all:
-          - *ref_10
+          - *ref_11
         immediate:
-          - *ref_10
+          - *ref_11
       properties:
-        - !<!Property> &ref_31
-          schema: *ref_7
+        - !<!Property> &ref_32
+          schema: *ref_8
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -315,8 +326,8 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_32
-          schema: *ref_11
+        - !<!Property> &ref_33
+          schema: *ref_12
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -325,7 +336,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           readOnly: true
           required: false
           serializedName: status
@@ -345,19 +356,19 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_35
+    - !<!ObjectSchema> &ref_36
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       parents: !<!Relations> 
         all:
-          - *ref_12
+          - *ref_13
         immediate:
-          - *ref_12
+          - *ref_13
       properties:
-        - !<!Property> &ref_37
-          schema: *ref_7
+        - !<!Property> &ref_38
+          schema: *ref_8
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -365,8 +376,8 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_38
-          schema: *ref_13
+        - !<!Property> &ref_39
+          schema: *ref_14
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -375,7 +386,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           readOnly: true
           required: false
           serializedName: status
@@ -395,14 +406,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_41
+    - !<!ObjectSchema> &ref_42
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_7
+          schema: *ref_8
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -411,7 +422,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_14
+          schema: *ref_15
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -420,7 +431,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           readOnly: true
           required: false
           serializedName: status
@@ -430,7 +441,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_15
+          schema: *ref_16
           required: false
           serializedName: additionalProperties
           language: !<!Languages> 
@@ -449,19 +460,19 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_43
+    - !<!ObjectSchema> &ref_44
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       parents: !<!Relations> 
         all:
-          - *ref_16
+          - *ref_17
         immediate:
-          - *ref_16
+          - *ref_17
       properties:
         - !<!Property> 
-          schema: *ref_7
+          schema: *ref_8
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -470,7 +481,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_17
+          schema: *ref_18
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -479,7 +490,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           readOnly: true
           required: false
           serializedName: status
@@ -489,7 +500,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_18
+          schema: *ref_19
           required: true
           serializedName: '@odata.location'
           language: !<!Languages> 
@@ -498,7 +509,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_19
+          schema: *ref_20
           required: false
           serializedName: additionalProperties
           language: !<!Languages> 
@@ -519,7 +530,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_21
-    schema: *ref_20
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -547,8 +558,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_22
-                schema: *ref_3
+              - !<!Parameter> &ref_23
+                schema: *ref_4
                 flattened: true
                 implementation: Method
                 required: true
@@ -560,33 +571,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_25
-                schema: *ref_7
+              - !<!Parameter> 
+                schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_22
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_26
+                schema: *ref_8
+                implementation: Method
+                originalParameter: *ref_23
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_23
+                targetProperty: *ref_24
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_26
-                schema: *ref_8
+              - !<!VirtualParameter> &ref_27
+                schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_22
+                originalParameter: *ref_23
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_24
+                targetProperty: *ref_25
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_25
               - *ref_26
+              - *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -602,7 +626,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -616,7 +640,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -642,8 +666,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_28
-                schema: *ref_6
+              - !<!Parameter> &ref_29
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -654,8 +678,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_22
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_28
+              - *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -671,7 +708,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -685,7 +722,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -711,8 +748,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_30
-                schema: *ref_29
+              - !<!Parameter> &ref_31
+                schema: *ref_30
                 flattened: true
                 implementation: Method
                 required: true
@@ -724,33 +761,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_33
-                schema: *ref_7
+              - !<!Parameter> 
+                schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_30
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_34
+                schema: *ref_8
+                implementation: Method
+                originalParameter: *ref_31
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_31
+                targetProperty: *ref_32
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_34
-                schema: *ref_11
+              - !<!VirtualParameter> &ref_35
+                schema: *ref_12
                 implementation: Method
-                originalParameter: *ref_30
+                originalParameter: *ref_31
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_32
+                targetProperty: *ref_33
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_33
               - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -766,7 +816,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -780,7 +830,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -806,8 +856,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_35
+              - !<!Parameter> &ref_37
+                schema: *ref_36
                 flattened: true
                 implementation: Method
                 required: true
@@ -819,33 +869,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_39
-                schema: *ref_7
+              - !<!Parameter> 
+                schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_36
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_40
+                schema: *ref_8
+                implementation: Method
+                originalParameter: *ref_37
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_37
+                targetProperty: *ref_38
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_40
-                schema: *ref_13
+              - !<!VirtualParameter> &ref_41
+                schema: *ref_14
                 implementation: Method
-                originalParameter: *ref_36
+                originalParameter: *ref_37
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_38
+                targetProperty: *ref_39
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_39
               - *ref_40
+              - *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -861,7 +924,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -875,7 +938,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -901,8 +964,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_42
-                schema: *ref_41
+              - !<!Parameter> &ref_43
+                schema: *ref_42
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -913,8 +976,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_22
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_42
+              - *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -930,7 +1006,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_41
+            schema: *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -944,7 +1020,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -970,8 +1046,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_44
-                schema: *ref_43
+              - !<!Parameter> &ref_45
+                schema: *ref_44
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -982,8 +1058,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_22
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_44
+              - *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -999,7 +1088,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_43
+            schema: *ref_44
             language: !<!Languages> 
               default:
                 name: ''
@@ -1013,7 +1102,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/additionalProperties/grouped.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: additionalProperties
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_5
+    - !<!BooleanSchema> &ref_6
       type: boolean
       language: !<!Languages> 
         default:
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_7
+    - !<!NumberSchema> &ref_8
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -20,7 +20,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_2
+    - !<!NumberSchema> &ref_3
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -32,14 +32,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_20
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -49,7 +49,7 @@ schemas: !<!Schemas>
           name: PetAPTrue-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_9
+    - !<!StringSchema> &ref_10
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -59,7 +59,7 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -69,7 +69,7 @@ schemas: !<!Schemas>
           name: PetAPObject-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -79,7 +79,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_13
+    - !<!StringSchema> &ref_14
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -89,7 +89,7 @@ schemas: !<!Schemas>
           name: PetAPString-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_15
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -99,7 +99,7 @@ schemas: !<!Schemas>
           name: PetAPInProperties-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_17
+    - !<!StringSchema> &ref_18
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -109,7 +109,7 @@ schemas: !<!Schemas>
           name: PetAPInPropertiesWithAPString-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_18
+    - !<!StringSchema> &ref_19
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -119,10 +119,21 @@ schemas: !<!Schemas>
           name: PetAPInPropertiesWithAPString-@odata.location
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_22
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_4
+    - !<!DictionarySchema> &ref_5
       type: dictionary
-      elementType: !<!AnySchema> &ref_0
+      elementType: !<!AnySchema> &ref_1
         type: any
         language: !<!Languages> 
           default:
@@ -134,70 +145,70 @@ schemas: !<!Schemas>
           name: PetAPTrue
           description: Dictionary of <any>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_10
+    - !<!DictionarySchema> &ref_11
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: PetAPObject
           description: Dictionary of <any>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_12
+    - !<!DictionarySchema> &ref_13
       type: dictionary
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: PetAPString
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_15
+    - !<!DictionarySchema> &ref_16
       type: dictionary
-      elementType: *ref_2
+      elementType: *ref_3
       language: !<!Languages> 
         default:
           name: PetAPInProperties-additionalProperties
           description: Dictionary of <number>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_16
+    - !<!DictionarySchema> &ref_17
       type: dictionary
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_19
+    - !<!DictionarySchema> &ref_20
       type: dictionary
-      elementType: *ref_2
+      elementType: *ref_3
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString-additionalProperties
           description: Dictionary of <number>
       protocol: !<!Protocols> {}
   any:
-    - *ref_0
+    - *ref_1
   objects:
-    - !<!ObjectSchema> &ref_3
+    - !<!ObjectSchema> &ref_4
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       children: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_6
+          - !<!ObjectSchema> &ref_7
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
             parents: !<!Relations> 
               all:
-                - *ref_3
                 - *ref_4
+                - *ref_5
               immediate:
-                - *ref_3
+                - *ref_4
             properties:
               - !<!Property> 
-                schema: *ref_5
+                schema: *ref_6
                 serializedName: friendly
                 language: !<!Languages> 
                   default:
@@ -216,15 +227,15 @@ schemas: !<!Schemas>
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_6
+          - *ref_7
       parents: !<!Relations> 
         all:
-          - *ref_4
+          - *ref_5
         immediate:
-          - *ref_4
+          - *ref_5
       properties:
-        - !<!Property> &ref_23
-          schema: *ref_7
+        - !<!Property> &ref_24
+          schema: *ref_8
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -232,8 +243,8 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_24
-          schema: *ref_8
+        - !<!Property> &ref_25
+          schema: *ref_9
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -242,7 +253,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           readOnly: true
           required: false
           serializedName: status
@@ -262,14 +273,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_27
+    - !<!ObjectSchema> &ref_28
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_7
+          schema: *ref_8
           serializedName: status
           language: !<!Languages> 
             default:
@@ -277,7 +288,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_9
+          schema: *ref_10
           serializedName: message
           language: !<!Languages> 
             default:
@@ -294,20 +305,20 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_6
-    - !<!ObjectSchema> &ref_29
+    - *ref_7
+    - !<!ObjectSchema> &ref_30
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       parents: !<!Relations> 
         all:
-          - *ref_10
+          - *ref_11
         immediate:
-          - *ref_10
+          - *ref_11
       properties:
-        - !<!Property> &ref_31
-          schema: *ref_7
+        - !<!Property> &ref_32
+          schema: *ref_8
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -315,8 +326,8 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_32
-          schema: *ref_11
+        - !<!Property> &ref_33
+          schema: *ref_12
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -325,7 +336,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           readOnly: true
           required: false
           serializedName: status
@@ -345,19 +356,19 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_35
+    - !<!ObjectSchema> &ref_36
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       parents: !<!Relations> 
         all:
-          - *ref_12
+          - *ref_13
         immediate:
-          - *ref_12
+          - *ref_13
       properties:
-        - !<!Property> &ref_37
-          schema: *ref_7
+        - !<!Property> &ref_38
+          schema: *ref_8
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -365,8 +376,8 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_38
-          schema: *ref_13
+        - !<!Property> &ref_39
+          schema: *ref_14
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -375,7 +386,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           readOnly: true
           required: false
           serializedName: status
@@ -395,14 +406,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_41
+    - !<!ObjectSchema> &ref_42
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_7
+          schema: *ref_8
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -411,7 +422,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_14
+          schema: *ref_15
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -420,7 +431,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           readOnly: true
           required: false
           serializedName: status
@@ -430,7 +441,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_15
+          schema: *ref_16
           required: false
           serializedName: additionalProperties
           language: !<!Languages> 
@@ -449,19 +460,19 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_43
+    - !<!ObjectSchema> &ref_44
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       parents: !<!Relations> 
         all:
-          - *ref_16
+          - *ref_17
         immediate:
-          - *ref_16
+          - *ref_17
       properties:
         - !<!Property> 
-          schema: *ref_7
+          schema: *ref_8
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -470,7 +481,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_17
+          schema: *ref_18
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -479,7 +490,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           readOnly: true
           required: false
           serializedName: status
@@ -489,7 +500,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_18
+          schema: *ref_19
           required: true
           serializedName: '@odata.location'
           language: !<!Languages> 
@@ -498,7 +509,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_19
+          schema: *ref_20
           required: false
           serializedName: additionalProperties
           language: !<!Languages> 
@@ -519,7 +530,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_21
-    schema: *ref_20
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -547,8 +558,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_22
-                schema: *ref_3
+              - !<!Parameter> &ref_23
+                schema: *ref_4
                 flattened: true
                 implementation: Method
                 required: true
@@ -560,33 +571,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_25
-                schema: *ref_7
+              - !<!Parameter> 
+                schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_22
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_26
+                schema: *ref_8
+                implementation: Method
+                originalParameter: *ref_23
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_23
+                targetProperty: *ref_24
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_26
-                schema: *ref_8
+              - !<!VirtualParameter> &ref_27
+                schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_22
+                originalParameter: *ref_23
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_24
+                targetProperty: *ref_25
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_25
               - *ref_26
+              - *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -602,7 +626,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -616,7 +640,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -642,8 +666,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_28
-                schema: *ref_6
+              - !<!Parameter> &ref_29
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -654,8 +678,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_22
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_28
+              - *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -671,7 +708,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -685,7 +722,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -711,8 +748,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_30
-                schema: *ref_29
+              - !<!Parameter> &ref_31
+                schema: *ref_30
                 flattened: true
                 implementation: Method
                 required: true
@@ -724,33 +761,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_33
-                schema: *ref_7
+              - !<!Parameter> 
+                schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_30
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_34
+                schema: *ref_8
+                implementation: Method
+                originalParameter: *ref_31
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_31
+                targetProperty: *ref_32
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_34
-                schema: *ref_11
+              - !<!VirtualParameter> &ref_35
+                schema: *ref_12
                 implementation: Method
-                originalParameter: *ref_30
+                originalParameter: *ref_31
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_32
+                targetProperty: *ref_33
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_33
               - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -766,7 +816,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -780,7 +830,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -806,8 +856,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_35
+              - !<!Parameter> &ref_37
+                schema: *ref_36
                 flattened: true
                 implementation: Method
                 required: true
@@ -819,33 +869,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_39
-                schema: *ref_7
+              - !<!Parameter> 
+                schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_36
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_40
+                schema: *ref_8
+                implementation: Method
+                originalParameter: *ref_37
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_37
+                targetProperty: *ref_38
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_40
-                schema: *ref_13
+              - !<!VirtualParameter> &ref_41
+                schema: *ref_14
                 implementation: Method
-                originalParameter: *ref_36
+                originalParameter: *ref_37
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_38
+                targetProperty: *ref_39
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_39
               - *ref_40
+              - *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -861,7 +924,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -875,7 +938,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -901,8 +964,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_42
-                schema: *ref_41
+              - !<!Parameter> &ref_43
+                schema: *ref_42
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -913,8 +976,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_22
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_42
+              - *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -930,7 +1006,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_41
+            schema: *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -944,7 +1020,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -970,8 +1046,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_44
-                schema: *ref_43
+              - !<!Parameter> &ref_45
+                schema: *ref_44
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -982,8 +1058,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_22
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_44
+              - *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -999,7 +1088,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_43
+            schema: *ref_44
             language: !<!Languages> 
               default:
                 name: ''
@@ -1013,7 +1102,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/additionalProperties/modeler.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/modeler.yaml
@@ -119,6 +119,17 @@ schemas: !<!Schemas>
           name: PetAPInPropertiesWithAPString-@odata.location
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_21
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_20
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_4
       type: dictionary
@@ -262,7 +273,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_22
+    - !<!ObjectSchema> &ref_23
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -295,7 +306,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_7
-    - !<!ObjectSchema> &ref_25
+    - !<!ObjectSchema> &ref_26
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -345,7 +356,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_27
+    - !<!ObjectSchema> &ref_28
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -395,7 +406,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_29
+    - !<!ObjectSchema> &ref_30
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -449,7 +460,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_31
+    - !<!ObjectSchema> &ref_32
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -518,7 +529,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_23
+  - !<!Parameter> &ref_24
     schema: *ref_20
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -543,11 +554,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_23
+          - *ref_24
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_21
+              - !<!Parameter> &ref_22
                 schema: *ref_6
                 implementation: Method
                 required: true
@@ -559,8 +570,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_21
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -590,7 +614,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -612,11 +636,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_23
+          - *ref_24
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_24
+              - !<!Parameter> &ref_25
                 schema: *ref_7
                 implementation: Method
                 required: true
@@ -628,8 +652,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_21
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_24
+              - *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -659,7 +696,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -681,12 +718,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_23
+          - *ref_24
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_26
-                schema: *ref_25
+              - !<!Parameter> &ref_27
+                schema: *ref_26
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -697,8 +734,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_21
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_26
+              - *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -714,7 +764,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -728,7 +778,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -750,12 +800,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_23
+          - *ref_24
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_28
-                schema: *ref_27
+              - !<!Parameter> &ref_29
+                schema: *ref_28
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -766,8 +816,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_21
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_28
+              - *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -783,7 +846,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -797,7 +860,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -819,12 +882,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_23
+          - *ref_24
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_30
-                schema: *ref_29
+              - !<!Parameter> &ref_31
+                schema: *ref_30
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -835,8 +898,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_21
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_30
+              - *ref_31
             language: !<!Languages> 
               default:
                 name: ''
@@ -852,7 +928,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -866,7 +942,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -888,12 +964,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_23
+          - *ref_24
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_32
-                schema: *ref_31
+              - !<!Parameter> &ref_33
+                schema: *ref_32
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -904,8 +980,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_21
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_32
+              - *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -921,7 +1010,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_31
+            schema: *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -935,7 +1024,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/additionalProperties/namer.yaml
+++ b/modelerfour/test/scenarios/additionalProperties/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: additionalProperties
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_5
+    - !<!BooleanSchema> &ref_6
       type: boolean
       language: !<!Languages> 
         default:
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_7
+    - !<!NumberSchema> &ref_8
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -20,7 +20,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_2
+    - !<!NumberSchema> &ref_3
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -32,14 +32,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_20
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -49,7 +49,7 @@ schemas: !<!Schemas>
           name: PetAPTrueName
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_9
+    - !<!StringSchema> &ref_10
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -59,7 +59,7 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -69,7 +69,7 @@ schemas: !<!Schemas>
           name: PetAPObjectName
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -79,7 +79,7 @@ schemas: !<!Schemas>
           name: String
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_13
+    - !<!StringSchema> &ref_14
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -89,7 +89,7 @@ schemas: !<!Schemas>
           name: PetAPStringName
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_15
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -99,7 +99,7 @@ schemas: !<!Schemas>
           name: PetAPInPropertiesName
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_17
+    - !<!StringSchema> &ref_18
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -109,7 +109,7 @@ schemas: !<!Schemas>
           name: PetAPInPropertiesWithAPStringName
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_18
+    - !<!StringSchema> &ref_19
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -119,10 +119,21 @@ schemas: !<!Schemas>
           name: PetAPInPropertiesWithAPStringOdataLocation
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_22
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_4
+    - !<!DictionarySchema> &ref_5
       type: dictionary
-      elementType: !<!AnySchema> &ref_0
+      elementType: !<!AnySchema> &ref_1
         type: any
         language: !<!Languages> 
           default:
@@ -134,70 +145,70 @@ schemas: !<!Schemas>
           name: PetAPTrue
           description: Dictionary of <any>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_10
+    - !<!DictionarySchema> &ref_11
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: PetAPObject
           description: Dictionary of <any>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_12
+    - !<!DictionarySchema> &ref_13
       type: dictionary
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: PetAPString
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_15
+    - !<!DictionarySchema> &ref_16
       type: dictionary
-      elementType: *ref_2
+      elementType: *ref_3
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesAdditionalProperties
           description: Dictionary of <number>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_16
+    - !<!DictionarySchema> &ref_17
       type: dictionary
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPString
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_19
+    - !<!DictionarySchema> &ref_20
       type: dictionary
-      elementType: *ref_2
+      elementType: *ref_3
       language: !<!Languages> 
         default:
           name: PetAPInPropertiesWithAPStringAdditionalProperties
           description: Dictionary of <number>
       protocol: !<!Protocols> {}
   any:
-    - *ref_0
+    - *ref_1
   objects:
-    - !<!ObjectSchema> &ref_3
+    - !<!ObjectSchema> &ref_4
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       children: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_6
+          - !<!ObjectSchema> &ref_7
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
             parents: !<!Relations> 
               all:
-                - *ref_3
                 - *ref_4
+                - *ref_5
               immediate:
-                - *ref_3
+                - *ref_4
             properties:
               - !<!Property> 
-                schema: *ref_5
+                schema: *ref_6
                 serializedName: friendly
                 language: !<!Languages> 
                   default:
@@ -216,15 +227,15 @@ schemas: !<!Schemas>
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_6
+          - *ref_7
       parents: !<!Relations> 
         all:
-          - *ref_4
+          - *ref_5
         immediate:
-          - *ref_4
+          - *ref_5
       properties:
-        - !<!Property> &ref_23
-          schema: *ref_7
+        - !<!Property> &ref_24
+          schema: *ref_8
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -232,8 +243,8 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_24
-          schema: *ref_8
+        - !<!Property> &ref_25
+          schema: *ref_9
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -242,7 +253,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           readOnly: true
           required: false
           serializedName: status
@@ -262,14 +273,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_27
+    - !<!ObjectSchema> &ref_28
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_7
+          schema: *ref_8
           serializedName: status
           language: !<!Languages> 
             default:
@@ -277,7 +288,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_9
+          schema: *ref_10
           serializedName: message
           language: !<!Languages> 
             default:
@@ -294,20 +305,20 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_6
-    - !<!ObjectSchema> &ref_29
+    - *ref_7
+    - !<!ObjectSchema> &ref_30
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       parents: !<!Relations> 
         all:
-          - *ref_10
+          - *ref_11
         immediate:
-          - *ref_10
+          - *ref_11
       properties:
-        - !<!Property> &ref_31
-          schema: *ref_7
+        - !<!Property> &ref_32
+          schema: *ref_8
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -315,8 +326,8 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_32
-          schema: *ref_11
+        - !<!Property> &ref_33
+          schema: *ref_12
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -325,7 +336,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           readOnly: true
           required: false
           serializedName: status
@@ -345,19 +356,19 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_35
+    - !<!ObjectSchema> &ref_36
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       parents: !<!Relations> 
         all:
-          - *ref_12
+          - *ref_13
         immediate:
-          - *ref_12
+          - *ref_13
       properties:
-        - !<!Property> &ref_37
-          schema: *ref_7
+        - !<!Property> &ref_38
+          schema: *ref_8
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -365,8 +376,8 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_38
-          schema: *ref_13
+        - !<!Property> &ref_39
+          schema: *ref_14
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -375,7 +386,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           readOnly: true
           required: false
           serializedName: status
@@ -395,14 +406,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_41
+    - !<!ObjectSchema> &ref_42
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_7
+          schema: *ref_8
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -411,7 +422,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_14
+          schema: *ref_15
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -420,7 +431,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           readOnly: true
           required: false
           serializedName: status
@@ -430,7 +441,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_15
+          schema: *ref_16
           required: false
           serializedName: additionalProperties
           language: !<!Languages> 
@@ -449,19 +460,19 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_43
+    - !<!ObjectSchema> &ref_44
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       parents: !<!Relations> 
         all:
-          - *ref_16
+          - *ref_17
         immediate:
-          - *ref_16
+          - *ref_17
       properties:
         - !<!Property> 
-          schema: *ref_7
+          schema: *ref_8
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -470,7 +481,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_17
+          schema: *ref_18
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -479,7 +490,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           readOnly: true
           required: false
           serializedName: status
@@ -489,7 +500,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_18
+          schema: *ref_19
           required: true
           serializedName: '@odata.location'
           language: !<!Languages> 
@@ -498,7 +509,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_19
+          schema: *ref_20
           required: false
           serializedName: additionalProperties
           language: !<!Languages> 
@@ -519,7 +530,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_21
-    schema: *ref_20
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -547,8 +558,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_22
-                schema: *ref_3
+              - !<!Parameter> &ref_23
+                schema: *ref_4
                 flattened: true
                 implementation: Method
                 required: true
@@ -560,33 +571,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_25
-                schema: *ref_7
+              - !<!Parameter> 
+                schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_22
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_26
+                schema: *ref_8
+                implementation: Method
+                originalParameter: *ref_23
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_23
+                targetProperty: *ref_24
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_26
-                schema: *ref_8
+              - !<!VirtualParameter> &ref_27
+                schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_22
+                originalParameter: *ref_23
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_24
+                targetProperty: *ref_25
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_25
               - *ref_26
+              - *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -602,7 +626,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -616,7 +640,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -642,8 +666,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_28
-                schema: *ref_6
+              - !<!Parameter> &ref_29
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -654,8 +678,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_22
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_28
+              - *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -671,7 +708,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -685,7 +722,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -711,8 +748,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_30
-                schema: *ref_29
+              - !<!Parameter> &ref_31
+                schema: *ref_30
                 flattened: true
                 implementation: Method
                 required: true
@@ -724,33 +761,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_33
-                schema: *ref_7
+              - !<!Parameter> 
+                schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_30
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_34
+                schema: *ref_8
+                implementation: Method
+                originalParameter: *ref_31
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_31
+                targetProperty: *ref_32
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_34
-                schema: *ref_11
+              - !<!VirtualParameter> &ref_35
+                schema: *ref_12
                 implementation: Method
-                originalParameter: *ref_30
+                originalParameter: *ref_31
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_32
+                targetProperty: *ref_33
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_33
               - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -766,7 +816,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -780,7 +830,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -806,8 +856,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_35
+              - !<!Parameter> &ref_37
+                schema: *ref_36
                 flattened: true
                 implementation: Method
                 required: true
@@ -819,33 +869,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_39
-                schema: *ref_7
+              - !<!Parameter> 
+                schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_36
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_40
+                schema: *ref_8
+                implementation: Method
+                originalParameter: *ref_37
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_37
+                targetProperty: *ref_38
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_40
-                schema: *ref_13
+              - !<!VirtualParameter> &ref_41
+                schema: *ref_14
                 implementation: Method
-                originalParameter: *ref_36
+                originalParameter: *ref_37
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_38
+                targetProperty: *ref_39
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_39
               - *ref_40
+              - *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -861,7 +924,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -875,7 +938,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -901,8 +964,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_42
-                schema: *ref_41
+              - !<!Parameter> &ref_43
+                schema: *ref_42
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -913,8 +976,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_22
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_42
+              - *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -930,7 +1006,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_41
+            schema: *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -944,7 +1020,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -970,8 +1046,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_44
-                schema: *ref_43
+              - !<!Parameter> &ref_45
+                schema: *ref_44
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -982,8 +1058,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_22
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_44
+              - *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -999,7 +1088,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_43
+            schema: *ref_44
             language: !<!Languages> 
               default:
                 name: ''
@@ -1013,7 +1102,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/advisor/flattened.yaml
+++ b/modelerfour/test/scenarios/advisor/flattened.yaml
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           description: 'Exclude the resource from Advisor evaluations. Valid values: False (default) or True.'
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_81
+    - !<!NumberSchema> &ref_82
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -192,7 +192,7 @@ schemas: !<!Schemas>
           name: ConfigurationListResult-nextLink
           description: The link used to get the next page of configurations.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_78
+    - !<!StringSchema> &ref_79
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -525,6 +525,16 @@ schemas: !<!Schemas>
           name: ApiVersion-2017-04-19
           description: Api Version (2017-04-19)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_69
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_19
       type: dictionary
@@ -571,7 +581,7 @@ schemas: !<!Schemas>
           description: The most recent time that Advisor checked the validity of the recommendation.
       protocol: !<!Protocols> {}
   uuids:
-    - !<!UuidSchema> &ref_79
+    - !<!UuidSchema> &ref_80
       type: uuid
       apiVersions:
         - !<!ApiVersion> 
@@ -738,7 +748,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_11
-    - !<!ObjectSchema> &ref_70
+    - !<!ObjectSchema> &ref_71
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -770,7 +780,7 @@ schemas: !<!Schemas>
           description: ARM error response body.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_71
+    - !<!ObjectSchema> &ref_72
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -812,7 +822,7 @@ schemas: !<!Schemas>
           description: The list of metadata entities
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_73
+    - !<!ObjectSchema> &ref_74
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -941,7 +951,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_23
     - *ref_24
-    - !<!ObjectSchema> &ref_85
+    - !<!ObjectSchema> &ref_86
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -987,7 +997,7 @@ schemas: !<!Schemas>
                             immediate:
                               - *ref_27
                           properties:
-                            - !<!Property> &ref_93
+                            - !<!Property> &ref_94
                               schema: *ref_28
                               flattenedNames:
                                 - properties
@@ -998,7 +1008,7 @@ schemas: !<!Schemas>
                                   name: suppressionId
                                   description: The GUID of the suppression.
                               protocol: !<!Protocols> {}
-                            - !<!Property> &ref_94
+                            - !<!Property> &ref_95
                               schema: *ref_29
                               flattenedNames:
                                 - properties
@@ -1265,7 +1275,7 @@ schemas: !<!Schemas>
     - *ref_26
     - *ref_46
     - *ref_27
-    - !<!ObjectSchema> &ref_88
+    - !<!ObjectSchema> &ref_89
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1388,7 +1398,7 @@ schemas: !<!Schemas>
     - *ref_53
     - *ref_54
     - *ref_30
-    - !<!ObjectSchema> &ref_105
+    - !<!ObjectSchema> &ref_106
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1441,7 +1451,7 @@ schemas: !<!Schemas>
     - *ref_63
     - *ref_64
 globalParameters:
-  - !<!Parameter> &ref_72
+  - !<!Parameter> &ref_73
     schema: *ref_65
     implementation: Client
     required: true
@@ -1494,7 +1504,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - !<!Parameter> &ref_69
+          - !<!Parameter> &ref_70
             schema: *ref_65
             implementation: Method
             required: true
@@ -1509,6 +1519,21 @@ operationGroups:
           - *ref_68
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1519,7 +1544,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_69
+          - *ref_70
         responses:
           - !<!SchemaResponse> 
             schema: *ref_14
@@ -1535,7 +1560,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1562,6 +1587,21 @@ operationGroups:
           - *ref_68
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1574,7 +1614,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1612,9 +1652,24 @@ operationGroups:
         parameters:
           - *ref_67
           - *ref_68
-          - *ref_72
+          - *ref_73
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1627,7 +1682,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_73
+            schema: *ref_74
             language: !<!Languages> 
               default:
                 name: ''
@@ -1657,11 +1712,11 @@ operationGroups:
         parameters:
           - *ref_67
           - *ref_68
-          - *ref_72
+          - *ref_73
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_74
+              - !<!Parameter> &ref_75
                 schema: *ref_23
                 implementation: Method
                 required: true
@@ -1673,8 +1728,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_74
+              - *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -1699,7 +1767,7 @@ operationGroups:
                 statusCodes:
                   - '204'
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1724,8 +1792,8 @@ operationGroups:
         parameters:
           - *ref_67
           - *ref_68
-          - *ref_72
-          - !<!Parameter> &ref_75
+          - *ref_73
+          - !<!Parameter> &ref_76
             schema: *ref_65
             implementation: Method
             required: true
@@ -1739,6 +1807,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1749,10 +1832,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_75
+          - *ref_76
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_73
+            schema: *ref_74
             language: !<!Languages> 
               default:
                 name: ''
@@ -1782,8 +1865,8 @@ operationGroups:
         parameters:
           - *ref_67
           - *ref_68
-          - *ref_72
-          - !<!Parameter> &ref_77
+          - *ref_73
+          - !<!Parameter> &ref_78
             schema: *ref_65
             implementation: Method
             required: true
@@ -1798,7 +1881,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_76
+              - !<!Parameter> &ref_77
                 schema: *ref_23
                 implementation: Method
                 required: true
@@ -1810,8 +1893,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_76
+              - *ref_77
             language: !<!Languages> 
               default:
                 name: ''
@@ -1825,7 +1921,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_77
+          - *ref_78
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1837,7 +1933,7 @@ operationGroups:
                 statusCodes:
                   - '204'
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1869,7 +1965,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - *ref_72
+          - *ref_73
           - *ref_68
         requests:
           - !<!Request> 
@@ -1900,7 +1996,7 @@ operationGroups:
                         name: Location
                         description: The URL where the status of the asynchronous operation can be checked.
                   - !<!HttpHeader> 
-                    schema: *ref_78
+                    schema: *ref_79
                     header: Retry-After
                     language:
                       default:
@@ -1919,9 +2015,9 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - *ref_72
-          - !<!Parameter> &ref_80
-            schema: *ref_79
+          - *ref_73
+          - !<!Parameter> &ref_81
+            schema: *ref_80
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1945,7 +2041,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_80
+          - *ref_81
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1976,9 +2072,9 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - *ref_72
+          - *ref_73
           - *ref_68
-          - !<!Parameter> &ref_82
+          - !<!Parameter> &ref_83
             schema: *ref_2
             implementation: Method
             language: !<!Languages> 
@@ -1989,8 +2085,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_83
-            schema: *ref_81
+          - !<!Parameter> &ref_84
+            schema: *ref_82
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2000,7 +2096,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_84
+          - !<!Parameter> &ref_85
             schema: *ref_2
             implementation: Method
             language: !<!Languages> 
@@ -2013,6 +2109,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2023,12 +2134,12 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_82
           - *ref_83
           - *ref_84
+          - *ref_85
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_85
+            schema: *ref_86
             language: !<!Languages> 
               default:
                 name: ''
@@ -2056,7 +2167,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - !<!Parameter> &ref_86
+          - !<!Parameter> &ref_87
             schema: *ref_2
             implementation: Method
             required: true
@@ -2068,7 +2179,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_87
+          - !<!Parameter> &ref_88
             schema: *ref_2
             implementation: Method
             required: true
@@ -2083,6 +2194,21 @@ operationGroups:
           - *ref_68
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2093,8 +2219,8 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_86
           - *ref_87
+          - *ref_88
         responses:
           - !<!SchemaResponse> 
             schema: *ref_26
@@ -2131,6 +2257,21 @@ operationGroups:
           - *ref_68
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2143,7 +2284,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_88
+            schema: *ref_89
             language: !<!Languages> 
               default:
                 name: ''
@@ -2179,7 +2320,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - !<!Parameter> &ref_89
+          - !<!Parameter> &ref_90
             schema: *ref_2
             implementation: Method
             required: true
@@ -2191,7 +2332,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_90
+          - !<!Parameter> &ref_91
             schema: *ref_2
             implementation: Method
             required: true
@@ -2203,7 +2344,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_91
+          - !<!Parameter> &ref_92
             schema: *ref_2
             implementation: Method
             required: true
@@ -2218,6 +2359,21 @@ operationGroups:
           - *ref_68
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2228,9 +2384,9 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_89
           - *ref_90
           - *ref_91
+          - *ref_92
         responses:
           - !<!SchemaResponse> 
             schema: *ref_30
@@ -2256,7 +2412,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - !<!Parameter> &ref_97
+          - !<!Parameter> &ref_98
             schema: *ref_2
             implementation: Method
             required: true
@@ -2268,7 +2424,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_98
+          - !<!Parameter> &ref_99
             schema: *ref_2
             implementation: Method
             required: true
@@ -2280,7 +2436,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_99
+          - !<!Parameter> &ref_100
             schema: *ref_2
             implementation: Method
             required: true
@@ -2296,7 +2452,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_92
+              - !<!Parameter> &ref_93
                 schema: *ref_30
                 flattened: true
                 implementation: Method
@@ -2309,31 +2465,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_95
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_96
                 schema: *ref_28
                 implementation: Method
-                originalParameter: *ref_92
+                originalParameter: *ref_93
                 pathToProperty: []
-                targetProperty: *ref_93
+                targetProperty: *ref_94
                 language: !<!Languages> 
                   default:
                     name: suppressionId
                     description: The GUID of the suppression.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_96
+              - !<!VirtualParameter> &ref_97
                 schema: *ref_29
                 implementation: Method
-                originalParameter: *ref_92
+                originalParameter: *ref_93
                 pathToProperty: []
-                targetProperty: *ref_94
+                targetProperty: *ref_95
                 language: !<!Languages> 
                   default:
                     name: ttl
                     description: The duration for which the suppression is valid.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_95
               - *ref_96
+              - *ref_97
             language: !<!Languages> 
               default:
                 name: ''
@@ -2347,9 +2516,9 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_97
           - *ref_98
           - *ref_99
+          - *ref_100
         responses:
           - !<!SchemaResponse> 
             schema: *ref_30
@@ -2375,7 +2544,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - !<!Parameter> &ref_100
+          - !<!Parameter> &ref_101
             schema: *ref_2
             implementation: Method
             required: true
@@ -2387,7 +2556,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_101
+          - !<!Parameter> &ref_102
             schema: *ref_2
             implementation: Method
             required: true
@@ -2399,7 +2568,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_102
+          - !<!Parameter> &ref_103
             schema: *ref_2
             implementation: Method
             required: true
@@ -2424,9 +2593,9 @@ operationGroups:
                 method: delete
                 uri: '{$host}'
         signatureParameters:
-          - *ref_100
           - *ref_101
           - *ref_102
+          - *ref_103
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2448,10 +2617,10 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - *ref_72
+          - *ref_73
           - *ref_68
-          - !<!Parameter> &ref_103
-            schema: *ref_81
+          - !<!Parameter> &ref_104
+            schema: *ref_82
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2461,7 +2630,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_104
+          - !<!Parameter> &ref_105
             schema: *ref_2
             implementation: Method
             language: !<!Languages> 
@@ -2474,6 +2643,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2484,11 +2668,11 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_103
           - *ref_104
+          - *ref_105
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_105
+            schema: *ref_106
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/advisor/grouped.yaml
+++ b/modelerfour/test/scenarios/advisor/grouped.yaml
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           description: 'Exclude the resource from Advisor evaluations. Valid values: False (default) or True.'
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_81
+    - !<!NumberSchema> &ref_82
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -192,7 +192,7 @@ schemas: !<!Schemas>
           name: ConfigurationListResult-nextLink
           description: The link used to get the next page of configurations.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_78
+    - !<!StringSchema> &ref_79
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -525,6 +525,16 @@ schemas: !<!Schemas>
           name: ApiVersion-2017-04-19
           description: Api Version (2017-04-19)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_69
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_19
       type: dictionary
@@ -571,7 +581,7 @@ schemas: !<!Schemas>
           description: The most recent time that Advisor checked the validity of the recommendation.
       protocol: !<!Protocols> {}
   uuids:
-    - !<!UuidSchema> &ref_79
+    - !<!UuidSchema> &ref_80
       type: uuid
       apiVersions:
         - !<!ApiVersion> 
@@ -738,7 +748,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_11
-    - !<!ObjectSchema> &ref_70
+    - !<!ObjectSchema> &ref_71
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -770,7 +780,7 @@ schemas: !<!Schemas>
           description: ARM error response body.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_71
+    - !<!ObjectSchema> &ref_72
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -812,7 +822,7 @@ schemas: !<!Schemas>
           description: The list of metadata entities
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_73
+    - !<!ObjectSchema> &ref_74
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -941,7 +951,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_23
     - *ref_24
-    - !<!ObjectSchema> &ref_85
+    - !<!ObjectSchema> &ref_86
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -987,7 +997,7 @@ schemas: !<!Schemas>
                             immediate:
                               - *ref_27
                           properties:
-                            - !<!Property> &ref_93
+                            - !<!Property> &ref_94
                               schema: *ref_28
                               flattenedNames:
                                 - properties
@@ -998,7 +1008,7 @@ schemas: !<!Schemas>
                                   name: suppressionId
                                   description: The GUID of the suppression.
                               protocol: !<!Protocols> {}
-                            - !<!Property> &ref_94
+                            - !<!Property> &ref_95
                               schema: *ref_29
                               flattenedNames:
                                 - properties
@@ -1265,7 +1275,7 @@ schemas: !<!Schemas>
     - *ref_26
     - *ref_46
     - *ref_27
-    - !<!ObjectSchema> &ref_88
+    - !<!ObjectSchema> &ref_89
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1388,7 +1398,7 @@ schemas: !<!Schemas>
     - *ref_53
     - *ref_54
     - *ref_30
-    - !<!ObjectSchema> &ref_105
+    - !<!ObjectSchema> &ref_106
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1441,7 +1451,7 @@ schemas: !<!Schemas>
     - *ref_63
     - *ref_64
 globalParameters:
-  - !<!Parameter> &ref_72
+  - !<!Parameter> &ref_73
     schema: *ref_65
     implementation: Client
     required: true
@@ -1494,7 +1504,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - !<!Parameter> &ref_69
+          - !<!Parameter> &ref_70
             schema: *ref_65
             implementation: Method
             required: true
@@ -1509,6 +1519,21 @@ operationGroups:
           - *ref_68
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1519,7 +1544,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_69
+          - *ref_70
         responses:
           - !<!SchemaResponse> 
             schema: *ref_14
@@ -1535,7 +1560,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1562,6 +1587,21 @@ operationGroups:
           - *ref_68
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1574,7 +1614,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1612,9 +1652,24 @@ operationGroups:
         parameters:
           - *ref_67
           - *ref_68
-          - *ref_72
+          - *ref_73
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1627,7 +1682,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_73
+            schema: *ref_74
             language: !<!Languages> 
               default:
                 name: ''
@@ -1657,11 +1712,11 @@ operationGroups:
         parameters:
           - *ref_67
           - *ref_68
-          - *ref_72
+          - *ref_73
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_74
+              - !<!Parameter> &ref_75
                 schema: *ref_23
                 implementation: Method
                 required: true
@@ -1673,8 +1728,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_74
+              - *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -1699,7 +1767,7 @@ operationGroups:
                 statusCodes:
                   - '204'
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1724,8 +1792,8 @@ operationGroups:
         parameters:
           - *ref_67
           - *ref_68
-          - *ref_72
-          - !<!Parameter> &ref_75
+          - *ref_73
+          - !<!Parameter> &ref_76
             schema: *ref_65
             implementation: Method
             required: true
@@ -1739,6 +1807,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1749,10 +1832,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_75
+          - *ref_76
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_73
+            schema: *ref_74
             language: !<!Languages> 
               default:
                 name: ''
@@ -1782,8 +1865,8 @@ operationGroups:
         parameters:
           - *ref_67
           - *ref_68
-          - *ref_72
-          - !<!Parameter> &ref_77
+          - *ref_73
+          - !<!Parameter> &ref_78
             schema: *ref_65
             implementation: Method
             required: true
@@ -1798,7 +1881,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_76
+              - !<!Parameter> &ref_77
                 schema: *ref_23
                 implementation: Method
                 required: true
@@ -1810,8 +1893,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_76
+              - *ref_77
             language: !<!Languages> 
               default:
                 name: ''
@@ -1825,7 +1921,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_77
+          - *ref_78
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1837,7 +1933,7 @@ operationGroups:
                 statusCodes:
                   - '204'
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1869,7 +1965,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - *ref_72
+          - *ref_73
           - *ref_68
         requests:
           - !<!Request> 
@@ -1900,7 +1996,7 @@ operationGroups:
                         name: Location
                         description: The URL where the status of the asynchronous operation can be checked.
                   - !<!HttpHeader> 
-                    schema: *ref_78
+                    schema: *ref_79
                     header: Retry-After
                     language:
                       default:
@@ -1919,9 +2015,9 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - *ref_72
-          - !<!Parameter> &ref_80
-            schema: *ref_79
+          - *ref_73
+          - !<!Parameter> &ref_81
+            schema: *ref_80
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1945,7 +2041,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_80
+          - *ref_81
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1976,9 +2072,9 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - *ref_72
+          - *ref_73
           - *ref_68
-          - !<!Parameter> &ref_82
+          - !<!Parameter> &ref_83
             schema: *ref_2
             implementation: Method
             language: !<!Languages> 
@@ -1989,8 +2085,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_83
-            schema: *ref_81
+          - !<!Parameter> &ref_84
+            schema: *ref_82
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2000,7 +2096,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_84
+          - !<!Parameter> &ref_85
             schema: *ref_2
             implementation: Method
             language: !<!Languages> 
@@ -2013,6 +2109,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2023,12 +2134,12 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_82
           - *ref_83
           - *ref_84
+          - *ref_85
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_85
+            schema: *ref_86
             language: !<!Languages> 
               default:
                 name: ''
@@ -2056,7 +2167,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - !<!Parameter> &ref_86
+          - !<!Parameter> &ref_87
             schema: *ref_2
             implementation: Method
             required: true
@@ -2068,7 +2179,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_87
+          - !<!Parameter> &ref_88
             schema: *ref_2
             implementation: Method
             required: true
@@ -2083,6 +2194,21 @@ operationGroups:
           - *ref_68
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2093,8 +2219,8 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_86
           - *ref_87
+          - *ref_88
         responses:
           - !<!SchemaResponse> 
             schema: *ref_26
@@ -2131,6 +2257,21 @@ operationGroups:
           - *ref_68
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2143,7 +2284,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_88
+            schema: *ref_89
             language: !<!Languages> 
               default:
                 name: ''
@@ -2179,7 +2320,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - !<!Parameter> &ref_89
+          - !<!Parameter> &ref_90
             schema: *ref_2
             implementation: Method
             required: true
@@ -2191,7 +2332,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_90
+          - !<!Parameter> &ref_91
             schema: *ref_2
             implementation: Method
             required: true
@@ -2203,7 +2344,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_91
+          - !<!Parameter> &ref_92
             schema: *ref_2
             implementation: Method
             required: true
@@ -2218,6 +2359,21 @@ operationGroups:
           - *ref_68
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2228,9 +2384,9 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_89
           - *ref_90
           - *ref_91
+          - *ref_92
         responses:
           - !<!SchemaResponse> 
             schema: *ref_30
@@ -2256,7 +2412,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - !<!Parameter> &ref_97
+          - !<!Parameter> &ref_98
             schema: *ref_2
             implementation: Method
             required: true
@@ -2268,7 +2424,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_98
+          - !<!Parameter> &ref_99
             schema: *ref_2
             implementation: Method
             required: true
@@ -2280,7 +2436,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_99
+          - !<!Parameter> &ref_100
             schema: *ref_2
             implementation: Method
             required: true
@@ -2296,7 +2452,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_92
+              - !<!Parameter> &ref_93
                 schema: *ref_30
                 flattened: true
                 implementation: Method
@@ -2309,31 +2465,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_95
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_96
                 schema: *ref_28
                 implementation: Method
-                originalParameter: *ref_92
+                originalParameter: *ref_93
                 pathToProperty: []
-                targetProperty: *ref_93
+                targetProperty: *ref_94
                 language: !<!Languages> 
                   default:
                     name: suppressionId
                     description: The GUID of the suppression.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_96
+              - !<!VirtualParameter> &ref_97
                 schema: *ref_29
                 implementation: Method
-                originalParameter: *ref_92
+                originalParameter: *ref_93
                 pathToProperty: []
-                targetProperty: *ref_94
+                targetProperty: *ref_95
                 language: !<!Languages> 
                   default:
                     name: ttl
                     description: The duration for which the suppression is valid.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_95
               - *ref_96
+              - *ref_97
             language: !<!Languages> 
               default:
                 name: ''
@@ -2347,9 +2516,9 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_97
           - *ref_98
           - *ref_99
+          - *ref_100
         responses:
           - !<!SchemaResponse> 
             schema: *ref_30
@@ -2375,7 +2544,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - !<!Parameter> &ref_100
+          - !<!Parameter> &ref_101
             schema: *ref_2
             implementation: Method
             required: true
@@ -2387,7 +2556,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_101
+          - !<!Parameter> &ref_102
             schema: *ref_2
             implementation: Method
             required: true
@@ -2399,7 +2568,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_102
+          - !<!Parameter> &ref_103
             schema: *ref_2
             implementation: Method
             required: true
@@ -2424,9 +2593,9 @@ operationGroups:
                 method: delete
                 uri: '{$host}'
         signatureParameters:
-          - *ref_100
           - *ref_101
           - *ref_102
+          - *ref_103
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2448,10 +2617,10 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - *ref_72
+          - *ref_73
           - *ref_68
-          - !<!Parameter> &ref_103
-            schema: *ref_81
+          - !<!Parameter> &ref_104
+            schema: *ref_82
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2461,7 +2630,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_104
+          - !<!Parameter> &ref_105
             schema: *ref_2
             implementation: Method
             language: !<!Languages> 
@@ -2474,6 +2643,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2484,11 +2668,11 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_103
           - *ref_104
+          - *ref_105
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_105
+            schema: *ref_106
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/advisor/modeler.yaml
+++ b/modelerfour/test/scenarios/advisor/modeler.yaml
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           description: 'Exclude the resource from Advisor evaluations. Valid values: False (default) or True.'
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_84
+    - !<!NumberSchema> &ref_85
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -192,7 +192,7 @@ schemas: !<!Schemas>
           name: ConfigurationListResult-nextLink
           description: The link used to get the next page of configurations.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_81
+    - !<!StringSchema> &ref_82
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -525,6 +525,16 @@ schemas: !<!Schemas>
           name: ApiVersion-2017-04-19
           description: Api Version (2017-04-19)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_71
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_18
       type: dictionary
@@ -571,7 +581,7 @@ schemas: !<!Schemas>
           description: The most recent time that Advisor checked the validity of the recommendation.
       protocol: !<!Protocols> {}
   uuids:
-    - !<!UuidSchema> &ref_82
+    - !<!UuidSchema> &ref_83
       type: uuid
       apiVersions:
         - !<!ApiVersion> 
@@ -752,7 +762,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_8
     - *ref_9
-    - !<!ObjectSchema> &ref_71
+    - !<!ObjectSchema> &ref_72
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -784,7 +794,7 @@ schemas: !<!Schemas>
           description: ARM error response body.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_74
+    - !<!ObjectSchema> &ref_75
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -826,7 +836,7 @@ schemas: !<!Schemas>
           description: The list of metadata entities
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_75
+    - !<!ObjectSchema> &ref_76
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -955,7 +965,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_20
     - *ref_21
-    - !<!ObjectSchema> &ref_88
+    - !<!ObjectSchema> &ref_89
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1293,7 +1303,7 @@ schemas: !<!Schemas>
     - *ref_38
     - *ref_39
     - *ref_36
-    - !<!ObjectSchema> &ref_91
+    - !<!ObjectSchema> &ref_92
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1417,7 +1427,7 @@ schemas: !<!Schemas>
     - *ref_47
     - *ref_37
     - *ref_48
-    - !<!ObjectSchema> &ref_104
+    - !<!ObjectSchema> &ref_105
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1470,7 +1480,7 @@ schemas: !<!Schemas>
     - *ref_57
     - *ref_58
 globalParameters:
-  - !<!Parameter> &ref_76
+  - !<!Parameter> &ref_77
     schema: *ref_68
     implementation: Client
     required: true
@@ -1484,7 +1494,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: path
-  - !<!Parameter> &ref_72
+  - !<!Parameter> &ref_73
     schema: *ref_0
     clientDefaultValue: 'https://management.azure.com'
     implementation: Client
@@ -1500,7 +1510,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_73
+  - !<!Parameter> &ref_74
     schema: *ref_69
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -1522,7 +1532,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2017-04-19'
         parameters:
-          - *ref_72
+          - *ref_73
           - !<!Parameter> &ref_70
             schema: *ref_68
             implementation: Method
@@ -1535,9 +1545,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_73
+          - *ref_74
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_71
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1564,7 +1589,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1587,10 +1612,25 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2017-04-19'
         parameters:
-          - *ref_72
           - *ref_73
+          - *ref_74
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_71
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1603,7 +1643,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_74
+            schema: *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -1639,11 +1679,26 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2017-04-19'
         parameters:
-          - *ref_72
           - *ref_73
-          - *ref_76
+          - *ref_74
+          - *ref_77
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_71
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1656,7 +1711,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_75
+            schema: *ref_76
             language: !<!Languages> 
               default:
                 name: ''
@@ -1684,13 +1739,13 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2017-04-19'
         parameters:
-          - *ref_72
           - *ref_73
-          - *ref_76
+          - *ref_74
+          - *ref_77
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_77
+              - !<!Parameter> &ref_78
                 schema: *ref_20
                 implementation: Method
                 required: true
@@ -1702,8 +1757,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_71
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_77
+              - *ref_78
             language: !<!Languages> 
               default:
                 name: ''
@@ -1728,7 +1796,7 @@ operationGroups:
                 statusCodes:
                   - '204'
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1751,10 +1819,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2017-04-19'
         parameters:
-          - *ref_72
           - *ref_73
-          - *ref_76
-          - !<!Parameter> &ref_78
+          - *ref_74
+          - *ref_77
+          - !<!Parameter> &ref_79
             schema: *ref_68
             implementation: Method
             required: true
@@ -1768,6 +1836,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_71
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1778,10 +1861,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_78
+          - *ref_79
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_75
+            schema: *ref_76
             language: !<!Languages> 
               default:
                 name: ''
@@ -1809,10 +1892,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2017-04-19'
         parameters:
-          - *ref_72
           - *ref_73
-          - *ref_76
-          - !<!Parameter> &ref_79
+          - *ref_74
+          - *ref_77
+          - !<!Parameter> &ref_80
             schema: *ref_68
             implementation: Method
             required: true
@@ -1827,7 +1910,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_80
+              - !<!Parameter> &ref_81
                 schema: *ref_20
                 implementation: Method
                 required: true
@@ -1839,8 +1922,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_71
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_80
+              - *ref_81
             language: !<!Languages> 
               default:
                 name: ''
@@ -1854,7 +1950,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_79
+          - *ref_80
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1866,7 +1962,7 @@ operationGroups:
                 statusCodes:
                   - '204'
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1897,9 +1993,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2017-04-19'
         parameters:
-          - *ref_72
-          - *ref_76
           - *ref_73
+          - *ref_77
+          - *ref_74
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -1929,7 +2025,7 @@ operationGroups:
                         name: Location
                         description: The URL where the status of the asynchronous operation can be checked.
                   - !<!HttpHeader> 
-                    schema: *ref_81
+                    schema: *ref_82
                     header: Retry-After
                     language:
                       default:
@@ -1947,10 +2043,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2017-04-19'
         parameters:
-          - *ref_72
-          - *ref_76
-          - !<!Parameter> &ref_83
-            schema: *ref_82
+          - *ref_73
+          - *ref_77
+          - !<!Parameter> &ref_84
+            schema: *ref_83
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1961,7 +2057,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_73
+          - *ref_74
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -1974,7 +2070,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_83
+          - *ref_84
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2004,10 +2100,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2017-04-19'
         parameters:
-          - *ref_72
-          - *ref_76
           - *ref_73
-          - !<!Parameter> &ref_85
+          - *ref_77
+          - *ref_74
+          - !<!Parameter> &ref_86
             schema: *ref_29
             implementation: Method
             language: !<!Languages> 
@@ -2018,8 +2114,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_86
-            schema: *ref_84
+          - !<!Parameter> &ref_87
+            schema: *ref_85
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2029,7 +2125,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_87
+          - !<!Parameter> &ref_88
             schema: *ref_29
             implementation: Method
             language: !<!Languages> 
@@ -2042,6 +2138,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_71
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2052,12 +2163,12 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_85
           - *ref_86
           - *ref_87
+          - *ref_88
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_88
+            schema: *ref_89
             language: !<!Languages> 
               default:
                 name: ''
@@ -2084,8 +2195,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2017-04-19'
         parameters:
-          - *ref_72
-          - !<!Parameter> &ref_89
+          - *ref_73
+          - !<!Parameter> &ref_90
             schema: *ref_29
             implementation: Method
             required: true
@@ -2097,7 +2208,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_90
+          - !<!Parameter> &ref_91
             schema: *ref_29
             implementation: Method
             required: true
@@ -2109,9 +2220,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_73
+          - *ref_74
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_71
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2122,8 +2248,8 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_89
           - *ref_90
+          - *ref_91
         responses:
           - !<!SchemaResponse> 
             schema: *ref_33
@@ -2156,10 +2282,25 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2017-04-19'
         parameters:
-          - *ref_72
           - *ref_73
+          - *ref_74
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_71
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2172,7 +2313,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_91
+            schema: *ref_92
             language: !<!Languages> 
               default:
                 name: ''
@@ -2207,8 +2348,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2017-04-19'
         parameters:
-          - *ref_72
-          - !<!Parameter> &ref_92
+          - *ref_73
+          - !<!Parameter> &ref_93
             schema: *ref_29
             implementation: Method
             required: true
@@ -2220,7 +2361,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_93
+          - !<!Parameter> &ref_94
             schema: *ref_29
             implementation: Method
             required: true
@@ -2232,7 +2373,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_94
+          - !<!Parameter> &ref_95
             schema: *ref_29
             implementation: Method
             required: true
@@ -2244,9 +2385,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_73
+          - *ref_74
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_71
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2257,9 +2413,9 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_92
           - *ref_93
           - *ref_94
+          - *ref_95
         responses:
           - !<!SchemaResponse> 
             schema: *ref_37
@@ -2284,8 +2440,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2017-04-19'
         parameters:
-          - *ref_72
-          - !<!Parameter> &ref_95
+          - *ref_73
+          - !<!Parameter> &ref_96
             schema: *ref_29
             implementation: Method
             required: true
@@ -2297,7 +2453,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_96
+          - !<!Parameter> &ref_97
             schema: *ref_29
             implementation: Method
             required: true
@@ -2309,7 +2465,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_97
+          - !<!Parameter> &ref_98
             schema: *ref_29
             implementation: Method
             required: true
@@ -2321,11 +2477,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_73
+          - *ref_74
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_98
+              - !<!Parameter> &ref_99
                 schema: *ref_37
                 implementation: Method
                 required: true
@@ -2337,8 +2493,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_71
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_98
+              - *ref_99
             language: !<!Languages> 
               default:
                 name: ''
@@ -2352,9 +2521,9 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_95
           - *ref_96
           - *ref_97
+          - *ref_98
         responses:
           - !<!SchemaResponse> 
             schema: *ref_37
@@ -2379,8 +2548,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2017-04-19'
         parameters:
-          - *ref_72
-          - !<!Parameter> &ref_99
+          - *ref_73
+          - !<!Parameter> &ref_100
             schema: *ref_29
             implementation: Method
             required: true
@@ -2392,7 +2561,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_100
+          - !<!Parameter> &ref_101
             schema: *ref_29
             implementation: Method
             required: true
@@ -2404,7 +2573,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_101
+          - !<!Parameter> &ref_102
             schema: *ref_29
             implementation: Method
             required: true
@@ -2416,7 +2585,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_73
+          - *ref_74
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -2429,9 +2598,9 @@ operationGroups:
                 method: delete
                 uri: '{$host}'
         signatureParameters:
-          - *ref_99
           - *ref_100
           - *ref_101
+          - *ref_102
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2452,11 +2621,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2017-04-19'
         parameters:
-          - *ref_72
-          - *ref_76
           - *ref_73
-          - !<!Parameter> &ref_102
-            schema: *ref_84
+          - *ref_77
+          - *ref_74
+          - !<!Parameter> &ref_103
+            schema: *ref_85
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2466,7 +2635,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_103
+          - !<!Parameter> &ref_104
             schema: *ref_29
             implementation: Method
             language: !<!Languages> 
@@ -2479,6 +2648,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_71
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2489,11 +2673,11 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_102
           - *ref_103
+          - *ref_104
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_104
+            schema: *ref_105
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/advisor/namer.yaml
+++ b/modelerfour/test/scenarios/advisor/namer.yaml
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           description: 'Exclude the resource from Advisor evaluations. Valid values: False (default) or True.'
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_81
+    - !<!NumberSchema> &ref_82
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -192,7 +192,7 @@ schemas: !<!Schemas>
           name: ConfigurationListResultNextLink
           description: The link used to get the next page of configurations.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_78
+    - !<!StringSchema> &ref_79
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -525,6 +525,16 @@ schemas: !<!Schemas>
           name: ApiVersion20170419
           description: Api Version (2017-04-19)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_69
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_19
       type: dictionary
@@ -571,7 +581,7 @@ schemas: !<!Schemas>
           description: The most recent time that Advisor checked the validity of the recommendation.
       protocol: !<!Protocols> {}
   uuids:
-    - !<!UuidSchema> &ref_79
+    - !<!UuidSchema> &ref_80
       type: uuid
       apiVersions:
         - !<!ApiVersion> 
@@ -738,7 +748,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_11
-    - !<!ObjectSchema> &ref_70
+    - !<!ObjectSchema> &ref_71
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -770,7 +780,7 @@ schemas: !<!Schemas>
           description: ARM error response body.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_71
+    - !<!ObjectSchema> &ref_72
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -812,7 +822,7 @@ schemas: !<!Schemas>
           description: The list of metadata entities
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_73
+    - !<!ObjectSchema> &ref_74
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -941,7 +951,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_23
     - *ref_24
-    - !<!ObjectSchema> &ref_85
+    - !<!ObjectSchema> &ref_86
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -987,7 +997,7 @@ schemas: !<!Schemas>
                             immediate:
                               - *ref_27
                           properties:
-                            - !<!Property> &ref_93
+                            - !<!Property> &ref_94
                               schema: *ref_28
                               flattenedNames:
                                 - properties
@@ -998,7 +1008,7 @@ schemas: !<!Schemas>
                                   name: suppressionId
                                   description: The GUID of the suppression.
                               protocol: !<!Protocols> {}
-                            - !<!Property> &ref_94
+                            - !<!Property> &ref_95
                               schema: *ref_29
                               flattenedNames:
                                 - properties
@@ -1265,7 +1275,7 @@ schemas: !<!Schemas>
     - *ref_26
     - *ref_46
     - *ref_27
-    - !<!ObjectSchema> &ref_88
+    - !<!ObjectSchema> &ref_89
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1388,7 +1398,7 @@ schemas: !<!Schemas>
     - *ref_53
     - *ref_54
     - *ref_30
-    - !<!ObjectSchema> &ref_105
+    - !<!ObjectSchema> &ref_106
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1441,7 +1451,7 @@ schemas: !<!Schemas>
     - *ref_63
     - *ref_64
 globalParameters:
-  - !<!Parameter> &ref_72
+  - !<!Parameter> &ref_73
     schema: *ref_65
     implementation: Client
     required: true
@@ -1494,7 +1504,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - !<!Parameter> &ref_69
+          - !<!Parameter> &ref_70
             schema: *ref_65
             implementation: Method
             required: true
@@ -1509,6 +1519,21 @@ operationGroups:
           - *ref_68
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1519,7 +1544,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_69
+          - *ref_70
         responses:
           - !<!SchemaResponse> 
             schema: *ref_14
@@ -1535,7 +1560,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1562,6 +1587,21 @@ operationGroups:
           - *ref_68
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1574,7 +1614,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1612,9 +1652,24 @@ operationGroups:
         parameters:
           - *ref_67
           - *ref_68
-          - *ref_72
+          - *ref_73
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1627,7 +1682,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_73
+            schema: *ref_74
             language: !<!Languages> 
               default:
                 name: ''
@@ -1657,11 +1712,11 @@ operationGroups:
         parameters:
           - *ref_67
           - *ref_68
-          - *ref_72
+          - *ref_73
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_74
+              - !<!Parameter> &ref_75
                 schema: *ref_23
                 implementation: Method
                 required: true
@@ -1673,8 +1728,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_74
+              - *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -1699,7 +1767,7 @@ operationGroups:
                 statusCodes:
                   - '204'
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1724,8 +1792,8 @@ operationGroups:
         parameters:
           - *ref_67
           - *ref_68
-          - *ref_72
-          - !<!Parameter> &ref_75
+          - *ref_73
+          - !<!Parameter> &ref_76
             schema: *ref_65
             implementation: Method
             required: true
@@ -1739,6 +1807,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1749,10 +1832,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_75
+          - *ref_76
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_73
+            schema: *ref_74
             language: !<!Languages> 
               default:
                 name: ''
@@ -1782,8 +1865,8 @@ operationGroups:
         parameters:
           - *ref_67
           - *ref_68
-          - *ref_72
-          - !<!Parameter> &ref_77
+          - *ref_73
+          - !<!Parameter> &ref_78
             schema: *ref_65
             implementation: Method
             required: true
@@ -1798,7 +1881,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_76
+              - !<!Parameter> &ref_77
                 schema: *ref_23
                 implementation: Method
                 required: true
@@ -1810,8 +1893,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_76
+              - *ref_77
             language: !<!Languages> 
               default:
                 name: ''
@@ -1825,7 +1921,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_77
+          - *ref_78
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1837,7 +1933,7 @@ operationGroups:
                 statusCodes:
                   - '204'
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1869,7 +1965,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - *ref_72
+          - *ref_73
           - *ref_68
         requests:
           - !<!Request> 
@@ -1900,7 +1996,7 @@ operationGroups:
                         name: Location
                         description: The URL where the status of the asynchronous operation can be checked.
                   - !<!HttpHeader> 
-                    schema: *ref_78
+                    schema: *ref_79
                     header: Retry-After
                     language:
                       default:
@@ -1919,9 +2015,9 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - *ref_72
-          - !<!Parameter> &ref_80
-            schema: *ref_79
+          - *ref_73
+          - !<!Parameter> &ref_81
+            schema: *ref_80
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1945,7 +2041,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_80
+          - *ref_81
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1976,9 +2072,9 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - *ref_72
+          - *ref_73
           - *ref_68
-          - !<!Parameter> &ref_82
+          - !<!Parameter> &ref_83
             schema: *ref_2
             implementation: Method
             language: !<!Languages> 
@@ -1989,8 +2085,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_83
-            schema: *ref_81
+          - !<!Parameter> &ref_84
+            schema: *ref_82
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2000,7 +2096,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_84
+          - !<!Parameter> &ref_85
             schema: *ref_2
             implementation: Method
             language: !<!Languages> 
@@ -2013,6 +2109,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2023,12 +2134,12 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_82
           - *ref_83
           - *ref_84
+          - *ref_85
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_85
+            schema: *ref_86
             language: !<!Languages> 
               default:
                 name: ''
@@ -2056,7 +2167,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - !<!Parameter> &ref_86
+          - !<!Parameter> &ref_87
             schema: *ref_2
             implementation: Method
             required: true
@@ -2068,7 +2179,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_87
+          - !<!Parameter> &ref_88
             schema: *ref_2
             implementation: Method
             required: true
@@ -2083,6 +2194,21 @@ operationGroups:
           - *ref_68
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2093,8 +2219,8 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_86
           - *ref_87
+          - *ref_88
         responses:
           - !<!SchemaResponse> 
             schema: *ref_26
@@ -2131,6 +2257,21 @@ operationGroups:
           - *ref_68
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2143,7 +2284,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_88
+            schema: *ref_89
             language: !<!Languages> 
               default:
                 name: ''
@@ -2179,7 +2320,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - !<!Parameter> &ref_89
+          - !<!Parameter> &ref_90
             schema: *ref_2
             implementation: Method
             required: true
@@ -2191,7 +2332,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_90
+          - !<!Parameter> &ref_91
             schema: *ref_2
             implementation: Method
             required: true
@@ -2203,7 +2344,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_91
+          - !<!Parameter> &ref_92
             schema: *ref_2
             implementation: Method
             required: true
@@ -2218,6 +2359,21 @@ operationGroups:
           - *ref_68
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2228,9 +2384,9 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_89
           - *ref_90
           - *ref_91
+          - *ref_92
         responses:
           - !<!SchemaResponse> 
             schema: *ref_30
@@ -2256,7 +2412,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - !<!Parameter> &ref_97
+          - !<!Parameter> &ref_98
             schema: *ref_2
             implementation: Method
             required: true
@@ -2268,7 +2424,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_98
+          - !<!Parameter> &ref_99
             schema: *ref_2
             implementation: Method
             required: true
@@ -2280,7 +2436,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_99
+          - !<!Parameter> &ref_100
             schema: *ref_2
             implementation: Method
             required: true
@@ -2296,7 +2452,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_92
+              - !<!Parameter> &ref_93
                 schema: *ref_30
                 flattened: true
                 implementation: Method
@@ -2309,31 +2465,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_95
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_96
                 schema: *ref_28
                 implementation: Method
-                originalParameter: *ref_92
+                originalParameter: *ref_93
                 pathToProperty: []
-                targetProperty: *ref_93
+                targetProperty: *ref_94
                 language: !<!Languages> 
                   default:
                     name: suppressionId
                     description: The GUID of the suppression.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_96
+              - !<!VirtualParameter> &ref_97
                 schema: *ref_29
                 implementation: Method
-                originalParameter: *ref_92
+                originalParameter: *ref_93
                 pathToProperty: []
-                targetProperty: *ref_94
+                targetProperty: *ref_95
                 language: !<!Languages> 
                   default:
                     name: ttl
                     description: The duration for which the suppression is valid.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_95
               - *ref_96
+              - *ref_97
             language: !<!Languages> 
               default:
                 name: ''
@@ -2347,9 +2516,9 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_97
           - *ref_98
           - *ref_99
+          - *ref_100
         responses:
           - !<!SchemaResponse> 
             schema: *ref_30
@@ -2375,7 +2544,7 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - !<!Parameter> &ref_100
+          - !<!Parameter> &ref_101
             schema: *ref_2
             implementation: Method
             required: true
@@ -2387,7 +2556,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_101
+          - !<!Parameter> &ref_102
             schema: *ref_2
             implementation: Method
             required: true
@@ -2399,7 +2568,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_102
+          - !<!Parameter> &ref_103
             schema: *ref_2
             implementation: Method
             required: true
@@ -2424,9 +2593,9 @@ operationGroups:
                 method: delete
                 uri: '{$host}'
         signatureParameters:
-          - *ref_100
           - *ref_101
           - *ref_102
+          - *ref_103
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2448,10 +2617,10 @@ operationGroups:
             version: '2017-04-19'
         parameters:
           - *ref_67
-          - *ref_72
+          - *ref_73
           - *ref_68
-          - !<!Parameter> &ref_103
-            schema: *ref_81
+          - !<!Parameter> &ref_104
+            schema: *ref_82
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2461,7 +2630,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_104
+          - !<!Parameter> &ref_105
             schema: *ref_2
             implementation: Method
             language: !<!Languages> 
@@ -2474,6 +2643,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2484,11 +2668,11 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_103
           - *ref_104
+          - *ref_105
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_105
+            schema: *ref_106
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-parameter-grouping/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/flattened.yaml
@@ -27,7 +27,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -36,7 +36,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
@@ -53,7 +53,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -63,15 +63,26 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_7
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_11
+    - !<!ObjectSchema> &ref_12
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -79,7 +90,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -98,7 +109,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -123,11 +134,11 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_8
+          - !<!Parameter> &ref_9
             schema: *ref_4
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_12 {}
+              x-ms-parameter-grouping: &ref_13 {}
             language: !<!Languages> 
               default:
                 name: customHeader
@@ -136,11 +147,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_9
+          - !<!Parameter> &ref_10
             schema: *ref_5
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_13 {}
+              x-ms-parameter-grouping: &ref_14 {}
             language: !<!Languages> 
               default:
                 name: query
@@ -149,7 +160,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_10
+          - !<!Parameter> &ref_11
             schema: *ref_4
             implementation: Method
             required: true
@@ -166,7 +177,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
+              - !<!Parameter> &ref_8
                 schema: *ref_6
                 implementation: Method
                 required: true
@@ -180,8 +191,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -195,9 +219,9 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_8
           - *ref_9
           - *ref_10
+          - *ref_11
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -210,7 +234,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -233,11 +257,11 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_14
+          - !<!Parameter> &ref_15
             schema: *ref_4
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_12
+              x-ms-parameter-grouping: *ref_13
             language: !<!Languages> 
               default:
                 name: customHeader
@@ -246,11 +270,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_15
+          - !<!Parameter> &ref_16
             schema: *ref_5
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_13
+              x-ms-parameter-grouping: *ref_14
             language: !<!Languages> 
               default:
                 name: query
@@ -261,6 +285,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -271,8 +310,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_14
           - *ref_15
+          - *ref_16
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -285,7 +324,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -308,11 +347,11 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_16
+          - !<!Parameter> &ref_17
             schema: *ref_4
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_20
+              x-ms-parameter-grouping: &ref_21
                 name: first-parameter-group
             language: !<!Languages> 
               default:
@@ -322,11 +361,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_17
+          - !<!Parameter> &ref_18
             schema: *ref_5
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_21
+              x-ms-parameter-grouping: &ref_22
                 name: first-parameter-group
             language: !<!Languages> 
               default:
@@ -336,7 +375,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_18
+          - !<!Parameter> &ref_19
             schema: *ref_4
             implementation: Method
             extensions:
@@ -350,7 +389,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_19
+          - !<!Parameter> &ref_20
             schema: *ref_5
             implementation: Method
             extensions:
@@ -366,6 +405,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -376,10 +430,10 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_16
           - *ref_17
           - *ref_18
           - *ref_19
+          - *ref_20
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -392,7 +446,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -415,11 +469,11 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_22
+          - !<!Parameter> &ref_23
             schema: *ref_4
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_20
+              x-ms-parameter-grouping: *ref_21
             language: !<!Languages> 
               default:
                 name: header-one
@@ -428,11 +482,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_23
+          - !<!Parameter> &ref_24
             schema: *ref_5
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_21
+              x-ms-parameter-grouping: *ref_22
             language: !<!Languages> 
               default:
                 name: query-one
@@ -443,6 +497,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -453,8 +522,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_22
           - *ref_23
+          - *ref_24
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -467,7 +536,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-parameter-grouping/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: azure-parameter-grouping
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_4
+    - !<!NumberSchema> &ref_5
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -16,7 +16,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_6
+    - !<!NumberSchema> &ref_7
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -27,7 +27,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -36,14 +36,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -53,7 +53,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -63,17 +63,28 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_20
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   groups:
-    - !<!GroupSchema> &ref_3
+    - !<!GroupSchema> &ref_4
       type: group
       properties:
         - !<!GroupProperty> 
-          schema: *ref_2
+          schema: *ref_3
           originalParameter:
             - !<!Parameter> &ref_16
-              schema: *ref_2
-              groupedBy: !<!Parameter> &ref_5
-                schema: *ref_3
+              schema: *ref_3
+              groupedBy: !<!Parameter> &ref_6
+                schema: *ref_4
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -97,11 +108,11 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_4
+          schema: *ref_5
           originalParameter:
             - !<!Parameter> &ref_17
-              schema: *ref_4
-              groupedBy: *ref_5
+              schema: *ref_5
+              groupedBy: *ref_6
               implementation: Method
               language: !<!Languages> 
                 default:
@@ -118,11 +129,11 @@ schemas: !<!Schemas>
               description: Query parameter with default
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_2
+          schema: *ref_3
           originalParameter:
             - !<!Parameter> &ref_18
-              schema: *ref_2
-              groupedBy: *ref_5
+              schema: *ref_3
+              groupedBy: *ref_6
               implementation: Method
               required: true
               language: !<!Languages> 
@@ -141,11 +152,11 @@ schemas: !<!Schemas>
               description: Path parameter
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_6
+          schema: *ref_7
           originalParameter:
             - !<!Parameter> &ref_19
-              schema: *ref_6
-              groupedBy: *ref_5
+              schema: *ref_7
+              groupedBy: *ref_6
               implementation: Method
               required: true
               language: !<!Languages> 
@@ -170,16 +181,16 @@ schemas: !<!Schemas>
           name: ParameterGroupingPostRequiredParameters
           description: Parameter group
       protocol: !<!Protocols> {}
-    - !<!GroupSchema> &ref_7
+    - !<!GroupSchema> &ref_8
       type: group
       properties:
         - !<!GroupProperty> 
-          schema: *ref_2
+          schema: *ref_3
           originalParameter:
-            - !<!Parameter> &ref_21
-              schema: *ref_2
-              groupedBy: !<!Parameter> &ref_8
-                schema: *ref_7
+            - !<!Parameter> &ref_22
+              schema: *ref_3
+              groupedBy: !<!Parameter> &ref_9
+                schema: *ref_8
                 implementation: Method
                 language: !<!Languages> 
                   default:
@@ -202,11 +213,11 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_4
+          schema: *ref_5
           originalParameter:
-            - !<!Parameter> &ref_22
-              schema: *ref_4
-              groupedBy: *ref_8
+            - !<!Parameter> &ref_23
+              schema: *ref_5
+              groupedBy: *ref_9
               implementation: Method
               language: !<!Languages> 
                 default:
@@ -229,16 +240,16 @@ schemas: !<!Schemas>
           name: ParameterGroupingPostOptionalParameters
           description: Parameter group
       protocol: !<!Protocols> {}
-    - !<!GroupSchema> &ref_9
+    - !<!GroupSchema> &ref_10
       type: group
       properties:
         - !<!GroupProperty> 
-          schema: *ref_2
+          schema: *ref_3
           originalParameter:
-            - !<!Parameter> &ref_23
-              schema: *ref_2
-              groupedBy: !<!Parameter> &ref_10
-                schema: *ref_9
+            - !<!Parameter> &ref_24
+              schema: *ref_3
+              groupedBy: !<!Parameter> &ref_11
+                schema: *ref_10
                 implementation: Method
                 language: !<!Languages> 
                   default:
@@ -254,10 +265,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_27
-              schema: *ref_2
-              groupedBy: !<!Parameter> &ref_11
-                schema: *ref_9
+            - !<!Parameter> &ref_28
+              schema: *ref_3
+              groupedBy: !<!Parameter> &ref_12
+                schema: *ref_10
                 implementation: Method
                 language: !<!Languages> 
                   default:
@@ -280,11 +291,11 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_4
+          schema: *ref_5
           originalParameter:
-            - !<!Parameter> &ref_24
-              schema: *ref_4
-              groupedBy: *ref_10
+            - !<!Parameter> &ref_25
+              schema: *ref_5
+              groupedBy: *ref_11
               implementation: Method
               language: !<!Languages> 
                 default:
@@ -294,9 +305,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: query
-            - !<!Parameter> &ref_28
-              schema: *ref_4
-              groupedBy: *ref_11
+            - !<!Parameter> &ref_29
+              schema: *ref_5
+              groupedBy: *ref_12
               implementation: Method
               language: !<!Languages> 
                 default:
@@ -319,16 +330,16 @@ schemas: !<!Schemas>
           name: first-parameter-group
           description: Parameter group
       protocol: !<!Protocols> {}
-    - !<!GroupSchema> &ref_12
+    - !<!GroupSchema> &ref_13
       type: group
       properties:
         - !<!GroupProperty> 
-          schema: *ref_2
+          schema: *ref_3
           originalParameter:
-            - !<!Parameter> &ref_25
-              schema: *ref_2
-              groupedBy: !<!Parameter> &ref_13
-                schema: *ref_12
+            - !<!Parameter> &ref_26
+              schema: *ref_3
+              groupedBy: !<!Parameter> &ref_14
+                schema: *ref_13
                 implementation: Method
                 language: !<!Languages> 
                   default:
@@ -351,11 +362,11 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_4
+          schema: *ref_5
           originalParameter:
-            - !<!Parameter> &ref_26
-              schema: *ref_4
-              groupedBy: *ref_13
+            - !<!Parameter> &ref_27
+              schema: *ref_5
+              groupedBy: *ref_14
               implementation: Method
               language: !<!Languages> 
                 default:
@@ -379,14 +390,14 @@ schemas: !<!Schemas>
           description: Parameter group
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_20
+    - !<!ObjectSchema> &ref_21
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -394,7 +405,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -413,7 +424,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_15
-    schema: *ref_14
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -445,9 +456,22 @@ operationGroups:
           - !<!Request> 
             parameters:
               - *ref_19
-              - *ref_5
+              - !<!Parameter> 
+                schema: *ref_20
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_6
             signatureParameters:
-              - *ref_5
+              - *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -473,7 +497,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -496,14 +520,27 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - *ref_21
           - *ref_22
+          - *ref_23
         requests:
           - !<!Request> 
             parameters:
-              - *ref_8
+              - !<!Parameter> 
+                schema: *ref_20
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_9
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -526,7 +563,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -549,18 +586,31 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - *ref_23
           - *ref_24
           - *ref_25
           - *ref_26
+          - *ref_27
         requests:
           - !<!Request> 
             parameters:
-              - *ref_10
-              - *ref_13
+              - !<!Parameter> 
+                schema: *ref_20
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_11
+              - *ref_14
             signatureParameters:
-              - *ref_10
-              - *ref_13
+              - *ref_11
+              - *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -583,7 +633,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -606,14 +656,27 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - *ref_27
           - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - *ref_11
+              - !<!Parameter> 
+                schema: *ref_20
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_12
             signatureParameters:
-              - *ref_11
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -636,7 +699,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-parameter-grouping/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/modeler.yaml
@@ -63,8 +63,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_9
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_10
+    - !<!ObjectSchema> &ref_11
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -97,7 +108,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_11
+  - !<!Parameter> &ref_12
     schema: *ref_2
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -122,12 +133,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_11
+          - *ref_12
           - !<!Parameter> &ref_5
             schema: *ref_3
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_12 {}
+              x-ms-parameter-grouping: &ref_13 {}
             language: !<!Languages> 
               default:
                 name: customHeader
@@ -140,7 +151,7 @@ operationGroups:
             schema: *ref_4
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_13 {}
+              x-ms-parameter-grouping: &ref_14 {}
             language: !<!Languages> 
               default:
                 name: query
@@ -166,7 +177,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
+              - !<!Parameter> &ref_10
                 schema: *ref_8
                 implementation: Method
                 required: true
@@ -180,8 +191,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -210,7 +234,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -232,12 +256,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_11
-          - !<!Parameter> &ref_14
+          - *ref_12
+          - !<!Parameter> &ref_15
             schema: *ref_3
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_12
+              x-ms-parameter-grouping: *ref_13
             language: !<!Languages> 
               default:
                 name: customHeader
@@ -246,11 +270,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_15
+          - !<!Parameter> &ref_16
             schema: *ref_4
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_13
+              x-ms-parameter-grouping: *ref_14
             language: !<!Languages> 
               default:
                 name: query
@@ -261,6 +285,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -271,8 +310,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_14
           - *ref_15
+          - *ref_16
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -285,7 +324,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -307,12 +346,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_11
-          - !<!Parameter> &ref_16
+          - *ref_12
+          - !<!Parameter> &ref_17
             schema: *ref_3
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_20
+              x-ms-parameter-grouping: &ref_21
                 name: first-parameter-group
             language: !<!Languages> 
               default:
@@ -322,11 +361,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_17
+          - !<!Parameter> &ref_18
             schema: *ref_4
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_21
+              x-ms-parameter-grouping: &ref_22
                 name: first-parameter-group
             language: !<!Languages> 
               default:
@@ -336,7 +375,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_18
+          - !<!Parameter> &ref_19
             schema: *ref_3
             implementation: Method
             extensions:
@@ -350,7 +389,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_19
+          - !<!Parameter> &ref_20
             schema: *ref_4
             implementation: Method
             extensions:
@@ -366,6 +405,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -376,10 +430,10 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_16
           - *ref_17
           - *ref_18
           - *ref_19
+          - *ref_20
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -392,7 +446,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -414,12 +468,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_11
-          - !<!Parameter> &ref_22
+          - *ref_12
+          - !<!Parameter> &ref_23
             schema: *ref_3
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_20
+              x-ms-parameter-grouping: *ref_21
             language: !<!Languages> 
               default:
                 name: header-one
@@ -428,11 +482,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_23
+          - !<!Parameter> &ref_24
             schema: *ref_4
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_21
+              x-ms-parameter-grouping: *ref_22
             language: !<!Languages> 
               default:
                 name: query-one
@@ -443,6 +497,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -453,8 +522,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_22
           - *ref_23
+          - *ref_24
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -467,7 +536,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-parameter-grouping/namer.yaml
+++ b/modelerfour/test/scenarios/azure-parameter-grouping/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: azure-parameter-grouping
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_2
+    - !<!NumberSchema> &ref_3
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -16,7 +16,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_4
+    - !<!NumberSchema> &ref_5
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -27,7 +27,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_12
+    - !<!NumberSchema> &ref_13
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -36,14 +36,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_0
+    - !<!StringSchema> &ref_1
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -53,7 +53,7 @@ schemas: !<!Schemas>
           name: String
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_13
+    - !<!StringSchema> &ref_14
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -63,17 +63,28 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_20
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   groups:
-    - !<!GroupSchema> &ref_1
+    - !<!GroupSchema> &ref_2
       type: group
       properties:
         - !<!GroupProperty> 
-          schema: *ref_0
+          schema: *ref_1
           originalParameter:
             - !<!Parameter> &ref_16
-              schema: *ref_0
-              groupedBy: !<!Parameter> &ref_3
-                schema: *ref_1
+              schema: *ref_1
+              groupedBy: !<!Parameter> &ref_4
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -97,11 +108,11 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_2
+          schema: *ref_3
           originalParameter:
             - !<!Parameter> &ref_17
-              schema: *ref_2
-              groupedBy: *ref_3
+              schema: *ref_3
+              groupedBy: *ref_4
               implementation: Method
               language: !<!Languages> 
                 default:
@@ -118,11 +129,11 @@ schemas: !<!Schemas>
               description: Query parameter with default
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_0
+          schema: *ref_1
           originalParameter:
             - !<!Parameter> &ref_18
-              schema: *ref_0
-              groupedBy: *ref_3
+              schema: *ref_1
+              groupedBy: *ref_4
               implementation: Method
               required: true
               language: !<!Languages> 
@@ -141,11 +152,11 @@ schemas: !<!Schemas>
               description: Path parameter
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_4
+          schema: *ref_5
           originalParameter:
             - !<!Parameter> &ref_19
-              schema: *ref_4
-              groupedBy: *ref_3
+              schema: *ref_5
+              groupedBy: *ref_4
               implementation: Method
               required: true
               language: !<!Languages> 
@@ -170,16 +181,16 @@ schemas: !<!Schemas>
           name: ParameterGroupingPostRequiredParameters
           description: Parameter group
       protocol: !<!Protocols> {}
-    - !<!GroupSchema> &ref_5
+    - !<!GroupSchema> &ref_6
       type: group
       properties:
         - !<!GroupProperty> 
-          schema: *ref_0
+          schema: *ref_1
           originalParameter:
-            - !<!Parameter> &ref_21
-              schema: *ref_0
-              groupedBy: !<!Parameter> &ref_6
-                schema: *ref_5
+            - !<!Parameter> &ref_22
+              schema: *ref_1
+              groupedBy: !<!Parameter> &ref_7
+                schema: *ref_6
                 implementation: Method
                 language: !<!Languages> 
                   default:
@@ -202,11 +213,11 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_2
+          schema: *ref_3
           originalParameter:
-            - !<!Parameter> &ref_22
-              schema: *ref_2
-              groupedBy: *ref_6
+            - !<!Parameter> &ref_23
+              schema: *ref_3
+              groupedBy: *ref_7
               implementation: Method
               language: !<!Languages> 
                 default:
@@ -229,16 +240,16 @@ schemas: !<!Schemas>
           name: ParameterGroupingPostOptionalParameters
           description: Parameter group
       protocol: !<!Protocols> {}
-    - !<!GroupSchema> &ref_7
+    - !<!GroupSchema> &ref_8
       type: group
       properties:
         - !<!GroupProperty> 
-          schema: *ref_0
+          schema: *ref_1
           originalParameter:
-            - !<!Parameter> &ref_23
-              schema: *ref_0
-              groupedBy: !<!Parameter> &ref_8
-                schema: *ref_7
+            - !<!Parameter> &ref_24
+              schema: *ref_1
+              groupedBy: !<!Parameter> &ref_9
+                schema: *ref_8
                 implementation: Method
                 language: !<!Languages> 
                   default:
@@ -254,10 +265,10 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_27
-              schema: *ref_0
-              groupedBy: !<!Parameter> &ref_9
-                schema: *ref_7
+            - !<!Parameter> &ref_28
+              schema: *ref_1
+              groupedBy: !<!Parameter> &ref_10
+                schema: *ref_8
                 implementation: Method
                 language: !<!Languages> 
                   default:
@@ -280,11 +291,11 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_2
+          schema: *ref_3
           originalParameter:
-            - !<!Parameter> &ref_24
-              schema: *ref_2
-              groupedBy: *ref_8
+            - !<!Parameter> &ref_25
+              schema: *ref_3
+              groupedBy: *ref_9
               implementation: Method
               language: !<!Languages> 
                 default:
@@ -294,9 +305,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: query
-            - !<!Parameter> &ref_28
-              schema: *ref_2
-              groupedBy: *ref_9
+            - !<!Parameter> &ref_29
+              schema: *ref_3
+              groupedBy: *ref_10
               implementation: Method
               language: !<!Languages> 
                 default:
@@ -319,16 +330,16 @@ schemas: !<!Schemas>
           name: FirstParameterGroup
           description: Parameter group
       protocol: !<!Protocols> {}
-    - !<!GroupSchema> &ref_10
+    - !<!GroupSchema> &ref_11
       type: group
       properties:
         - !<!GroupProperty> 
-          schema: *ref_0
+          schema: *ref_1
           originalParameter:
-            - !<!Parameter> &ref_25
-              schema: *ref_0
-              groupedBy: !<!Parameter> &ref_11
-                schema: *ref_10
+            - !<!Parameter> &ref_26
+              schema: *ref_1
+              groupedBy: !<!Parameter> &ref_12
+                schema: *ref_11
                 implementation: Method
                 language: !<!Languages> 
                   default:
@@ -351,11 +362,11 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!GroupProperty> 
-          schema: *ref_2
+          schema: *ref_3
           originalParameter:
-            - !<!Parameter> &ref_26
-              schema: *ref_2
-              groupedBy: *ref_11
+            - !<!Parameter> &ref_27
+              schema: *ref_3
+              groupedBy: *ref_12
               implementation: Method
               language: !<!Languages> 
                 default:
@@ -379,14 +390,14 @@ schemas: !<!Schemas>
           description: Parameter group
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_20
+    - !<!ObjectSchema> &ref_21
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_12
+          schema: *ref_13
           serializedName: status
           language: !<!Languages> 
             default:
@@ -394,7 +405,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_13
+          schema: *ref_14
           serializedName: message
           language: !<!Languages> 
             default:
@@ -413,7 +424,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_15
-    schema: *ref_14
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -445,9 +456,22 @@ operationGroups:
           - !<!Request> 
             parameters:
               - *ref_19
-              - *ref_3
+              - !<!Parameter> 
+                schema: *ref_20
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_4
             signatureParameters:
-              - *ref_3
+              - *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -473,7 +497,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -496,14 +520,27 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - *ref_21
           - *ref_22
+          - *ref_23
         requests:
           - !<!Request> 
             parameters:
-              - *ref_6
+              - !<!Parameter> 
+                schema: *ref_20
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_7
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -526,7 +563,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -549,18 +586,31 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - *ref_23
           - *ref_24
           - *ref_25
           - *ref_26
+          - *ref_27
         requests:
           - !<!Request> 
             parameters:
-              - *ref_8
-              - *ref_11
+              - !<!Parameter> 
+                schema: *ref_20
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_9
+              - *ref_12
             signatureParameters:
-              - *ref_8
-              - *ref_11
+              - *ref_9
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -583,7 +633,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -606,14 +656,27 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - *ref_27
           - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - *ref_9
+              - !<!Parameter> 
+                schema: *ref_20
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_10
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -636,7 +699,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-report/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-report/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: azure-report
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -24,7 +24,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
@@ -41,7 +41,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -51,24 +51,35 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_7
+    - !<!DictionarySchema> &ref_8
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: paths·obr50g·report-azure·get·responses·200·content·application-json·schema
           description: Dictionary of <integer>
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_8
+    - !<!ObjectSchema> &ref_9
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -76,7 +87,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -95,7 +106,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -120,7 +131,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_4
-          - !<!Parameter> &ref_6
+          - !<!Parameter> &ref_7
             schema: *ref_5
             implementation: Method
             language: !<!Languages> 
@@ -133,6 +144,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -143,10 +169,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_6
+          - *ref_7
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -160,7 +186,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-report/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-report/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: azure-report
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -24,7 +24,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
@@ -41,7 +41,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -51,24 +51,35 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_7
+    - !<!DictionarySchema> &ref_8
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: paths·obr50g·report-azure·get·responses·200·content·application-json·schema
           description: Dictionary of <integer>
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_8
+    - !<!ObjectSchema> &ref_9
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -76,7 +87,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -95,7 +106,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -120,7 +131,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_4
-          - !<!Parameter> &ref_6
+          - !<!Parameter> &ref_7
             schema: *ref_5
             implementation: Method
             language: !<!Languages> 
@@ -133,6 +144,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -143,10 +169,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_6
+          - *ref_7
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -160,7 +186,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-report/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-report/modeler.yaml
@@ -51,8 +51,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_3
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_6
+    - !<!DictionarySchema> &ref_7
       type: dictionary
       elementType: *ref_0
       language: !<!Languages> 
@@ -61,7 +72,7 @@ schemas: !<!Schemas>
           description: Dictionary of <integer>
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -94,7 +105,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_8
+  - !<!Parameter> &ref_9
     schema: *ref_3
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -119,7 +130,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_8
+          - *ref_9
           - !<!Parameter> &ref_5
             schema: *ref_4
             implementation: Method
@@ -133,6 +144,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -146,7 +172,7 @@ operationGroups:
           - *ref_5
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -160,7 +186,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-report/namer.yaml
+++ b/modelerfour/test/scenarios/azure-report/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: azure-report
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -24,7 +24,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
@@ -41,7 +41,7 @@ schemas: !<!Schemas>
           name: String
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -51,24 +51,35 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_7
+    - !<!DictionarySchema> &ref_8
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: DictionaryOfInteger
           description: Dictionary of <integer>
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_8
+    - !<!ObjectSchema> &ref_9
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -76,7 +87,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -95,7 +106,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -120,7 +131,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_4
-          - !<!Parameter> &ref_6
+          - !<!Parameter> &ref_7
             schema: *ref_5
             implementation: Method
             language: !<!Languages> 
@@ -133,6 +144,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -143,10 +169,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_6
+          - *ref_7
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -160,7 +186,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-resource-x/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: azure-resource-x
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_9
+    - !<!NumberSchema> &ref_10
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: ResourceX-id
           description: Resource Id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -40,7 +40,7 @@ schemas: !<!Schemas>
           name: ResourceX-type
           description: Resource Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_0
+    - !<!StringSchema> &ref_1
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -50,7 +50,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_6
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -60,7 +60,7 @@ schemas: !<!Schemas>
           name: ResourceX-location
           description: Resource Location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -70,7 +70,7 @@ schemas: !<!Schemas>
           name: ResourceX-name
           description: Resource Name
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -80,7 +80,7 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -90,7 +90,7 @@ schemas: !<!Schemas>
           name: FlattenedResourceProperties-pname
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_10
+    - !<!StringSchema> &ref_11
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -100,37 +100,48 @@ schemas: !<!Schemas>
           name: FlattenedResourceProperties-provisioningState
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_17
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_4
+    - !<!DictionarySchema> &ref_5
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: ResourceX-tags
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_20
+    - !<!DictionarySchema> &ref_21
       type: dictionary
-      elementType: !<!ObjectSchema> &ref_1
+      elementType: !<!ObjectSchema> &ref_2
         type: object
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
         parents: !<!Relations> 
           all:
-            - !<!ObjectSchema> &ref_7
+            - !<!ObjectSchema> &ref_8
               type: object
               apiVersions:
                 - !<!ApiVersion> 
                   version: 1.0.0
               children: !<!Relations> 
                 all:
-                  - *ref_1
+                  - *ref_2
                 immediate:
-                  - *ref_1
+                  - *ref_2
               properties:
                 - !<!Property> 
-                  schema: *ref_2
+                  schema: *ref_3
                   readOnly: true
                   serializedName: id
                   language: !<!Languages> 
@@ -139,7 +150,7 @@ schemas: !<!Schemas>
                       description: Resource Id
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_3
+                  schema: *ref_4
                   readOnly: true
                   serializedName: type
                   language: !<!Languages> 
@@ -148,7 +159,7 @@ schemas: !<!Schemas>
                       description: Resource Type
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_4
+                  schema: *ref_5
                   serializedName: tags
                   language: !<!Languages> 
                     default:
@@ -156,7 +167,7 @@ schemas: !<!Schemas>
                       description: Dictionary of <string>
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_5
+                  schema: *ref_6
                   serializedName: location
                   language: !<!Languages> 
                     default:
@@ -164,7 +175,7 @@ schemas: !<!Schemas>
                       description: Resource Location
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_6
+                  schema: *ref_7
                   readOnly: true
                   serializedName: name
                   language: !<!Languages> 
@@ -186,10 +197,10 @@ schemas: !<!Schemas>
                   namespace: ''
               protocol: !<!Protocols> {}
           immediate:
-            - *ref_7
+            - *ref_8
         properties:
           - !<!Property> 
-            schema: *ref_8
+            schema: *ref_9
             flattenedNames:
               - properties
               - pname
@@ -200,7 +211,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_9
+            schema: *ref_10
             flattenedNames:
               - properties
               - lsize
@@ -211,7 +222,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_10
+            schema: *ref_11
             flattenedNames:
               - properties
               - provisioningState
@@ -237,24 +248,24 @@ schemas: !<!Schemas>
           name: paths·lx8sp0·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_12
+    - !<!DictionarySchema> &ref_13
       type: dictionary
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
   objects:
-    - *ref_7
-    - !<!ObjectSchema> &ref_18
+    - *ref_8
+    - !<!ObjectSchema> &ref_19
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_9
+          schema: *ref_10
           serializedName: status
           language: !<!Languages> 
             default:
@@ -262,7 +273,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_11
+          schema: *ref_12
           serializedName: message
           language: !<!Languages> 
             default:
@@ -279,15 +290,15 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_1
-    - !<!ObjectSchema> &ref_22
+    - *ref_2
+    - !<!ObjectSchema> &ref_23
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: productresource
           language: !<!Languages> 
             default:
@@ -295,12 +306,12 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: !<!ArraySchema> &ref_13
+          schema: !<!ArraySchema> &ref_14
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            elementType: *ref_1
+            elementType: *ref_2
             language: !<!Languages> 
               default:
                 name: ResourceCollection-arrayofresources
@@ -313,7 +324,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_12
+          schema: *ref_13
           serializedName: dictionaryofresources
           language: !<!Languages> 
             default:
@@ -337,27 +348,27 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_7
+      elementType: *ref_8
       language: !<!Languages> 
         default:
           name: paths·1y4igfn·azure-resource_flatten-array·put·requestbody·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_19
+    - !<!ArraySchema> &ref_20
       type: array
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·elolk8·azure-resource_flatten-array·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - *ref_13
+    - *ref_14
 globalParameters:
   - !<!Parameter> &ref_15
-    schema: *ref_14
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -385,7 +396,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
+              - !<!Parameter> &ref_18
                 schema: *ref_16
                 implementation: Method
                 required: false
@@ -397,8 +408,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -424,7 +448,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -449,6 +473,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -461,7 +500,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_19
+            schema: *ref_20
             language: !<!Languages> 
               default:
                 name: ''
@@ -475,7 +514,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -501,8 +540,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_21
-                schema: *ref_20
+              - !<!Parameter> &ref_22
+                schema: *ref_21
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -513,8 +552,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -540,7 +592,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -565,6 +617,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -577,7 +644,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -591,7 +658,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -617,8 +684,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_23
-                schema: *ref_22
+              - !<!Parameter> &ref_24
+                schema: *ref_23
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -629,8 +696,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_23
+              - *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -656,7 +736,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -681,6 +761,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -693,7 +788,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -707,7 +802,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-resource-x/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: azure-resource-x
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_9
+    - !<!NumberSchema> &ref_10
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: ResourceX-id
           description: Resource Id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -40,7 +40,7 @@ schemas: !<!Schemas>
           name: ResourceX-type
           description: Resource Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_0
+    - !<!StringSchema> &ref_1
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -50,7 +50,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_6
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -60,7 +60,7 @@ schemas: !<!Schemas>
           name: ResourceX-location
           description: Resource Location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -70,7 +70,7 @@ schemas: !<!Schemas>
           name: ResourceX-name
           description: Resource Name
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -80,7 +80,7 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -90,7 +90,7 @@ schemas: !<!Schemas>
           name: FlattenedResourceProperties-pname
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_10
+    - !<!StringSchema> &ref_11
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -100,37 +100,48 @@ schemas: !<!Schemas>
           name: FlattenedResourceProperties-provisioningState
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_17
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_4
+    - !<!DictionarySchema> &ref_5
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: ResourceX-tags
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_20
+    - !<!DictionarySchema> &ref_21
       type: dictionary
-      elementType: !<!ObjectSchema> &ref_1
+      elementType: !<!ObjectSchema> &ref_2
         type: object
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
         parents: !<!Relations> 
           all:
-            - !<!ObjectSchema> &ref_7
+            - !<!ObjectSchema> &ref_8
               type: object
               apiVersions:
                 - !<!ApiVersion> 
                   version: 1.0.0
               children: !<!Relations> 
                 all:
-                  - *ref_1
+                  - *ref_2
                 immediate:
-                  - *ref_1
+                  - *ref_2
               properties:
                 - !<!Property> 
-                  schema: *ref_2
+                  schema: *ref_3
                   readOnly: true
                   serializedName: id
                   language: !<!Languages> 
@@ -139,7 +150,7 @@ schemas: !<!Schemas>
                       description: Resource Id
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_3
+                  schema: *ref_4
                   readOnly: true
                   serializedName: type
                   language: !<!Languages> 
@@ -148,7 +159,7 @@ schemas: !<!Schemas>
                       description: Resource Type
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_4
+                  schema: *ref_5
                   serializedName: tags
                   language: !<!Languages> 
                     default:
@@ -156,7 +167,7 @@ schemas: !<!Schemas>
                       description: Dictionary of <string>
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_5
+                  schema: *ref_6
                   serializedName: location
                   language: !<!Languages> 
                     default:
@@ -164,7 +175,7 @@ schemas: !<!Schemas>
                       description: Resource Location
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_6
+                  schema: *ref_7
                   readOnly: true
                   serializedName: name
                   language: !<!Languages> 
@@ -186,10 +197,10 @@ schemas: !<!Schemas>
                   namespace: ''
               protocol: !<!Protocols> {}
           immediate:
-            - *ref_7
+            - *ref_8
         properties:
           - !<!Property> 
-            schema: *ref_8
+            schema: *ref_9
             flattenedNames:
               - properties
               - pname
@@ -200,7 +211,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_9
+            schema: *ref_10
             flattenedNames:
               - properties
               - lsize
@@ -211,7 +222,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_10
+            schema: *ref_11
             flattenedNames:
               - properties
               - provisioningState
@@ -237,24 +248,24 @@ schemas: !<!Schemas>
           name: paths·lx8sp0·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_12
+    - !<!DictionarySchema> &ref_13
       type: dictionary
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
   objects:
-    - *ref_7
-    - !<!ObjectSchema> &ref_18
+    - *ref_8
+    - !<!ObjectSchema> &ref_19
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_9
+          schema: *ref_10
           serializedName: status
           language: !<!Languages> 
             default:
@@ -262,7 +273,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_11
+          schema: *ref_12
           serializedName: message
           language: !<!Languages> 
             default:
@@ -279,15 +290,15 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_1
-    - !<!ObjectSchema> &ref_22
+    - *ref_2
+    - !<!ObjectSchema> &ref_23
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: productresource
           language: !<!Languages> 
             default:
@@ -295,12 +306,12 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: !<!ArraySchema> &ref_13
+          schema: !<!ArraySchema> &ref_14
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            elementType: *ref_1
+            elementType: *ref_2
             language: !<!Languages> 
               default:
                 name: ResourceCollection-arrayofresources
@@ -313,7 +324,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_12
+          schema: *ref_13
           serializedName: dictionaryofresources
           language: !<!Languages> 
             default:
@@ -337,27 +348,27 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_7
+      elementType: *ref_8
       language: !<!Languages> 
         default:
           name: paths·1y4igfn·azure-resource_flatten-array·put·requestbody·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_19
+    - !<!ArraySchema> &ref_20
       type: array
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·elolk8·azure-resource_flatten-array·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - *ref_13
+    - *ref_14
 globalParameters:
   - !<!Parameter> &ref_15
-    schema: *ref_14
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -385,7 +396,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
+              - !<!Parameter> &ref_18
                 schema: *ref_16
                 implementation: Method
                 required: false
@@ -397,8 +408,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -424,7 +448,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -449,6 +473,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -461,7 +500,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_19
+            schema: *ref_20
             language: !<!Languages> 
               default:
                 name: ''
@@ -475,7 +514,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -501,8 +540,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_21
-                schema: *ref_20
+              - !<!Parameter> &ref_22
+                schema: *ref_21
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -513,8 +552,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -540,7 +592,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -565,6 +617,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -577,7 +644,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -591,7 +658,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -617,8 +684,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_23
-                schema: *ref_22
+              - !<!Parameter> &ref_24
+                schema: *ref_23
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -629,8 +696,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_23
+              - *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -656,7 +736,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -681,6 +761,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -693,7 +788,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -707,7 +802,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-resource-x/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/modeler.yaml
@@ -100,6 +100,17 @@ schemas: !<!Schemas>
           name: FlattenedResourceProperties-provisioningState
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_17
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_15
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_12
       type: dictionary
@@ -109,7 +120,7 @@ schemas: !<!Schemas>
           name: ResourceX-tags
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_21
+    - !<!DictionarySchema> &ref_22
       type: dictionary
       elementType: !<!ObjectSchema> &ref_8
         type: object
@@ -264,7 +275,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
   objects:
     - *ref_7
-    - !<!ObjectSchema> &ref_18
+    - !<!ObjectSchema> &ref_19
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -298,7 +309,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_8
     - *ref_11
-    - !<!ObjectSchema> &ref_23
+    - !<!ObjectSchema> &ref_24
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -361,7 +372,7 @@ schemas: !<!Schemas>
           name: paths·1y4igfn·azure-resource_flatten-array·put·requestbody·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_20
+    - !<!ArraySchema> &ref_21
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -374,7 +385,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_14
 globalParameters:
-  - !<!Parameter> &ref_19
+  - !<!Parameter> &ref_20
     schema: *ref_15
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -399,11 +410,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_19
+          - *ref_20
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
+              - !<!Parameter> &ref_18
                 schema: *ref_16
                 implementation: Method
                 required: false
@@ -415,8 +426,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -442,7 +466,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -464,9 +488,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_19
+          - *ref_20
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -479,7 +518,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -493,7 +532,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -515,12 +554,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_19
+          - *ref_20
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_22
-                schema: *ref_21
+              - !<!Parameter> &ref_23
+                schema: *ref_22
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -531,8 +570,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_22
+              - *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -558,7 +610,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -580,9 +632,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_19
+          - *ref_20
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -595,7 +662,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_21
+            schema: *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -609,7 +676,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -631,12 +698,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_19
+          - *ref_20
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_24
-                schema: *ref_23
+              - !<!Parameter> &ref_25
+                schema: *ref_24
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -647,8 +714,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_24
+              - *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -674,7 +754,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -696,9 +776,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_19
+          - *ref_20
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -711,7 +806,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -725,7 +820,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-resource-x/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource-x/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: azure-resource-x
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_9
+    - !<!NumberSchema> &ref_10
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: ResourceXId
           description: Resource Id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -40,7 +40,7 @@ schemas: !<!Schemas>
           name: ResourceXType
           description: Resource Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_0
+    - !<!StringSchema> &ref_1
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -50,7 +50,7 @@ schemas: !<!Schemas>
           name: String
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_6
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -60,7 +60,7 @@ schemas: !<!Schemas>
           name: ResourceXLocation
           description: Resource Location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -70,7 +70,7 @@ schemas: !<!Schemas>
           name: ResourceXName
           description: Resource Name
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -80,7 +80,7 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -90,7 +90,7 @@ schemas: !<!Schemas>
           name: FlattenedResourcePropertiesPname
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_10
+    - !<!StringSchema> &ref_11
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -100,37 +100,48 @@ schemas: !<!Schemas>
           name: FlattenedResourcePropertiesProvisioningState
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_17
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_4
+    - !<!DictionarySchema> &ref_5
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: ResourceXTags
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_20
+    - !<!DictionarySchema> &ref_21
       type: dictionary
-      elementType: !<!ObjectSchema> &ref_1
+      elementType: !<!ObjectSchema> &ref_2
         type: object
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
         parents: !<!Relations> 
           all:
-            - !<!ObjectSchema> &ref_7
+            - !<!ObjectSchema> &ref_8
               type: object
               apiVersions:
                 - !<!ApiVersion> 
                   version: 1.0.0
               children: !<!Relations> 
                 all:
-                  - *ref_1
+                  - *ref_2
                 immediate:
-                  - *ref_1
+                  - *ref_2
               properties:
                 - !<!Property> 
-                  schema: *ref_2
+                  schema: *ref_3
                   readOnly: true
                   serializedName: id
                   language: !<!Languages> 
@@ -139,7 +150,7 @@ schemas: !<!Schemas>
                       description: Resource Id
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_3
+                  schema: *ref_4
                   readOnly: true
                   serializedName: type
                   language: !<!Languages> 
@@ -148,7 +159,7 @@ schemas: !<!Schemas>
                       description: Resource Type
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_4
+                  schema: *ref_5
                   serializedName: tags
                   language: !<!Languages> 
                     default:
@@ -156,7 +167,7 @@ schemas: !<!Schemas>
                       description: Dictionary of <string>
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_5
+                  schema: *ref_6
                   serializedName: location
                   language: !<!Languages> 
                     default:
@@ -164,7 +175,7 @@ schemas: !<!Schemas>
                       description: Resource Location
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_6
+                  schema: *ref_7
                   readOnly: true
                   serializedName: name
                   language: !<!Languages> 
@@ -186,10 +197,10 @@ schemas: !<!Schemas>
                   namespace: ''
               protocol: !<!Protocols> {}
           immediate:
-            - *ref_7
+            - *ref_8
         properties:
           - !<!Property> 
-            schema: *ref_8
+            schema: *ref_9
             flattenedNames:
               - properties
               - pname
@@ -200,7 +211,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_9
+            schema: *ref_10
             flattenedNames:
               - properties
               - lsize
@@ -211,7 +222,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_10
+            schema: *ref_11
             flattenedNames:
               - properties
               - provisioningState
@@ -237,24 +248,24 @@ schemas: !<!Schemas>
           name: DictionaryOfFlattenedProduct
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_12
+    - !<!DictionarySchema> &ref_13
       type: dictionary
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: ResourceCollectionDictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
   objects:
-    - *ref_7
-    - !<!ObjectSchema> &ref_18
+    - *ref_8
+    - !<!ObjectSchema> &ref_19
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_9
+          schema: *ref_10
           serializedName: status
           language: !<!Languages> 
             default:
@@ -262,7 +273,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_11
+          schema: *ref_12
           serializedName: message
           language: !<!Languages> 
             default:
@@ -279,15 +290,15 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_1
-    - !<!ObjectSchema> &ref_22
+    - *ref_2
+    - !<!ObjectSchema> &ref_23
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: productresource
           language: !<!Languages> 
             default:
@@ -295,12 +306,12 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: !<!ArraySchema> &ref_13
+          schema: !<!ArraySchema> &ref_14
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            elementType: *ref_1
+            elementType: *ref_2
             language: !<!Languages> 
               default:
                 name: ResourceCollectionArrayofresources
@@ -313,7 +324,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_12
+          schema: *ref_13
           serializedName: dictionaryofresources
           language: !<!Languages> 
             default:
@@ -337,27 +348,27 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_7
+      elementType: *ref_8
       language: !<!Languages> 
         default:
           name: ArrayOfResourceX
           description: Array of ResourceX
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_19
+    - !<!ArraySchema> &ref_20
       type: array
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: ArrayOfFlattenedProduct
           description: Array of FlattenedProduct
       protocol: !<!Protocols> {}
-    - *ref_13
+    - *ref_14
 globalParameters:
   - !<!Parameter> &ref_15
-    schema: *ref_14
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -385,7 +396,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
+              - !<!Parameter> &ref_18
                 schema: *ref_16
                 implementation: Method
                 required: false
@@ -397,8 +408,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -424,7 +448,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -449,6 +473,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -461,7 +500,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_19
+            schema: *ref_20
             language: !<!Languages> 
               default:
                 name: ''
@@ -475,7 +514,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -501,8 +540,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_21
-                schema: *ref_20
+              - !<!Parameter> &ref_22
+                schema: *ref_21
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -513,8 +552,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -540,7 +592,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -565,6 +617,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -577,7 +644,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -591,7 +658,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -617,8 +684,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_23
-                schema: *ref_22
+              - !<!Parameter> &ref_24
+                schema: *ref_23
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -629,8 +696,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_23
+              - *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -656,7 +736,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -681,6 +761,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -693,7 +788,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -707,7 +802,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-resource/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-resource/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: azure-resource
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_9
+    - !<!NumberSchema> &ref_10
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: Resource-id
           description: Resource Id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -40,7 +40,7 @@ schemas: !<!Schemas>
           name: Resource-type
           description: Resource Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_0
+    - !<!StringSchema> &ref_1
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -50,7 +50,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_6
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -60,7 +60,7 @@ schemas: !<!Schemas>
           name: Resource-location
           description: Resource Location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -70,7 +70,7 @@ schemas: !<!Schemas>
           name: Resource-name
           description: Resource Name
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -80,7 +80,7 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -90,7 +90,7 @@ schemas: !<!Schemas>
           name: FlattenedResourceProperties-pname
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_10
+    - !<!StringSchema> &ref_11
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -100,37 +100,48 @@ schemas: !<!Schemas>
           name: FlattenedResourceProperties-provisioningState
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_17
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_4
+    - !<!DictionarySchema> &ref_5
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: Resource-tags
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_20
+    - !<!DictionarySchema> &ref_21
       type: dictionary
-      elementType: !<!ObjectSchema> &ref_1
+      elementType: !<!ObjectSchema> &ref_2
         type: object
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
         parents: !<!Relations> 
           all:
-            - !<!ObjectSchema> &ref_7
+            - !<!ObjectSchema> &ref_8
               type: object
               apiVersions:
                 - !<!ApiVersion> 
                   version: 1.0.0
               children: !<!Relations> 
                 all:
-                  - *ref_1
+                  - *ref_2
                 immediate:
-                  - *ref_1
+                  - *ref_2
               properties:
                 - !<!Property> 
-                  schema: *ref_2
+                  schema: *ref_3
                   readOnly: true
                   serializedName: id
                   language: !<!Languages> 
@@ -139,7 +150,7 @@ schemas: !<!Schemas>
                       description: Resource Id
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_3
+                  schema: *ref_4
                   readOnly: true
                   serializedName: type
                   language: !<!Languages> 
@@ -148,7 +159,7 @@ schemas: !<!Schemas>
                       description: Resource Type
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_4
+                  schema: *ref_5
                   serializedName: tags
                   language: !<!Languages> 
                     default:
@@ -156,7 +167,7 @@ schemas: !<!Schemas>
                       description: Dictionary of <string>
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_5
+                  schema: *ref_6
                   serializedName: location
                   language: !<!Languages> 
                     default:
@@ -164,7 +175,7 @@ schemas: !<!Schemas>
                       description: Resource Location
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_6
+                  schema: *ref_7
                   readOnly: true
                   serializedName: name
                   language: !<!Languages> 
@@ -186,10 +197,10 @@ schemas: !<!Schemas>
                   namespace: ''
               protocol: !<!Protocols> {}
           immediate:
-            - *ref_7
+            - *ref_8
         properties:
           - !<!Property> 
-            schema: *ref_8
+            schema: *ref_9
             flattenedNames:
               - properties
               - pname
@@ -200,7 +211,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_9
+            schema: *ref_10
             flattenedNames:
               - properties
               - lsize
@@ -211,7 +222,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_10
+            schema: *ref_11
             flattenedNames:
               - properties
               - provisioningState
@@ -237,24 +248,24 @@ schemas: !<!Schemas>
           name: paths·lx8sp0·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_12
+    - !<!DictionarySchema> &ref_13
       type: dictionary
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
   objects:
-    - *ref_7
-    - !<!ObjectSchema> &ref_18
+    - *ref_8
+    - !<!ObjectSchema> &ref_19
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_9
+          schema: *ref_10
           serializedName: status
           language: !<!Languages> 
             default:
@@ -262,7 +273,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_11
+          schema: *ref_12
           serializedName: message
           language: !<!Languages> 
             default:
@@ -279,15 +290,15 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_1
-    - !<!ObjectSchema> &ref_22
+    - *ref_2
+    - !<!ObjectSchema> &ref_23
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: productresource
           language: !<!Languages> 
             default:
@@ -295,12 +306,12 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: !<!ArraySchema> &ref_13
+          schema: !<!ArraySchema> &ref_14
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            elementType: *ref_1
+            elementType: *ref_2
             language: !<!Languages> 
               default:
                 name: ResourceCollection-arrayofresources
@@ -313,7 +324,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_12
+          schema: *ref_13
           serializedName: dictionaryofresources
           language: !<!Languages> 
             default:
@@ -337,27 +348,27 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_7
+      elementType: *ref_8
       language: !<!Languages> 
         default:
           name: paths·1y4igfn·azure-resource_flatten-array·put·requestbody·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_19
+    - !<!ArraySchema> &ref_20
       type: array
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·elolk8·azure-resource_flatten-array·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - *ref_13
+    - *ref_14
 globalParameters:
   - !<!Parameter> &ref_15
-    schema: *ref_14
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -385,7 +396,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
+              - !<!Parameter> &ref_18
                 schema: *ref_16
                 implementation: Method
                 required: false
@@ -397,8 +408,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -424,7 +448,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -449,6 +473,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -461,7 +500,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_19
+            schema: *ref_20
             language: !<!Languages> 
               default:
                 name: ''
@@ -475,7 +514,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -501,8 +540,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_21
-                schema: *ref_20
+              - !<!Parameter> &ref_22
+                schema: *ref_21
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -513,8 +552,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -540,7 +592,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -565,6 +617,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -577,7 +644,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -591,7 +658,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -617,8 +684,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_23
-                schema: *ref_22
+              - !<!Parameter> &ref_24
+                schema: *ref_23
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -629,8 +696,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_23
+              - *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -656,7 +736,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -681,6 +761,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -693,7 +788,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -707,7 +802,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-resource/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-resource/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: azure-resource
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_9
+    - !<!NumberSchema> &ref_10
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: Resource-id
           description: Resource Id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -40,7 +40,7 @@ schemas: !<!Schemas>
           name: Resource-type
           description: Resource Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_0
+    - !<!StringSchema> &ref_1
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -50,7 +50,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_6
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -60,7 +60,7 @@ schemas: !<!Schemas>
           name: Resource-location
           description: Resource Location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -70,7 +70,7 @@ schemas: !<!Schemas>
           name: Resource-name
           description: Resource Name
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -80,7 +80,7 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -90,7 +90,7 @@ schemas: !<!Schemas>
           name: FlattenedResourceProperties-pname
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_10
+    - !<!StringSchema> &ref_11
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -100,37 +100,48 @@ schemas: !<!Schemas>
           name: FlattenedResourceProperties-provisioningState
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_17
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_4
+    - !<!DictionarySchema> &ref_5
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: Resource-tags
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_20
+    - !<!DictionarySchema> &ref_21
       type: dictionary
-      elementType: !<!ObjectSchema> &ref_1
+      elementType: !<!ObjectSchema> &ref_2
         type: object
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
         parents: !<!Relations> 
           all:
-            - !<!ObjectSchema> &ref_7
+            - !<!ObjectSchema> &ref_8
               type: object
               apiVersions:
                 - !<!ApiVersion> 
                   version: 1.0.0
               children: !<!Relations> 
                 all:
-                  - *ref_1
+                  - *ref_2
                 immediate:
-                  - *ref_1
+                  - *ref_2
               properties:
                 - !<!Property> 
-                  schema: *ref_2
+                  schema: *ref_3
                   readOnly: true
                   serializedName: id
                   language: !<!Languages> 
@@ -139,7 +150,7 @@ schemas: !<!Schemas>
                       description: Resource Id
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_3
+                  schema: *ref_4
                   readOnly: true
                   serializedName: type
                   language: !<!Languages> 
@@ -148,7 +159,7 @@ schemas: !<!Schemas>
                       description: Resource Type
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_4
+                  schema: *ref_5
                   serializedName: tags
                   language: !<!Languages> 
                     default:
@@ -156,7 +167,7 @@ schemas: !<!Schemas>
                       description: Dictionary of <string>
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_5
+                  schema: *ref_6
                   serializedName: location
                   language: !<!Languages> 
                     default:
@@ -164,7 +175,7 @@ schemas: !<!Schemas>
                       description: Resource Location
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_6
+                  schema: *ref_7
                   readOnly: true
                   serializedName: name
                   language: !<!Languages> 
@@ -186,10 +197,10 @@ schemas: !<!Schemas>
                   namespace: ''
               protocol: !<!Protocols> {}
           immediate:
-            - *ref_7
+            - *ref_8
         properties:
           - !<!Property> 
-            schema: *ref_8
+            schema: *ref_9
             flattenedNames:
               - properties
               - pname
@@ -200,7 +211,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_9
+            schema: *ref_10
             flattenedNames:
               - properties
               - lsize
@@ -211,7 +222,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_10
+            schema: *ref_11
             flattenedNames:
               - properties
               - provisioningState
@@ -237,24 +248,24 @@ schemas: !<!Schemas>
           name: paths·lx8sp0·azure-resource_flatten-dictionary·put·requestbody·content·application-json·schema
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_12
+    - !<!DictionarySchema> &ref_13
       type: dictionary
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: ResourceCollection-dictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
   objects:
-    - *ref_7
-    - !<!ObjectSchema> &ref_18
+    - *ref_8
+    - !<!ObjectSchema> &ref_19
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_9
+          schema: *ref_10
           serializedName: status
           language: !<!Languages> 
             default:
@@ -262,7 +273,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_11
+          schema: *ref_12
           serializedName: message
           language: !<!Languages> 
             default:
@@ -279,15 +290,15 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_1
-    - !<!ObjectSchema> &ref_22
+    - *ref_2
+    - !<!ObjectSchema> &ref_23
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: productresource
           language: !<!Languages> 
             default:
@@ -295,12 +306,12 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: !<!ArraySchema> &ref_13
+          schema: !<!ArraySchema> &ref_14
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            elementType: *ref_1
+            elementType: *ref_2
             language: !<!Languages> 
               default:
                 name: ResourceCollection-arrayofresources
@@ -313,7 +324,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_12
+          schema: *ref_13
           serializedName: dictionaryofresources
           language: !<!Languages> 
             default:
@@ -337,27 +348,27 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_7
+      elementType: *ref_8
       language: !<!Languages> 
         default:
           name: paths·1y4igfn·azure-resource_flatten-array·put·requestbody·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_19
+    - !<!ArraySchema> &ref_20
       type: array
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·elolk8·azure-resource_flatten-array·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - *ref_13
+    - *ref_14
 globalParameters:
   - !<!Parameter> &ref_15
-    schema: *ref_14
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -385,7 +396,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
+              - !<!Parameter> &ref_18
                 schema: *ref_16
                 implementation: Method
                 required: false
@@ -397,8 +408,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -424,7 +448,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -449,6 +473,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -461,7 +500,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_19
+            schema: *ref_20
             language: !<!Languages> 
               default:
                 name: ''
@@ -475,7 +514,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -501,8 +540,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_21
-                schema: *ref_20
+              - !<!Parameter> &ref_22
+                schema: *ref_21
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -513,8 +552,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -540,7 +592,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -565,6 +617,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -577,7 +644,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -591,7 +658,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -617,8 +684,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_23
-                schema: *ref_22
+              - !<!Parameter> &ref_24
+                schema: *ref_23
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -629,8 +696,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_23
+              - *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -656,7 +736,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -681,6 +761,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -693,7 +788,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -707,7 +802,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-resource/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-resource/modeler.yaml
@@ -100,6 +100,17 @@ schemas: !<!Schemas>
           name: FlattenedResourceProperties-provisioningState
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_17
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_15
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_12
       type: dictionary
@@ -109,7 +120,7 @@ schemas: !<!Schemas>
           name: Resource-tags
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_21
+    - !<!DictionarySchema> &ref_22
       type: dictionary
       elementType: !<!ObjectSchema> &ref_8
         type: object
@@ -264,7 +275,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
   objects:
     - *ref_7
-    - !<!ObjectSchema> &ref_18
+    - !<!ObjectSchema> &ref_19
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -298,7 +309,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_8
     - *ref_11
-    - !<!ObjectSchema> &ref_23
+    - !<!ObjectSchema> &ref_24
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -361,7 +372,7 @@ schemas: !<!Schemas>
           name: paths·1y4igfn·azure-resource_flatten-array·put·requestbody·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_20
+    - !<!ArraySchema> &ref_21
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -374,7 +385,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_14
 globalParameters:
-  - !<!Parameter> &ref_19
+  - !<!Parameter> &ref_20
     schema: *ref_15
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -399,11 +410,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_19
+          - *ref_20
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
+              - !<!Parameter> &ref_18
                 schema: *ref_16
                 implementation: Method
                 required: false
@@ -415,8 +426,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -442,7 +466,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -464,9 +488,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_19
+          - *ref_20
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -479,7 +518,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -493,7 +532,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -515,12 +554,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_19
+          - *ref_20
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_22
-                schema: *ref_21
+              - !<!Parameter> &ref_23
+                schema: *ref_22
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -531,8 +570,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_22
+              - *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -558,7 +610,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -580,9 +632,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_19
+          - *ref_20
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -595,7 +662,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_21
+            schema: *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -609,7 +676,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -631,12 +698,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_19
+          - *ref_20
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_24
-                schema: *ref_23
+              - !<!Parameter> &ref_25
+                schema: *ref_24
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -647,8 +714,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_24
+              - *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -674,7 +754,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -696,9 +776,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_19
+          - *ref_20
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -711,7 +806,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -725,7 +820,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-resource/namer.yaml
+++ b/modelerfour/test/scenarios/azure-resource/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: azure-resource
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_9
+    - !<!NumberSchema> &ref_10
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: ResourceId
           description: Resource Id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -40,7 +40,7 @@ schemas: !<!Schemas>
           name: ResourceType
           description: Resource Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_0
+    - !<!StringSchema> &ref_1
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -50,7 +50,7 @@ schemas: !<!Schemas>
           name: String
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_6
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -60,7 +60,7 @@ schemas: !<!Schemas>
           name: ResourceLocation
           description: Resource Location
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -70,7 +70,7 @@ schemas: !<!Schemas>
           name: ResourceName
           description: Resource Name
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -80,7 +80,7 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -90,7 +90,7 @@ schemas: !<!Schemas>
           name: FlattenedResourcePropertiesPname
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_10
+    - !<!StringSchema> &ref_11
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -100,37 +100,48 @@ schemas: !<!Schemas>
           name: FlattenedResourcePropertiesProvisioningState
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_17
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_4
+    - !<!DictionarySchema> &ref_5
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: ResourceTags
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_20
+    - !<!DictionarySchema> &ref_21
       type: dictionary
-      elementType: !<!ObjectSchema> &ref_1
+      elementType: !<!ObjectSchema> &ref_2
         type: object
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
         parents: !<!Relations> 
           all:
-            - !<!ObjectSchema> &ref_7
+            - !<!ObjectSchema> &ref_8
               type: object
               apiVersions:
                 - !<!ApiVersion> 
                   version: 1.0.0
               children: !<!Relations> 
                 all:
-                  - *ref_1
+                  - *ref_2
                 immediate:
-                  - *ref_1
+                  - *ref_2
               properties:
                 - !<!Property> 
-                  schema: *ref_2
+                  schema: *ref_3
                   readOnly: true
                   serializedName: id
                   language: !<!Languages> 
@@ -139,7 +150,7 @@ schemas: !<!Schemas>
                       description: Resource Id
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_3
+                  schema: *ref_4
                   readOnly: true
                   serializedName: type
                   language: !<!Languages> 
@@ -148,7 +159,7 @@ schemas: !<!Schemas>
                       description: Resource Type
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_4
+                  schema: *ref_5
                   serializedName: tags
                   language: !<!Languages> 
                     default:
@@ -156,7 +167,7 @@ schemas: !<!Schemas>
                       description: Dictionary of <string>
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_5
+                  schema: *ref_6
                   serializedName: location
                   language: !<!Languages> 
                     default:
@@ -164,7 +175,7 @@ schemas: !<!Schemas>
                       description: Resource Location
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_6
+                  schema: *ref_7
                   readOnly: true
                   serializedName: name
                   language: !<!Languages> 
@@ -186,10 +197,10 @@ schemas: !<!Schemas>
                   namespace: ''
               protocol: !<!Protocols> {}
           immediate:
-            - *ref_7
+            - *ref_8
         properties:
           - !<!Property> 
-            schema: *ref_8
+            schema: *ref_9
             flattenedNames:
               - properties
               - pname
@@ -200,7 +211,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_9
+            schema: *ref_10
             flattenedNames:
               - properties
               - lsize
@@ -211,7 +222,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_10
+            schema: *ref_11
             flattenedNames:
               - properties
               - provisioningState
@@ -237,24 +248,24 @@ schemas: !<!Schemas>
           name: DictionaryOfFlattenedProduct
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_12
+    - !<!DictionarySchema> &ref_13
       type: dictionary
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: ResourceCollectionDictionaryofresources
           description: Dictionary of <FlattenedProduct>
       protocol: !<!Protocols> {}
   objects:
-    - *ref_7
-    - !<!ObjectSchema> &ref_18
+    - *ref_8
+    - !<!ObjectSchema> &ref_19
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_9
+          schema: *ref_10
           serializedName: status
           language: !<!Languages> 
             default:
@@ -262,7 +273,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_11
+          schema: *ref_12
           serializedName: message
           language: !<!Languages> 
             default:
@@ -279,15 +290,15 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_1
-    - !<!ObjectSchema> &ref_22
+    - *ref_2
+    - !<!ObjectSchema> &ref_23
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: productresource
           language: !<!Languages> 
             default:
@@ -295,12 +306,12 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: !<!ArraySchema> &ref_13
+          schema: !<!ArraySchema> &ref_14
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            elementType: *ref_1
+            elementType: *ref_2
             language: !<!Languages> 
               default:
                 name: ResourceCollectionArrayofresources
@@ -313,7 +324,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_12
+          schema: *ref_13
           serializedName: dictionaryofresources
           language: !<!Languages> 
             default:
@@ -337,27 +348,27 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_7
+      elementType: *ref_8
       language: !<!Languages> 
         default:
           name: ArrayOfResource
           description: Array of Resource
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_19
+    - !<!ArraySchema> &ref_20
       type: array
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: ArrayOfFlattenedProduct
           description: Array of FlattenedProduct
       protocol: !<!Protocols> {}
-    - *ref_13
+    - *ref_14
 globalParameters:
   - !<!Parameter> &ref_15
-    schema: *ref_14
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -385,7 +396,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
+              - !<!Parameter> &ref_18
                 schema: *ref_16
                 implementation: Method
                 required: false
@@ -397,8 +408,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -424,7 +448,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -449,6 +473,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -461,7 +500,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_19
+            schema: *ref_20
             language: !<!Languages> 
               default:
                 name: ''
@@ -475,7 +514,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -501,8 +540,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_21
-                schema: *ref_20
+              - !<!Parameter> &ref_22
+                schema: *ref_21
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -513,8 +552,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -540,7 +592,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -565,6 +617,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -577,7 +644,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -591,7 +658,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -617,8 +684,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_23
-                schema: *ref_22
+              - !<!Parameter> &ref_24
+                schema: *ref_23
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -629,8 +696,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_23
+              - *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -656,7 +736,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -681,6 +761,21 @@ operationGroups:
           - *ref_15
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_17
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -693,7 +788,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -707,7 +802,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_18
+            schema: *ref_19
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-special-properties/flattened.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/flattened.yaml
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_25
+    - !<!NumberSchema> &ref_26
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -73,6 +73,16 @@ schemas: !<!Schemas>
           name: type·for·constantId
           description: ''
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_8
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_6
       type: constant
       value: !<!ConstantValue> 
@@ -83,7 +93,7 @@ schemas: !<!Schemas>
           name: ApiVersion-2015-07-01-preview
           description: Api Version (2015-07-01-preview)
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_16
+    - !<!ConstantSchema> &ref_17
       type: constant
       value: !<!ConstantValue> 
         value: '2.0'
@@ -93,7 +103,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_20
+    - !<!ConstantSchema> &ref_21
       type: constant
       value: !<!ConstantValue> 
         value: path1/path2/path3
@@ -103,7 +113,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_24
+    - !<!ConstantSchema> &ref_25
       type: constant
       value: !<!ConstantValue> 
         value: value1&q2=value2&q3=value3
@@ -114,7 +124,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_9
+    - !<!ObjectSchema> &ref_10
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -186,7 +196,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_10
+  - !<!Parameter> &ref_11
     schema: *ref_5
     implementation: Client
     required: true
@@ -216,7 +226,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_11
+  - !<!Parameter> &ref_12
     schema: *ref_6
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -282,7 +292,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - !<!Parameter> &ref_8
+          - !<!Parameter> &ref_9
             schema: *ref_5
             implementation: Method
             required: true
@@ -296,6 +306,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -306,7 +331,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_8
+          - *ref_9
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -319,7 +344,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -350,9 +375,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - *ref_10
+          - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -375,7 +415,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,9 +438,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - *ref_10
+          - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -423,7 +478,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -446,10 +501,25 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - *ref_10
           - *ref_11
+          - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -472,7 +542,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -495,9 +565,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - *ref_10
+          - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -520,7 +605,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -543,9 +628,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - *ref_10
+          - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -568,7 +668,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -599,7 +699,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - !<!Parameter> &ref_12
+          - !<!Parameter> &ref_13
             schema: *ref_5
             implementation: Method
             required: true
@@ -613,6 +713,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -623,7 +738,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_12
+          - *ref_13
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -636,7 +751,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -659,7 +774,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - !<!Parameter> &ref_13
+          - !<!Parameter> &ref_14
             schema: *ref_5
             implementation: Method
             required: true
@@ -673,6 +788,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -683,7 +813,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_13
+          - *ref_14
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -696,7 +826,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -719,7 +849,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - !<!Parameter> &ref_14
+          - !<!Parameter> &ref_15
             schema: *ref_5
             implementation: Method
             required: true
@@ -733,6 +863,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -743,7 +888,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_14
+          - *ref_15
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -756,7 +901,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -779,7 +924,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - !<!Parameter> &ref_15
+          - !<!Parameter> &ref_16
             schema: *ref_5
             implementation: Method
             required: true
@@ -793,6 +938,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -803,7 +963,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_15
+          - *ref_16
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -816,7 +976,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -847,9 +1007,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - *ref_11
+          - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -872,7 +1047,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -895,9 +1070,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - *ref_11
+          - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -920,7 +1110,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -943,9 +1133,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - *ref_11
+          - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -968,7 +1173,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -991,9 +1196,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - *ref_11
+          - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1016,7 +1236,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -1048,7 +1268,7 @@ operationGroups:
         parameters:
           - *ref_7
           - !<!Parameter> 
-            schema: *ref_16
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1061,6 +1281,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1083,7 +1318,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -1106,7 +1341,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - !<!Parameter> &ref_17
+          - !<!Parameter> &ref_18
             schema: *ref_5
             implementation: Method
             language: !<!Languages> 
@@ -1119,6 +1354,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1129,7 +1379,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_17
+          - *ref_18
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1142,7 +1392,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -1166,7 +1416,7 @@ operationGroups:
         parameters:
           - *ref_7
           - !<!Parameter> 
-            schema: *ref_16
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1179,6 +1429,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1201,7 +1466,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -1225,7 +1490,7 @@ operationGroups:
         parameters:
           - *ref_7
           - !<!Parameter> 
-            schema: *ref_16
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1238,6 +1503,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1260,7 +1540,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -1291,7 +1571,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - !<!Parameter> &ref_18
+          - !<!Parameter> &ref_19
             schema: *ref_5
             implementation: Method
             required: true
@@ -1307,6 +1587,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1317,7 +1612,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_18
+          - *ref_19
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1330,7 +1625,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -1353,7 +1648,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - !<!Parameter> &ref_19
+          - !<!Parameter> &ref_20
             schema: *ref_5
             implementation: Method
             required: true
@@ -1369,6 +1664,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1379,7 +1689,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_19
+          - *ref_20
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1392,7 +1702,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -1416,7 +1726,7 @@ operationGroups:
         parameters:
           - *ref_7
           - !<!Parameter> 
-            schema: *ref_20
+            schema: *ref_21
             implementation: Method
             required: true
             extensions:
@@ -1431,6 +1741,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1453,7 +1778,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -1476,7 +1801,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - !<!Parameter> &ref_21
+          - !<!Parameter> &ref_22
             schema: *ref_5
             implementation: Method
             required: true
@@ -1492,6 +1817,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1502,7 +1842,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_21
+          - *ref_22
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1515,7 +1855,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -1538,7 +1878,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - !<!Parameter> &ref_22
+          - !<!Parameter> &ref_23
             schema: *ref_5
             implementation: Method
             extensions:
@@ -1553,6 +1893,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1563,7 +1918,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_22
+          - *ref_23
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1576,7 +1931,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -1599,7 +1954,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - !<!Parameter> &ref_23
+          - !<!Parameter> &ref_24
             schema: *ref_5
             implementation: Method
             required: true
@@ -1615,6 +1970,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1625,7 +1995,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_23
+          - *ref_24
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1638,7 +2008,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -1662,7 +2032,7 @@ operationGroups:
         parameters:
           - *ref_7
           - !<!Parameter> 
-            schema: *ref_24
+            schema: *ref_25
             implementation: Method
             required: true
             extensions:
@@ -1677,6 +2047,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1699,7 +2084,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -1730,7 +2115,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - !<!Parameter> &ref_26
+          - !<!Parameter> &ref_27
             schema: *ref_5
             implementation: Method
             language: !<!Languages> 
@@ -1741,8 +2126,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_27
-            schema: *ref_25
+          - !<!Parameter> &ref_28
+            schema: *ref_26
             implementation: Method
             language: !<!Languages> 
               default:
@@ -1752,7 +2137,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_5
             implementation: Method
             language: !<!Languages> 
@@ -1765,6 +2150,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1775,9 +2175,9 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_26
           - *ref_27
           - *ref_28
+          - *ref_29
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1790,7 +2190,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -1823,7 +2223,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - !<!Parameter> &ref_29
+          - !<!Parameter> &ref_30
             schema: *ref_5
             implementation: Method
             required: true
@@ -1839,6 +2239,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1846,79 +2261,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpRequest> 
                 path: /azurespecials/customNamedRequestId
-                method: post
-                uri: '{$host}'
-        signatureParameters:
-          - *ref_29
-        responses:
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                headers:
-                  - !<!HttpHeader> 
-                    schema: *ref_5
-                    header: foo-request-id
-                    language:
-                      default:
-                        name: foo-request-id
-                        description: Gets the foo-request-id.
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_9
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        extensions:
-          x-ms-request-id: foo-request-id
-        language: !<!Languages> 
-          default:
-            name: customNamedRequestId
-            description: Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
-        protocol: !<!Protocols> {}
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: 2015-07-01-preview
-        parameters:
-          - *ref_7
-          - !<!Parameter> &ref_30
-            schema: *ref_5
-            implementation: Method
-            required: true
-            extensions:
-              x-ms-client-request-id: true
-              x-ms-parameter-grouping: {}
-            language: !<!Languages> 
-              default:
-                name: foo-client-request-id
-                description: The fooRequestId
-                serializedName: foo-client-request-id
-            protocol: !<!Protocols> 
-              http: !<!HttpParameter> 
-                in: header
-        requests:
-          - !<!Request> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpRequest> 
-                path: /azurespecials/customNamedRequestIdParamGrouping
                 method: post
                 uri: '{$host}'
         signatureParameters:
@@ -1943,7 +2285,95 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        extensions:
+          x-ms-request-id: foo-request-id
+        language: !<!Languages> 
+          default:
+            name: customNamedRequestId
+            description: Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 2015-07-01-preview
+        parameters:
+          - *ref_7
+          - !<!Parameter> &ref_31
+            schema: *ref_5
+            implementation: Method
+            required: true
+            extensions:
+              x-ms-client-request-id: true
+              x-ms-parameter-grouping: {}
+            language: !<!Languages> 
+              default:
+                name: foo-client-request-id
+                description: The fooRequestId
+                serializedName: foo-client-request-id
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: header
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpRequest> 
+                path: /azurespecials/customNamedRequestIdParamGrouping
+                method: post
+                uri: '{$host}'
+        signatureParameters:
+          - *ref_31
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                headers:
+                  - !<!HttpHeader> 
+                    schema: *ref_5
+                    header: foo-request-id
+                    language:
+                      default:
+                        name: foo-request-id
+                        description: Gets the foo-request-id.
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -1968,7 +2398,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_7
-          - !<!Parameter> &ref_31
+          - !<!Parameter> &ref_32
             schema: *ref_5
             implementation: Method
             required: true
@@ -1984,6 +2414,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1994,7 +2439,7 @@ operationGroups:
                 method: head
                 uri: '{$host}'
         signatureParameters:
-          - *ref_31
+          - *ref_32
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2024,7 +2469,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-special-properties/grouped.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/grouped.yaml
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_26
+    - !<!NumberSchema> &ref_27
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -73,6 +73,16 @@ schemas: !<!Schemas>
           name: type·for·constantId
           description: ''
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_9
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_7
       type: constant
       value: !<!ConstantValue> 
@@ -83,7 +93,7 @@ schemas: !<!Schemas>
           name: ApiVersion-2015-07-01-preview
           description: Api Version (2015-07-01-preview)
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_17
+    - !<!ConstantSchema> &ref_18
       type: constant
       value: !<!ConstantValue> 
         value: '2.0'
@@ -93,7 +103,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_21
+    - !<!ConstantSchema> &ref_22
       type: constant
       value: !<!ConstantValue> 
         value: path1/path2/path3
@@ -103,7 +113,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_25
+    - !<!ConstantSchema> &ref_26
       type: constant
       value: !<!ConstantValue> 
         value: value1&q2=value2&q3=value3
@@ -120,9 +130,9 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_5
           originalParameter:
-            - !<!Parameter> &ref_31
+            - !<!Parameter> &ref_32
               schema: *ref_5
-              groupedBy: !<!Parameter> &ref_32
+              groupedBy: !<!Parameter> &ref_33
                 schema: *ref_6
                 implementation: Method
                 required: true
@@ -158,7 +168,7 @@ schemas: !<!Schemas>
           description: Parameter group
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_10
+    - !<!ObjectSchema> &ref_11
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -230,7 +240,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_11
+  - !<!Parameter> &ref_12
     schema: *ref_5
     implementation: Client
     required: true
@@ -260,7 +270,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_12
+  - !<!Parameter> &ref_13
     schema: *ref_7
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -326,7 +336,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_9
+          - !<!Parameter> &ref_10
             schema: *ref_5
             implementation: Method
             required: true
@@ -340,6 +350,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -350,7 +375,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_9
+          - *ref_10
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -363,7 +388,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -394,9 +419,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_11
+          - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -419,7 +459,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -442,9 +482,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_11
+          - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -467,7 +522,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -490,10 +545,25 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_11
           - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -516,7 +586,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -539,9 +609,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_11
+          - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -564,7 +649,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -587,9 +672,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_11
+          - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -612,7 +712,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -643,7 +743,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_13
+          - !<!Parameter> &ref_14
             schema: *ref_5
             implementation: Method
             required: true
@@ -657,6 +757,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -667,7 +782,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_13
+          - *ref_14
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -680,7 +795,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -703,7 +818,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_14
+          - !<!Parameter> &ref_15
             schema: *ref_5
             implementation: Method
             required: true
@@ -717,6 +832,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -727,7 +857,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_14
+          - *ref_15
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -740,7 +870,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -763,7 +893,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_15
+          - !<!Parameter> &ref_16
             schema: *ref_5
             implementation: Method
             required: true
@@ -777,6 +907,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -787,7 +932,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_15
+          - *ref_16
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -800,7 +945,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -823,7 +968,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_16
+          - !<!Parameter> &ref_17
             schema: *ref_5
             implementation: Method
             required: true
@@ -837,6 +982,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -847,7 +1007,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_16
+          - *ref_17
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -860,7 +1020,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -891,9 +1051,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -916,7 +1091,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -939,9 +1114,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -964,7 +1154,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -987,9 +1177,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1012,7 +1217,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1035,9 +1240,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1060,7 +1280,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1092,7 +1312,7 @@ operationGroups:
         parameters:
           - *ref_8
           - !<!Parameter> 
-            schema: *ref_17
+            schema: *ref_18
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1105,6 +1325,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1127,7 +1362,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1150,7 +1385,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_18
+          - !<!Parameter> &ref_19
             schema: *ref_5
             implementation: Method
             language: !<!Languages> 
@@ -1163,6 +1398,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1173,7 +1423,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_18
+          - *ref_19
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1186,7 +1436,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1210,7 +1460,7 @@ operationGroups:
         parameters:
           - *ref_8
           - !<!Parameter> 
-            schema: *ref_17
+            schema: *ref_18
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1223,6 +1473,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1245,7 +1510,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1269,7 +1534,7 @@ operationGroups:
         parameters:
           - *ref_8
           - !<!Parameter> 
-            schema: *ref_17
+            schema: *ref_18
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1282,6 +1547,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1304,7 +1584,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1335,7 +1615,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_19
+          - !<!Parameter> &ref_20
             schema: *ref_5
             implementation: Method
             required: true
@@ -1351,6 +1631,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1361,7 +1656,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_19
+          - *ref_20
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1374,7 +1669,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1397,7 +1692,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_20
+          - !<!Parameter> &ref_21
             schema: *ref_5
             implementation: Method
             required: true
@@ -1413,6 +1708,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1423,7 +1733,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_20
+          - *ref_21
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1436,7 +1746,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1460,7 +1770,7 @@ operationGroups:
         parameters:
           - *ref_8
           - !<!Parameter> 
-            schema: *ref_21
+            schema: *ref_22
             implementation: Method
             required: true
             extensions:
@@ -1475,6 +1785,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1497,7 +1822,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1520,7 +1845,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_22
+          - !<!Parameter> &ref_23
             schema: *ref_5
             implementation: Method
             required: true
@@ -1536,6 +1861,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1546,7 +1886,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_22
+          - *ref_23
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1559,7 +1899,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1582,7 +1922,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_23
+          - !<!Parameter> &ref_24
             schema: *ref_5
             implementation: Method
             extensions:
@@ -1597,6 +1937,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1607,7 +1962,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_23
+          - *ref_24
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1620,7 +1975,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1643,7 +1998,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_24
+          - !<!Parameter> &ref_25
             schema: *ref_5
             implementation: Method
             required: true
@@ -1659,6 +2014,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1669,7 +2039,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_24
+          - *ref_25
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1682,7 +2052,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1706,7 +2076,7 @@ operationGroups:
         parameters:
           - *ref_8
           - !<!Parameter> 
-            schema: *ref_25
+            schema: *ref_26
             implementation: Method
             required: true
             extensions:
@@ -1721,6 +2091,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1743,7 +2128,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1774,7 +2159,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_27
+          - !<!Parameter> &ref_28
             schema: *ref_5
             implementation: Method
             language: !<!Languages> 
@@ -1785,8 +2170,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_28
-            schema: *ref_26
+          - !<!Parameter> &ref_29
+            schema: *ref_27
             implementation: Method
             language: !<!Languages> 
               default:
@@ -1796,7 +2181,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_29
+          - !<!Parameter> &ref_30
             schema: *ref_5
             implementation: Method
             language: !<!Languages> 
@@ -1809,6 +2194,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1819,9 +2219,9 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_27
           - *ref_28
           - *ref_29
+          - *ref_30
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1834,7 +2234,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1867,7 +2267,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_30
+          - !<!Parameter> &ref_31
             schema: *ref_5
             implementation: Method
             required: true
@@ -1883,6 +2283,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1893,7 +2308,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_30
+          - *ref_31
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1914,7 +2329,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1939,13 +2354,26 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_31
+          - *ref_32
         requests:
           - !<!Request> 
             parameters:
-              - *ref_32
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_33
             signatureParameters:
-              - *ref_32
+              - *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -1976,7 +2404,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -2001,7 +2429,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_33
+          - !<!Parameter> &ref_34
             schema: *ref_5
             implementation: Method
             required: true
@@ -2017,6 +2445,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2027,7 +2470,7 @@ operationGroups:
                 method: head
                 uri: '{$host}'
         signatureParameters:
-          - *ref_33
+          - *ref_34
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2057,7 +2500,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-special-properties/modeler.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/modeler.yaml
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_25
+    - !<!NumberSchema> &ref_26
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -73,7 +73,17 @@ schemas: !<!Schemas>
           name: type·for·constantId
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_10
+    - !<!ConstantSchema> &ref_8
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_4
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_11
       type: constant
       value: !<!ConstantValue> 
         value: 2015-07-01-preview
@@ -83,7 +93,7 @@ schemas: !<!Schemas>
           name: ApiVersion-2015-07-01-preview
           description: Api Version (2015-07-01-preview)
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_16
+    - !<!ConstantSchema> &ref_17
       type: constant
       value: !<!ConstantValue> 
         value: '2.0'
@@ -93,7 +103,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_20
+    - !<!ConstantSchema> &ref_21
       type: constant
       value: !<!ConstantValue> 
         value: path1/path2/path3
@@ -103,7 +113,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_24
+    - !<!ConstantSchema> &ref_25
       type: constant
       value: !<!ConstantValue> 
         value: value1&q2=value2&q3=value3
@@ -114,7 +124,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_8
+    - !<!ObjectSchema> &ref_9
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -186,7 +196,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_9
+  - !<!Parameter> &ref_10
     schema: *ref_6
     implementation: Client
     required: true
@@ -216,8 +226,8 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_15
-    schema: *ref_10
+  - !<!Parameter> &ref_16
+    schema: *ref_11
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
     required: true
@@ -296,6 +306,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -319,7 +344,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -350,9 +375,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - *ref_9
+          - *ref_10
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -375,7 +415,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,9 +438,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - *ref_9
+          - *ref_10
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -423,7 +478,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -446,10 +501,25 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - *ref_9
-          - *ref_15
+          - *ref_10
+          - *ref_16
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -472,7 +542,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -495,9 +565,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - *ref_9
+          - *ref_10
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -520,7 +605,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -543,9 +628,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - *ref_9
+          - *ref_10
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -568,7 +668,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -599,7 +699,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_11
+          - !<!Parameter> &ref_12
             schema: *ref_6
             implementation: Method
             required: true
@@ -613,6 +713,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -623,7 +738,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_11
+          - *ref_12
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -636,7 +751,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -659,7 +774,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_12
+          - !<!Parameter> &ref_13
             schema: *ref_6
             implementation: Method
             required: true
@@ -673,6 +788,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -683,7 +813,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_12
+          - *ref_13
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -696,7 +826,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -719,7 +849,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_13
+          - !<!Parameter> &ref_14
             schema: *ref_6
             implementation: Method
             required: true
@@ -733,6 +863,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -743,7 +888,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_13
+          - *ref_14
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -756,7 +901,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -779,7 +924,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_14
+          - !<!Parameter> &ref_15
             schema: *ref_6
             implementation: Method
             required: true
@@ -793,6 +938,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -803,7 +963,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_14
+          - *ref_15
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -816,7 +976,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -847,9 +1007,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - *ref_15
+          - *ref_16
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -872,7 +1047,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -895,9 +1070,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - *ref_15
+          - *ref_16
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -920,7 +1110,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -943,9 +1133,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - *ref_15
+          - *ref_16
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -968,7 +1173,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -991,9 +1196,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - *ref_15
+          - *ref_16
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1016,7 +1236,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -1048,7 +1268,7 @@ operationGroups:
         parameters:
           - *ref_5
           - !<!Parameter> 
-            schema: *ref_16
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1061,6 +1281,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1083,7 +1318,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -1106,7 +1341,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_17
+          - !<!Parameter> &ref_18
             schema: *ref_6
             implementation: Method
             language: !<!Languages> 
@@ -1119,6 +1354,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1129,7 +1379,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_17
+          - *ref_18
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1142,7 +1392,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -1166,7 +1416,7 @@ operationGroups:
         parameters:
           - *ref_5
           - !<!Parameter> 
-            schema: *ref_16
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1179,6 +1429,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1201,7 +1466,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -1225,7 +1490,7 @@ operationGroups:
         parameters:
           - *ref_5
           - !<!Parameter> 
-            schema: *ref_16
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1238,6 +1503,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1260,7 +1540,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -1291,7 +1571,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_18
+          - !<!Parameter> &ref_19
             schema: *ref_6
             implementation: Method
             required: true
@@ -1307,6 +1587,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1317,7 +1612,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_18
+          - *ref_19
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1330,7 +1625,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -1353,7 +1648,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_19
+          - !<!Parameter> &ref_20
             schema: *ref_6
             implementation: Method
             required: true
@@ -1369,6 +1664,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1379,7 +1689,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_19
+          - *ref_20
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1392,7 +1702,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -1416,7 +1726,7 @@ operationGroups:
         parameters:
           - *ref_5
           - !<!Parameter> 
-            schema: *ref_20
+            schema: *ref_21
             implementation: Method
             required: true
             extensions:
@@ -1431,6 +1741,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1453,7 +1778,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -1476,7 +1801,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_21
+          - !<!Parameter> &ref_22
             schema: *ref_6
             implementation: Method
             required: true
@@ -1492,6 +1817,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1502,7 +1842,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_21
+          - *ref_22
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1515,7 +1855,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -1538,7 +1878,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_22
+          - !<!Parameter> &ref_23
             schema: *ref_6
             implementation: Method
             extensions:
@@ -1553,6 +1893,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1563,7 +1918,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_22
+          - *ref_23
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1576,7 +1931,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -1599,7 +1954,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_23
+          - !<!Parameter> &ref_24
             schema: *ref_6
             implementation: Method
             required: true
@@ -1615,6 +1970,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1625,7 +1995,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_23
+          - *ref_24
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1638,7 +2008,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -1662,7 +2032,7 @@ operationGroups:
         parameters:
           - *ref_5
           - !<!Parameter> 
-            schema: *ref_24
+            schema: *ref_25
             implementation: Method
             required: true
             extensions:
@@ -1677,6 +2047,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1699,7 +2084,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -1730,7 +2115,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_26
+          - !<!Parameter> &ref_27
             schema: *ref_6
             implementation: Method
             language: !<!Languages> 
@@ -1741,8 +2126,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_27
-            schema: *ref_25
+          - !<!Parameter> &ref_28
+            schema: *ref_26
             implementation: Method
             language: !<!Languages> 
               default:
@@ -1752,7 +2137,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_6
             implementation: Method
             language: !<!Languages> 
@@ -1765,6 +2150,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1775,9 +2175,9 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_26
           - *ref_27
           - *ref_28
+          - *ref_29
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1790,7 +2190,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -1823,7 +2223,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_29
+          - !<!Parameter> &ref_30
             schema: *ref_6
             implementation: Method
             required: true
@@ -1839,6 +2239,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1846,79 +2261,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpRequest> 
                 path: /azurespecials/customNamedRequestId
-                method: post
-                uri: '{$host}'
-        signatureParameters:
-          - *ref_29
-        responses:
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                headers:
-                  - !<!HttpHeader> 
-                    schema: *ref_6
-                    header: foo-request-id
-                    language:
-                      default:
-                        name: foo-request-id
-                        description: Gets the foo-request-id.
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_8
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        extensions:
-          x-ms-request-id: foo-request-id
-        language: !<!Languages> 
-          default:
-            name: customNamedRequestId
-            description: Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
-        protocol: !<!Protocols> {}
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: 2015-07-01-preview
-        parameters:
-          - *ref_5
-          - !<!Parameter> &ref_30
-            schema: *ref_6
-            implementation: Method
-            required: true
-            extensions:
-              x-ms-client-request-id: true
-              x-ms-parameter-grouping: {}
-            language: !<!Languages> 
-              default:
-                name: foo-client-request-id
-                description: The fooRequestId
-                serializedName: foo-client-request-id
-            protocol: !<!Protocols> 
-              http: !<!HttpParameter> 
-                in: header
-        requests:
-          - !<!Request> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpRequest> 
-                path: /azurespecials/customNamedRequestIdParamGrouping
                 method: post
                 uri: '{$host}'
         signatureParameters:
@@ -1943,7 +2285,95 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        extensions:
+          x-ms-request-id: foo-request-id
+        language: !<!Languages> 
+          default:
+            name: customNamedRequestId
+            description: Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 2015-07-01-preview
+        parameters:
+          - *ref_5
+          - !<!Parameter> &ref_31
+            schema: *ref_6
+            implementation: Method
+            required: true
+            extensions:
+              x-ms-client-request-id: true
+              x-ms-parameter-grouping: {}
+            language: !<!Languages> 
+              default:
+                name: foo-client-request-id
+                description: The fooRequestId
+                serializedName: foo-client-request-id
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: header
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpRequest> 
+                path: /azurespecials/customNamedRequestIdParamGrouping
+                method: post
+                uri: '{$host}'
+        signatureParameters:
+          - *ref_31
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                headers:
+                  - !<!HttpHeader> 
+                    schema: *ref_6
+                    header: foo-request-id
+                    language:
+                      default:
+                        name: foo-request-id
+                        description: Gets the foo-request-id.
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -1968,7 +2398,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_31
+          - !<!Parameter> &ref_32
             schema: *ref_6
             implementation: Method
             required: true
@@ -1984,6 +2414,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1994,7 +2439,7 @@ operationGroups:
                 method: head
                 uri: '{$host}'
         signatureParameters:
-          - *ref_31
+          - *ref_32
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2024,7 +2469,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/azure-special-properties/namer.yaml
+++ b/modelerfour/test/scenarios/azure-special-properties/namer.yaml
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_26
+    - !<!NumberSchema> &ref_27
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -73,6 +73,16 @@ schemas: !<!Schemas>
           name: Constant0
           description: ''
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_9
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_7
       type: constant
       value: !<!ConstantValue> 
@@ -83,34 +93,34 @@ schemas: !<!Schemas>
           name: ApiVersion20150701Preview
           description: Api Version (2015-07-01-preview)
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_17
+    - !<!ConstantSchema> &ref_18
       type: constant
       value: !<!ConstantValue> 
         value: '2.0'
       valueType: *ref_1
       language: !<!Languages> 
         default:
-          name: Constant2
+          name: Constant3
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_21
+    - !<!ConstantSchema> &ref_22
       type: constant
       value: !<!ConstantValue> 
         value: path1/path2/path3
       valueType: *ref_1
       language: !<!Languages> 
         default:
-          name: Constant3
+          name: Constant4
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_25
+    - !<!ConstantSchema> &ref_26
       type: constant
       value: !<!ConstantValue> 
         value: value1&q2=value2&q3=value3
       valueType: *ref_1
       language: !<!Languages> 
         default:
-          name: Constant4
+          name: Constant5
           description: ''
       protocol: !<!Protocols> {}
   groups:
@@ -120,9 +130,9 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_2
           originalParameter:
-            - !<!Parameter> &ref_31
+            - !<!Parameter> &ref_32
               schema: *ref_2
-              groupedBy: !<!Parameter> &ref_32
+              groupedBy: !<!Parameter> &ref_33
                 schema: *ref_3
                 implementation: Method
                 required: true
@@ -158,7 +168,7 @@ schemas: !<!Schemas>
           description: Parameter group
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_10
+    - !<!ObjectSchema> &ref_11
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -230,7 +240,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_11
+  - !<!Parameter> &ref_12
     schema: *ref_2
     implementation: Client
     required: true
@@ -260,7 +270,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_12
+  - !<!Parameter> &ref_13
     schema: *ref_7
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -326,7 +336,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_9
+          - !<!Parameter> &ref_10
             schema: *ref_2
             implementation: Method
             required: true
@@ -340,6 +350,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -350,7 +375,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_9
+          - *ref_10
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -363,7 +388,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -394,9 +419,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_11
+          - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -419,7 +459,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -442,9 +482,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_11
+          - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -467,7 +522,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -490,10 +545,25 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_11
           - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -516,7 +586,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -539,9 +609,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_11
+          - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -564,7 +649,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -587,9 +672,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_11
+          - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -612,7 +712,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -643,7 +743,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_13
+          - !<!Parameter> &ref_14
             schema: *ref_2
             implementation: Method
             required: true
@@ -657,6 +757,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -667,7 +782,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_13
+          - *ref_14
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -680,7 +795,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -703,7 +818,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_14
+          - !<!Parameter> &ref_15
             schema: *ref_2
             implementation: Method
             required: true
@@ -717,6 +832,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -727,7 +857,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_14
+          - *ref_15
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -740,7 +870,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -763,7 +893,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_15
+          - !<!Parameter> &ref_16
             schema: *ref_2
             implementation: Method
             required: true
@@ -777,6 +907,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -787,7 +932,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_15
+          - *ref_16
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -800,7 +945,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -823,7 +968,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_16
+          - !<!Parameter> &ref_17
             schema: *ref_2
             implementation: Method
             required: true
@@ -837,6 +982,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -847,7 +1007,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_16
+          - *ref_17
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -860,7 +1020,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -891,9 +1051,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -916,7 +1091,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -939,9 +1114,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -964,7 +1154,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -987,9 +1177,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1012,7 +1217,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1035,9 +1240,24 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1060,7 +1280,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1092,7 +1312,7 @@ operationGroups:
         parameters:
           - *ref_8
           - !<!Parameter> 
-            schema: *ref_17
+            schema: *ref_18
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1105,6 +1325,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1127,7 +1362,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1150,7 +1385,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_18
+          - !<!Parameter> &ref_19
             schema: *ref_2
             implementation: Method
             language: !<!Languages> 
@@ -1163,6 +1398,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1173,7 +1423,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_18
+          - *ref_19
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1186,7 +1436,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1210,7 +1460,7 @@ operationGroups:
         parameters:
           - *ref_8
           - !<!Parameter> 
-            schema: *ref_17
+            schema: *ref_18
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1223,6 +1473,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1245,7 +1510,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1269,7 +1534,7 @@ operationGroups:
         parameters:
           - *ref_8
           - !<!Parameter> 
-            schema: *ref_17
+            schema: *ref_18
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1282,6 +1547,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1304,7 +1584,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1335,7 +1615,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_19
+          - !<!Parameter> &ref_20
             schema: *ref_2
             implementation: Method
             required: true
@@ -1351,6 +1631,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1361,7 +1656,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_19
+          - *ref_20
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1374,7 +1669,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1397,7 +1692,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_20
+          - !<!Parameter> &ref_21
             schema: *ref_2
             implementation: Method
             required: true
@@ -1413,6 +1708,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1423,7 +1733,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_20
+          - *ref_21
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1436,7 +1746,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1460,7 +1770,7 @@ operationGroups:
         parameters:
           - *ref_8
           - !<!Parameter> 
-            schema: *ref_21
+            schema: *ref_22
             implementation: Method
             required: true
             extensions:
@@ -1475,6 +1785,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1497,7 +1822,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1520,7 +1845,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_22
+          - !<!Parameter> &ref_23
             schema: *ref_2
             implementation: Method
             required: true
@@ -1536,6 +1861,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1546,7 +1886,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_22
+          - *ref_23
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1559,7 +1899,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1582,7 +1922,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_23
+          - !<!Parameter> &ref_24
             schema: *ref_2
             implementation: Method
             extensions:
@@ -1597,6 +1937,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1607,7 +1962,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_23
+          - *ref_24
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1620,7 +1975,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1643,7 +1998,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_24
+          - !<!Parameter> &ref_25
             schema: *ref_2
             implementation: Method
             required: true
@@ -1659,6 +2014,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1669,7 +2039,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_24
+          - *ref_25
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1682,7 +2052,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1706,7 +2076,7 @@ operationGroups:
         parameters:
           - *ref_8
           - !<!Parameter> 
-            schema: *ref_25
+            schema: *ref_26
             implementation: Method
             required: true
             extensions:
@@ -1721,6 +2091,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1743,7 +2128,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1774,7 +2159,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_27
+          - !<!Parameter> &ref_28
             schema: *ref_2
             implementation: Method
             language: !<!Languages> 
@@ -1785,8 +2170,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_28
-            schema: *ref_26
+          - !<!Parameter> &ref_29
+            schema: *ref_27
             implementation: Method
             language: !<!Languages> 
               default:
@@ -1796,7 +2181,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_29
+          - !<!Parameter> &ref_30
             schema: *ref_2
             implementation: Method
             language: !<!Languages> 
@@ -1809,6 +2194,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1819,9 +2219,9 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_27
           - *ref_28
           - *ref_29
+          - *ref_30
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1834,7 +2234,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1867,7 +2267,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_30
+          - !<!Parameter> &ref_31
             schema: *ref_2
             implementation: Method
             required: true
@@ -1883,6 +2283,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1893,7 +2308,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_30
+          - *ref_31
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1914,7 +2329,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -1939,13 +2354,26 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - *ref_31
+          - *ref_32
         requests:
           - !<!Request> 
             parameters:
-              - *ref_32
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_33
             signatureParameters:
-              - *ref_32
+              - *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -1976,7 +2404,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -2001,7 +2429,7 @@ operationGroups:
             version: 2015-07-01-preview
         parameters:
           - *ref_8
-          - !<!Parameter> &ref_33
+          - !<!Parameter> &ref_34
             schema: *ref_2
             implementation: Method
             required: true
@@ -2017,6 +2445,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2027,7 +2470,7 @@ operationGroups:
                 method: head
                 uri: '{$host}'
         signatureParameters:
-          - *ref_33
+          - *ref_34
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2057,7 +2500,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/blob-storage/flattened.yaml
+++ b/modelerfour/test/scenarios/blob-storage/flattened.yaml
@@ -59,7 +59,7 @@ schemas: !<!Schemas>
           name: boolean
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_233
+    - !<!BooleanSchema> &ref_234
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -70,7 +70,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-has-immutability-policy
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_234
+    - !<!BooleanSchema> &ref_235
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -81,7 +81,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-has-legal-hold
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_459
+    - !<!BooleanSchema> &ref_460
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -92,7 +92,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_581
+    - !<!BooleanSchema> &ref_582
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -103,7 +103,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_606
+    - !<!BooleanSchema> &ref_607
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -114,7 +114,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-incremental-copy
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_623
+    - !<!BooleanSchema> &ref_624
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -125,7 +125,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_626
+    - !<!BooleanSchema> &ref_627
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -136,7 +136,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-access-tier-inferred
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_982
+    - !<!BooleanSchema> &ref_983
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -147,7 +147,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1195
+    - !<!BooleanSchema> &ref_1196
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -158,7 +158,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1294
+    - !<!BooleanSchema> &ref_1295
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -169,7 +169,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_766
+    - !<!BooleanSchema> &ref_767
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -180,7 +180,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_863
+    - !<!BooleanSchema> &ref_864
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -191,7 +191,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1315
+    - !<!BooleanSchema> &ref_1316
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -202,7 +202,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1338
+    - !<!BooleanSchema> &ref_1339
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -213,7 +213,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1371
+    - !<!BooleanSchema> &ref_1372
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -224,7 +224,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1016
+    - !<!BooleanSchema> &ref_1017
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -235,7 +235,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1078
+    - !<!BooleanSchema> &ref_1079
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -246,7 +246,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1226
+    - !<!BooleanSchema> &ref_1227
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -257,7 +257,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1263
+    - !<!BooleanSchema> &ref_1264
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -299,7 +299,7 @@ schemas: !<!Schemas>
           name: integer
           description: The maximum amount time that a browser should cache the preflight OPTIONS request.
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_166
+    - !<!NumberSchema> &ref_167
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -319,7 +319,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_200
+    - !<!NumberSchema> &ref_201
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -331,7 +331,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_290
+    - !<!NumberSchema> &ref_291
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -359,7 +359,7 @@ schemas: !<!Schemas>
           name: blobSequenceNumber
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_454
+    - !<!NumberSchema> &ref_455
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -371,7 +371,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_534
+    - !<!NumberSchema> &ref_535
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -383,7 +383,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_543
+    - !<!NumberSchema> &ref_544
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -395,7 +395,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_554
+    - !<!NumberSchema> &ref_555
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -407,7 +407,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-committed-block-count
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_559
+    - !<!NumberSchema> &ref_560
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -419,7 +419,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_568
+    - !<!NumberSchema> &ref_569
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -431,7 +431,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_580
+    - !<!NumberSchema> &ref_581
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -443,7 +443,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-committed-block-count
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_608
+    - !<!NumberSchema> &ref_609
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -455,7 +455,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_616
+    - !<!NumberSchema> &ref_617
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -467,7 +467,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_622
+    - !<!NumberSchema> &ref_623
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -479,7 +479,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-committed-block-count
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_714
+    - !<!NumberSchema> &ref_715
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -491,7 +491,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_744
+    - !<!NumberSchema> &ref_745
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -503,7 +503,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_955
+    - !<!NumberSchema> &ref_956
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -515,7 +515,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_839
+    - !<!NumberSchema> &ref_840
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -527,7 +527,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-lease-time
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1384
+    - !<!NumberSchema> &ref_1385
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -547,7 +547,7 @@ schemas: !<!Schemas>
           name: integer
           description: The block size in bytes.
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_989
+    - !<!NumberSchema> &ref_990
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -559,7 +559,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1041
+    - !<!NumberSchema> &ref_1042
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -571,7 +571,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1074
+    - !<!NumberSchema> &ref_1075
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -583,7 +583,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1094
+    - !<!NumberSchema> &ref_1095
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -623,7 +623,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1112
+    - !<!NumberSchema> &ref_1113
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -635,7 +635,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-content-length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1130
+    - !<!NumberSchema> &ref_1131
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -647,7 +647,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1148
+    - !<!NumberSchema> &ref_1149
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -659,7 +659,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1199
+    - !<!NumberSchema> &ref_1200
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -670,7 +670,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1225
+    - !<!NumberSchema> &ref_1226
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -682,7 +682,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-committed-block-count
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1261
+    - !<!NumberSchema> &ref_1262
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -805,7 +805,7 @@ schemas: !<!Schemas>
           name: StaticWebsite-ErrorDocument404Path
           description: The absolute path of the custom 404 page
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_145
+    - !<!StringSchema> &ref_146
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -816,7 +816,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_146
+    - !<!StringSchema> &ref_147
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -827,7 +827,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_148
+    - !<!StringSchema> &ref_149
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -848,17 +848,6 @@ schemas: !<!Schemas>
           name: StorageError-Message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_151
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_152
       type: string
       apiVersions:
@@ -868,7 +857,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_153
       type: string
@@ -879,7 +868,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_154
       type: string
@@ -890,9 +879,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_159
+    - !<!StringSchema> &ref_155
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -901,7 +890,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_160
       type: string
@@ -912,7 +901,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_161
       type: string
@@ -923,9 +912,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_162
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_163
+    - !<!StringSchema> &ref_164
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -936,7 +936,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_165
+    - !<!StringSchema> &ref_166
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -947,7 +947,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_174
+    - !<!StringSchema> &ref_175
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -958,7 +958,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_175
+    - !<!StringSchema> &ref_176
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1065,7 +1065,7 @@ schemas: !<!Schemas>
           name: KeyInfo-Expiry
           description: The date-time the key expires in ISO 8601 UTC time
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_186
+    - !<!StringSchema> &ref_187
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1076,7 +1076,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_187
+    - !<!StringSchema> &ref_188
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1087,7 +1087,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_188
+    - !<!StringSchema> &ref_189
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1148,7 +1148,7 @@ schemas: !<!Schemas>
           name: UserDelegationKey-Value
           description: The key as a base64 string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_190
+    - !<!StringSchema> &ref_191
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1158,17 +1158,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_192
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_193
       type: string
@@ -1179,7 +1168,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_194
       type: string
@@ -1190,9 +1179,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_195
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_198
+    - !<!StringSchema> &ref_199
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1203,7 +1203,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_201
+    - !<!StringSchema> &ref_202
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1214,17 +1214,6 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_208
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_209
       type: string
       apiVersions:
@@ -1234,7 +1223,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_210
       type: string
@@ -1245,9 +1234,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_211
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_212
+    - !<!StringSchema> &ref_213
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1257,17 +1257,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_218
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_219
       type: string
@@ -1278,7 +1267,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_220
       type: string
@@ -1289,9 +1278,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_222
+    - !<!StringSchema> &ref_221
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1300,7 +1289,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_223
       type: string
@@ -1311,9 +1300,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-error-code
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_224
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-meta
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_227
+    - !<!StringSchema> &ref_228
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1323,17 +1323,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_229
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_230
       type: string
@@ -1344,7 +1333,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_231
       type: string
@@ -1355,9 +1344,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_232
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_235
+    - !<!StringSchema> &ref_236
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1367,17 +1367,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_243
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_244
       type: string
@@ -1388,7 +1377,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_245
       type: string
@@ -1399,7 +1388,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_246
       type: string
@@ -1410,9 +1399,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_247
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_254
+    - !<!StringSchema> &ref_255
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1422,17 +1422,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_256
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_257
       type: string
@@ -1443,7 +1432,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_258
       type: string
@@ -1454,9 +1443,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_259
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_260
+    - !<!StringSchema> &ref_261
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1467,7 +1467,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_266
+    - !<!StringSchema> &ref_267
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1478,7 +1478,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_268
+    - !<!StringSchema> &ref_269
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1489,7 +1489,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_269
+    - !<!StringSchema> &ref_270
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1500,7 +1500,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_270
+    - !<!StringSchema> &ref_271
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1531,7 +1531,7 @@ schemas: !<!Schemas>
           name: AccessPolicy-Permission
           description: the permissions for the acl policy
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_272
+    - !<!StringSchema> &ref_273
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1542,7 +1542,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_281
+    - !<!StringSchema> &ref_282
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1552,17 +1552,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_283
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_284
       type: string
@@ -1573,7 +1562,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_285
       type: string
@@ -1584,9 +1573,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_286
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_287
+    - !<!StringSchema> &ref_288
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1597,7 +1597,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_291
+    - !<!StringSchema> &ref_292
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1607,17 +1607,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_299
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_300
       type: string
@@ -1628,7 +1617,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_301
       type: string
@@ -1639,7 +1628,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_302
       type: string
@@ -1650,9 +1639,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_303
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_304
+    - !<!StringSchema> &ref_305
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1663,7 +1663,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_306
+    - !<!StringSchema> &ref_307
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1673,17 +1673,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_313
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_314
       type: string
@@ -1694,7 +1683,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_315
       type: string
@@ -1705,9 +1694,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_316
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_317
+    - !<!StringSchema> &ref_318
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1718,7 +1718,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_324
+    - !<!StringSchema> &ref_325
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1728,17 +1728,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_326
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_327
       type: string
@@ -1749,7 +1738,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_328
       type: string
@@ -1760,7 +1749,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_329
       type: string
@@ -1771,9 +1760,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_330
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_331
+    - !<!StringSchema> &ref_332
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1784,7 +1784,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_338
+    - !<!StringSchema> &ref_339
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1794,17 +1794,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_340
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_341
       type: string
@@ -1815,7 +1804,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_342
       type: string
@@ -1826,9 +1815,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_343
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_344
+    - !<!StringSchema> &ref_345
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1839,7 +1839,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_346
+    - !<!StringSchema> &ref_347
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1850,7 +1850,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_354
+    - !<!StringSchema> &ref_355
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1861,17 +1861,6 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-lease-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_355
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_356
       type: string
       apiVersions:
@@ -1881,7 +1870,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_357
       type: string
@@ -1892,9 +1881,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_358
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_359
+    - !<!StringSchema> &ref_360
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1905,7 +1905,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_368
+    - !<!StringSchema> &ref_369
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1916,7 +1916,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_369
+    - !<!StringSchema> &ref_370
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1927,7 +1927,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_370
+    - !<!StringSchema> &ref_371
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1938,7 +1938,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_371
+    - !<!StringSchema> &ref_372
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2175,7 +2175,7 @@ schemas: !<!Schemas>
           name: ListBlobsFlatSegmentResponse-NextMarker
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_373
+    - !<!StringSchema> &ref_374
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2186,7 +2186,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_382
+    - !<!StringSchema> &ref_383
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2197,7 +2197,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_383
+    - !<!StringSchema> &ref_384
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2208,7 +2208,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_384
+    - !<!StringSchema> &ref_385
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2299,17 +2299,6 @@ schemas: !<!Schemas>
           name: ListBlobsHierarchySegmentResponse-NextMarker
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_386
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-error-code
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_387
       type: string
       apiVersions:
@@ -2319,7 +2308,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_388
       type: string
@@ -2330,7 +2319,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_389
       type: string
@@ -2341,9 +2330,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_390
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_391
+    - !<!StringSchema> &ref_392
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2354,7 +2354,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_393
+    - !<!StringSchema> &ref_394
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2365,17 +2365,6 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_410
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_411
       type: string
       apiVersions:
@@ -2385,7 +2374,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_412
       type: string
@@ -2396,9 +2385,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_415
+    - !<!StringSchema> &ref_413
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2407,7 +2396,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_416
       type: string
@@ -2418,9 +2407,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_417
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_418
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2451,7 +2451,7 @@ schemas: !<!Schemas>
           name: DataLakeStorageError-error-Message
           description: The service error message.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_418
+    - !<!StringSchema> &ref_419
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2461,17 +2461,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-continuation
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_450
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_451
       type: string
@@ -2482,7 +2471,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_452
       type: string
@@ -2493,7 +2482,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_453
       type: string
@@ -2504,9 +2493,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_456
+    - !<!StringSchema> &ref_454
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2515,7 +2504,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_457
       type: string
@@ -2526,7 +2515,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_458
       type: string
@@ -2537,9 +2526,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_469
+    - !<!StringSchema> &ref_459
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2548,7 +2537,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-continuation
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_470
       type: string
@@ -2559,7 +2548,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-continuation
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_471
       type: string
@@ -2570,7 +2559,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_472
       type: string
@@ -2581,9 +2570,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_474
+    - !<!StringSchema> &ref_473
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2592,7 +2581,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_475
       type: string
@@ -2603,7 +2592,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_476
       type: string
@@ -2614,9 +2603,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_477
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_478
+    - !<!StringSchema> &ref_479
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2626,17 +2626,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_492
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_493
       type: string
@@ -2647,7 +2636,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_494
       type: string
@@ -2658,7 +2647,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_495
       type: string
@@ -2669,7 +2658,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_496
       type: string
@@ -2680,9 +2669,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_497
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_507
+    - !<!StringSchema> &ref_508
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2692,17 +2692,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_509
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-owner
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_510
       type: string
@@ -2713,7 +2702,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-group
+          header: x-ms-owner
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_511
       type: string
@@ -2724,7 +2713,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-permissions
+          header: x-ms-group
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_512
       type: string
@@ -2735,7 +2724,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-acl
+          header: x-ms-permissions
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_513
       type: string
@@ -2746,7 +2735,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-acl
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_514
       type: string
@@ -2757,7 +2746,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_515
       type: string
@@ -2768,7 +2757,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_516
       type: string
@@ -2779,7 +2768,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_517
       type: string
@@ -2790,7 +2779,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_518
       type: string
@@ -2801,9 +2790,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-meta
+          header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_535
+    - !<!StringSchema> &ref_519
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2812,7 +2801,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Type
+          header: x-ms-meta
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_536
       type: string
@@ -2823,7 +2812,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Range
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_537
       type: string
@@ -2834,9 +2823,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Content-Range
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_539
+    - !<!StringSchema> &ref_538
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2845,7 +2834,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Encoding
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_540
       type: string
@@ -2856,7 +2845,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Cache-Control
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_541
       type: string
@@ -2867,7 +2856,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Disposition
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_542
       type: string
@@ -2878,9 +2867,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
+          header: Content-Disposition
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_545
+    - !<!StringSchema> &ref_543
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2889,7 +2878,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-status-description
+          header: Content-Language
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_546
       type: string
@@ -2900,7 +2889,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-id
+          header: x-ms-copy-status-description
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_547
       type: string
@@ -2911,7 +2900,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-progress
+          header: x-ms-copy-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_548
       type: string
@@ -2922,7 +2911,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-source
+          header: x-ms-copy-progress
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_549
       type: string
@@ -2933,7 +2922,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-copy-source
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_550
       type: string
@@ -2944,7 +2933,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_551
       type: string
@@ -2955,7 +2944,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_552
       type: string
@@ -2966,9 +2955,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_553
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: Accept-Ranges
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_555
+    - !<!StringSchema> &ref_556
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2979,7 +2979,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_558
+    - !<!StringSchema> &ref_559
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2989,17 +2989,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-meta
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_560
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_561
       type: string
@@ -3010,7 +2999,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Range
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_562
       type: string
@@ -3021,9 +3010,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Content-Range
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_564
+    - !<!StringSchema> &ref_563
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3032,7 +3021,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Encoding
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_565
       type: string
@@ -3043,7 +3032,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Cache-Control
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_566
       type: string
@@ -3054,7 +3043,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Disposition
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_567
       type: string
@@ -3065,9 +3054,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
+          header: Content-Disposition
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_571
+    - !<!StringSchema> &ref_568
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3076,7 +3065,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-status-description
+          header: Content-Language
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_572
       type: string
@@ -3087,7 +3076,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-id
+          header: x-ms-copy-status-description
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_573
       type: string
@@ -3098,7 +3087,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-progress
+          header: x-ms-copy-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_574
       type: string
@@ -3109,7 +3098,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-source
+          header: x-ms-copy-progress
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_575
       type: string
@@ -3120,7 +3109,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-copy-source
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_576
       type: string
@@ -3131,7 +3120,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_577
       type: string
@@ -3142,7 +3131,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_578
       type: string
@@ -3153,9 +3142,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_579
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: Accept-Ranges
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_582
+    - !<!StringSchema> &ref_583
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3166,7 +3166,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_584
+    - !<!StringSchema> &ref_585
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3177,7 +3177,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_600
+    - !<!StringSchema> &ref_601
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3188,7 +3188,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-meta
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_602
+    - !<!StringSchema> &ref_603
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3199,7 +3199,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-status-description
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_603
+    - !<!StringSchema> &ref_604
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3210,7 +3210,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_604
+    - !<!StringSchema> &ref_605
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3221,7 +3221,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-progress
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_605
+    - !<!StringSchema> &ref_606
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3232,7 +3232,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-source
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_607
+    - !<!StringSchema> &ref_608
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3243,7 +3243,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-destination-snapshot
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_609
+    - !<!StringSchema> &ref_610
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3254,7 +3254,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_610
+    - !<!StringSchema> &ref_611
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3264,17 +3264,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_612
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_613
       type: string
@@ -3285,7 +3274,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Disposition
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_614
       type: string
@@ -3296,7 +3285,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
+          header: Content-Disposition
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_615
       type: string
@@ -3307,9 +3296,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Cache-Control
+          header: Content-Language
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_617
+    - !<!StringSchema> &ref_616
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3318,7 +3307,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_618
       type: string
@@ -3329,7 +3318,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_619
       type: string
@@ -3340,9 +3329,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_620
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_621
+    - !<!StringSchema> &ref_622
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3353,7 +3353,7 @@ schemas: !<!Schemas>
           description: ''
           header: Accept-Ranges
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_624
+    - !<!StringSchema> &ref_625
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3364,7 +3364,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_625
+    - !<!StringSchema> &ref_626
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3375,7 +3375,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-access-tier
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_627
+    - !<!StringSchema> &ref_628
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3386,7 +3386,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-archive-status
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_629
+    - !<!StringSchema> &ref_630
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3396,17 +3396,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_640
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_641
       type: string
@@ -3417,7 +3406,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_642
       type: string
@@ -3428,9 +3417,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_643
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_644
+    - !<!StringSchema> &ref_645
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3441,7 +3441,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_657
+    - !<!StringSchema> &ref_658
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3451,17 +3451,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_659
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_660
       type: string
@@ -3472,7 +3461,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_661
       type: string
@@ -3483,7 +3472,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_662
       type: string
@@ -3494,7 +3483,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_663
       type: string
@@ -3505,9 +3494,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_664
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_673
+    - !<!StringSchema> &ref_674
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3517,17 +3517,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_675
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-owner
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_676
       type: string
@@ -3538,7 +3527,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-group
+          header: x-ms-owner
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_677
       type: string
@@ -3549,7 +3538,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-permissions
+          header: x-ms-group
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_678
       type: string
@@ -3560,7 +3549,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-acl
+          header: x-ms-permissions
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_679
       type: string
@@ -3571,7 +3560,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-acl
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_680
       type: string
@@ -3582,7 +3571,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_681
       type: string
@@ -3593,7 +3582,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_682
       type: string
@@ -3604,7 +3593,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_683
       type: string
@@ -3615,9 +3604,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_684
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_709
+    - !<!StringSchema> &ref_710
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3628,17 +3628,6 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_711
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_712
       type: string
       apiVersions:
@@ -3648,7 +3637,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_713
       type: string
@@ -3659,9 +3648,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_716
+    - !<!StringSchema> &ref_714
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3670,7 +3659,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_717
       type: string
@@ -3681,9 +3670,251 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_718
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_719
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_728
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: ETag
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_979
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-client-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_980
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_981
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_984
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_985
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-error-code
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1189
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: ETag
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1192
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-client-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1193
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1194
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1197
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1198
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-error-code
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1288
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: ETag
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1291
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-client-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1292
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1293
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1296
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1297
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-error-code
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_723
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-client-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_724
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_725
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3703,64 +3934,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_978
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_979
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_980
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_983
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-encryption-key-sha256
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_984
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1188
+    - !<!StringSchema> &ref_743
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3770,193 +3946,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1191
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1192
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1193
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1196
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-encryption-key-sha256
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1197
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1287
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1290
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1291
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1292
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1295
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-encryption-key-sha256
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1296
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_722
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_723
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_724
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_726
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_742
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_745
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_746
       type: string
@@ -3967,7 +3956,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_747
       type: string
@@ -3978,9 +3967,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_748
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_749
+    - !<!StringSchema> &ref_750
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3991,7 +3991,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_760
+    - !<!StringSchema> &ref_761
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4001,17 +4001,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_762
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_763
       type: string
@@ -4022,7 +4011,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_764
       type: string
@@ -4033,9 +4022,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_767
+    - !<!StringSchema> &ref_765
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4044,7 +4033,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_768
       type: string
@@ -4055,9 +4044,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_769
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_777
+    - !<!StringSchema> &ref_778
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4067,17 +4067,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_779
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_780
       type: string
@@ -4088,7 +4077,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_781
       type: string
@@ -4099,7 +4088,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_782
       type: string
@@ -4110,9 +4099,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_783
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_784
+    - !<!StringSchema> &ref_785
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4123,7 +4123,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_792
+    - !<!StringSchema> &ref_793
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4133,17 +4133,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_794
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_795
       type: string
@@ -4154,7 +4143,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_796
       type: string
@@ -4165,9 +4154,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_797
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_798
+    - !<!StringSchema> &ref_799
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4178,7 +4178,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_806
+    - !<!StringSchema> &ref_807
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4188,17 +4188,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_808
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_809
       type: string
@@ -4209,7 +4198,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_810
       type: string
@@ -4220,7 +4209,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_811
       type: string
@@ -4231,9 +4220,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_812
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_813
+    - !<!StringSchema> &ref_814
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4244,7 +4244,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_822
+    - !<!StringSchema> &ref_823
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4254,17 +4254,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_824
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_825
       type: string
@@ -4275,7 +4264,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_826
       type: string
@@ -4286,7 +4275,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-lease-id
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_827
       type: string
@@ -4297,9 +4286,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-lease-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_828
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_829
+    - !<!StringSchema> &ref_830
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4310,7 +4310,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_837
+    - !<!StringSchema> &ref_838
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4320,17 +4320,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_840
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_841
       type: string
@@ -4341,7 +4330,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_842
       type: string
@@ -4352,9 +4341,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_843
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_844
+    - !<!StringSchema> &ref_845
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4364,17 +4364,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_856
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-snapshot
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_857
       type: string
@@ -4385,9 +4374,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: x-ms-snapshot
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_859
+    - !<!StringSchema> &ref_858
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4396,7 +4385,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_860
       type: string
@@ -4407,7 +4396,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_861
       type: string
@@ -4418,9 +4407,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_862
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_864
+    - !<!StringSchema> &ref_865
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4431,7 +4431,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_882
+    - !<!StringSchema> &ref_883
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4441,17 +4441,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_884
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_885
       type: string
@@ -4462,7 +4451,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_886
       type: string
@@ -4473,9 +4462,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_888
+    - !<!StringSchema> &ref_887
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4484,7 +4473,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_889
       type: string
@@ -4495,9 +4484,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-copy-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_890
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_907
+    - !<!StringSchema> &ref_908
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4508,17 +4508,6 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_909
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_910
       type: string
       apiVersions:
@@ -4528,7 +4517,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_911
       type: string
@@ -4539,9 +4528,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_912
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_913
+    - !<!StringSchema> &ref_914
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4552,7 +4552,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_917
+    - !<!StringSchema> &ref_918
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4563,7 +4563,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_920
+    - !<!StringSchema> &ref_921
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4573,17 +4573,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_925
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_926
       type: string
@@ -4594,9 +4583,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_927
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_928
+    - !<!StringSchema> &ref_929
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4606,17 +4606,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_935
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_936
       type: string
@@ -4627,7 +4616,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_937
       type: string
@@ -4638,7 +4627,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_938
       type: string
@@ -4649,7 +4638,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_939
       type: string
@@ -4660,7 +4649,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_940
       type: string
@@ -4671,7 +4660,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_941
       type: string
@@ -4682,7 +4671,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_942
       type: string
@@ -4693,7 +4682,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_943
       type: string
@@ -4704,7 +4693,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_944
       type: string
@@ -4715,9 +4704,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_945
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_946
+    - !<!StringSchema> &ref_947
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4728,7 +4728,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1298
+    - !<!StringSchema> &ref_1299
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4738,17 +4738,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1311
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1312
       type: string
@@ -4759,9 +4748,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1316
+    - !<!StringSchema> &ref_1313
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4770,7 +4759,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1317
       type: string
@@ -4781,9 +4770,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1318
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1229
+    - !<!StringSchema> &ref_1230
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4794,7 +4794,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1335
+    - !<!StringSchema> &ref_1336
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4805,7 +4805,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1336
+    - !<!StringSchema> &ref_1337
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4816,7 +4816,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1339
+    - !<!StringSchema> &ref_1340
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4827,7 +4827,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1340
+    - !<!StringSchema> &ref_1341
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4886,7 +4886,7 @@ schemas: !<!Schemas>
           name: BlockLookupList-LatestItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1363
+    - !<!StringSchema> &ref_1364
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4896,17 +4896,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1367
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1368
       type: string
@@ -4917,7 +4906,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1369
       type: string
@@ -4928,9 +4917,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1372
+    - !<!StringSchema> &ref_1370
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4939,7 +4928,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1373
       type: string
@@ -4950,9 +4939,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1382
+    - !<!StringSchema> &ref_1374
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4961,7 +4950,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1383
       type: string
@@ -4972,9 +4961,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Type
+          header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1385
+    - !<!StringSchema> &ref_1384
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4983,7 +4972,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1386
       type: string
@@ -4994,9 +4983,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1387
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1388
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5017,7 +5017,7 @@ schemas: !<!Schemas>
           name: Block-Name
           description: The base64 encoded block ID.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1389
+    - !<!StringSchema> &ref_1390
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5028,7 +5028,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1008
+    - !<!StringSchema> &ref_1009
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5038,17 +5038,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1012
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1013
       type: string
@@ -5059,7 +5048,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1014
       type: string
@@ -5070,9 +5059,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1017
+    - !<!StringSchema> &ref_1015
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5081,7 +5070,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1018
       type: string
@@ -5092,9 +5081,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1019
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1037
+    - !<!StringSchema> &ref_1038
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5104,17 +5104,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1042
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1043
       type: string
@@ -5125,7 +5114,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1044
       type: string
@@ -5136,9 +5125,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1046
+    - !<!StringSchema> &ref_1045
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5147,7 +5136,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1047
       type: string
@@ -5158,9 +5147,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1075
+    - !<!StringSchema> &ref_1048
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5169,7 +5158,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1076
       type: string
@@ -5180,9 +5169,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1079
+    - !<!StringSchema> &ref_1077
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5191,7 +5180,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1080
       type: string
@@ -5202,9 +5191,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1081
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1093
+    - !<!StringSchema> &ref_1094
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5214,17 +5214,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1095
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1096
       type: string
@@ -5235,7 +5224,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1097
       type: string
@@ -5246,9 +5235,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1099
+    - !<!StringSchema> &ref_1098
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5257,7 +5246,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1100
       type: string
@@ -5268,9 +5257,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1113
+    - !<!StringSchema> &ref_1101
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5279,7 +5268,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1114
       type: string
@@ -5290,7 +5279,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1115
       type: string
@@ -5301,9 +5290,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1116
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1117
+    - !<!StringSchema> &ref_1118
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5314,7 +5314,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1128
+    - !<!StringSchema> &ref_1129
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5324,17 +5324,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1131
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1132
       type: string
@@ -5345,7 +5334,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1133
       type: string
@@ -5356,9 +5345,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1134
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1135
+    - !<!StringSchema> &ref_1136
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5369,7 +5369,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1146
+    - !<!StringSchema> &ref_1147
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5379,17 +5379,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1149
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1150
       type: string
@@ -5400,7 +5389,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1151
       type: string
@@ -5411,9 +5400,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1152
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1153
+    - !<!StringSchema> &ref_1154
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5424,7 +5424,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1162
+    - !<!StringSchema> &ref_1163
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5434,17 +5434,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1164
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1165
       type: string
@@ -5455,7 +5444,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1166
       type: string
@@ -5466,9 +5455,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1168
+    - !<!StringSchema> &ref_1167
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5477,7 +5466,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1169
       type: string
@@ -5488,9 +5477,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-copy-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1170
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1216
+    - !<!StringSchema> &ref_1217
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5500,17 +5500,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1220
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1221
       type: string
@@ -5521,7 +5510,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1222
       type: string
@@ -5532,9 +5521,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1223
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1224
+    - !<!StringSchema> &ref_1225
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5544,17 +5544,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-blob-append-offset
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1227
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1228
       type: string
@@ -5565,9 +5554,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1229
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1253
+    - !<!StringSchema> &ref_1254
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5578,7 +5578,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1257
+    - !<!StringSchema> &ref_1258
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5589,7 +5589,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1258
+    - !<!StringSchema> &ref_1259
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5600,7 +5600,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1260
+    - !<!StringSchema> &ref_1261
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5611,7 +5611,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-append-offset
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1262
+    - !<!StringSchema> &ref_1263
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5622,7 +5622,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1264
+    - !<!StringSchema> &ref_1265
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5832,7 +5832,7 @@ schemas: !<!Schemas>
           name: ArchiveStatus
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_948
+    - !<!ChoiceSchema> &ref_949
       choices:
         - !<!ChoiceValue> 
           value: P4
@@ -5910,7 +5910,7 @@ schemas: !<!Schemas>
           name: PremiumPageBlobAccessTier
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_865
+    - !<!ChoiceSchema> &ref_866
       choices:
         - !<!ChoiceValue> 
           value: High
@@ -6700,7 +6700,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-lease-duration
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_196
+    - !<!SealedChoiceSchema> &ref_197
       choices:
         - !<!ChoiceValue> 
           value: Standard_LRS
@@ -6743,7 +6743,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-sku-name
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_197
+    - !<!SealedChoiceSchema> &ref_198
       choices:
         - !<!ChoiceValue> 
           value: Storage
@@ -6908,7 +6908,7 @@ schemas: !<!Schemas>
           name: PathRenameMode
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_630
+    - !<!SealedChoiceSchema> &ref_631
       choices:
         - !<!ChoiceValue> 
           value: include
@@ -6932,7 +6932,7 @@ schemas: !<!Schemas>
           name: DeleteSnapshotsOptionType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_1374
+    - !<!SealedChoiceSchema> &ref_1375
       choices:
         - !<!ChoiceValue> 
           value: committed
@@ -6963,7 +6963,7 @@ schemas: !<!Schemas>
           name: BlockListType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_1136
+    - !<!SealedChoiceSchema> &ref_1137
       choices:
         - !<!ChoiceValue> 
           value: max
@@ -7024,7 +7024,17 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_155
+    - !<!ConstantSchema> &ref_142
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/xml
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/xml'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_156
       type: constant
       value: !<!ConstantValue> 
         value: stats
@@ -7034,7 +7044,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_164
+    - !<!ConstantSchema> &ref_165
       type: constant
       value: !<!ConstantValue> 
         value: list
@@ -7044,7 +7054,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_167
+    - !<!ConstantSchema> &ref_168
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -7057,7 +7067,7 @@ schemas: !<!Schemas>
           name: ListContainersIncludeType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_176
+    - !<!ConstantSchema> &ref_177
       type: constant
       value: !<!ConstantValue> 
         value: userdelegationkey
@@ -7067,7 +7077,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_191
+    - !<!ConstantSchema> &ref_192
       type: constant
       value: !<!ConstantValue> 
         value: account
@@ -7077,7 +7087,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_199
+    - !<!ConstantSchema> &ref_200
       type: constant
       value: !<!ConstantValue> 
         value: batch
@@ -7087,7 +7097,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_211
+    - !<!ConstantSchema> &ref_212
       type: constant
       value: !<!ConstantValue> 
         value: container
@@ -7097,7 +7107,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_247
+    - !<!ConstantSchema> &ref_248
       type: constant
       value: !<!ConstantValue> 
         value: metadata
@@ -7107,7 +7117,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_261
+    - !<!ConstantSchema> &ref_262
       type: constant
       value: !<!ConstantValue> 
         value: acl
@@ -7117,7 +7127,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_288
+    - !<!ConstantSchema> &ref_289
       type: constant
       value: !<!ConstantValue> 
         value: lease
@@ -7127,7 +7137,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_289
+    - !<!ConstantSchema> &ref_290
       type: constant
       value: !<!ConstantValue> 
         value: acquire
@@ -7137,7 +7147,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_305
+    - !<!ConstantSchema> &ref_306
       type: constant
       value: !<!ConstantValue> 
         value: release
@@ -7147,7 +7157,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_318
+    - !<!ConstantSchema> &ref_319
       type: constant
       value: !<!ConstantValue> 
         value: renew
@@ -7157,7 +7167,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_332
+    - !<!ConstantSchema> &ref_333
       type: constant
       value: !<!ConstantValue> 
         value: break
@@ -7167,7 +7177,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_345
+    - !<!ConstantSchema> &ref_346
       type: constant
       value: !<!ConstantValue> 
         value: change
@@ -7177,7 +7187,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_392
+    - !<!ConstantSchema> &ref_393
       type: constant
       value: !<!ConstantValue> 
         value: directory
@@ -7187,7 +7197,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_477
+    - !<!ConstantSchema> &ref_478
       type: constant
       value: !<!ConstantValue> 
         value: setAccessControl
@@ -7197,7 +7207,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_497
+    - !<!ConstantSchema> &ref_498
       type: constant
       value: !<!ConstantValue> 
         value: getAccessControl
@@ -7207,7 +7217,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_519
+    - !<!ConstantSchema> &ref_520
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -7220,7 +7230,7 @@ schemas: !<!Schemas>
           name: EncryptionAlgorithmType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_947
+    - !<!ConstantSchema> &ref_948
       type: constant
       value: !<!ConstantValue> 
         value: PageBlob
@@ -7230,7 +7240,7 @@ schemas: !<!Schemas>
           name: BlobType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1170
+    - !<!ConstantSchema> &ref_1171
       type: constant
       value: !<!ConstantValue> 
         value: AppendBlob
@@ -7240,7 +7250,7 @@ schemas: !<!Schemas>
           name: BlobType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1265
+    - !<!ConstantSchema> &ref_1266
       type: constant
       value: !<!ConstantValue> 
         value: BlockBlob
@@ -7250,7 +7260,7 @@ schemas: !<!Schemas>
           name: BlobType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_719
+    - !<!ConstantSchema> &ref_720
       type: constant
       value: !<!ConstantValue> 
         value: undelete
@@ -7260,7 +7270,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_845
+    - !<!ConstantSchema> &ref_846
       type: constant
       value: !<!ConstantValue> 
         value: snapshot
@@ -7270,7 +7280,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_890
+    - !<!ConstantSchema> &ref_891
       type: constant
       value: !<!ConstantValue> 
         value: 'true'
@@ -7280,7 +7290,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_914
+    - !<!ConstantSchema> &ref_915
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -7294,7 +7304,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-status
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_918
+    - !<!ConstantSchema> &ref_919
       type: constant
       value: !<!ConstantValue> 
         value: copy
@@ -7304,7 +7314,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_919
+    - !<!ConstantSchema> &ref_920
       type: constant
       value: !<!ConstantValue> 
         value: abort
@@ -7314,7 +7324,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_929
+    - !<!ConstantSchema> &ref_930
       type: constant
       value: !<!ConstantValue> 
         value: tier
@@ -7324,7 +7334,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1297
+    - !<!ConstantSchema> &ref_1298
       type: constant
       value: !<!ConstantValue> 
         value: block
@@ -7334,7 +7344,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1341
+    - !<!ConstantSchema> &ref_1342
       type: constant
       value: !<!ConstantValue> 
         value: blocklist
@@ -7344,7 +7354,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_985
+    - !<!ConstantSchema> &ref_986
       type: constant
       value: !<!ConstantValue> 
         value: page
@@ -7354,7 +7364,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_986
+    - !<!ConstantSchema> &ref_987
       type: constant
       value: !<!ConstantValue> 
         value: update
@@ -7364,7 +7374,7 @@ schemas: !<!Schemas>
           name: PageWriteType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1019
+    - !<!ConstantSchema> &ref_1020
       type: constant
       value: !<!ConstantValue> 
         value: clear
@@ -7374,7 +7384,7 @@ schemas: !<!Schemas>
           name: PageWriteType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1081
+    - !<!ConstantSchema> &ref_1082
       type: constant
       value: !<!ConstantValue> 
         value: pagelist
@@ -7384,7 +7394,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1154
+    - !<!ConstantSchema> &ref_1155
       type: constant
       value: !<!ConstantValue> 
         value: incrementalcopy
@@ -7394,7 +7404,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1198
+    - !<!ConstantSchema> &ref_1199
       type: constant
       value: !<!ConstantValue> 
         value: appendblock
@@ -7422,7 +7432,7 @@ schemas: !<!Schemas>
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
   binaries:
-    - !<!BinarySchema> &ref_202
+    - !<!BinarySchema> &ref_203
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7432,7 +7442,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_1266
+    - !<!BinarySchema> &ref_1267
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7442,7 +7452,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_1299
+    - !<!BinarySchema> &ref_1300
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7452,7 +7462,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_990
+    - !<!BinarySchema> &ref_991
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7462,7 +7472,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_1200
+    - !<!BinarySchema> &ref_1201
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7484,7 +7494,7 @@ schemas: !<!Schemas>
           name: BlobProperties-Content-MD5
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_538
+    - !<!ByteArraySchema> &ref_539
       type: byte-array
       format: byte
       apiVersions:
@@ -7496,7 +7506,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_556
+    - !<!ByteArraySchema> &ref_557
       type: byte-array
       format: byte
       apiVersions:
@@ -7508,7 +7518,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-content-md5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_563
+    - !<!ByteArraySchema> &ref_564
       type: byte-array
       format: byte
       apiVersions:
@@ -7520,7 +7530,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_569
+    - !<!ByteArraySchema> &ref_570
       type: byte-array
       format: byte
       apiVersions:
@@ -7532,7 +7542,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_583
+    - !<!ByteArraySchema> &ref_584
       type: byte-array
       format: byte
       apiVersions:
@@ -7544,7 +7554,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-content-md5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_611
+    - !<!ByteArraySchema> &ref_612
       type: byte-array
       format: byte
       apiVersions:
@@ -7556,7 +7566,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_728
+    - !<!ByteArraySchema> &ref_729
       type: byte-array
       format: byte
       apiVersions:
@@ -7567,7 +7577,7 @@ schemas: !<!Schemas>
           name: components·16jr1zi·parameters·blobcontentmd5·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_977
+    - !<!ByteArraySchema> &ref_978
       type: byte-array
       format: byte
       apiVersions:
@@ -7579,7 +7589,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1190
+    - !<!ByteArraySchema> &ref_1191
       type: byte-array
       format: byte
       apiVersions:
@@ -7591,7 +7601,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_987
+    - !<!ByteArraySchema> &ref_988
       type: byte-array
       format: byte
       apiVersions:
@@ -7602,7 +7612,7 @@ schemas: !<!Schemas>
           name: components·18jrsfm·parameters·contentmd5·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1289
+    - !<!ByteArraySchema> &ref_1290
       type: byte-array
       format: byte
       apiVersions:
@@ -7614,7 +7624,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_891
+    - !<!ByteArraySchema> &ref_892
       type: byte-array
       format: byte
       apiVersions:
@@ -7625,7 +7635,7 @@ schemas: !<!Schemas>
           name: components·1t0oq3p·parameters·sourcecontentmd5·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_915
+    - !<!ByteArraySchema> &ref_916
       type: byte-array
       format: byte
       apiVersions:
@@ -7637,7 +7647,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_916
+    - !<!ByteArraySchema> &ref_917
       type: byte-array
       format: byte
       apiVersions:
@@ -7649,7 +7659,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_988
+    - !<!ByteArraySchema> &ref_989
       type: byte-array
       format: byte
       apiVersions:
@@ -7660,7 +7670,7 @@ schemas: !<!Schemas>
           name: components·rar3zb·parameters·contentcrc64·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1310
+    - !<!ByteArraySchema> &ref_1311
       type: byte-array
       format: byte
       apiVersions:
@@ -7672,7 +7682,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1314
+    - !<!ByteArraySchema> &ref_1315
       type: byte-array
       format: byte
       apiVersions:
@@ -7684,7 +7694,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1048
+    - !<!ByteArraySchema> &ref_1049
       type: byte-array
       format: byte
       apiVersions:
@@ -7695,7 +7705,7 @@ schemas: !<!Schemas>
           name: components·1rd7mnm·parameters·sourcecontentcrc64·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1333
+    - !<!ByteArraySchema> &ref_1334
       type: byte-array
       format: byte
       apiVersions:
@@ -7707,7 +7717,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1334
+    - !<!ByteArraySchema> &ref_1335
       type: byte-array
       format: byte
       apiVersions:
@@ -7719,7 +7729,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1365
+    - !<!ByteArraySchema> &ref_1366
       type: byte-array
       format: byte
       apiVersions:
@@ -7731,7 +7741,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1366
+    - !<!ByteArraySchema> &ref_1367
       type: byte-array
       format: byte
       apiVersions:
@@ -7743,7 +7753,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1010
+    - !<!ByteArraySchema> &ref_1011
       type: byte-array
       format: byte
       apiVersions:
@@ -7755,7 +7765,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1011
+    - !<!ByteArraySchema> &ref_1012
       type: byte-array
       format: byte
       apiVersions:
@@ -7767,7 +7777,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1039
+    - !<!ByteArraySchema> &ref_1040
       type: byte-array
       format: byte
       apiVersions:
@@ -7779,7 +7789,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1040
+    - !<!ByteArraySchema> &ref_1041
       type: byte-array
       format: byte
       apiVersions:
@@ -7791,7 +7801,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1072
+    - !<!ByteArraySchema> &ref_1073
       type: byte-array
       format: byte
       apiVersions:
@@ -7803,7 +7813,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1073
+    - !<!ByteArraySchema> &ref_1074
       type: byte-array
       format: byte
       apiVersions:
@@ -7815,7 +7825,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1218
+    - !<!ByteArraySchema> &ref_1219
       type: byte-array
       format: byte
       apiVersions:
@@ -7827,7 +7837,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1219
+    - !<!ByteArraySchema> &ref_1220
       type: byte-array
       format: byte
       apiVersions:
@@ -7839,7 +7849,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1255
+    - !<!ByteArraySchema> &ref_1256
       type: byte-array
       format: byte
       apiVersions:
@@ -7851,7 +7861,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1256
+    - !<!ByteArraySchema> &ref_1257
       type: byte-array
       format: byte
       apiVersions:
@@ -7864,7 +7874,7 @@ schemas: !<!Schemas>
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
   dateTimes:
-    - !<!DateTimeSchema> &ref_162
+    - !<!DateTimeSchema> &ref_163
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7898,7 +7908,7 @@ schemas: !<!Schemas>
           name: ContainerProperties-Last-Modified
           description: ''
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_189
+    - !<!DateTimeSchema> &ref_190
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7932,7 +7942,7 @@ schemas: !<!Schemas>
           name: UserDelegationKey-SignedExpiry
           description: The date-time the key expires
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_195
+    - !<!DateTimeSchema> &ref_196
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7944,7 +7954,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_217
+    - !<!DateTimeSchema> &ref_218
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7956,7 +7966,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_221
+    - !<!DateTimeSchema> &ref_222
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7968,7 +7978,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_228
+    - !<!DateTimeSchema> &ref_229
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7980,7 +7990,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_232
+    - !<!DateTimeSchema> &ref_233
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7992,7 +8002,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_237
+    - !<!DateTimeSchema> &ref_238
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8004,7 +8014,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_255
+    - !<!DateTimeSchema> &ref_256
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8016,7 +8026,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_259
+    - !<!DateTimeSchema> &ref_260
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8028,7 +8038,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_267
+    - !<!DateTimeSchema> &ref_268
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8040,7 +8050,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_271
+    - !<!DateTimeSchema> &ref_272
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8074,7 +8084,7 @@ schemas: !<!Schemas>
           name: AccessPolicy-Expiry
           description: the date-time the policy expires
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_282
+    - !<!DateTimeSchema> &ref_283
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8086,7 +8096,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_286
+    - !<!DateTimeSchema> &ref_287
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8098,7 +8108,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_298
+    - !<!DateTimeSchema> &ref_299
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8110,7 +8120,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_303
+    - !<!DateTimeSchema> &ref_304
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8122,7 +8132,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_312
+    - !<!DateTimeSchema> &ref_313
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8134,7 +8144,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_316
+    - !<!DateTimeSchema> &ref_317
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8146,7 +8156,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_325
+    - !<!DateTimeSchema> &ref_326
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8158,7 +8168,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_330
+    - !<!DateTimeSchema> &ref_331
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8170,7 +8180,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_339
+    - !<!DateTimeSchema> &ref_340
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8182,7 +8192,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_343
+    - !<!DateTimeSchema> &ref_344
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8194,7 +8204,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_353
+    - !<!DateTimeSchema> &ref_354
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8206,7 +8216,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_358
+    - !<!DateTimeSchema> &ref_359
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8218,7 +8228,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_372
+    - !<!DateTimeSchema> &ref_373
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8285,7 +8295,7 @@ schemas: !<!Schemas>
           name: BlobProperties-AccessTierChangeTime
           description: ''
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_385
+    - !<!DateTimeSchema> &ref_386
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8297,7 +8307,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_390
+    - !<!DateTimeSchema> &ref_391
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8309,7 +8319,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_409
+    - !<!DateTimeSchema> &ref_410
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8321,7 +8331,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_413
+    - !<!DateTimeSchema> &ref_414
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8333,7 +8343,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_427
+    - !<!DateTimeSchema> &ref_428
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8345,7 +8355,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_455
+    - !<!DateTimeSchema> &ref_456
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8357,19 +8367,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_473
-      type: date-time
-      format: date-time-rfc1123
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: date-time
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_490
+    - !<!DateTimeSchema> &ref_474
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8391,9 +8389,21 @@ schemas: !<!Schemas>
         default:
           name: date-time
           description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!DateTimeSchema> &ref_492
+      type: date-time
+      format: date-time-rfc1123
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: date-time
+          description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_506
+    - !<!DateTimeSchema> &ref_507
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8405,7 +8415,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_508
+    - !<!DateTimeSchema> &ref_509
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8417,7 +8427,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_533
+    - !<!DateTimeSchema> &ref_534
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8429,7 +8439,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_544
+    - !<!DateTimeSchema> &ref_545
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8441,7 +8451,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-completion-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_553
+    - !<!DateTimeSchema> &ref_554
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8453,7 +8463,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_557
+    - !<!DateTimeSchema> &ref_558
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8465,7 +8475,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_570
+    - !<!DateTimeSchema> &ref_571
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8477,7 +8487,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-completion-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_579
+    - !<!DateTimeSchema> &ref_580
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8488,18 +8498,6 @@ schemas: !<!Schemas>
           name: date-time
           description: ''
           header: Date
-      protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_598
-      type: date-time
-      format: date-time-rfc1123
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: date-time
-          description: ''
-          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!DateTimeSchema> &ref_599
       type: date-time
@@ -8511,9 +8509,21 @@ schemas: !<!Schemas>
         default:
           name: date-time
           description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!DateTimeSchema> &ref_600
+      type: date-time
+      format: date-time-rfc1123
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: date-time
+          description: ''
           header: x-ms-creation-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_601
+    - !<!DateTimeSchema> &ref_602
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8525,7 +8535,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-completion-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_620
+    - !<!DateTimeSchema> &ref_621
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8537,7 +8547,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_628
+    - !<!DateTimeSchema> &ref_629
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8549,7 +8559,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-access-tier-change-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_643
+    - !<!DateTimeSchema> &ref_644
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8561,7 +8571,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_656
+    - !<!DateTimeSchema> &ref_657
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8573,7 +8583,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_658
+    - !<!DateTimeSchema> &ref_659
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8585,7 +8595,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_672
+    - !<!DateTimeSchema> &ref_673
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8597,7 +8607,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_674
+    - !<!DateTimeSchema> &ref_675
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8609,7 +8619,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_710
+    - !<!DateTimeSchema> &ref_711
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8621,7 +8631,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_715
+    - !<!DateTimeSchema> &ref_716
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8633,7 +8643,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_976
+    - !<!DateTimeSchema> &ref_977
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8645,7 +8655,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_981
+    - !<!DateTimeSchema> &ref_982
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8657,7 +8667,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1189
+    - !<!DateTimeSchema> &ref_1190
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8669,7 +8679,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1194
+    - !<!DateTimeSchema> &ref_1195
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8681,7 +8691,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1288
+    - !<!DateTimeSchema> &ref_1289
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8693,7 +8703,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1293
+    - !<!DateTimeSchema> &ref_1294
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8705,7 +8715,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_725
+    - !<!DateTimeSchema> &ref_726
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8717,7 +8727,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_743
+    - !<!DateTimeSchema> &ref_744
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8729,7 +8739,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_748
+    - !<!DateTimeSchema> &ref_749
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8741,7 +8751,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_761
+    - !<!DateTimeSchema> &ref_762
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8753,7 +8763,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_765
+    - !<!DateTimeSchema> &ref_766
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8765,7 +8775,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_778
+    - !<!DateTimeSchema> &ref_779
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8777,7 +8787,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_783
+    - !<!DateTimeSchema> &ref_784
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8789,7 +8799,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_793
+    - !<!DateTimeSchema> &ref_794
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8801,7 +8811,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_797
+    - !<!DateTimeSchema> &ref_798
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8813,7 +8823,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_807
+    - !<!DateTimeSchema> &ref_808
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8825,7 +8835,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_812
+    - !<!DateTimeSchema> &ref_813
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8837,7 +8847,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_823
+    - !<!DateTimeSchema> &ref_824
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8849,7 +8859,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_828
+    - !<!DateTimeSchema> &ref_829
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8861,7 +8871,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_838
+    - !<!DateTimeSchema> &ref_839
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8873,7 +8883,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_843
+    - !<!DateTimeSchema> &ref_844
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8885,7 +8895,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_858
+    - !<!DateTimeSchema> &ref_859
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8897,7 +8907,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_862
+    - !<!DateTimeSchema> &ref_863
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8909,7 +8919,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_883
+    - !<!DateTimeSchema> &ref_884
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8921,7 +8931,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_887
+    - !<!DateTimeSchema> &ref_888
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8933,7 +8943,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_908
+    - !<!DateTimeSchema> &ref_909
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8945,7 +8955,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_912
+    - !<!DateTimeSchema> &ref_913
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8957,7 +8967,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_927
+    - !<!DateTimeSchema> &ref_928
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8969,7 +8979,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_945
+    - !<!DateTimeSchema> &ref_946
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8981,7 +8991,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1313
+    - !<!DateTimeSchema> &ref_1314
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8993,7 +9003,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1337
+    - !<!DateTimeSchema> &ref_1338
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9005,7 +9015,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1364
+    - !<!DateTimeSchema> &ref_1365
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9017,7 +9027,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1370
+    - !<!DateTimeSchema> &ref_1371
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9029,7 +9039,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1381
+    - !<!DateTimeSchema> &ref_1382
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9041,7 +9051,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1388
+    - !<!DateTimeSchema> &ref_1389
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9053,7 +9063,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1009
+    - !<!DateTimeSchema> &ref_1010
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9065,7 +9075,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1015
+    - !<!DateTimeSchema> &ref_1016
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9077,7 +9087,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1038
+    - !<!DateTimeSchema> &ref_1039
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9089,7 +9099,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1045
+    - !<!DateTimeSchema> &ref_1046
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9101,7 +9111,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1071
+    - !<!DateTimeSchema> &ref_1072
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9113,7 +9123,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1077
+    - !<!DateTimeSchema> &ref_1078
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9125,7 +9135,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1092
+    - !<!DateTimeSchema> &ref_1093
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9137,7 +9147,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1098
+    - !<!DateTimeSchema> &ref_1099
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9149,7 +9159,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1111
+    - !<!DateTimeSchema> &ref_1112
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9161,7 +9171,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1116
+    - !<!DateTimeSchema> &ref_1117
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9173,7 +9183,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1129
+    - !<!DateTimeSchema> &ref_1130
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9185,7 +9195,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1134
+    - !<!DateTimeSchema> &ref_1135
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9197,7 +9207,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1147
+    - !<!DateTimeSchema> &ref_1148
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9209,7 +9219,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1152
+    - !<!DateTimeSchema> &ref_1153
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9221,7 +9231,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1163
+    - !<!DateTimeSchema> &ref_1164
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9233,7 +9243,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1167
+    - !<!DateTimeSchema> &ref_1168
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9245,7 +9255,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1217
+    - !<!DateTimeSchema> &ref_1218
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9257,7 +9267,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1223
+    - !<!DateTimeSchema> &ref_1224
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9269,7 +9279,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1254
+    - !<!DateTimeSchema> &ref_1255
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9281,7 +9291,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1259
+    - !<!DateTimeSchema> &ref_1260
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9294,7 +9304,7 @@ schemas: !<!Schemas>
           header: Date
       protocol: !<!Protocols> {}
   uris:
-    - !<!UriSchema> &ref_866
+    - !<!UriSchema> &ref_867
       type: uri
       apiVersions:
         - !<!ApiVersion> 
@@ -9653,7 +9663,7 @@ schemas: !<!Schemas>
     - *ref_13
     - *ref_24
     - *ref_25
-    - !<!ObjectSchema> &ref_147
+    - !<!ObjectSchema> &ref_148
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -9677,7 +9687,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_158
+    - !<!ObjectSchema> &ref_159
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -9737,7 +9747,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_29
-    - !<!ObjectSchema> &ref_173
+    - !<!ObjectSchema> &ref_174
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -9966,13 +9976,13 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_44
     - *ref_45
-    - !<!ObjectSchema> &ref_177
+    - !<!ObjectSchema> &ref_178
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
       properties:
-        - !<!Property> &ref_179
+        - !<!Property> &ref_180
           schema: *ref_46
           required: true
           serializedName: Start
@@ -9981,7 +9991,7 @@ schemas: !<!Schemas>
               name: Start
               description: The date-time the key is active in ISO 8601 UTC time
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_180
+        - !<!Property> &ref_181
           schema: *ref_47
           required: true
           serializedName: Expiry
@@ -10000,7 +10010,7 @@ schemas: !<!Schemas>
           description: Key information
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_185
+    - !<!ObjectSchema> &ref_186
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -10164,7 +10174,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_59
-    - !<!ObjectSchema> &ref_367
+    - !<!ObjectSchema> &ref_368
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -10693,7 +10703,7 @@ schemas: !<!Schemas>
     - *ref_94
     - *ref_95
     - *ref_96
-    - !<!ObjectSchema> &ref_381
+    - !<!ObjectSchema> &ref_382
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -10872,7 +10882,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_104
     - *ref_105
-    - !<!ObjectSchema> &ref_414
+    - !<!ObjectSchema> &ref_415
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -10928,7 +10938,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_108
-    - !<!ObjectSchema> &ref_1342
+    - !<!ObjectSchema> &ref_1343
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -11004,7 +11014,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_1380
+    - !<!ObjectSchema> &ref_1381
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -11100,7 +11110,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_114
-    - !<!ObjectSchema> &ref_1091
+    - !<!ObjectSchema> &ref_1092
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -11235,7 +11245,7 @@ schemas: !<!Schemas>
   arrays:
     - *ref_119
     - *ref_120
-    - !<!ArraySchema> &ref_265
+    - !<!ArraySchema> &ref_266
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -11252,7 +11262,7 @@ schemas: !<!Schemas>
           name: SignedIdentifiers
           description: a collection of signed identifiers
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_360
+    - !<!ArraySchema> &ref_361
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -11307,7 +11317,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: header
-  - !<!Parameter> &ref_419
+  - !<!Parameter> &ref_420
     schema: *ref_134
     implementation: Client
     extensions:
@@ -11354,7 +11364,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_143
+          - !<!Parameter> &ref_144
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -11368,7 +11378,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_139
-          - !<!Parameter> &ref_144
+          - !<!Parameter> &ref_145
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -11382,7 +11392,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_142
+              - !<!Parameter> &ref_143
                 schema: *ref_141
                 implementation: Method
                 required: true
@@ -11394,8 +11404,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_142
+              - *ref_143
             language: !<!Languages> 
               default:
                 name: ''
@@ -11409,8 +11432,8 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_143
           - *ref_144
+          - *ref_145
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -11428,14 +11451,14 @@ operationGroups:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_145
+                    schema: *ref_146
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_146
+                    schema: *ref_147
                     header: x-ms-version
                     language:
                       default:
@@ -11445,7 +11468,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -11454,7 +11477,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_148
+                    schema: *ref_149
                     header: x-ms-error-code
                     language:
                       default:
@@ -11500,7 +11523,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_149
+          - !<!Parameter> &ref_150
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -11514,7 +11537,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_139
-          - !<!Parameter> &ref_150
+          - !<!Parameter> &ref_151
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -11527,6 +11550,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11537,8 +11575,8 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_149
           - *ref_150
+          - *ref_151
         responses:
           - !<!SchemaResponse> 
             schema: *ref_141
@@ -11550,21 +11588,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_151
+                    schema: *ref_152
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_152
+                    schema: *ref_153
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_153
+                    schema: *ref_154
                     header: x-ms-version
                     language:
                       default:
@@ -11577,7 +11615,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -11586,7 +11624,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_154
+                    schema: *ref_155
                     header: x-ms-error-code
                     language:
                       default:
@@ -11621,7 +11659,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_155
+            schema: *ref_156
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -11632,7 +11670,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_156
+          - !<!Parameter> &ref_157
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -11646,7 +11684,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_139
-          - !<!Parameter> &ref_157
+          - !<!Parameter> &ref_158
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -11659,6 +11697,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11669,11 +11722,11 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_156
           - *ref_157
+          - *ref_158
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_158
+            schema: *ref_159
             language: !<!Languages> 
               default:
                 name: ''
@@ -11682,28 +11735,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_159
+                    schema: *ref_160
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_160
+                    schema: *ref_161
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_161
+                    schema: *ref_162
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_162
+                    schema: *ref_163
                     header: Date
                     language:
                       default:
@@ -11716,7 +11769,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -11725,7 +11778,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_163
+                    schema: *ref_164
                     header: x-ms-error-code
                     language:
                       default:
@@ -11748,7 +11801,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_164
+            schema: *ref_165
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -11759,8 +11812,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_168
-            schema: *ref_165
+          - !<!Parameter> &ref_169
+            schema: *ref_166
             implementation: Method
             language: !<!Languages> 
               default:
@@ -11770,8 +11823,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_169
-            schema: *ref_165
+          - !<!Parameter> &ref_170
+            schema: *ref_166
             implementation: Method
             language: !<!Languages> 
               default:
@@ -11784,8 +11837,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_170
-            schema: *ref_166
+          - !<!Parameter> &ref_171
+            schema: *ref_167
             implementation: Method
             language: !<!Languages> 
               default:
@@ -11799,7 +11852,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_167
+            schema: *ref_168
             implementation: Method
             language: !<!Languages> 
               default:
@@ -11809,7 +11862,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_171
+          - !<!Parameter> &ref_172
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -11823,7 +11876,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_139
-          - !<!Parameter> &ref_172
+          - !<!Parameter> &ref_173
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -11836,6 +11889,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11846,14 +11914,14 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_168
           - *ref_169
           - *ref_170
           - *ref_171
           - *ref_172
+          - *ref_173
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_173
+            schema: *ref_174
             language: !<!Languages> 
               default:
                 name: ''
@@ -11862,21 +11930,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_165
+                    schema: *ref_166
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_174
+                    schema: *ref_175
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_175
+                    schema: *ref_176
                     header: x-ms-version
                     language:
                       default:
@@ -11889,7 +11957,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -11938,7 +12006,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_176
+            schema: *ref_177
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -11949,7 +12017,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_183
+          - !<!Parameter> &ref_184
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -11963,7 +12031,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_139
-          - !<!Parameter> &ref_184
+          - !<!Parameter> &ref_185
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -11977,8 +12045,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_178
-                schema: *ref_177
+              - !<!Parameter> &ref_179
+                schema: *ref_178
                 flattened: true
                 implementation: Method
                 required: true
@@ -11990,33 +12058,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - !<!VirtualParameter> &ref_181
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_182
                 schema: *ref_46
                 implementation: Method
-                originalParameter: *ref_178
+                originalParameter: *ref_179
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_179
+                targetProperty: *ref_180
                 language: !<!Languages> 
                   default:
                     name: Start
                     description: The date-time the key is active in ISO 8601 UTC time
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_182
+              - !<!VirtualParameter> &ref_183
                 schema: *ref_47
                 implementation: Method
-                originalParameter: *ref_178
+                originalParameter: *ref_179
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_180
+                targetProperty: *ref_181
                 language: !<!Languages> 
                   default:
                     name: Expiry
                     description: The date-time the key expires in ISO 8601 UTC time
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_181
               - *ref_182
+              - *ref_183
             language: !<!Languages> 
               default:
                 name: ''
@@ -12030,11 +12111,11 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_183
           - *ref_184
+          - *ref_185
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_185
+            schema: *ref_186
             language: !<!Languages> 
               default:
                 name: ''
@@ -12043,28 +12124,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_186
+                    schema: *ref_187
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_187
+                    schema: *ref_188
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_188
+                    schema: *ref_189
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_189
+                    schema: *ref_190
                     header: Date
                     language:
                       default:
@@ -12077,7 +12158,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -12086,7 +12167,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_190
+                    schema: *ref_191
                     header: x-ms-error-code
                     language:
                       default:
@@ -12109,7 +12190,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_191
+            schema: *ref_192
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12135,6 +12216,21 @@ operationGroups:
           - *ref_139
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12155,42 +12251,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_192
+                    schema: *ref_193
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_193
+                    schema: *ref_194
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_194
+                    schema: *ref_195
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_195
+                    schema: *ref_196
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_196
+                    schema: *ref_197
                     header: x-ms-sku-name
                     language:
                       default:
                         name: SkuName
                         description: Identifies the sku name of the account
                   - !<!HttpHeader> 
-                    schema: *ref_197
+                    schema: *ref_198
                     header: x-ms-account-kind
                     language:
                       default:
@@ -12200,7 +12296,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -12209,7 +12305,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_198
+                    schema: *ref_199
                     header: x-ms-error-code
                     language:
                       default:
@@ -12232,7 +12328,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_199
+            schema: *ref_200
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12243,8 +12339,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_204
-            schema: *ref_200
+          - !<!Parameter> &ref_205
+            schema: *ref_201
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12255,8 +12351,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_205
-            schema: *ref_201
+          - !<!Parameter> &ref_206
+            schema: *ref_202
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12267,7 +12363,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_206
+          - !<!Parameter> &ref_207
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -12281,7 +12377,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_139
-          - !<!Parameter> &ref_207
+          - !<!Parameter> &ref_208
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -12295,8 +12391,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_203
-                schema: *ref_202
+              - !<!Parameter> &ref_204
+                schema: *ref_203
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -12307,8 +12403,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_203
+              - *ref_204
             language: !<!Languages> 
               default:
                 name: ''
@@ -12322,10 +12431,10 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_204
           - *ref_205
           - *ref_206
           - *ref_207
+          - *ref_208
         responses:
           - !<!BinaryResponse> 
             binary: true
@@ -12337,21 +12446,21 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_201
+                    schema: *ref_202
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The media type of the body of the response. For batch requests, this is multipart/mixed; boundary=batchresponse_GUID'
                   - !<!HttpHeader> 
-                    schema: *ref_208
+                    schema: *ref_209
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_209
+                    schema: *ref_210
                     header: x-ms-version
                     language:
                       default:
@@ -12364,7 +12473,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -12373,7 +12482,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_210
+                    schema: *ref_211
                     header: x-ms-error-code
                     language:
                       default:
@@ -12404,7 +12513,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_211
+            schema: *ref_212
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12415,7 +12524,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_213
+          - !<!Parameter> &ref_214
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -12428,8 +12537,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_214
-            schema: *ref_212
+          - !<!Parameter> &ref_215
+            schema: *ref_213
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -12444,7 +12553,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_215
+          - !<!Parameter> &ref_216
             schema: *ref_40
             implementation: Method
             language: !<!Languages> 
@@ -12456,7 +12565,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_216
+          - !<!Parameter> &ref_217
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -12469,6 +12578,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12479,10 +12603,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_213
           - *ref_214
           - *ref_215
           - *ref_216
+          - *ref_217
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -12493,42 +12617,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_212
+                    schema: *ref_213
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_217
+                    schema: *ref_218
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_218
+                    schema: *ref_219
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_219
+                    schema: *ref_220
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_220
+                    schema: *ref_221
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_221
+                    schema: *ref_222
                     header: Date
                     language:
                       default:
@@ -12538,7 +12662,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -12547,7 +12671,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_222
+                    schema: *ref_223
                     header: x-ms-error-code
                     language:
                       default:
@@ -12570,7 +12694,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_211
+            schema: *ref_212
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12581,7 +12705,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_224
+          - !<!Parameter> &ref_225
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -12594,11 +12718,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_225
-            schema: *ref_223
+          - !<!Parameter> &ref_226
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_236
+              x-ms-parameter-grouping: &ref_237
                 name: lease-access-conditions
             language: !<!Languages> 
               default:
@@ -12609,7 +12733,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_226
+          - !<!Parameter> &ref_227
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -12622,6 +12746,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12632,9 +12771,9 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_224
           - *ref_225
           - *ref_226
+          - *ref_227
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -12645,21 +12784,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_223
+                    schema: *ref_224
                     header: x-ms-meta
                     language:
                       default:
                         name: Metadata
                         description: ''
                   - !<!HttpHeader> 
-                    schema: *ref_227
+                    schema: *ref_228
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_228
+                    schema: *ref_229
                     header: Last-Modified
                     language:
                       default:
@@ -12687,28 +12826,28 @@ operationGroups:
                         name: LeaseStatus
                         description: The current lease status of the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_229
+                    schema: *ref_230
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_230
+                    schema: *ref_231
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_231
+                    schema: *ref_232
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_232
+                    schema: *ref_233
                     header: Date
                     language:
                       default:
@@ -12722,14 +12861,14 @@ operationGroups:
                         name: BlobPublicAccess
                         description: Indicated whether data in the container may be accessed publicly and the level of access
                   - !<!HttpHeader> 
-                    schema: *ref_233
+                    schema: *ref_234
                     header: x-ms-has-immutability-policy
                     language:
                       default:
                         name: HasImmutabilityPolicy
                         description: Indicates whether the container has an immutability policy set on it.
                   - !<!HttpHeader> 
-                    schema: *ref_234
+                    schema: *ref_235
                     header: x-ms-has-legal-hold
                     language:
                       default:
@@ -12739,7 +12878,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -12748,7 +12887,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_235
+                    schema: *ref_236
                     header: x-ms-error-code
                     language:
                       default:
@@ -12771,7 +12910,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_211
+            schema: *ref_212
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12782,7 +12921,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_238
+          - !<!Parameter> &ref_239
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -12795,11 +12934,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_239
-            schema: *ref_223
+          - !<!Parameter> &ref_240
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -12808,11 +12947,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_240
-            schema: *ref_237
+          - !<!Parameter> &ref_241
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_248
+              x-ms-parameter-grouping: &ref_249
                 name: modified-access-conditions
             language: !<!Languages> 
               default:
@@ -12822,11 +12961,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_241
-            schema: *ref_237
+          - !<!Parameter> &ref_242
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_273
+              x-ms-parameter-grouping: &ref_274
                 name: modified-access-conditions
             language: !<!Languages> 
               default:
@@ -12837,7 +12976,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_242
+          - !<!Parameter> &ref_243
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -12850,6 +12989,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12860,11 +13014,11 @@ operationGroups:
                 method: delete
                 uri: '{url}'
         signatureParameters:
-          - *ref_238
           - *ref_239
           - *ref_240
           - *ref_241
           - *ref_242
+          - *ref_243
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -12875,28 +13029,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_243
+                    schema: *ref_244
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_244
+                    schema: *ref_245
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_245
+                    schema: *ref_246
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_237
+                    schema: *ref_238
                     header: Date
                     language:
                       default:
@@ -12906,7 +13060,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -12915,7 +13069,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_246
+                    schema: *ref_247
                     header: x-ms-error-code
                     language:
                       default:
@@ -12938,7 +13092,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_211
+            schema: *ref_212
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12950,7 +13104,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_247
+            schema: *ref_248
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12961,7 +13115,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_249
+          - !<!Parameter> &ref_250
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -12974,11 +13128,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_250
-            schema: *ref_223
+          - !<!Parameter> &ref_251
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -12987,8 +13141,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_251
-            schema: *ref_212
+          - !<!Parameter> &ref_252
+            schema: *ref_213
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -13003,11 +13157,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_252
-            schema: *ref_237
+          - !<!Parameter> &ref_253
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -13017,7 +13171,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_253
+          - !<!Parameter> &ref_254
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -13030,6 +13184,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13040,11 +13209,11 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_249
           - *ref_250
           - *ref_251
           - *ref_252
           - *ref_253
+          - *ref_254
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -13055,42 +13224,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_254
+                    schema: *ref_255
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_255
+                    schema: *ref_256
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_256
+                    schema: *ref_257
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_257
+                    schema: *ref_258
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_258
+                    schema: *ref_259
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_259
+                    schema: *ref_260
                     header: Date
                     language:
                       default:
@@ -13100,7 +13269,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -13109,7 +13278,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_260
+                    schema: *ref_261
                     header: x-ms-error-code
                     language:
                       default:
@@ -13132,7 +13301,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_211
+            schema: *ref_212
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13144,7 +13313,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_261
+            schema: *ref_262
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13155,7 +13324,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_262
+          - !<!Parameter> &ref_263
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -13168,11 +13337,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_263
-            schema: *ref_223
+          - !<!Parameter> &ref_264
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -13182,7 +13351,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_264
+          - !<!Parameter> &ref_265
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -13195,6 +13364,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13205,12 +13389,12 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_262
           - *ref_263
           - *ref_264
+          - *ref_265
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_265
+            schema: *ref_266
             language: !<!Languages> 
               default:
                 name: ''
@@ -13226,42 +13410,42 @@ operationGroups:
                         name: BlobPublicAccess
                         description: Indicated whether data in the container may be accessed publicly and the level of access
                   - !<!HttpHeader> 
-                    schema: *ref_266
+                    schema: *ref_267
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_267
+                    schema: *ref_268
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_268
+                    schema: *ref_269
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_269
+                    schema: *ref_270
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_270
+                    schema: *ref_271
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_271
+                    schema: *ref_272
                     header: Date
                     language:
                       default:
@@ -13274,7 +13458,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -13283,7 +13467,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_272
+                    schema: *ref_273
                     header: x-ms-error-code
                     language:
                       default:
@@ -13306,7 +13490,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_211
+            schema: *ref_212
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13318,7 +13502,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_261
+            schema: *ref_262
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13329,7 +13513,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_275
+          - !<!Parameter> &ref_276
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -13342,11 +13526,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_276
-            schema: *ref_223
+          - !<!Parameter> &ref_277
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -13355,7 +13539,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_277
+          - !<!Parameter> &ref_278
             schema: *ref_40
             implementation: Method
             language: !<!Languages> 
@@ -13366,11 +13550,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_278
-            schema: *ref_237
+          - !<!Parameter> &ref_279
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -13379,11 +13563,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_279
-            schema: *ref_237
+          - !<!Parameter> &ref_280
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -13393,7 +13577,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_280
+          - !<!Parameter> &ref_281
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -13407,8 +13591,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_274
-                schema: *ref_265
+              - !<!Parameter> &ref_275
+                schema: *ref_266
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -13419,8 +13603,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_274
+              - *ref_275
             language: !<!Languages> 
               default:
                 name: ''
@@ -13434,12 +13631,12 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_275
           - *ref_276
           - *ref_277
           - *ref_278
           - *ref_279
           - *ref_280
+          - *ref_281
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -13450,42 +13647,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_281
+                    schema: *ref_282
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_282
+                    schema: *ref_283
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_283
+                    schema: *ref_284
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_284
+                    schema: *ref_285
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_285
+                    schema: *ref_286
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_286
+                    schema: *ref_287
                     header: Date
                     language:
                       default:
@@ -13495,7 +13692,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -13504,7 +13701,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_287
+                    schema: *ref_288
                     header: x-ms-error-code
                     language:
                       default:
@@ -13527,7 +13724,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_288
+            schema: *ref_289
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13539,7 +13736,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_211
+            schema: *ref_212
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13551,7 +13748,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_289
+            schema: *ref_290
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13562,7 +13759,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_292
+          - !<!Parameter> &ref_293
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -13575,8 +13772,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_293
-            schema: *ref_290
+          - !<!Parameter> &ref_294
+            schema: *ref_291
             implementation: Method
             language: !<!Languages> 
               default:
@@ -13586,8 +13783,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_294
-            schema: *ref_291
+          - !<!Parameter> &ref_295
+            schema: *ref_292
             implementation: Method
             language: !<!Languages> 
               default:
@@ -13597,11 +13794,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_295
-            schema: *ref_237
+          - !<!Parameter> &ref_296
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -13610,11 +13807,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_296
-            schema: *ref_237
+          - !<!Parameter> &ref_297
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -13624,7 +13821,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_297
+          - !<!Parameter> &ref_298
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -13637,6 +13834,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13647,12 +13859,12 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_292
           - *ref_293
           - *ref_294
           - *ref_295
           - *ref_296
           - *ref_297
+          - *ref_298
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -13663,49 +13875,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_291
+                    schema: *ref_292
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_298
+                    schema: *ref_299
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_299
+                    schema: *ref_300
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a container's lease
                   - !<!HttpHeader> 
-                    schema: *ref_300
+                    schema: *ref_301
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_301
+                    schema: *ref_302
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_302
+                    schema: *ref_303
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_303
+                    schema: *ref_304
                     header: Date
                     language:
                       default:
@@ -13715,7 +13927,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -13724,7 +13936,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_304
+                    schema: *ref_305
                     header: x-ms-error-code
                     language:
                       default:
@@ -13747,7 +13959,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_288
+            schema: *ref_289
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13759,7 +13971,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_211
+            schema: *ref_212
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13771,7 +13983,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_305
+            schema: *ref_306
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13782,7 +13994,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_307
+          - !<!Parameter> &ref_308
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -13795,8 +14007,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_308
-            schema: *ref_306
+          - !<!Parameter> &ref_309
+            schema: *ref_307
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13807,11 +14019,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_309
-            schema: *ref_237
+          - !<!Parameter> &ref_310
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -13820,11 +14032,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_310
-            schema: *ref_237
+          - !<!Parameter> &ref_311
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -13834,7 +14046,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_311
+          - !<!Parameter> &ref_312
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -13847,6 +14059,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13857,11 +14084,11 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_307
           - *ref_308
           - *ref_309
           - *ref_310
           - *ref_311
+          - *ref_312
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -13872,42 +14099,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_306
+                    schema: *ref_307
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_312
+                    schema: *ref_313
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_313
+                    schema: *ref_314
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_314
+                    schema: *ref_315
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_315
+                    schema: *ref_316
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_316
+                    schema: *ref_317
                     header: Date
                     language:
                       default:
@@ -13917,7 +14144,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -13926,7 +14153,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_317
+                    schema: *ref_318
                     header: x-ms-error-code
                     language:
                       default:
@@ -13949,7 +14176,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_288
+            schema: *ref_289
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13961,7 +14188,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_211
+            schema: *ref_212
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13973,7 +14200,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_318
+            schema: *ref_319
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13984,7 +14211,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_319
+          - !<!Parameter> &ref_320
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -13997,8 +14224,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_320
-            schema: *ref_306
+          - !<!Parameter> &ref_321
+            schema: *ref_307
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14009,11 +14236,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_321
-            schema: *ref_237
+          - !<!Parameter> &ref_322
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -14022,11 +14249,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_322
-            schema: *ref_237
+          - !<!Parameter> &ref_323
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -14036,7 +14263,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_323
+          - !<!Parameter> &ref_324
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -14049,6 +14276,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14059,11 +14301,11 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_319
           - *ref_320
           - *ref_321
           - *ref_322
           - *ref_323
+          - *ref_324
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -14074,49 +14316,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_324
+                    schema: *ref_325
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_325
+                    schema: *ref_326
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_326
+                    schema: *ref_327
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a container's lease
                   - !<!HttpHeader> 
-                    schema: *ref_327
+                    schema: *ref_328
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_328
+                    schema: *ref_329
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_329
+                    schema: *ref_330
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_330
+                    schema: *ref_331
                     header: Date
                     language:
                       default:
@@ -14126,7 +14368,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -14135,7 +14377,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_331
+                    schema: *ref_332
                     header: x-ms-error-code
                     language:
                       default:
@@ -14158,7 +14400,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_288
+            schema: *ref_289
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14170,7 +14412,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_211
+            schema: *ref_212
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14182,7 +14424,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_332
+            schema: *ref_333
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14193,7 +14435,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_333
+          - !<!Parameter> &ref_334
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -14206,8 +14448,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_334
-            schema: *ref_290
+          - !<!Parameter> &ref_335
+            schema: *ref_291
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14220,11 +14462,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_335
-            schema: *ref_237
+          - !<!Parameter> &ref_336
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -14233,11 +14475,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_336
-            schema: *ref_237
+          - !<!Parameter> &ref_337
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -14247,7 +14489,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_337
+          - !<!Parameter> &ref_338
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -14260,6 +14502,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14270,11 +14527,11 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_333
           - *ref_334
           - *ref_335
           - *ref_336
           - *ref_337
+          - *ref_338
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -14285,49 +14542,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_338
+                    schema: *ref_339
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_339
+                    schema: *ref_340
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_290
+                    schema: *ref_291
                     header: x-ms-lease-time
                     language:
                       default:
                         name: LeaseTime
                         description: 'Approximate time remaining in the lease period, in seconds.'
                   - !<!HttpHeader> 
-                    schema: *ref_340
+                    schema: *ref_341
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_341
+                    schema: *ref_342
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_342
+                    schema: *ref_343
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_343
+                    schema: *ref_344
                     header: Date
                     language:
                       default:
@@ -14337,7 +14594,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -14346,7 +14603,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_344
+                    schema: *ref_345
                     header: x-ms-error-code
                     language:
                       default:
@@ -14369,7 +14626,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_288
+            schema: *ref_289
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14381,7 +14638,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_211
+            schema: *ref_212
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14393,7 +14650,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_345
+            schema: *ref_346
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14404,7 +14661,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_347
+          - !<!Parameter> &ref_348
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -14417,8 +14674,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_348
-            schema: *ref_306
+          - !<!Parameter> &ref_349
+            schema: *ref_307
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14429,8 +14686,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_349
-            schema: *ref_346
+          - !<!Parameter> &ref_350
+            schema: *ref_347
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14441,11 +14698,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_350
-            schema: *ref_237
+          - !<!Parameter> &ref_351
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -14454,11 +14711,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_351
-            schema: *ref_237
+          - !<!Parameter> &ref_352
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -14468,7 +14725,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_352
+          - !<!Parameter> &ref_353
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -14481,6 +14738,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14491,12 +14763,12 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_347
           - *ref_348
           - *ref_349
           - *ref_350
           - *ref_351
           - *ref_352
+          - *ref_353
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -14507,49 +14779,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_346
+                    schema: *ref_347
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_353
+                    schema: *ref_354
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_354
+                    schema: *ref_355
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a container's lease
                   - !<!HttpHeader> 
-                    schema: *ref_355
+                    schema: *ref_356
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_356
+                    schema: *ref_357
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_357
+                    schema: *ref_358
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_358
+                    schema: *ref_359
                     header: Date
                     language:
                       default:
@@ -14559,7 +14831,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -14568,7 +14840,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_359
+                    schema: *ref_360
                     header: x-ms-error-code
                     language:
                       default:
@@ -14591,7 +14863,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_211
+            schema: *ref_212
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14603,7 +14875,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_164
+            schema: *ref_165
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14614,8 +14886,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_361
-            schema: *ref_165
+          - !<!Parameter> &ref_362
+            schema: *ref_166
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14625,8 +14897,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_362
-            schema: *ref_165
+          - !<!Parameter> &ref_363
+            schema: *ref_166
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14639,8 +14911,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_363
-            schema: *ref_166
+          - !<!Parameter> &ref_364
+            schema: *ref_167
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14653,8 +14925,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_364
-            schema: *ref_360
+          - !<!Parameter> &ref_365
+            schema: *ref_361
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14665,7 +14937,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
                 style: form
-          - !<!Parameter> &ref_365
+          - !<!Parameter> &ref_366
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -14679,7 +14951,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_139
-          - !<!Parameter> &ref_366
+          - !<!Parameter> &ref_367
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -14692,6 +14964,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14702,15 +14989,15 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_361
           - *ref_362
           - *ref_363
           - *ref_364
           - *ref_365
           - *ref_366
+          - *ref_367
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_367
+            schema: *ref_368
             language: !<!Languages> 
               default:
                 name: ''
@@ -14719,35 +15006,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_368
+                    schema: *ref_369
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The media type of the body of the response. For List Blobs this is 'application/xml'
                   - !<!HttpHeader> 
-                    schema: *ref_369
+                    schema: *ref_370
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_370
+                    schema: *ref_371
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_371
+                    schema: *ref_372
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_372
+                    schema: *ref_373
                     header: Date
                     language:
                       default:
@@ -14760,7 +15047,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -14797,7 +15084,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_211
+            schema: *ref_212
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14809,7 +15096,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_164
+            schema: *ref_165
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14820,8 +15107,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_374
-            schema: *ref_165
+          - !<!Parameter> &ref_375
+            schema: *ref_166
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14831,8 +15118,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_375
-            schema: *ref_373
+          - !<!Parameter> &ref_376
+            schema: *ref_374
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14845,8 +15132,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_376
-            schema: *ref_165
+          - !<!Parameter> &ref_377
+            schema: *ref_166
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14859,8 +15146,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_377
-            schema: *ref_166
+          - !<!Parameter> &ref_378
+            schema: *ref_167
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14873,8 +15160,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_378
-            schema: *ref_360
+          - !<!Parameter> &ref_379
+            schema: *ref_361
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14885,7 +15172,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
                 style: form
-          - !<!Parameter> &ref_379
+          - !<!Parameter> &ref_380
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -14899,7 +15186,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_139
-          - !<!Parameter> &ref_380
+          - !<!Parameter> &ref_381
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -14912,6 +15199,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14922,16 +15224,16 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_374
           - *ref_375
           - *ref_376
           - *ref_377
           - *ref_378
           - *ref_379
           - *ref_380
+          - *ref_381
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_381
+            schema: *ref_382
             language: !<!Languages> 
               default:
                 name: ''
@@ -14940,35 +15242,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_373
+                    schema: *ref_374
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The media type of the body of the response. For List Blobs this is 'application/xml'
                   - !<!HttpHeader> 
-                    schema: *ref_382
+                    schema: *ref_383
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_383
+                    schema: *ref_384
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_384
+                    schema: *ref_385
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_385
+                    schema: *ref_386
                     header: Date
                     language:
                       default:
@@ -14981,7 +15283,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -14990,7 +15292,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_386
+                    schema: *ref_387
                     header: x-ms-error-code
                     language:
                       default:
@@ -15018,7 +15320,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_191
+            schema: *ref_192
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15044,6 +15346,21 @@ operationGroups:
           - *ref_139
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15064,42 +15381,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_387
+                    schema: *ref_388
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_388
+                    schema: *ref_389
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_389
+                    schema: *ref_390
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_390
+                    schema: *ref_391
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_196
+                    schema: *ref_197
                     header: x-ms-sku-name
                     language:
                       default:
                         name: SkuName
                         description: Identifies the sku name of the account
                   - !<!HttpHeader> 
-                    schema: *ref_197
+                    schema: *ref_198
                     header: x-ms-account-kind
                     language:
                       default:
@@ -15109,7 +15426,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -15118,7 +15435,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_391
+                    schema: *ref_392
                     header: x-ms-error-code
                     language:
                       default:
@@ -15149,7 +15466,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_392
+            schema: *ref_393
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15160,7 +15477,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_394
+          - !<!Parameter> &ref_395
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -15173,8 +15490,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_395
-            schema: *ref_393
+          - !<!Parameter> &ref_396
+            schema: *ref_394
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15184,8 +15501,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_396
-            schema: *ref_393
+          - !<!Parameter> &ref_397
+            schema: *ref_394
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15197,8 +15514,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_397
-            schema: *ref_393
+          - !<!Parameter> &ref_398
+            schema: *ref_394
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15211,11 +15528,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_398
-            schema: *ref_393
+          - !<!Parameter> &ref_399
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_420
+              x-ms-parameter-grouping: &ref_421
                 name: directory-http-headers
             language: !<!Languages> 
               default:
@@ -15225,11 +15542,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_399
-            schema: *ref_393
+          - !<!Parameter> &ref_400
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_421
+              x-ms-parameter-grouping: &ref_422
                 name: directory-http-headers
             language: !<!Languages> 
               default:
@@ -15239,11 +15556,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_400
-            schema: *ref_393
+          - !<!Parameter> &ref_401
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_422
+              x-ms-parameter-grouping: &ref_423
                 name: directory-http-headers
             language: !<!Languages> 
               default:
@@ -15253,11 +15570,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_401
-            schema: *ref_393
+          - !<!Parameter> &ref_402
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_423
+              x-ms-parameter-grouping: &ref_424
                 name: directory-http-headers
             language: !<!Languages> 
               default:
@@ -15267,11 +15584,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_402
-            schema: *ref_393
+          - !<!Parameter> &ref_403
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_424
+              x-ms-parameter-grouping: &ref_425
                 name: directory-http-headers
             language: !<!Languages> 
               default:
@@ -15281,11 +15598,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_403
-            schema: *ref_223
+          - !<!Parameter> &ref_404
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -15294,11 +15611,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_404
-            schema: *ref_237
+          - !<!Parameter> &ref_405
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -15307,11 +15624,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_405
-            schema: *ref_237
+          - !<!Parameter> &ref_406
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -15320,11 +15637,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_406
-            schema: *ref_393
+          - !<!Parameter> &ref_407
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_425
+              x-ms-parameter-grouping: &ref_426
                 name: modified-access-conditions
             language: !<!Languages> 
               default:
@@ -15334,11 +15651,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_407
-            schema: *ref_393
+          - !<!Parameter> &ref_408
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_426
+              x-ms-parameter-grouping: &ref_427
                 name: modified-access-conditions
             language: !<!Languages> 
               default:
@@ -15349,7 +15666,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_408
+          - !<!Parameter> &ref_409
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -15362,6 +15679,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15372,7 +15704,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_394
           - *ref_395
           - *ref_396
           - *ref_397
@@ -15387,6 +15718,7 @@ operationGroups:
           - *ref_406
           - *ref_407
           - *ref_408
+          - *ref_409
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -15397,49 +15729,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_393
+                    schema: *ref_394
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_409
+                    schema: *ref_410
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_410
+                    schema: *ref_411
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_411
+                    schema: *ref_412
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_412
+                    schema: *ref_413
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_200
+                    schema: *ref_201
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_413
+                    schema: *ref_414
                     header: Date
                     language:
                       default:
@@ -15449,7 +15781,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_414
+            schema: *ref_415
             language: !<!Languages> 
               default:
                 name: ''
@@ -15458,21 +15790,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_415
+                    schema: *ref_416
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_416
+                    schema: *ref_417
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_417
+                    schema: *ref_418
                     header: x-ms-version
                     language:
                       default:
@@ -15497,7 +15829,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_135
-          - !<!Parameter> &ref_428
+          - !<!Parameter> &ref_429
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -15510,8 +15842,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_429
-            schema: *ref_418
+          - !<!Parameter> &ref_430
+            schema: *ref_419
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15523,9 +15855,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_419
-          - !<!Parameter> &ref_430
-            schema: *ref_418
+          - *ref_420
+          - !<!Parameter> &ref_431
+            schema: *ref_419
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15538,8 +15870,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_431
-            schema: *ref_393
+          - !<!Parameter> &ref_432
+            schema: *ref_394
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15549,8 +15881,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_432
-            schema: *ref_393
+          - !<!Parameter> &ref_433
+            schema: *ref_394
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15562,8 +15894,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_433
-            schema: *ref_393
+          - !<!Parameter> &ref_434
+            schema: *ref_394
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15576,11 +15908,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_434
-            schema: *ref_393
+          - !<!Parameter> &ref_435
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: cacheControl
@@ -15589,11 +15921,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_435
-            schema: *ref_393
+          - !<!Parameter> &ref_436
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: contentType
@@ -15602,11 +15934,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_436
-            schema: *ref_393
+          - !<!Parameter> &ref_437
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_422
+              x-ms-parameter-grouping: *ref_423
             language: !<!Languages> 
               default:
                 name: contentEncoding
@@ -15615,11 +15947,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_437
-            schema: *ref_393
+          - !<!Parameter> &ref_438
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_423
+              x-ms-parameter-grouping: *ref_424
             language: !<!Languages> 
               default:
                 name: contentLanguage
@@ -15628,11 +15960,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_438
-            schema: *ref_393
+          - !<!Parameter> &ref_439
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_424
+              x-ms-parameter-grouping: *ref_425
             language: !<!Languages> 
               default:
                 name: contentDisposition
@@ -15641,11 +15973,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_439
-            schema: *ref_223
+          - !<!Parameter> &ref_440
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -15654,8 +15986,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_440
-            schema: *ref_418
+          - !<!Parameter> &ref_441
+            schema: *ref_419
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15665,11 +15997,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_441
-            schema: *ref_237
+          - !<!Parameter> &ref_442
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -15678,11 +16010,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_442
-            schema: *ref_237
+          - !<!Parameter> &ref_443
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -15691,11 +16023,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_443
-            schema: *ref_393
+          - !<!Parameter> &ref_444
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -15704,11 +16036,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_444
-            schema: *ref_393
+          - !<!Parameter> &ref_445
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -15717,11 +16049,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_445
-            schema: *ref_427
+          - !<!Parameter> &ref_446
+            schema: *ref_428
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_684
+              x-ms-parameter-grouping: &ref_685
                 name: source-modified-access-conditions
             language: !<!Languages> 
               default:
@@ -15731,11 +16063,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_446
-            schema: *ref_427
+          - !<!Parameter> &ref_447
+            schema: *ref_428
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_685
+              x-ms-parameter-grouping: &ref_686
                 name: source-modified-access-conditions
             language: !<!Languages> 
               default:
@@ -15745,11 +16077,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_447
-            schema: *ref_418
+          - !<!Parameter> &ref_448
+            schema: *ref_419
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_686
+              x-ms-parameter-grouping: &ref_687
                 name: source-modified-access-conditions
             language: !<!Languages> 
               default:
@@ -15759,11 +16091,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_448
-            schema: *ref_418
+          - !<!Parameter> &ref_449
+            schema: *ref_419
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_687
+              x-ms-parameter-grouping: &ref_688
                 name: source-modified-access-conditions
             language: !<!Languages> 
               default:
@@ -15774,7 +16106,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_449
+          - !<!Parameter> &ref_450
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -15787,6 +16119,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15797,7 +16144,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_428
           - *ref_429
           - *ref_430
           - *ref_431
@@ -15819,6 +16165,7 @@ operationGroups:
           - *ref_447
           - *ref_448
           - *ref_449
+          - *ref_450
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -15829,7 +16176,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_418
+                    schema: *ref_419
                     header: x-ms-continuation
                     language:
                       default:
@@ -15838,49 +16185,49 @@ operationGroups:
                           When renaming a directory, the number of paths that are renamed with each invocation is limited. If the number of paths to be renamed exceeds this limit, a continuation token is returned in this response header.
                           When a continuation token is returned in the response, it must be specified in a subsequent invocation of the rename operation to continue renaming the directory.
                   - !<!HttpHeader> 
-                    schema: *ref_450
+                    schema: *ref_451
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_427
+                    schema: *ref_428
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_451
+                    schema: *ref_452
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_452
+                    schema: *ref_453
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_453
+                    schema: *ref_454
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_454
+                    schema: *ref_455
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_455
+                    schema: *ref_456
                     header: Date
                     language:
                       default:
@@ -15890,7 +16237,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_414
+            schema: *ref_415
             language: !<!Languages> 
               default:
                 name: ''
@@ -15899,21 +16246,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_456
+                    schema: *ref_457
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_457
+                    schema: *ref_458
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_458
+                    schema: *ref_459
                     header: x-ms-version
                     language:
                       default:
@@ -15938,7 +16285,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_135
-          - !<!Parameter> &ref_460
+          - !<!Parameter> &ref_461
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -15951,8 +16298,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_461
-            schema: *ref_459
+          - !<!Parameter> &ref_462
+            schema: *ref_460
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15963,8 +16310,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_462
-            schema: *ref_418
+          - !<!Parameter> &ref_463
+            schema: *ref_419
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15976,11 +16323,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_463
-            schema: *ref_223
+          - !<!Parameter> &ref_464
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -15989,11 +16336,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_464
-            schema: *ref_237
+          - !<!Parameter> &ref_465
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -16002,11 +16349,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_465
-            schema: *ref_237
+          - !<!Parameter> &ref_466
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -16015,11 +16362,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_466
-            schema: *ref_393
+          - !<!Parameter> &ref_467
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -16028,11 +16375,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_467
-            schema: *ref_393
+          - !<!Parameter> &ref_468
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -16042,7 +16389,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_468
+          - !<!Parameter> &ref_469
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -16055,6 +16402,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16065,7 +16427,6 @@ operationGroups:
                 method: delete
                 uri: '{url}'
         signatureParameters:
-          - *ref_460
           - *ref_461
           - *ref_462
           - *ref_463
@@ -16074,6 +16435,7 @@ operationGroups:
           - *ref_466
           - *ref_467
           - *ref_468
+          - *ref_469
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -16084,7 +16446,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_469
+                    schema: *ref_470
                     header: x-ms-continuation
                     language:
                       default:
@@ -16093,28 +16455,28 @@ operationGroups:
                           When renaming a directory, the number of paths that are renamed with each invocation is limited. If the number of paths to be renamed exceeds this limit, a continuation token is returned in this response header.
                           When a continuation token is returned in the response, it must be specified in a subsequent invocation of the rename operation to continue renaming the directory.
                   - !<!HttpHeader> 
-                    schema: *ref_470
+                    schema: *ref_471
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_471
+                    schema: *ref_472
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_472
+                    schema: *ref_473
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_473
+                    schema: *ref_474
                     header: Date
                     language:
                       default:
@@ -16124,7 +16486,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_414
+            schema: *ref_415
             language: !<!Languages> 
               default:
                 name: ''
@@ -16133,21 +16495,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_474
+                    schema: *ref_475
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_475
+                    schema: *ref_476
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_476
+                    schema: *ref_477
                     header: x-ms-version
                     language:
                       default:
@@ -16170,7 +16532,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_477
+            schema: *ref_478
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16181,7 +16543,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_479
+          - !<!Parameter> &ref_480
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -16194,11 +16556,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_480
-            schema: *ref_223
+          - !<!Parameter> &ref_481
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -16207,8 +16569,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_481
-            schema: *ref_478
+          - !<!Parameter> &ref_482
+            schema: *ref_479
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16218,8 +16580,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_482
-            schema: *ref_478
+          - !<!Parameter> &ref_483
+            schema: *ref_479
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16229,8 +16591,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_483
-            schema: *ref_393
+          - !<!Parameter> &ref_484
+            schema: *ref_394
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16242,8 +16604,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_484
-            schema: *ref_478
+          - !<!Parameter> &ref_485
+            schema: *ref_479
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16255,11 +16617,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_485
-            schema: *ref_393
+          - !<!Parameter> &ref_486
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -16268,11 +16630,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_486
-            schema: *ref_393
+          - !<!Parameter> &ref_487
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -16281,11 +16643,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_487
-            schema: *ref_237
+          - !<!Parameter> &ref_488
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -16294,11 +16656,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_488
-            schema: *ref_237
+          - !<!Parameter> &ref_489
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -16307,7 +16669,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_489
+          - !<!Parameter> &ref_490
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -16321,6 +16683,21 @@ operationGroups:
           - *ref_139
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16331,7 +16708,6 @@ operationGroups:
                 method: patch
                 uri: '{url}'
         signatureParameters:
-          - *ref_479
           - *ref_480
           - *ref_481
           - *ref_482
@@ -16342,6 +16718,7 @@ operationGroups:
           - *ref_487
           - *ref_488
           - *ref_489
+          - *ref_490
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -16352,35 +16729,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_490
+                    schema: *ref_491
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_478
+                    schema: *ref_479
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_491
+                    schema: *ref_492
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_492
+                    schema: *ref_493
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_493
+                    schema: *ref_494
                     header: x-ms-version
                     language:
                       default:
@@ -16390,7 +16767,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_414
+            schema: *ref_415
             language: !<!Languages> 
               default:
                 name: ''
@@ -16399,21 +16776,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_494
+                    schema: *ref_495
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_495
+                    schema: *ref_496
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_496
+                    schema: *ref_497
                     header: x-ms-version
                     language:
                       default:
@@ -16436,7 +16813,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_497
+            schema: *ref_498
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16447,7 +16824,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_498
+          - !<!Parameter> &ref_499
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -16460,8 +16837,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_499
-            schema: *ref_459
+          - !<!Parameter> &ref_500
+            schema: *ref_460
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16473,11 +16850,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_500
-            schema: *ref_223
+          - !<!Parameter> &ref_501
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -16486,11 +16863,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_501
-            schema: *ref_393
+          - !<!Parameter> &ref_502
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -16499,11 +16876,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_502
-            schema: *ref_393
+          - !<!Parameter> &ref_503
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -16512,11 +16889,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_503
-            schema: *ref_237
+          - !<!Parameter> &ref_504
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -16525,11 +16902,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_504
-            schema: *ref_237
+          - !<!Parameter> &ref_505
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -16538,7 +16915,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_505
+          - !<!Parameter> &ref_506
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -16552,6 +16929,21 @@ operationGroups:
           - *ref_139
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16562,7 +16954,6 @@ operationGroups:
                 method: head
                 uri: '{url}'
         signatureParameters:
-          - *ref_498
           - *ref_499
           - *ref_500
           - *ref_501
@@ -16570,6 +16961,7 @@ operationGroups:
           - *ref_503
           - *ref_504
           - *ref_505
+          - *ref_506
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -16580,63 +16972,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_506
+                    schema: *ref_507
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_507
+                    schema: *ref_508
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_508
+                    schema: *ref_509
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_509
+                    schema: *ref_510
                     header: x-ms-owner
                     language:
                       default:
                         name: x-ms-owner
                         description: The owner of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_510
+                    schema: *ref_511
                     header: x-ms-group
                     language:
                       default:
                         name: x-ms-group
                         description: The owning group of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_511
+                    schema: *ref_512
                     header: x-ms-permissions
                     language:
                       default:
                         name: x-ms-permissions
                         description: 'The POSIX access permissions for the file owner, the file owning group, and others. Included in the response if Hierarchical Namespace is enabled for the account.'
                   - !<!HttpHeader> 
-                    schema: *ref_512
+                    schema: *ref_513
                     header: x-ms-acl
                     language:
                       default:
                         name: x-ms-acl
                         description: The POSIX access control list for the file or directory.  Included in the response only if the action is "getAccessControl" and Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_513
+                    schema: *ref_514
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_514
+                    schema: *ref_515
                     header: x-ms-version
                     language:
                       default:
@@ -16646,7 +17038,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_414
+            schema: *ref_415
             language: !<!Languages> 
               default:
                 name: ''
@@ -16655,21 +17047,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_515
+                    schema: *ref_516
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_516
+                    schema: *ref_517
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_517
+                    schema: *ref_518
                     header: x-ms-version
                     language:
                       default:
@@ -16699,8 +17091,8 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_135
-          - !<!Parameter> &ref_520
-            schema: *ref_518
+          - !<!Parameter> &ref_521
+            schema: *ref_519
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16712,7 +17104,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_521
+          - !<!Parameter> &ref_522
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -16725,8 +17117,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_522
-            schema: *ref_518
+          - !<!Parameter> &ref_523
+            schema: *ref_519
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16736,11 +17128,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_523
-            schema: *ref_223
+          - !<!Parameter> &ref_524
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -16749,8 +17141,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_524
-            schema: *ref_459
+          - !<!Parameter> &ref_525
+            schema: *ref_460
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16760,8 +17152,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_525
-            schema: *ref_459
+          - !<!Parameter> &ref_526
+            schema: *ref_460
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16771,11 +17163,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_526
-            schema: *ref_518
+          - !<!Parameter> &ref_527
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_585
+              x-ms-parameter-grouping: &ref_586
                 name: cpk-info
             language: !<!Languages> 
               default:
@@ -16787,11 +17179,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_527
-            schema: *ref_518
+          - !<!Parameter> &ref_528
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_586
+              x-ms-parameter-grouping: &ref_587
                 name: cpk-info
             language: !<!Languages> 
               default:
@@ -16802,10 +17194,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_519
+            schema: *ref_520
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_587
+              x-ms-parameter-grouping: &ref_588
                 name: cpk-info
             language: !<!Languages> 
               default:
@@ -16815,11 +17207,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_528
-            schema: *ref_237
+          - !<!Parameter> &ref_529
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -16828,11 +17220,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_529
-            schema: *ref_237
+          - !<!Parameter> &ref_530
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -16841,11 +17233,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_530
-            schema: *ref_393
+          - !<!Parameter> &ref_531
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -16854,11 +17246,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_531
-            schema: *ref_393
+          - !<!Parameter> &ref_532
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -16868,7 +17260,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_532
+          - !<!Parameter> &ref_533
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -16881,6 +17273,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16891,7 +17298,6 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_520
           - *ref_521
           - *ref_522
           - *ref_523
@@ -16904,6 +17310,7 @@ operationGroups:
           - *ref_530
           - *ref_531
           - *ref_532
+          - *ref_533
         responses:
           - !<!BinaryResponse> 
             binary: true
@@ -16915,70 +17322,70 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_533
+                    schema: *ref_534
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_518
+                    schema: *ref_519
                     header: x-ms-meta
                     language:
                       default:
                         name: Metadata
                         description: ''
                   - !<!HttpHeader> 
-                    schema: *ref_534
+                    schema: *ref_535
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The number of bytes present in the response body.
                   - !<!HttpHeader> 
-                    schema: *ref_535
+                    schema: *ref_536
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The media type of the body of the response. For Download Blob this is 'application/octet-stream'
                   - !<!HttpHeader> 
-                    schema: *ref_536
+                    schema: *ref_537
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the blob by setting the 'Range' request header.
                   - !<!HttpHeader> 
-                    schema: *ref_537
+                    schema: *ref_538
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_538
+                    schema: *ref_539
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_539
+                    schema: *ref_540
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: This header returns the value that was specified for the Content-Encoding request header
                   - !<!HttpHeader> 
-                    schema: *ref_540
+                    schema: *ref_541
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: This header is returned if it was previously specified for the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_541
+                    schema: *ref_542
                     header: Content-Disposition
                     language:
                       default:
@@ -16988,14 +17395,14 @@ operationGroups:
                           payload, and also can be used to attach additional metadata. For example, if set to attachment, it indicates that the user-agent should not display the response, but instead show a Save As dialog with a filename
                           other than the blob name specified.
                   - !<!HttpHeader> 
-                    schema: *ref_542
+                    schema: *ref_543
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: This header returns the value that was specified for the Content-Language request header.
                   - !<!HttpHeader> 
-                    schema: *ref_543
+                    schema: *ref_544
                     header: x-ms-blob-sequence-number
                     language:
                       default:
@@ -17009,7 +17416,7 @@ operationGroups:
                         name: BlobType
                         description: The blob's type.
                   - !<!HttpHeader> 
-                    schema: *ref_544
+                    schema: *ref_545
                     header: x-ms-copy-completion-time
                     language:
                       default:
@@ -17018,7 +17425,7 @@ operationGroups:
                           Conclusion time of the last attempted Copy Blob operation where this blob was the destination blob. This value can specify the time of a completed, aborted, or failed copy attempt. This header does not appear if a
                           copy is pending, if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List.
                   - !<!HttpHeader> 
-                    schema: *ref_545
+                    schema: *ref_546
                     header: x-ms-copy-status-description
                     language:
                       default:
@@ -17027,14 +17434,14 @@ operationGroups:
                           Only appears when x-ms-copy-status is failed or pending. Describes the cause of the last fatal or non-fatal copy operation failure. This header does not appear if this blob has never been the destination in a Copy
                           Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List
                   - !<!HttpHeader> 
-                    schema: *ref_546
+                    schema: *ref_547
                     header: x-ms-copy-id
                     language:
                       default:
                         name: CopyId
                         description: 'String identifier for this copy operation. Use with Get Blob Properties to check the status of this copy operation, or pass to Abort Copy Blob to abort a pending copy.'
                   - !<!HttpHeader> 
-                    schema: *ref_547
+                    schema: *ref_548
                     header: x-ms-copy-progress
                     language:
                       default:
@@ -17044,7 +17451,7 @@ operationGroups:
                           header does not appear if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block
                           List
                   - !<!HttpHeader> 
-                    schema: *ref_548
+                    schema: *ref_549
                     header: x-ms-copy-source
                     language:
                       default:
@@ -17081,49 +17488,49 @@ operationGroups:
                         name: LeaseStatus
                         description: The current lease status of the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_549
+                    schema: *ref_550
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_550
+                    schema: *ref_551
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_551
+                    schema: *ref_552
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_552
+                    schema: *ref_553
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial blob content.
                   - !<!HttpHeader> 
-                    schema: *ref_553
+                    schema: *ref_554
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_554
+                    schema: *ref_555
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_459
+                    schema: *ref_460
                     header: x-ms-server-encrypted
                     language:
                       default:
@@ -17132,14 +17539,14 @@ operationGroups:
                           The value of this header is set to true if the blob data and application metadata are completely encrypted using the specified algorithm. Otherwise, the value is set to false (when the blob is unencrypted, or if
                           only parts of the blob/application metadata are encrypted).
                   - !<!HttpHeader> 
-                    schema: *ref_555
+                    schema: *ref_556
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
                         name: EncryptionKeySha256
                         description: The SHA-256 hash of the encryption key used to encrypt the blob. This header is only returned when the blob was encrypted with a customer-provided key.
                   - !<!HttpHeader> 
-                    schema: *ref_556
+                    schema: *ref_557
                     header: x-ms-blob-content-md5
                     language:
                       default:
@@ -17162,70 +17569,70 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_557
+                    schema: *ref_558
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_558
+                    schema: *ref_559
                     header: x-ms-meta
                     language:
                       default:
                         name: Metadata
                         description: ''
                   - !<!HttpHeader> 
-                    schema: *ref_559
+                    schema: *ref_560
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The number of bytes present in the response body.
                   - !<!HttpHeader> 
-                    schema: *ref_560
+                    schema: *ref_561
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The media type of the body of the response. For Download Blob this is 'application/octet-stream'
                   - !<!HttpHeader> 
-                    schema: *ref_561
+                    schema: *ref_562
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the blob by setting the 'Range' request header.
                   - !<!HttpHeader> 
-                    schema: *ref_562
+                    schema: *ref_563
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_563
+                    schema: *ref_564
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_564
+                    schema: *ref_565
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: This header returns the value that was specified for the Content-Encoding request header
                   - !<!HttpHeader> 
-                    schema: *ref_565
+                    schema: *ref_566
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: This header is returned if it was previously specified for the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_566
+                    schema: *ref_567
                     header: Content-Disposition
                     language:
                       default:
@@ -17235,14 +17642,14 @@ operationGroups:
                           payload, and also can be used to attach additional metadata. For example, if set to attachment, it indicates that the user-agent should not display the response, but instead show a Save As dialog with a filename
                           other than the blob name specified.
                   - !<!HttpHeader> 
-                    schema: *ref_567
+                    schema: *ref_568
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: This header returns the value that was specified for the Content-Language request header.
                   - !<!HttpHeader> 
-                    schema: *ref_568
+                    schema: *ref_569
                     header: x-ms-blob-sequence-number
                     language:
                       default:
@@ -17256,7 +17663,7 @@ operationGroups:
                         name: BlobType
                         description: The blob's type.
                   - !<!HttpHeader> 
-                    schema: *ref_569
+                    schema: *ref_570
                     header: x-ms-content-crc64
                     language:
                       default:
@@ -17265,7 +17672,7 @@ operationGroups:
                           If the request is to read a specified range and the x-ms-range-get-content-crc64 is set to true, then the request returns a crc64 for the range, as long as the range size is less than or equal to 4 MB. If both
                           x-ms-range-get-content-crc64 & x-ms-range-get-content-md5 is specified in the same request, it will fail with 400(Bad Request)
                   - !<!HttpHeader> 
-                    schema: *ref_570
+                    schema: *ref_571
                     header: x-ms-copy-completion-time
                     language:
                       default:
@@ -17274,7 +17681,7 @@ operationGroups:
                           Conclusion time of the last attempted Copy Blob operation where this blob was the destination blob. This value can specify the time of a completed, aborted, or failed copy attempt. This header does not appear if a
                           copy is pending, if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List.
                   - !<!HttpHeader> 
-                    schema: *ref_571
+                    schema: *ref_572
                     header: x-ms-copy-status-description
                     language:
                       default:
@@ -17283,14 +17690,14 @@ operationGroups:
                           Only appears when x-ms-copy-status is failed or pending. Describes the cause of the last fatal or non-fatal copy operation failure. This header does not appear if this blob has never been the destination in a Copy
                           Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List
                   - !<!HttpHeader> 
-                    schema: *ref_572
+                    schema: *ref_573
                     header: x-ms-copy-id
                     language:
                       default:
                         name: CopyId
                         description: 'String identifier for this copy operation. Use with Get Blob Properties to check the status of this copy operation, or pass to Abort Copy Blob to abort a pending copy.'
                   - !<!HttpHeader> 
-                    schema: *ref_573
+                    schema: *ref_574
                     header: x-ms-copy-progress
                     language:
                       default:
@@ -17300,7 +17707,7 @@ operationGroups:
                           header does not appear if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block
                           List
                   - !<!HttpHeader> 
-                    schema: *ref_574
+                    schema: *ref_575
                     header: x-ms-copy-source
                     language:
                       default:
@@ -17337,49 +17744,49 @@ operationGroups:
                         name: LeaseStatus
                         description: The current lease status of the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_575
+                    schema: *ref_576
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_576
+                    schema: *ref_577
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_577
+                    schema: *ref_578
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_578
+                    schema: *ref_579
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial blob content.
                   - !<!HttpHeader> 
-                    schema: *ref_579
+                    schema: *ref_580
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_580
+                    schema: *ref_581
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_581
+                    schema: *ref_582
                     header: x-ms-server-encrypted
                     language:
                       default:
@@ -17388,14 +17795,14 @@ operationGroups:
                           The value of this header is set to true if the blob data and application metadata are completely encrypted using the specified algorithm. Otherwise, the value is set to false (when the blob is unencrypted, or if
                           only parts of the blob/application metadata are encrypted).
                   - !<!HttpHeader> 
-                    schema: *ref_582
+                    schema: *ref_583
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
                         name: EncryptionKeySha256
                         description: The SHA-256 hash of the encryption key used to encrypt the blob. This header is only returned when the blob was encrypted with a customer-provided key.
                   - !<!HttpHeader> 
-                    schema: *ref_583
+                    schema: *ref_584
                     header: x-ms-blob-content-md5
                     language:
                       default:
@@ -17410,7 +17817,7 @@ operationGroups:
                   - '206'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -17419,7 +17826,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_584
+                    schema: *ref_585
                     header: x-ms-error-code
                     language:
                       default:
@@ -17441,8 +17848,8 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_135
-          - !<!Parameter> &ref_588
-            schema: *ref_518
+          - !<!Parameter> &ref_589
+            schema: *ref_519
             implementation: Method
             language: !<!Languages> 
               default:
@@ -17454,7 +17861,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_589
+          - !<!Parameter> &ref_590
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -17467,11 +17874,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_590
-            schema: *ref_223
+          - !<!Parameter> &ref_591
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -17480,11 +17887,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_591
-            schema: *ref_518
+          - !<!Parameter> &ref_592
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_585
+              x-ms-parameter-grouping: *ref_586
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -17495,11 +17902,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_592
-            schema: *ref_518
+          - !<!Parameter> &ref_593
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_586
+              x-ms-parameter-grouping: *ref_587
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -17509,10 +17916,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_519
+            schema: *ref_520
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_587
+              x-ms-parameter-grouping: *ref_588
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -17521,11 +17928,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_593
-            schema: *ref_237
+          - !<!Parameter> &ref_594
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -17534,11 +17941,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_594
-            schema: *ref_237
+          - !<!Parameter> &ref_595
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -17547,11 +17954,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_595
-            schema: *ref_393
+          - !<!Parameter> &ref_596
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -17560,11 +17967,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_596
-            schema: *ref_393
+          - !<!Parameter> &ref_597
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -17574,7 +17981,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_597
+          - !<!Parameter> &ref_598
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -17587,6 +17994,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -17597,7 +18019,6 @@ operationGroups:
                 method: head
                 uri: '{url}'
         signatureParameters:
-          - *ref_588
           - *ref_589
           - *ref_590
           - *ref_591
@@ -17607,6 +18028,7 @@ operationGroups:
           - *ref_595
           - *ref_596
           - *ref_597
+          - *ref_598
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -17617,21 +18039,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_598
+                    schema: *ref_599
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_599
+                    schema: *ref_600
                     header: x-ms-creation-time
                     language:
                       default:
                         name: CreationTime
                         description: Returns the date and time the blob was created.
                   - !<!HttpHeader> 
-                    schema: *ref_600
+                    schema: *ref_601
                     header: x-ms-meta
                     language:
                       default:
@@ -17645,7 +18067,7 @@ operationGroups:
                         name: BlobType
                         description: The blob's type.
                   - !<!HttpHeader> 
-                    schema: *ref_601
+                    schema: *ref_602
                     header: x-ms-copy-completion-time
                     language:
                       default:
@@ -17654,7 +18076,7 @@ operationGroups:
                           Conclusion time of the last attempted Copy Blob operation where this blob was the destination blob. This value can specify the time of a completed, aborted, or failed copy attempt. This header does not appear if a
                           copy is pending, if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List.
                   - !<!HttpHeader> 
-                    schema: *ref_602
+                    schema: *ref_603
                     header: x-ms-copy-status-description
                     language:
                       default:
@@ -17663,14 +18085,14 @@ operationGroups:
                           Only appears when x-ms-copy-status is failed or pending. Describes the cause of the last fatal or non-fatal copy operation failure. This header does not appear if this blob has never been the destination in a Copy
                           Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List
                   - !<!HttpHeader> 
-                    schema: *ref_603
+                    schema: *ref_604
                     header: x-ms-copy-id
                     language:
                       default:
                         name: CopyId
                         description: 'String identifier for this copy operation. Use with Get Blob Properties to check the status of this copy operation, or pass to Abort Copy Blob to abort a pending copy.'
                   - !<!HttpHeader> 
-                    schema: *ref_604
+                    schema: *ref_605
                     header: x-ms-copy-progress
                     language:
                       default:
@@ -17680,7 +18102,7 @@ operationGroups:
                           header does not appear if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block
                           List
                   - !<!HttpHeader> 
-                    schema: *ref_605
+                    schema: *ref_606
                     header: x-ms-copy-source
                     language:
                       default:
@@ -17696,14 +18118,14 @@ operationGroups:
                         name: CopyStatus
                         description: State of the copy operation identified by x-ms-copy-id.
                   - !<!HttpHeader> 
-                    schema: *ref_606
+                    schema: *ref_607
                     header: x-ms-incremental-copy
                     language:
                       default:
                         name: IsIncrementalCopy
                         description: Included if the blob is incremental copy blob.
                   - !<!HttpHeader> 
-                    schema: *ref_607
+                    schema: *ref_608
                     header: x-ms-copy-destination-snapshot
                     language:
                       default:
@@ -17731,42 +18153,42 @@ operationGroups:
                         name: LeaseStatus
                         description: The current lease status of the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_608
+                    schema: *ref_609
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The number of bytes present in the response body.
                   - !<!HttpHeader> 
-                    schema: *ref_609
+                    schema: *ref_610
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The content type specified for the blob. The default content type is 'application/octet-stream'
                   - !<!HttpHeader> 
-                    schema: *ref_610
+                    schema: *ref_611
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_611
+                    schema: *ref_612
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_612
+                    schema: *ref_613
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: This header returns the value that was specified for the Content-Encoding request header
                   - !<!HttpHeader> 
-                    schema: *ref_613
+                    schema: *ref_614
                     header: Content-Disposition
                     language:
                       default:
@@ -17776,70 +18198,70 @@ operationGroups:
                           payload, and also can be used to attach additional metadata. For example, if set to attachment, it indicates that the user-agent should not display the response, but instead show a Save As dialog with a filename
                           other than the blob name specified.
                   - !<!HttpHeader> 
-                    schema: *ref_614
+                    schema: *ref_615
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: This header returns the value that was specified for the Content-Language request header.
                   - !<!HttpHeader> 
-                    schema: *ref_615
+                    schema: *ref_616
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: This header is returned if it was previously specified for the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_616
+                    schema: *ref_617
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for a page blob. This header is not returned for block blobs or append blobs
                   - !<!HttpHeader> 
-                    schema: *ref_617
+                    schema: *ref_618
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_618
+                    schema: *ref_619
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_619
+                    schema: *ref_620
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_620
+                    schema: *ref_621
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_621
+                    schema: *ref_622
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial blob content.
                   - !<!HttpHeader> 
-                    schema: *ref_622
+                    schema: *ref_623
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_623
+                    schema: *ref_624
                     header: x-ms-server-encrypted
                     language:
                       default:
@@ -17848,14 +18270,14 @@ operationGroups:
                           The value of this header is set to true if the blob data and application metadata are completely encrypted using the specified algorithm. Otherwise, the value is set to false (when the blob is unencrypted, or if
                           only parts of the blob/application metadata are encrypted).
                   - !<!HttpHeader> 
-                    schema: *ref_624
+                    schema: *ref_625
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
                         name: EncryptionKeySha256
                         description: The SHA-256 hash of the encryption key used to encrypt the metadata. This header is only returned when the metadata was encrypted with a customer-provided key.
                   - !<!HttpHeader> 
-                    schema: *ref_625
+                    schema: *ref_626
                     header: x-ms-access-tier
                     language:
                       default:
@@ -17864,14 +18286,14 @@ operationGroups:
                           The tier of page blob on a premium storage account or tier of block blob on blob storage LRS accounts. For a list of allowed premium page blob tiers, see
                           https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage#features. For blob storage LRS accounts, valid values are Hot/Cool/Archive.
                   - !<!HttpHeader> 
-                    schema: *ref_626
+                    schema: *ref_627
                     header: x-ms-access-tier-inferred
                     language:
                       default:
                         name: AccessTierInferred
                         description: 'For page blobs on a premium storage account only. If the access tier is not explicitly set on the blob, the tier is inferred based on its content length and this header will be returned with true value.'
                   - !<!HttpHeader> 
-                    schema: *ref_627
+                    schema: *ref_628
                     header: x-ms-archive-status
                     language:
                       default:
@@ -17880,7 +18302,7 @@ operationGroups:
                           For blob storage LRS accounts, valid values are rehydrate-pending-to-hot/rehydrate-pending-to-cool. If the blob is being rehydrated and is not complete then this header is returned indicating that rehydrate is
                           pending and also tells the destination tier.
                   - !<!HttpHeader> 
-                    schema: *ref_628
+                    schema: *ref_629
                     header: x-ms-access-tier-change-time
                     language:
                       default:
@@ -17890,7 +18312,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -17899,7 +18321,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_629
+                    schema: *ref_630
                     header: x-ms-error-code
                     language:
                       default:
@@ -17921,8 +18343,8 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_135
-          - !<!Parameter> &ref_631
-            schema: *ref_518
+          - !<!Parameter> &ref_632
+            schema: *ref_519
             implementation: Method
             language: !<!Languages> 
               default:
@@ -17934,7 +18356,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_632
+          - !<!Parameter> &ref_633
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -17947,11 +18369,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_633
-            schema: *ref_223
+          - !<!Parameter> &ref_634
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -17960,8 +18382,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_634
-            schema: *ref_630
+          - !<!Parameter> &ref_635
+            schema: *ref_631
             implementation: Method
             language: !<!Languages> 
               default:
@@ -17971,11 +18393,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_635
-            schema: *ref_237
+          - !<!Parameter> &ref_636
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -17984,11 +18406,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_636
-            schema: *ref_237
+          - !<!Parameter> &ref_637
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -17997,11 +18419,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_637
-            schema: *ref_393
+          - !<!Parameter> &ref_638
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -18010,11 +18432,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_638
-            schema: *ref_393
+          - !<!Parameter> &ref_639
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -18024,7 +18446,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_639
+          - !<!Parameter> &ref_640
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -18037,6 +18459,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -18047,7 +18484,6 @@ operationGroups:
                 method: delete
                 uri: '{url}'
         signatureParameters:
-          - *ref_631
           - *ref_632
           - *ref_633
           - *ref_634
@@ -18056,6 +18492,7 @@ operationGroups:
           - *ref_637
           - *ref_638
           - *ref_639
+          - *ref_640
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -18066,28 +18503,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_640
+                    schema: *ref_641
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_641
+                    schema: *ref_642
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_642
+                    schema: *ref_643
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_643
+                    schema: *ref_644
                     header: Date
                     language:
                       default:
@@ -18097,7 +18534,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -18106,7 +18543,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_644
+                    schema: *ref_645
                     header: x-ms-error-code
                     language:
                       default:
@@ -18134,7 +18571,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_477
+            schema: *ref_478
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18145,7 +18582,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_645
+          - !<!Parameter> &ref_646
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -18158,11 +18595,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_646
-            schema: *ref_223
+          - !<!Parameter> &ref_647
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -18171,8 +18608,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_647
-            schema: *ref_478
+          - !<!Parameter> &ref_648
+            schema: *ref_479
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18182,8 +18619,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_648
-            schema: *ref_478
+          - !<!Parameter> &ref_649
+            schema: *ref_479
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18193,8 +18630,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_649
-            schema: *ref_393
+          - !<!Parameter> &ref_650
+            schema: *ref_394
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18206,8 +18643,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_650
-            schema: *ref_478
+          - !<!Parameter> &ref_651
+            schema: *ref_479
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18219,11 +18656,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_651
-            schema: *ref_393
+          - !<!Parameter> &ref_652
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -18232,11 +18669,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_652
-            schema: *ref_393
+          - !<!Parameter> &ref_653
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -18245,11 +18682,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_653
-            schema: *ref_237
+          - !<!Parameter> &ref_654
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -18258,11 +18695,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_654
-            schema: *ref_237
+          - !<!Parameter> &ref_655
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -18271,7 +18708,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_655
+          - !<!Parameter> &ref_656
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -18285,6 +18722,21 @@ operationGroups:
           - *ref_139
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -18295,7 +18747,6 @@ operationGroups:
                 method: patch
                 uri: '{url}'
         signatureParameters:
-          - *ref_645
           - *ref_646
           - *ref_647
           - *ref_648
@@ -18306,6 +18757,7 @@ operationGroups:
           - *ref_653
           - *ref_654
           - *ref_655
+          - *ref_656
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -18316,35 +18768,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_656
+                    schema: *ref_657
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_657
+                    schema: *ref_658
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_658
+                    schema: *ref_659
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_659
+                    schema: *ref_660
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_660
+                    schema: *ref_661
                     header: x-ms-version
                     language:
                       default:
@@ -18354,7 +18806,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_414
+            schema: *ref_415
             language: !<!Languages> 
               default:
                 name: ''
@@ -18363,21 +18815,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_661
+                    schema: *ref_662
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_662
+                    schema: *ref_663
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_663
+                    schema: *ref_664
                     header: x-ms-version
                     language:
                       default:
@@ -18400,7 +18852,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_497
+            schema: *ref_498
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18411,7 +18863,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_664
+          - !<!Parameter> &ref_665
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -18424,8 +18876,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_665
-            schema: *ref_459
+          - !<!Parameter> &ref_666
+            schema: *ref_460
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18437,11 +18889,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_666
-            schema: *ref_223
+          - !<!Parameter> &ref_667
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -18450,11 +18902,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_667
-            schema: *ref_393
+          - !<!Parameter> &ref_668
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -18463,11 +18915,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_668
-            schema: *ref_393
+          - !<!Parameter> &ref_669
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -18476,11 +18928,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_669
-            schema: *ref_237
+          - !<!Parameter> &ref_670
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -18489,11 +18941,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_670
-            schema: *ref_237
+          - !<!Parameter> &ref_671
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -18502,7 +18954,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_671
+          - !<!Parameter> &ref_672
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -18516,6 +18968,21 @@ operationGroups:
           - *ref_139
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -18526,7 +18993,6 @@ operationGroups:
                 method: head
                 uri: '{url}'
         signatureParameters:
-          - *ref_664
           - *ref_665
           - *ref_666
           - *ref_667
@@ -18534,6 +19000,7 @@ operationGroups:
           - *ref_669
           - *ref_670
           - *ref_671
+          - *ref_672
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -18544,63 +19011,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_672
+                    schema: *ref_673
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_673
+                    schema: *ref_674
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_674
+                    schema: *ref_675
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_675
+                    schema: *ref_676
                     header: x-ms-owner
                     language:
                       default:
                         name: x-ms-owner
                         description: The owner of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_676
+                    schema: *ref_677
                     header: x-ms-group
                     language:
                       default:
                         name: x-ms-group
                         description: The owning group of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_677
+                    schema: *ref_678
                     header: x-ms-permissions
                     language:
                       default:
                         name: x-ms-permissions
                         description: 'The POSIX access permissions for the file owner, the file owning group, and others. Included in the response if Hierarchical Namespace is enabled for the account.'
                   - !<!HttpHeader> 
-                    schema: *ref_678
+                    schema: *ref_679
                     header: x-ms-acl
                     language:
                       default:
                         name: x-ms-acl
                         description: The POSIX access control list for the file or directory.  Included in the response only if the action is "getAccessControl" and Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_679
+                    schema: *ref_680
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_680
+                    schema: *ref_681
                     header: x-ms-version
                     language:
                       default:
@@ -18610,7 +19077,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_414
+            schema: *ref_415
             language: !<!Languages> 
               default:
                 name: ''
@@ -18619,21 +19086,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_681
+                    schema: *ref_682
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_682
+                    schema: *ref_683
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_683
+                    schema: *ref_684
                     header: x-ms-version
                     language:
                       default:
@@ -18655,7 +19122,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_135
-          - !<!Parameter> &ref_688
+          - !<!Parameter> &ref_689
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -18668,9 +19135,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_419
-          - !<!Parameter> &ref_689
-            schema: *ref_418
+          - *ref_420
+          - !<!Parameter> &ref_690
+            schema: *ref_419
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18683,8 +19150,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_690
-            schema: *ref_393
+          - !<!Parameter> &ref_691
+            schema: *ref_394
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18694,8 +19161,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_691
-            schema: *ref_393
+          - !<!Parameter> &ref_692
+            schema: *ref_394
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18707,8 +19174,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_692
-            schema: *ref_393
+          - !<!Parameter> &ref_693
+            schema: *ref_394
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18721,11 +19188,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_693
-            schema: *ref_393
+          - !<!Parameter> &ref_694
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: cacheControl
@@ -18734,11 +19201,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_694
-            schema: *ref_393
+          - !<!Parameter> &ref_695
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: contentType
@@ -18747,11 +19214,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_695
-            schema: *ref_393
+          - !<!Parameter> &ref_696
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_422
+              x-ms-parameter-grouping: *ref_423
             language: !<!Languages> 
               default:
                 name: contentEncoding
@@ -18760,11 +19227,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_696
-            schema: *ref_393
+          - !<!Parameter> &ref_697
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_423
+              x-ms-parameter-grouping: *ref_424
             language: !<!Languages> 
               default:
                 name: contentLanguage
@@ -18773,11 +19240,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_697
-            schema: *ref_393
+          - !<!Parameter> &ref_698
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_424
+              x-ms-parameter-grouping: *ref_425
             language: !<!Languages> 
               default:
                 name: contentDisposition
@@ -18786,11 +19253,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_698
-            schema: *ref_223
+          - !<!Parameter> &ref_699
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -18799,8 +19266,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_699
-            schema: *ref_418
+          - !<!Parameter> &ref_700
+            schema: *ref_419
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18810,11 +19277,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_700
-            schema: *ref_237
+          - !<!Parameter> &ref_701
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -18823,11 +19290,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_701
-            schema: *ref_237
+          - !<!Parameter> &ref_702
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -18836,11 +19303,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_702
-            schema: *ref_393
+          - !<!Parameter> &ref_703
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -18849,11 +19316,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_703
-            schema: *ref_393
+          - !<!Parameter> &ref_704
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -18862,11 +19329,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_704
-            schema: *ref_427
+          - !<!Parameter> &ref_705
+            schema: *ref_428
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_684
+              x-ms-parameter-grouping: *ref_685
             language: !<!Languages> 
               default:
                 name: sourceIfModifiedSince
@@ -18875,11 +19342,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_705
-            schema: *ref_427
+          - !<!Parameter> &ref_706
+            schema: *ref_428
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_685
+              x-ms-parameter-grouping: *ref_686
             language: !<!Languages> 
               default:
                 name: sourceIfUnmodifiedSince
@@ -18888,11 +19355,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_706
-            schema: *ref_418
+          - !<!Parameter> &ref_707
+            schema: *ref_419
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_686
+              x-ms-parameter-grouping: *ref_687
             language: !<!Languages> 
               default:
                 name: sourceIfMatch
@@ -18901,11 +19368,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_707
-            schema: *ref_418
+          - !<!Parameter> &ref_708
+            schema: *ref_419
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_687
+              x-ms-parameter-grouping: *ref_688
             language: !<!Languages> 
               default:
                 name: sourceIfNoneMatch
@@ -18915,7 +19382,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_708
+          - !<!Parameter> &ref_709
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -18928,6 +19395,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -18938,7 +19420,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_688
           - *ref_689
           - *ref_690
           - *ref_691
@@ -18959,6 +19440,7 @@ operationGroups:
           - *ref_706
           - *ref_707
           - *ref_708
+          - *ref_709
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -18969,49 +19451,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_709
+                    schema: *ref_710
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_710
+                    schema: *ref_711
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_711
+                    schema: *ref_712
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_712
+                    schema: *ref_713
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_713
+                    schema: *ref_714
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_714
+                    schema: *ref_715
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_715
+                    schema: *ref_716
                     header: Date
                     language:
                       default:
@@ -19021,7 +19503,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_414
+            schema: *ref_415
             language: !<!Languages> 
               default:
                 name: ''
@@ -19030,21 +19512,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_716
+                    schema: *ref_717
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_717
+                    schema: *ref_718
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_718
+                    schema: *ref_719
                     header: x-ms-version
                     language:
                       default:
@@ -19070,7 +19552,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_719
+            schema: *ref_720
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19081,7 +19563,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_720
+          - !<!Parameter> &ref_721
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -19095,7 +19577,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_139
-          - !<!Parameter> &ref_721
+          - !<!Parameter> &ref_722
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -19108,6 +19590,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -19118,8 +19615,8 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_720
           - *ref_721
+          - *ref_722
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -19130,28 +19627,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_722
+                    schema: *ref_723
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_723
+                    schema: *ref_724
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_724
+                    schema: *ref_725
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_725
+                    schema: *ref_726
                     header: Date
                     language:
                       default:
@@ -19161,7 +19658,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -19170,7 +19667,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_726
+                    schema: *ref_727
                     header: x-ms-error-code
                     language:
                       default:
@@ -19204,7 +19701,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_729
+          - !<!Parameter> &ref_730
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -19217,11 +19714,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_730
-            schema: *ref_727
+          - !<!Parameter> &ref_731
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_953
+              x-ms-parameter-grouping: &ref_954
                 name: blob-HTTP-headers
             language: !<!Languages> 
               default:
@@ -19231,11 +19728,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_731
-            schema: *ref_727
+          - !<!Parameter> &ref_732
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_949
+              x-ms-parameter-grouping: &ref_950
                 name: blob-HTTP-headers
             language: !<!Languages> 
               default:
@@ -19245,11 +19742,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_732
-            schema: *ref_728
+          - !<!Parameter> &ref_733
+            schema: *ref_729
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_952
+              x-ms-parameter-grouping: &ref_953
                 name: blob-HTTP-headers
             language: !<!Languages> 
               default:
@@ -19259,11 +19756,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_733
-            schema: *ref_727
+          - !<!Parameter> &ref_734
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_950
+              x-ms-parameter-grouping: &ref_951
                 name: blob-HTTP-headers
             language: !<!Languages> 
               default:
@@ -19273,11 +19770,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_734
-            schema: *ref_727
+          - !<!Parameter> &ref_735
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_951
+              x-ms-parameter-grouping: &ref_952
                 name: blob-HTTP-headers
             language: !<!Languages> 
               default:
@@ -19287,11 +19784,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_735
-            schema: *ref_223
+          - !<!Parameter> &ref_736
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -19300,11 +19797,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_736
-            schema: *ref_237
+          - !<!Parameter> &ref_737
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -19313,11 +19810,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_737
-            schema: *ref_237
+          - !<!Parameter> &ref_738
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -19326,11 +19823,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_738
-            schema: *ref_393
+          - !<!Parameter> &ref_739
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -19339,11 +19836,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_739
-            schema: *ref_393
+          - !<!Parameter> &ref_740
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -19352,11 +19849,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_740
-            schema: *ref_727
+          - !<!Parameter> &ref_741
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_954
+              x-ms-parameter-grouping: &ref_955
                 name: blob-HTTP-headers
             language: !<!Languages> 
               default:
@@ -19367,7 +19864,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_741
+          - !<!Parameter> &ref_742
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -19380,6 +19877,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -19390,7 +19902,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_729
           - *ref_730
           - *ref_731
           - *ref_732
@@ -19403,6 +19914,7 @@ operationGroups:
           - *ref_739
           - *ref_740
           - *ref_741
+          - *ref_742
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -19413,49 +19925,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_742
+                    schema: *ref_743
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_743
+                    schema: *ref_744
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_744
+                    schema: *ref_745
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for a page blob. This header is not returned for block blobs or append blobs
                   - !<!HttpHeader> 
-                    schema: *ref_745
+                    schema: *ref_746
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_746
+                    schema: *ref_747
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_747
+                    schema: *ref_748
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_748
+                    schema: *ref_749
                     header: Date
                     language:
                       default:
@@ -19465,7 +19977,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -19474,7 +19986,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_749
+                    schema: *ref_750
                     header: x-ms-error-code
                     language:
                       default:
@@ -19497,7 +20009,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_247
+            schema: *ref_248
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19508,7 +20020,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_750
+          - !<!Parameter> &ref_751
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -19521,8 +20033,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_751
-            schema: *ref_212
+          - !<!Parameter> &ref_752
+            schema: *ref_213
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -19537,11 +20049,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_752
-            schema: *ref_223
+          - !<!Parameter> &ref_753
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -19550,11 +20062,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_753
-            schema: *ref_518
+          - !<!Parameter> &ref_754
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_585
+              x-ms-parameter-grouping: *ref_586
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -19565,11 +20077,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_754
-            schema: *ref_518
+          - !<!Parameter> &ref_755
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_586
+              x-ms-parameter-grouping: *ref_587
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -19579,10 +20091,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_519
+            schema: *ref_520
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_587
+              x-ms-parameter-grouping: *ref_588
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -19591,11 +20103,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_755
-            schema: *ref_237
+          - !<!Parameter> &ref_756
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -19604,11 +20116,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_756
-            schema: *ref_237
+          - !<!Parameter> &ref_757
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -19617,11 +20129,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_757
-            schema: *ref_393
+          - !<!Parameter> &ref_758
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -19630,11 +20142,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_758
-            schema: *ref_393
+          - !<!Parameter> &ref_759
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -19644,7 +20156,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_759
+          - !<!Parameter> &ref_760
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -19657,6 +20169,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -19667,7 +20194,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_750
           - *ref_751
           - *ref_752
           - *ref_753
@@ -19677,6 +20203,7 @@ operationGroups:
           - *ref_757
           - *ref_758
           - *ref_759
+          - *ref_760
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -19687,56 +20214,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_760
+                    schema: *ref_761
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_761
+                    schema: *ref_762
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_762
+                    schema: *ref_763
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_763
+                    schema: *ref_764
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_764
+                    schema: *ref_765
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_765
+                    schema: *ref_766
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_766
+                    schema: *ref_767
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_767
+                    schema: *ref_768
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -19746,7 +20273,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -19755,7 +20282,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_768
+                    schema: *ref_769
                     header: x-ms-error-code
                     language:
                       default:
@@ -19778,7 +20305,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_288
+            schema: *ref_289
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19790,7 +20317,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_289
+            schema: *ref_290
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19801,7 +20328,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_769
+          - !<!Parameter> &ref_770
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -19814,8 +20341,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_770
-            schema: *ref_290
+          - !<!Parameter> &ref_771
+            schema: *ref_291
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19825,8 +20352,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_771
-            schema: *ref_291
+          - !<!Parameter> &ref_772
+            schema: *ref_292
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19836,11 +20363,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_772
-            schema: *ref_237
+          - !<!Parameter> &ref_773
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -19849,11 +20376,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_773
-            schema: *ref_237
+          - !<!Parameter> &ref_774
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -19862,11 +20389,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_774
-            schema: *ref_393
+          - !<!Parameter> &ref_775
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -19875,11 +20402,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_775
-            schema: *ref_393
+          - !<!Parameter> &ref_776
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -19889,7 +20416,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_776
+          - !<!Parameter> &ref_777
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -19902,6 +20429,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -19912,7 +20454,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_769
           - *ref_770
           - *ref_771
           - *ref_772
@@ -19920,6 +20461,7 @@ operationGroups:
           - *ref_774
           - *ref_775
           - *ref_776
+          - *ref_777
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -19930,49 +20472,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_777
+                    schema: *ref_778
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_778
+                    schema: *ref_779
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_779
+                    schema: *ref_780
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a blobs's lease
                   - !<!HttpHeader> 
-                    schema: *ref_780
+                    schema: *ref_781
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_781
+                    schema: *ref_782
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_782
+                    schema: *ref_783
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_783
+                    schema: *ref_784
                     header: Date
                     language:
                       default:
@@ -19982,7 +20524,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -19991,7 +20533,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_784
+                    schema: *ref_785
                     header: x-ms-error-code
                     language:
                       default:
@@ -20014,7 +20556,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_288
+            schema: *ref_289
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20026,7 +20568,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_305
+            schema: *ref_306
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20037,7 +20579,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_785
+          - !<!Parameter> &ref_786
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -20050,8 +20592,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_786
-            schema: *ref_306
+          - !<!Parameter> &ref_787
+            schema: *ref_307
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20062,11 +20604,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_787
-            schema: *ref_237
+          - !<!Parameter> &ref_788
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -20075,11 +20617,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_788
-            schema: *ref_237
+          - !<!Parameter> &ref_789
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -20088,11 +20630,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_789
-            schema: *ref_393
+          - !<!Parameter> &ref_790
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -20101,11 +20643,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_790
-            schema: *ref_393
+          - !<!Parameter> &ref_791
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -20115,7 +20657,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_791
+          - !<!Parameter> &ref_792
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -20128,6 +20670,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -20138,13 +20695,13 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_785
           - *ref_786
           - *ref_787
           - *ref_788
           - *ref_789
           - *ref_790
           - *ref_791
+          - *ref_792
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -20155,42 +20712,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_792
+                    schema: *ref_793
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_793
+                    schema: *ref_794
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_794
+                    schema: *ref_795
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_795
+                    schema: *ref_796
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_796
+                    schema: *ref_797
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_797
+                    schema: *ref_798
                     header: Date
                     language:
                       default:
@@ -20200,7 +20757,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -20209,7 +20766,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_798
+                    schema: *ref_799
                     header: x-ms-error-code
                     language:
                       default:
@@ -20232,7 +20789,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_288
+            schema: *ref_289
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20244,7 +20801,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_318
+            schema: *ref_319
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20255,7 +20812,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_799
+          - !<!Parameter> &ref_800
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -20268,8 +20825,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_800
-            schema: *ref_306
+          - !<!Parameter> &ref_801
+            schema: *ref_307
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20280,11 +20837,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_801
-            schema: *ref_237
+          - !<!Parameter> &ref_802
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -20293,11 +20850,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_802
-            schema: *ref_237
+          - !<!Parameter> &ref_803
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -20306,11 +20863,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_803
-            schema: *ref_393
+          - !<!Parameter> &ref_804
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -20319,11 +20876,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_804
-            schema: *ref_393
+          - !<!Parameter> &ref_805
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -20333,7 +20890,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_805
+          - !<!Parameter> &ref_806
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -20346,6 +20903,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -20356,13 +20928,13 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_799
           - *ref_800
           - *ref_801
           - *ref_802
           - *ref_803
           - *ref_804
           - *ref_805
+          - *ref_806
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -20373,49 +20945,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_806
+                    schema: *ref_807
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_807
+                    schema: *ref_808
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_808
+                    schema: *ref_809
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a blobs's lease
                   - !<!HttpHeader> 
-                    schema: *ref_809
+                    schema: *ref_810
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_810
+                    schema: *ref_811
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_811
+                    schema: *ref_812
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_812
+                    schema: *ref_813
                     header: Date
                     language:
                       default:
@@ -20425,7 +20997,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -20434,7 +21006,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_813
+                    schema: *ref_814
                     header: x-ms-error-code
                     language:
                       default:
@@ -20457,7 +21029,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_288
+            schema: *ref_289
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20469,7 +21041,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_345
+            schema: *ref_346
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20480,7 +21052,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_814
+          - !<!Parameter> &ref_815
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -20493,8 +21065,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_815
-            schema: *ref_306
+          - !<!Parameter> &ref_816
+            schema: *ref_307
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20505,8 +21077,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_816
-            schema: *ref_346
+          - !<!Parameter> &ref_817
+            schema: *ref_347
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20517,11 +21089,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_817
-            schema: *ref_237
+          - !<!Parameter> &ref_818
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -20530,11 +21102,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_818
-            schema: *ref_237
+          - !<!Parameter> &ref_819
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -20543,11 +21115,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_819
-            schema: *ref_393
+          - !<!Parameter> &ref_820
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -20556,11 +21128,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_820
-            schema: *ref_393
+          - !<!Parameter> &ref_821
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -20570,7 +21142,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_821
+          - !<!Parameter> &ref_822
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -20583,6 +21155,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -20593,7 +21180,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_814
           - *ref_815
           - *ref_816
           - *ref_817
@@ -20601,6 +21187,7 @@ operationGroups:
           - *ref_819
           - *ref_820
           - *ref_821
+          - *ref_822
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -20611,49 +21198,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_822
+                    schema: *ref_823
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_823
+                    schema: *ref_824
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_824
+                    schema: *ref_825
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_825
+                    schema: *ref_826
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_826
+                    schema: *ref_827
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a blobs's lease
                   - !<!HttpHeader> 
-                    schema: *ref_827
+                    schema: *ref_828
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_828
+                    schema: *ref_829
                     header: Date
                     language:
                       default:
@@ -20663,7 +21250,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -20672,7 +21259,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_829
+                    schema: *ref_830
                     header: x-ms-error-code
                     language:
                       default:
@@ -20695,7 +21282,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_288
+            schema: *ref_289
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20707,7 +21294,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_332
+            schema: *ref_333
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20718,7 +21305,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_830
+          - !<!Parameter> &ref_831
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -20731,8 +21318,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_831
-            schema: *ref_290
+          - !<!Parameter> &ref_832
+            schema: *ref_291
             implementation: Method
             language: !<!Languages> 
               default:
@@ -20745,11 +21332,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_832
-            schema: *ref_237
+          - !<!Parameter> &ref_833
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -20758,11 +21345,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_833
-            schema: *ref_237
+          - !<!Parameter> &ref_834
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -20771,11 +21358,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_834
-            schema: *ref_393
+          - !<!Parameter> &ref_835
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -20784,11 +21371,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_835
-            schema: *ref_393
+          - !<!Parameter> &ref_836
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -20798,7 +21385,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_836
+          - !<!Parameter> &ref_837
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -20811,6 +21398,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -20821,13 +21423,13 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_830
           - *ref_831
           - *ref_832
           - *ref_833
           - *ref_834
           - *ref_835
           - *ref_836
+          - *ref_837
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -20838,49 +21440,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_837
+                    schema: *ref_838
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_838
+                    schema: *ref_839
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_839
+                    schema: *ref_840
                     header: x-ms-lease-time
                     language:
                       default:
                         name: LeaseTime
                         description: 'Approximate time remaining in the lease period, in seconds.'
                   - !<!HttpHeader> 
-                    schema: *ref_840
+                    schema: *ref_841
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_841
+                    schema: *ref_842
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_842
+                    schema: *ref_843
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_843
+                    schema: *ref_844
                     header: Date
                     language:
                       default:
@@ -20890,7 +21492,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -20899,7 +21501,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_844
+                    schema: *ref_845
                     header: x-ms-error-code
                     language:
                       default:
@@ -20922,7 +21524,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_845
+            schema: *ref_846
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20933,7 +21535,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_846
+          - !<!Parameter> &ref_847
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -20946,8 +21548,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_847
-            schema: *ref_212
+          - !<!Parameter> &ref_848
+            schema: *ref_213
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -20962,11 +21564,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_848
-            schema: *ref_518
+          - !<!Parameter> &ref_849
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_585
+              x-ms-parameter-grouping: *ref_586
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -20977,11 +21579,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_849
-            schema: *ref_518
+          - !<!Parameter> &ref_850
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_586
+              x-ms-parameter-grouping: *ref_587
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -20991,10 +21593,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_519
+            schema: *ref_520
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_587
+              x-ms-parameter-grouping: *ref_588
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -21003,11 +21605,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_850
-            schema: *ref_237
+          - !<!Parameter> &ref_851
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -21016,11 +21618,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_851
-            schema: *ref_237
+          - !<!Parameter> &ref_852
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -21029,11 +21631,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_852
-            schema: *ref_393
+          - !<!Parameter> &ref_853
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -21042,11 +21644,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_853
-            schema: *ref_393
+          - !<!Parameter> &ref_854
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -21055,11 +21657,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_854
-            schema: *ref_223
+          - !<!Parameter> &ref_855
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -21069,7 +21671,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_855
+          - !<!Parameter> &ref_856
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -21082,6 +21684,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -21092,7 +21709,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_846
           - *ref_847
           - *ref_848
           - *ref_849
@@ -21102,6 +21718,7 @@ operationGroups:
           - *ref_853
           - *ref_854
           - *ref_855
+          - *ref_856
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -21112,56 +21729,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_856
+                    schema: *ref_857
                     header: x-ms-snapshot
                     language:
                       default:
                         name: Snapshot
                         description: Uniquely identifies the snapshot and indicates the snapshot version. It may be used in subsequent requests to access the snapshot
                   - !<!HttpHeader> 
-                    schema: *ref_857
+                    schema: *ref_858
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_858
+                    schema: *ref_859
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_859
+                    schema: *ref_860
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_860
+                    schema: *ref_861
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_861
+                    schema: *ref_862
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_862
+                    schema: *ref_863
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_863
+                    schema: *ref_864
                     header: x-ms-request-server-encrypted
                     language:
                       default:
@@ -21173,7 +21790,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -21182,7 +21799,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_864
+                    schema: *ref_865
                     header: x-ms-error-code
                     language:
                       default:
@@ -21204,7 +21821,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_135
-          - !<!Parameter> &ref_867
+          - !<!Parameter> &ref_868
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -21217,8 +21834,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_868
-            schema: *ref_212
+          - !<!Parameter> &ref_869
+            schema: *ref_213
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -21233,7 +21850,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_869
+          - !<!Parameter> &ref_870
             schema: *ref_86
             implementation: Method
             language: !<!Languages> 
@@ -21244,8 +21861,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_870
-            schema: *ref_865
+          - !<!Parameter> &ref_871
+            schema: *ref_866
             implementation: Method
             language: !<!Languages> 
               default:
@@ -21255,11 +21872,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_871
-            schema: *ref_427
+          - !<!Parameter> &ref_872
+            schema: *ref_428
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_684
+              x-ms-parameter-grouping: *ref_685
             language: !<!Languages> 
               default:
                 name: sourceIfModifiedSince
@@ -21268,11 +21885,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_872
-            schema: *ref_427
+          - !<!Parameter> &ref_873
+            schema: *ref_428
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_685
+              x-ms-parameter-grouping: *ref_686
             language: !<!Languages> 
               default:
                 name: sourceIfUnmodifiedSince
@@ -21281,11 +21898,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_873
-            schema: *ref_418
+          - !<!Parameter> &ref_874
+            schema: *ref_419
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_686
+              x-ms-parameter-grouping: *ref_687
             language: !<!Languages> 
               default:
                 name: sourceIfMatch
@@ -21294,11 +21911,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_874
-            schema: *ref_418
+          - !<!Parameter> &ref_875
+            schema: *ref_419
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_687
+              x-ms-parameter-grouping: *ref_688
             language: !<!Languages> 
               default:
                 name: sourceIfNoneMatch
@@ -21307,11 +21924,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_875
-            schema: *ref_237
+          - !<!Parameter> &ref_876
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -21320,11 +21937,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_876
-            schema: *ref_237
+          - !<!Parameter> &ref_877
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -21333,11 +21950,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_877
-            schema: *ref_393
+          - !<!Parameter> &ref_878
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -21346,11 +21963,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_878
-            schema: *ref_393
+          - !<!Parameter> &ref_879
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -21359,8 +21976,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_879
-            schema: *ref_866
+          - !<!Parameter> &ref_880
+            schema: *ref_867
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -21373,11 +21990,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_880
-            schema: *ref_223
+          - !<!Parameter> &ref_881
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -21387,7 +22004,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_881
+          - !<!Parameter> &ref_882
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -21400,6 +22017,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -21410,7 +22042,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_867
           - *ref_868
           - *ref_869
           - *ref_870
@@ -21425,6 +22056,7 @@ operationGroups:
           - *ref_879
           - *ref_880
           - *ref_881
+          - *ref_882
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -21435,49 +22067,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_882
+                    schema: *ref_883
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_883
+                    schema: *ref_884
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_884
+                    schema: *ref_885
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_885
+                    schema: *ref_886
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_886
+                    schema: *ref_887
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_887
+                    schema: *ref_888
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_888
+                    schema: *ref_889
                     header: x-ms-copy-id
                     language:
                       default:
@@ -21494,7 +22126,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -21503,7 +22135,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_889
+                    schema: *ref_890
                     header: x-ms-error-code
                     language:
                       default:
@@ -21526,7 +22158,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_890
+            schema: *ref_891
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -21537,7 +22169,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_892
+          - !<!Parameter> &ref_893
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -21550,8 +22182,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_893
-            schema: *ref_212
+          - !<!Parameter> &ref_894
+            schema: *ref_213
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -21566,7 +22198,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_894
+          - !<!Parameter> &ref_895
             schema: *ref_86
             implementation: Method
             language: !<!Languages> 
@@ -21577,11 +22209,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_895
-            schema: *ref_427
+          - !<!Parameter> &ref_896
+            schema: *ref_428
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_684
+              x-ms-parameter-grouping: *ref_685
             language: !<!Languages> 
               default:
                 name: sourceIfModifiedSince
@@ -21590,11 +22222,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_896
-            schema: *ref_427
+          - !<!Parameter> &ref_897
+            schema: *ref_428
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_685
+              x-ms-parameter-grouping: *ref_686
             language: !<!Languages> 
               default:
                 name: sourceIfUnmodifiedSince
@@ -21603,11 +22235,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_897
-            schema: *ref_418
+          - !<!Parameter> &ref_898
+            schema: *ref_419
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_686
+              x-ms-parameter-grouping: *ref_687
             language: !<!Languages> 
               default:
                 name: sourceIfMatch
@@ -21616,11 +22248,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_898
-            schema: *ref_418
+          - !<!Parameter> &ref_899
+            schema: *ref_419
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_687
+              x-ms-parameter-grouping: *ref_688
             language: !<!Languages> 
               default:
                 name: sourceIfNoneMatch
@@ -21629,11 +22261,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_899
-            schema: *ref_237
+          - !<!Parameter> &ref_900
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -21642,11 +22274,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_900
-            schema: *ref_237
+          - !<!Parameter> &ref_901
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -21655,11 +22287,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_901
-            schema: *ref_393
+          - !<!Parameter> &ref_902
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -21668,11 +22300,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_902
-            schema: *ref_393
+          - !<!Parameter> &ref_903
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -21681,8 +22313,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_903
-            schema: *ref_866
+          - !<!Parameter> &ref_904
+            schema: *ref_867
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -21695,11 +22327,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_904
-            schema: *ref_223
+          - !<!Parameter> &ref_905
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -21709,7 +22341,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_905
+          - !<!Parameter> &ref_906
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -21720,8 +22352,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_906
-            schema: *ref_891
+          - !<!Parameter> &ref_907
+            schema: *ref_892
             implementation: Method
             language: !<!Languages> 
               default:
@@ -21733,6 +22365,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -21743,7 +22390,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_892
           - *ref_893
           - *ref_894
           - *ref_895
@@ -21758,6 +22404,7 @@ operationGroups:
           - *ref_904
           - *ref_905
           - *ref_906
+          - *ref_907
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -21768,70 +22415,70 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_907
+                    schema: *ref_908
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_908
+                    schema: *ref_909
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_909
+                    schema: *ref_910
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_910
+                    schema: *ref_911
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_911
+                    schema: *ref_912
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_912
+                    schema: *ref_913
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_913
+                    schema: *ref_914
                     header: x-ms-copy-id
                     language:
                       default:
                         name: CopyId
                         description: String identifier for this copy operation.
                   - !<!HttpHeader> 
-                    schema: *ref_914
+                    schema: *ref_915
                     header: x-ms-copy-status
                     language:
                       default:
                         name: CopyStatus
                         description: State of the copy operation identified by x-ms-copy-id.
                   - !<!HttpHeader> 
-                    schema: *ref_915
+                    schema: *ref_916
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: This response header is returned so that the client can check for the integrity of the copied content. This header is only returned if the source content MD5 was specified.
                   - !<!HttpHeader> 
-                    schema: *ref_916
+                    schema: *ref_917
                     header: x-ms-content-crc64
                     language:
                       default:
@@ -21841,7 +22488,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -21850,7 +22497,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_917
+                    schema: *ref_918
                     header: x-ms-error-code
                     language:
                       default:
@@ -21873,7 +22520,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_918
+            schema: *ref_919
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -21885,7 +22532,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_919
+            schema: *ref_920
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -21896,8 +22543,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_921
-            schema: *ref_920
+          - !<!Parameter> &ref_922
+            schema: *ref_921
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -21908,7 +22555,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_922
+          - !<!Parameter> &ref_923
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -21921,11 +22568,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_923
-            schema: *ref_223
+          - !<!Parameter> &ref_924
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -21935,7 +22582,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_924
+          - !<!Parameter> &ref_925
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -21948,6 +22595,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -21958,10 +22620,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_921
           - *ref_922
           - *ref_923
           - *ref_924
+          - *ref_925
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -21972,28 +22634,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_920
+                    schema: *ref_921
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_925
+                    schema: *ref_926
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_926
+                    schema: *ref_927
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_927
+                    schema: *ref_928
                     header: Date
                     language:
                       default:
@@ -22003,7 +22665,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -22012,7 +22674,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_928
+                    schema: *ref_929
                     header: x-ms-error-code
                     language:
                       default:
@@ -22035,7 +22697,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_929
+            schema: *ref_930
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22046,7 +22708,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_930
+          - !<!Parameter> &ref_931
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -22059,7 +22721,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_931
+          - !<!Parameter> &ref_932
             schema: *ref_86
             implementation: Method
             required: true
@@ -22071,8 +22733,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_932
-            schema: *ref_865
+          - !<!Parameter> &ref_933
+            schema: *ref_866
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22083,7 +22745,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_933
+          - !<!Parameter> &ref_934
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -22094,11 +22756,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_934
-            schema: *ref_223
+          - !<!Parameter> &ref_935
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -22109,6 +22771,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -22119,11 +22796,11 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_930
           - *ref_931
           - *ref_932
           - *ref_933
           - *ref_934
+          - *ref_935
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -22134,21 +22811,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_935
+                    schema: *ref_936
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_936
+                    schema: *ref_937
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_937
+                    schema: *ref_938
                     header: x-ms-version
                     language:
                       default:
@@ -22165,21 +22842,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_938
+                    schema: *ref_939
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_939
+                    schema: *ref_940
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_940
+                    schema: *ref_941
                     header: x-ms-version
                     language:
                       default:
@@ -22189,7 +22866,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -22198,7 +22875,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_941
+                    schema: *ref_942
                     header: x-ms-error-code
                     language:
                       default:
@@ -22223,7 +22900,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_191
+            schema: *ref_192
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22249,6 +22926,21 @@ operationGroups:
           - *ref_139
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -22269,42 +22961,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_942
+                    schema: *ref_943
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_943
+                    schema: *ref_944
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_944
+                    schema: *ref_945
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_945
+                    schema: *ref_946
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_196
+                    schema: *ref_197
                     header: x-ms-sku-name
                     language:
                       default:
                         name: SkuName
                         description: Identifies the sku name of the account
                   - !<!HttpHeader> 
-                    schema: *ref_197
+                    schema: *ref_198
                     header: x-ms-account-kind
                     language:
                       default:
@@ -22314,7 +23006,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -22323,7 +23015,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_946
+                    schema: *ref_947
                     header: x-ms-error-code
                     language:
                       default:
@@ -22354,7 +23046,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_947
+            schema: *ref_948
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22365,7 +23057,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_956
+          - !<!Parameter> &ref_957
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -22378,8 +23070,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_957
-            schema: *ref_200
+          - !<!Parameter> &ref_958
+            schema: *ref_201
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22390,8 +23082,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_958
-            schema: *ref_948
+          - !<!Parameter> &ref_959
+            schema: *ref_949
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22401,11 +23093,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_959
-            schema: *ref_727
+          - !<!Parameter> &ref_960
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_949
+              x-ms-parameter-grouping: *ref_950
             language: !<!Languages> 
               default:
                 name: blobContentType
@@ -22414,29 +23106,16 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_960
-            schema: *ref_727
-            implementation: Method
-            extensions:
-              x-ms-parameter-grouping: *ref_950
-            language: !<!Languages> 
-              default:
-                name: blobContentEncoding
-                description: 'Optional. Sets the blob''s content encoding. If specified, this property is stored with the blob and returned with a read request.'
-                serializedName: x-ms-blob-content-encoding
-            protocol: !<!Protocols> 
-              http: !<!HttpParameter> 
-                in: header
           - !<!Parameter> &ref_961
-            schema: *ref_727
+            schema: *ref_728
             implementation: Method
             extensions:
               x-ms-parameter-grouping: *ref_951
             language: !<!Languages> 
               default:
-                name: blobContentLanguage
-                description: 'Optional. Set the blob''s content language. If specified, this property is stored with the blob and returned with a read request.'
-                serializedName: x-ms-blob-content-language
+                name: blobContentEncoding
+                description: 'Optional. Sets the blob''s content encoding. If specified, this property is stored with the blob and returned with a read request.'
+                serializedName: x-ms-blob-content-encoding
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
@@ -22447,17 +23126,30 @@ operationGroups:
               x-ms-parameter-grouping: *ref_952
             language: !<!Languages> 
               default:
+                name: blobContentLanguage
+                description: 'Optional. Set the blob''s content language. If specified, this property is stored with the blob and returned with a read request.'
+                serializedName: x-ms-blob-content-language
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: header
+          - !<!Parameter> &ref_963
+            schema: *ref_729
+            implementation: Method
+            extensions:
+              x-ms-parameter-grouping: *ref_953
+            language: !<!Languages> 
+              default:
                 name: blobContentMD5
                 description: 'Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks were validated when each was uploaded.'
                 serializedName: x-ms-blob-content-md5
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_963
-            schema: *ref_727
+          - !<!Parameter> &ref_964
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_953
+              x-ms-parameter-grouping: *ref_954
             language: !<!Languages> 
               default:
                 name: blobCacheControl
@@ -22466,8 +23158,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_964
-            schema: *ref_212
+          - !<!Parameter> &ref_965
+            schema: *ref_213
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -22482,11 +23174,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_965
-            schema: *ref_223
+          - !<!Parameter> &ref_966
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -22495,11 +23187,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_966
-            schema: *ref_727
+          - !<!Parameter> &ref_967
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_954
+              x-ms-parameter-grouping: *ref_955
             language: !<!Languages> 
               default:
                 name: blobContentDisposition
@@ -22508,11 +23200,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_967
-            schema: *ref_518
+          - !<!Parameter> &ref_968
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_585
+              x-ms-parameter-grouping: *ref_586
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -22523,11 +23215,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_968
-            schema: *ref_518
+          - !<!Parameter> &ref_969
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_586
+              x-ms-parameter-grouping: *ref_587
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -22537,10 +23229,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_519
+            schema: *ref_520
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_587
+              x-ms-parameter-grouping: *ref_588
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -22549,11 +23241,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_969
-            schema: *ref_237
+          - !<!Parameter> &ref_970
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -22562,11 +23254,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_970
-            schema: *ref_237
+          - !<!Parameter> &ref_971
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -22575,11 +23267,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_971
-            schema: *ref_393
+          - !<!Parameter> &ref_972
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -22588,11 +23280,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_972
-            schema: *ref_393
+          - !<!Parameter> &ref_973
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -22601,8 +23293,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_973
-            schema: *ref_744
+          - !<!Parameter> &ref_974
+            schema: *ref_745
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22613,8 +23305,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_974
-            schema: *ref_955
+          - !<!Parameter> &ref_975
+            schema: *ref_956
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22625,7 +23317,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_975
+          - !<!Parameter> &ref_976
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -22638,6 +23330,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -22648,7 +23355,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_956
           - *ref_957
           - *ref_958
           - *ref_959
@@ -22668,6 +23374,7 @@ operationGroups:
           - *ref_973
           - *ref_974
           - *ref_975
+          - *ref_976
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -22678,63 +23385,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_727
+                    schema: *ref_728
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_976
+                    schema: *ref_977
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_977
+                    schema: *ref_978
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_978
+                    schema: *ref_979
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_979
+                    schema: *ref_980
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_980
+                    schema: *ref_981
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_981
+                    schema: *ref_982
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_982
+                    schema: *ref_983
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_983
+                    schema: *ref_984
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -22744,7 +23451,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -22753,7 +23460,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_984
+                    schema: *ref_985
                     header: x-ms-error-code
                     language:
                       default:
@@ -22776,7 +23483,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_985
+            schema: *ref_986
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22788,7 +23495,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_986
+            schema: *ref_987
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22802,8 +23509,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_992
-            schema: *ref_200
+          - !<!Parameter> &ref_993
+            schema: *ref_201
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22814,8 +23521,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_993
-            schema: *ref_987
+          - !<!Parameter> &ref_994
+            schema: *ref_988
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22825,8 +23532,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_994
-            schema: *ref_988
+          - !<!Parameter> &ref_995
+            schema: *ref_989
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22836,7 +23543,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_995
+          - !<!Parameter> &ref_996
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -22849,8 +23556,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_996
-            schema: *ref_518
+          - !<!Parameter> &ref_997
+            schema: *ref_519
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22860,11 +23567,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_997
-            schema: *ref_223
+          - !<!Parameter> &ref_998
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -22873,11 +23580,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_998
-            schema: *ref_518
+          - !<!Parameter> &ref_999
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_585
+              x-ms-parameter-grouping: *ref_586
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -22888,11 +23595,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_999
-            schema: *ref_518
+          - !<!Parameter> &ref_1000
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_586
+              x-ms-parameter-grouping: *ref_587
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -22902,10 +23609,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_519
+            schema: *ref_520
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_587
+              x-ms-parameter-grouping: *ref_588
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -22914,11 +23621,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1000
-            schema: *ref_989
+          - !<!Parameter> &ref_1001
+            schema: *ref_990
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_1020
+              x-ms-parameter-grouping: &ref_1021
                 name: sequence-number-access-conditions
             language: !<!Languages> 
               default:
@@ -22928,11 +23635,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1001
-            schema: *ref_989
+          - !<!Parameter> &ref_1002
+            schema: *ref_990
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_1021
+              x-ms-parameter-grouping: &ref_1022
                 name: sequence-number-access-conditions
             language: !<!Languages> 
               default:
@@ -22942,11 +23649,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1002
-            schema: *ref_989
+          - !<!Parameter> &ref_1003
+            schema: *ref_990
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_1022
+              x-ms-parameter-grouping: &ref_1023
                 name: sequence-number-access-conditions
             language: !<!Languages> 
               default:
@@ -22956,11 +23663,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1003
-            schema: *ref_237
+          - !<!Parameter> &ref_1004
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -22969,11 +23676,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1004
-            schema: *ref_237
+          - !<!Parameter> &ref_1005
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -22982,11 +23689,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1005
-            schema: *ref_393
+          - !<!Parameter> &ref_1006
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -22995,11 +23702,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1006
-            schema: *ref_393
+          - !<!Parameter> &ref_1007
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -23009,7 +23716,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_1007
+          - !<!Parameter> &ref_1008
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -23023,8 +23730,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_991
-                schema: *ref_990
+              - !<!Parameter> &ref_992
+                schema: *ref_991
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -23035,8 +23742,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_991
+              - *ref_992
             language: !<!Languages> 
               default:
                 name: ''
@@ -23051,7 +23771,6 @@ operationGroups:
                   - application/octet-stream
                 uri: '{url}'
         signatureParameters:
-          - *ref_992
           - *ref_993
           - *ref_994
           - *ref_995
@@ -23067,6 +23786,7 @@ operationGroups:
           - *ref_1005
           - *ref_1006
           - *ref_1007
+          - *ref_1008
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -23077,77 +23797,77 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1008
+                    schema: *ref_1009
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1009
+                    schema: *ref_1010
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1010
+                    schema: *ref_1011
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1011
+                    schema: *ref_1012
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_989
+                    schema: *ref_990
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for the page blob.
                   - !<!HttpHeader> 
-                    schema: *ref_1012
+                    schema: *ref_1013
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1013
+                    schema: *ref_1014
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1014
+                    schema: *ref_1015
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1015
+                    schema: *ref_1016
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1016
+                    schema: *ref_1017
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1017
+                    schema: *ref_1018
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -23157,7 +23877,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -23166,7 +23886,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1018
+                    schema: *ref_1019
                     header: x-ms-error-code
                     language:
                       default:
@@ -23189,7 +23909,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_985
+            schema: *ref_986
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23201,7 +23921,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_1019
+            schema: *ref_1020
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23215,8 +23935,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1023
-            schema: *ref_200
+          - !<!Parameter> &ref_1024
+            schema: *ref_201
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23227,7 +23947,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1024
+          - !<!Parameter> &ref_1025
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -23240,8 +23960,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1025
-            schema: *ref_518
+          - !<!Parameter> &ref_1026
+            schema: *ref_519
             implementation: Method
             language: !<!Languages> 
               default:
@@ -23251,11 +23971,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1026
-            schema: *ref_223
+          - !<!Parameter> &ref_1027
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -23264,11 +23984,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1027
-            schema: *ref_518
+          - !<!Parameter> &ref_1028
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_585
+              x-ms-parameter-grouping: *ref_586
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -23279,11 +23999,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1028
-            schema: *ref_518
+          - !<!Parameter> &ref_1029
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_586
+              x-ms-parameter-grouping: *ref_587
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -23293,10 +24013,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_519
+            schema: *ref_520
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_587
+              x-ms-parameter-grouping: *ref_588
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -23305,11 +24025,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1029
-            schema: *ref_989
+          - !<!Parameter> &ref_1030
+            schema: *ref_990
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_1020
+              x-ms-parameter-grouping: *ref_1021
             language: !<!Languages> 
               default:
                 name: ifSequenceNumberLessThanOrEqualTo
@@ -23318,11 +24038,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1030
-            schema: *ref_989
+          - !<!Parameter> &ref_1031
+            schema: *ref_990
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_1021
+              x-ms-parameter-grouping: *ref_1022
             language: !<!Languages> 
               default:
                 name: ifSequenceNumberLessThan
@@ -23331,11 +24051,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1031
-            schema: *ref_989
+          - !<!Parameter> &ref_1032
+            schema: *ref_990
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_1022
+              x-ms-parameter-grouping: *ref_1023
             language: !<!Languages> 
               default:
                 name: ifSequenceNumberEqualTo
@@ -23344,11 +24064,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1032
-            schema: *ref_237
+          - !<!Parameter> &ref_1033
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -23357,11 +24077,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1033
-            schema: *ref_237
+          - !<!Parameter> &ref_1034
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -23370,11 +24090,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1034
-            schema: *ref_393
+          - !<!Parameter> &ref_1035
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -23383,11 +24103,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1035
-            schema: *ref_393
+          - !<!Parameter> &ref_1036
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -23397,7 +24117,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_1036
+          - !<!Parameter> &ref_1037
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -23410,6 +24130,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -23420,7 +24155,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1023
           - *ref_1024
           - *ref_1025
           - *ref_1026
@@ -23434,6 +24168,7 @@ operationGroups:
           - *ref_1034
           - *ref_1035
           - *ref_1036
+          - *ref_1037
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -23444,63 +24179,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1037
+                    schema: *ref_1038
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1038
+                    schema: *ref_1039
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1039
+                    schema: *ref_1040
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1040
+                    schema: *ref_1041
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1041
+                    schema: *ref_1042
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for the page blob.
                   - !<!HttpHeader> 
-                    schema: *ref_1042
+                    schema: *ref_1043
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1043
+                    schema: *ref_1044
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1044
+                    schema: *ref_1045
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1045
+                    schema: *ref_1046
                     header: Date
                     language:
                       default:
@@ -23510,7 +24245,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -23519,7 +24254,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1046
+                    schema: *ref_1047
                     header: x-ms-error-code
                     language:
                       default:
@@ -23542,7 +24277,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_985
+            schema: *ref_986
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23554,7 +24289,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_986
+            schema: *ref_987
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23568,8 +24303,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1049
-            schema: *ref_866
+          - !<!Parameter> &ref_1050
+            schema: *ref_867
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23580,8 +24315,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1050
-            schema: *ref_1047
+          - !<!Parameter> &ref_1051
+            schema: *ref_1048
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23592,8 +24327,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1051
-            schema: *ref_891
+          - !<!Parameter> &ref_1052
+            schema: *ref_892
             implementation: Method
             language: !<!Languages> 
               default:
@@ -23603,8 +24338,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1052
-            schema: *ref_1048
+          - !<!Parameter> &ref_1053
+            schema: *ref_1049
             implementation: Method
             language: !<!Languages> 
               default:
@@ -23614,8 +24349,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1053
-            schema: *ref_200
+          - !<!Parameter> &ref_1054
+            schema: *ref_201
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23626,7 +24361,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1054
+          - !<!Parameter> &ref_1055
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -23639,8 +24374,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1055
-            schema: *ref_1047
+          - !<!Parameter> &ref_1056
+            schema: *ref_1048
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23651,11 +24386,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1056
-            schema: *ref_518
+          - !<!Parameter> &ref_1057
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_585
+              x-ms-parameter-grouping: *ref_586
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -23666,11 +24401,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1057
-            schema: *ref_518
+          - !<!Parameter> &ref_1058
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_586
+              x-ms-parameter-grouping: *ref_587
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -23680,10 +24415,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_519
+            schema: *ref_520
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_587
+              x-ms-parameter-grouping: *ref_588
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -23692,11 +24427,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1058
-            schema: *ref_223
+          - !<!Parameter> &ref_1059
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -23705,11 +24440,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1059
-            schema: *ref_989
+          - !<!Parameter> &ref_1060
+            schema: *ref_990
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_1020
+              x-ms-parameter-grouping: *ref_1021
             language: !<!Languages> 
               default:
                 name: ifSequenceNumberLessThanOrEqualTo
@@ -23718,11 +24453,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1060
-            schema: *ref_989
+          - !<!Parameter> &ref_1061
+            schema: *ref_990
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_1021
+              x-ms-parameter-grouping: *ref_1022
             language: !<!Languages> 
               default:
                 name: ifSequenceNumberLessThan
@@ -23731,11 +24466,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1061
-            schema: *ref_989
+          - !<!Parameter> &ref_1062
+            schema: *ref_990
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_1022
+              x-ms-parameter-grouping: *ref_1023
             language: !<!Languages> 
               default:
                 name: ifSequenceNumberEqualTo
@@ -23744,11 +24479,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1062
-            schema: *ref_237
+          - !<!Parameter> &ref_1063
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -23757,11 +24492,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1063
-            schema: *ref_237
+          - !<!Parameter> &ref_1064
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -23770,11 +24505,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1064
-            schema: *ref_393
+          - !<!Parameter> &ref_1065
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -23783,11 +24518,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1065
-            schema: *ref_393
+          - !<!Parameter> &ref_1066
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -23796,11 +24531,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1066
-            schema: *ref_427
+          - !<!Parameter> &ref_1067
+            schema: *ref_428
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_684
+              x-ms-parameter-grouping: *ref_685
             language: !<!Languages> 
               default:
                 name: sourceIfModifiedSince
@@ -23809,11 +24544,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1067
-            schema: *ref_427
+          - !<!Parameter> &ref_1068
+            schema: *ref_428
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_685
+              x-ms-parameter-grouping: *ref_686
             language: !<!Languages> 
               default:
                 name: sourceIfUnmodifiedSince
@@ -23822,11 +24557,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1068
-            schema: *ref_418
+          - !<!Parameter> &ref_1069
+            schema: *ref_419
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_686
+              x-ms-parameter-grouping: *ref_687
             language: !<!Languages> 
               default:
                 name: sourceIfMatch
@@ -23835,11 +24570,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1069
-            schema: *ref_418
+          - !<!Parameter> &ref_1070
+            schema: *ref_419
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_687
+              x-ms-parameter-grouping: *ref_688
             language: !<!Languages> 
               default:
                 name: sourceIfNoneMatch
@@ -23849,7 +24584,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_1070
+          - !<!Parameter> &ref_1071
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -23862,6 +24597,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -23872,7 +24622,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1049
           - *ref_1050
           - *ref_1051
           - *ref_1052
@@ -23894,6 +24643,7 @@ operationGroups:
           - *ref_1068
           - *ref_1069
           - *ref_1070
+          - *ref_1071
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -23904,70 +24654,70 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1047
+                    schema: *ref_1048
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1071
+                    schema: *ref_1072
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1072
+                    schema: *ref_1073
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1073
+                    schema: *ref_1074
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1074
+                    schema: *ref_1075
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for the page blob.
                   - !<!HttpHeader> 
-                    schema: *ref_1075
+                    schema: *ref_1076
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1076
+                    schema: *ref_1077
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1077
+                    schema: *ref_1078
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1078
+                    schema: *ref_1079
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1079
+                    schema: *ref_1080
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -23977,7 +24727,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -23986,7 +24736,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1080
+                    schema: *ref_1081
                     header: x-ms-error-code
                     language:
                       default:
@@ -24009,7 +24759,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_1081
+            schema: *ref_1082
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24020,8 +24770,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1082
-            schema: *ref_518
+          - !<!Parameter> &ref_1083
+            schema: *ref_519
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24033,7 +24783,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1083
+          - !<!Parameter> &ref_1084
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -24046,8 +24796,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1084
-            schema: *ref_518
+          - !<!Parameter> &ref_1085
+            schema: *ref_519
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24057,11 +24807,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1085
-            schema: *ref_223
+          - !<!Parameter> &ref_1086
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -24070,11 +24820,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1086
-            schema: *ref_237
+          - !<!Parameter> &ref_1087
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -24083,11 +24833,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1087
-            schema: *ref_237
+          - !<!Parameter> &ref_1088
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -24096,11 +24846,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1088
-            schema: *ref_393
+          - !<!Parameter> &ref_1089
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -24109,11 +24859,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1089
-            schema: *ref_393
+          - !<!Parameter> &ref_1090
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -24123,7 +24873,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_1090
+          - !<!Parameter> &ref_1091
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -24136,6 +24886,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -24146,7 +24911,6 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_1082
           - *ref_1083
           - *ref_1084
           - *ref_1085
@@ -24155,9 +24919,10 @@ operationGroups:
           - *ref_1088
           - *ref_1089
           - *ref_1090
+          - *ref_1091
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1091
+            schema: *ref_1092
             language: !<!Languages> 
               default:
                 name: ''
@@ -24166,49 +24931,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1092
+                    schema: *ref_1093
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1093
+                    schema: *ref_1094
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1094
+                    schema: *ref_1095
                     header: x-ms-blob-content-length
                     language:
                       default:
                         name: BlobContentLength
                         description: The size of the blob in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_1095
+                    schema: *ref_1096
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1096
+                    schema: *ref_1097
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1097
+                    schema: *ref_1098
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1098
+                    schema: *ref_1099
                     header: Date
                     language:
                       default:
@@ -24221,7 +24986,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -24230,7 +24995,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1099
+                    schema: *ref_1100
                     header: x-ms-error-code
                     language:
                       default:
@@ -24253,7 +25018,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_1081
+            schema: *ref_1082
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24264,8 +25029,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1101
-            schema: *ref_518
+          - !<!Parameter> &ref_1102
+            schema: *ref_519
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24277,7 +25042,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1102
+          - !<!Parameter> &ref_1103
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -24290,8 +25055,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1103
-            schema: *ref_1100
+          - !<!Parameter> &ref_1104
+            schema: *ref_1101
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24304,8 +25069,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1104
-            schema: *ref_518
+          - !<!Parameter> &ref_1105
+            schema: *ref_519
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24315,11 +25080,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1105
-            schema: *ref_223
+          - !<!Parameter> &ref_1106
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -24328,11 +25093,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1106
-            schema: *ref_237
+          - !<!Parameter> &ref_1107
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -24341,11 +25106,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1107
-            schema: *ref_237
+          - !<!Parameter> &ref_1108
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -24354,11 +25119,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1108
-            schema: *ref_393
+          - !<!Parameter> &ref_1109
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -24367,11 +25132,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1109
-            schema: *ref_393
+          - !<!Parameter> &ref_1110
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -24381,7 +25146,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_1110
+          - !<!Parameter> &ref_1111
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -24394,6 +25159,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -24404,7 +25184,6 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_1101
           - *ref_1102
           - *ref_1103
           - *ref_1104
@@ -24414,9 +25193,10 @@ operationGroups:
           - *ref_1108
           - *ref_1109
           - *ref_1110
+          - *ref_1111
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1091
+            schema: *ref_1092
             language: !<!Languages> 
               default:
                 name: ''
@@ -24425,49 +25205,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1111
+                    schema: *ref_1112
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1100
+                    schema: *ref_1101
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1112
+                    schema: *ref_1113
                     header: x-ms-blob-content-length
                     language:
                       default:
                         name: BlobContentLength
                         description: The size of the blob in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_1113
+                    schema: *ref_1114
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1114
+                    schema: *ref_1115
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1115
+                    schema: *ref_1116
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1116
+                    schema: *ref_1117
                     header: Date
                     language:
                       default:
@@ -24480,7 +25260,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -24489,7 +25269,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1117
+                    schema: *ref_1118
                     header: x-ms-error-code
                     language:
                       default:
@@ -24523,7 +25303,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1118
+          - !<!Parameter> &ref_1119
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -24536,11 +25316,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1119
-            schema: *ref_223
+          - !<!Parameter> &ref_1120
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -24549,11 +25329,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1120
-            schema: *ref_518
+          - !<!Parameter> &ref_1121
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_585
+              x-ms-parameter-grouping: *ref_586
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -24564,11 +25344,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1121
-            schema: *ref_518
+          - !<!Parameter> &ref_1122
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_586
+              x-ms-parameter-grouping: *ref_587
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -24578,10 +25358,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_519
+            schema: *ref_520
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_587
+              x-ms-parameter-grouping: *ref_588
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -24590,11 +25370,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1122
-            schema: *ref_237
+          - !<!Parameter> &ref_1123
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -24603,11 +25383,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1123
-            schema: *ref_237
+          - !<!Parameter> &ref_1124
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -24616,11 +25396,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1124
-            schema: *ref_393
+          - !<!Parameter> &ref_1125
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -24629,11 +25409,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1125
-            schema: *ref_393
+          - !<!Parameter> &ref_1126
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -24642,8 +25422,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1126
-            schema: *ref_744
+          - !<!Parameter> &ref_1127
+            schema: *ref_745
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24655,7 +25435,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_1127
+          - !<!Parameter> &ref_1128
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -24668,6 +25448,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -24678,7 +25473,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1118
           - *ref_1119
           - *ref_1120
           - *ref_1121
@@ -24688,6 +25482,7 @@ operationGroups:
           - *ref_1125
           - *ref_1126
           - *ref_1127
+          - *ref_1128
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -24698,49 +25493,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1128
+                    schema: *ref_1129
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1129
+                    schema: *ref_1130
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1130
+                    schema: *ref_1131
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for a page blob. This header is not returned for block blobs or append blobs
                   - !<!HttpHeader> 
-                    schema: *ref_1131
+                    schema: *ref_1132
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1132
+                    schema: *ref_1133
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1133
+                    schema: *ref_1134
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1134
+                    schema: *ref_1135
                     header: Date
                     language:
                       default:
@@ -24750,7 +25545,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -24759,7 +25554,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1135
+                    schema: *ref_1136
                     header: x-ms-error-code
                     language:
                       default:
@@ -24793,7 +25588,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1137
+          - !<!Parameter> &ref_1138
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -24806,11 +25601,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1138
-            schema: *ref_223
+          - !<!Parameter> &ref_1139
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -24819,11 +25614,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1139
-            schema: *ref_237
+          - !<!Parameter> &ref_1140
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -24832,11 +25627,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1140
-            schema: *ref_237
+          - !<!Parameter> &ref_1141
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -24845,11 +25640,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1141
-            schema: *ref_393
+          - !<!Parameter> &ref_1142
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -24858,11 +25653,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1142
-            schema: *ref_393
+          - !<!Parameter> &ref_1143
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -24871,8 +25666,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1143
-            schema: *ref_1136
+          - !<!Parameter> &ref_1144
+            schema: *ref_1137
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24883,8 +25678,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1144
-            schema: *ref_955
+          - !<!Parameter> &ref_1145
+            schema: *ref_956
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24895,7 +25690,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_1145
+          - !<!Parameter> &ref_1146
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -24908,6 +25703,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -24918,7 +25728,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1137
           - *ref_1138
           - *ref_1139
           - *ref_1140
@@ -24927,6 +25736,7 @@ operationGroups:
           - *ref_1143
           - *ref_1144
           - *ref_1145
+          - *ref_1146
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -24937,49 +25747,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1146
+                    schema: *ref_1147
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1147
+                    schema: *ref_1148
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1148
+                    schema: *ref_1149
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for a page blob. This header is not returned for block blobs or append blobs
                   - !<!HttpHeader> 
-                    schema: *ref_1149
+                    schema: *ref_1150
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1150
+                    schema: *ref_1151
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1151
+                    schema: *ref_1152
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1152
+                    schema: *ref_1153
                     header: Date
                     language:
                       default:
@@ -24989,7 +25799,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -24998,7 +25808,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1153
+                    schema: *ref_1154
                     header: x-ms-error-code
                     language:
                       default:
@@ -25021,7 +25831,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_1154
+            schema: *ref_1155
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25032,7 +25842,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1155
+          - !<!Parameter> &ref_1156
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -25045,11 +25855,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1156
-            schema: *ref_237
+          - !<!Parameter> &ref_1157
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -25058,11 +25868,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1157
-            schema: *ref_237
+          - !<!Parameter> &ref_1158
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -25071,11 +25881,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1158
-            schema: *ref_393
+          - !<!Parameter> &ref_1159
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -25084,11 +25894,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1159
-            schema: *ref_393
+          - !<!Parameter> &ref_1160
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -25097,8 +25907,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1160
-            schema: *ref_866
+          - !<!Parameter> &ref_1161
+            schema: *ref_867
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25112,7 +25922,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_1161
+          - !<!Parameter> &ref_1162
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -25125,6 +25935,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -25135,13 +25960,13 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1155
           - *ref_1156
           - *ref_1157
           - *ref_1158
           - *ref_1159
           - *ref_1160
           - *ref_1161
+          - *ref_1162
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -25152,49 +25977,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1162
+                    schema: *ref_1163
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1163
+                    schema: *ref_1164
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1164
+                    schema: *ref_1165
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1165
+                    schema: *ref_1166
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1166
+                    schema: *ref_1167
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1167
+                    schema: *ref_1168
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1168
+                    schema: *ref_1169
                     header: x-ms-copy-id
                     language:
                       default:
@@ -25211,7 +26036,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -25220,7 +26045,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1169
+                    schema: *ref_1170
                     header: x-ms-error-code
                     language:
                       default:
@@ -25253,7 +26078,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_1170
+            schema: *ref_1171
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25264,7 +26089,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1171
+          - !<!Parameter> &ref_1172
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -25277,8 +26102,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1172
-            schema: *ref_200
+          - !<!Parameter> &ref_1173
+            schema: *ref_201
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25289,11 +26114,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1173
-            schema: *ref_727
+          - !<!Parameter> &ref_1174
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_949
+              x-ms-parameter-grouping: *ref_950
             language: !<!Languages> 
               default:
                 name: blobContentType
@@ -25302,29 +26127,16 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1174
-            schema: *ref_727
-            implementation: Method
-            extensions:
-              x-ms-parameter-grouping: *ref_950
-            language: !<!Languages> 
-              default:
-                name: blobContentEncoding
-                description: 'Optional. Sets the blob''s content encoding. If specified, this property is stored with the blob and returned with a read request.'
-                serializedName: x-ms-blob-content-encoding
-            protocol: !<!Protocols> 
-              http: !<!HttpParameter> 
-                in: header
           - !<!Parameter> &ref_1175
-            schema: *ref_727
+            schema: *ref_728
             implementation: Method
             extensions:
               x-ms-parameter-grouping: *ref_951
             language: !<!Languages> 
               default:
-                name: blobContentLanguage
-                description: 'Optional. Set the blob''s content language. If specified, this property is stored with the blob and returned with a read request.'
-                serializedName: x-ms-blob-content-language
+                name: blobContentEncoding
+                description: 'Optional. Sets the blob''s content encoding. If specified, this property is stored with the blob and returned with a read request.'
+                serializedName: x-ms-blob-content-encoding
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
@@ -25335,17 +26147,30 @@ operationGroups:
               x-ms-parameter-grouping: *ref_952
             language: !<!Languages> 
               default:
+                name: blobContentLanguage
+                description: 'Optional. Set the blob''s content language. If specified, this property is stored with the blob and returned with a read request.'
+                serializedName: x-ms-blob-content-language
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: header
+          - !<!Parameter> &ref_1177
+            schema: *ref_729
+            implementation: Method
+            extensions:
+              x-ms-parameter-grouping: *ref_953
+            language: !<!Languages> 
+              default:
                 name: blobContentMD5
                 description: 'Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks were validated when each was uploaded.'
                 serializedName: x-ms-blob-content-md5
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1177
-            schema: *ref_727
+          - !<!Parameter> &ref_1178
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_953
+              x-ms-parameter-grouping: *ref_954
             language: !<!Languages> 
               default:
                 name: blobCacheControl
@@ -25354,8 +26179,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1178
-            schema: *ref_212
+          - !<!Parameter> &ref_1179
+            schema: *ref_213
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -25370,11 +26195,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1179
-            schema: *ref_223
+          - !<!Parameter> &ref_1180
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -25383,11 +26208,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1180
-            schema: *ref_727
+          - !<!Parameter> &ref_1181
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_954
+              x-ms-parameter-grouping: *ref_955
             language: !<!Languages> 
               default:
                 name: blobContentDisposition
@@ -25396,11 +26221,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1181
-            schema: *ref_518
+          - !<!Parameter> &ref_1182
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_585
+              x-ms-parameter-grouping: *ref_586
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -25411,11 +26236,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1182
-            schema: *ref_518
+          - !<!Parameter> &ref_1183
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_586
+              x-ms-parameter-grouping: *ref_587
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -25425,10 +26250,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_519
+            schema: *ref_520
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_587
+              x-ms-parameter-grouping: *ref_588
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -25437,11 +26262,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1183
-            schema: *ref_237
+          - !<!Parameter> &ref_1184
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -25450,11 +26275,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1184
-            schema: *ref_237
+          - !<!Parameter> &ref_1185
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -25463,11 +26288,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1185
-            schema: *ref_393
+          - !<!Parameter> &ref_1186
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -25476,11 +26301,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1186
-            schema: *ref_393
+          - !<!Parameter> &ref_1187
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -25490,7 +26315,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_1187
+          - !<!Parameter> &ref_1188
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -25503,6 +26328,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -25513,7 +26353,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1171
           - *ref_1172
           - *ref_1173
           - *ref_1174
@@ -25530,6 +26369,7 @@ operationGroups:
           - *ref_1185
           - *ref_1186
           - *ref_1187
+          - *ref_1188
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -25540,63 +26380,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1188
+                    schema: *ref_1189
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1189
+                    schema: *ref_1190
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1190
+                    schema: *ref_1191
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1191
+                    schema: *ref_1192
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1192
+                    schema: *ref_1193
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1193
+                    schema: *ref_1194
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1194
+                    schema: *ref_1195
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1195
+                    schema: *ref_1196
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1196
+                    schema: *ref_1197
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -25606,7 +26446,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -25615,7 +26455,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1197
+                    schema: *ref_1198
                     header: x-ms-error-code
                     language:
                       default:
@@ -25638,7 +26478,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_1198
+            schema: *ref_1199
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25649,7 +26489,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1202
+          - !<!Parameter> &ref_1203
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -25662,8 +26502,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1203
-            schema: *ref_200
+          - !<!Parameter> &ref_1204
+            schema: *ref_201
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25674,8 +26514,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1204
-            schema: *ref_987
+          - !<!Parameter> &ref_1205
+            schema: *ref_988
             implementation: Method
             language: !<!Languages> 
               default:
@@ -25685,8 +26525,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1205
-            schema: *ref_988
+          - !<!Parameter> &ref_1206
+            schema: *ref_989
             implementation: Method
             language: !<!Languages> 
               default:
@@ -25696,11 +26536,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1206
-            schema: *ref_223
+          - !<!Parameter> &ref_1207
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -25709,11 +26549,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1207
-            schema: *ref_1199
+          - !<!Parameter> &ref_1208
+            schema: *ref_1200
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_1230
+              x-ms-parameter-grouping: &ref_1231
                 name: append-position-access-conditions
             language: !<!Languages> 
               default:
@@ -25725,11 +26565,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1208
-            schema: *ref_1199
+          - !<!Parameter> &ref_1209
+            schema: *ref_1200
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_1231
+              x-ms-parameter-grouping: &ref_1232
                 name: append-position-access-conditions
             language: !<!Languages> 
               default:
@@ -25741,11 +26581,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1209
-            schema: *ref_518
+          - !<!Parameter> &ref_1210
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_585
+              x-ms-parameter-grouping: *ref_586
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -25756,11 +26596,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1210
-            schema: *ref_518
+          - !<!Parameter> &ref_1211
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_586
+              x-ms-parameter-grouping: *ref_587
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -25770,10 +26610,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_519
+            schema: *ref_520
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_587
+              x-ms-parameter-grouping: *ref_588
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -25782,11 +26622,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1211
-            schema: *ref_237
+          - !<!Parameter> &ref_1212
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -25795,11 +26635,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1212
-            schema: *ref_237
+          - !<!Parameter> &ref_1213
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -25808,11 +26648,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1213
-            schema: *ref_393
+          - !<!Parameter> &ref_1214
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -25821,11 +26661,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1214
-            schema: *ref_393
+          - !<!Parameter> &ref_1215
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -25835,7 +26675,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_1215
+          - !<!Parameter> &ref_1216
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -25849,8 +26689,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1201
-                schema: *ref_1200
+              - !<!Parameter> &ref_1202
+                schema: *ref_1201
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -25861,8 +26701,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_1201
+              - *ref_1202
             language: !<!Languages> 
               default:
                 name: ''
@@ -25877,7 +26730,6 @@ operationGroups:
                   - application/octet-stream
                 uri: '{url}'
         signatureParameters:
-          - *ref_1202
           - *ref_1203
           - *ref_1204
           - *ref_1205
@@ -25891,6 +26743,7 @@ operationGroups:
           - *ref_1213
           - *ref_1214
           - *ref_1215
+          - *ref_1216
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -25901,84 +26754,84 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1216
+                    schema: *ref_1217
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1217
+                    schema: *ref_1218
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1218
+                    schema: *ref_1219
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1219
+                    schema: *ref_1220
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1220
+                    schema: *ref_1221
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1221
+                    schema: *ref_1222
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1222
+                    schema: *ref_1223
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1223
+                    schema: *ref_1224
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1224
+                    schema: *ref_1225
                     header: x-ms-blob-append-offset
                     language:
                       default:
                         name: BlobAppendOffset
                         description: 'This response header is returned only for append operations. It returns the offset at which the block was committed, in bytes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1225
+                    schema: *ref_1226
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_1226
+                    schema: *ref_1227
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1227
+                    schema: *ref_1228
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -25988,7 +26841,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -25997,7 +26850,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1228
+                    schema: *ref_1229
                     header: x-ms-error-code
                     language:
                       default:
@@ -26022,7 +26875,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_1198
+            schema: *ref_1199
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26033,8 +26886,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1232
-            schema: *ref_866
+          - !<!Parameter> &ref_1233
+            schema: *ref_867
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26045,8 +26898,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1233
-            schema: *ref_1229
+          - !<!Parameter> &ref_1234
+            schema: *ref_1230
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26056,8 +26909,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1234
-            schema: *ref_891
+          - !<!Parameter> &ref_1235
+            schema: *ref_892
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26067,8 +26920,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1235
-            schema: *ref_1048
+          - !<!Parameter> &ref_1236
+            schema: *ref_1049
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26078,7 +26931,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1236
+          - !<!Parameter> &ref_1237
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -26091,8 +26944,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1237
-            schema: *ref_200
+          - !<!Parameter> &ref_1238
+            schema: *ref_201
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26103,8 +26956,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1238
-            schema: *ref_987
+          - !<!Parameter> &ref_1239
+            schema: *ref_988
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26114,11 +26967,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1239
-            schema: *ref_518
+          - !<!Parameter> &ref_1240
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_585
+              x-ms-parameter-grouping: *ref_586
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -26129,11 +26982,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1240
-            schema: *ref_518
+          - !<!Parameter> &ref_1241
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_586
+              x-ms-parameter-grouping: *ref_587
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -26143,10 +26996,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_519
+            schema: *ref_520
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_587
+              x-ms-parameter-grouping: *ref_588
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -26155,11 +27008,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1241
-            schema: *ref_223
+          - !<!Parameter> &ref_1242
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -26168,11 +27021,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1242
-            schema: *ref_1199
+          - !<!Parameter> &ref_1243
+            schema: *ref_1200
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_1230
+              x-ms-parameter-grouping: *ref_1231
             language: !<!Languages> 
               default:
                 name: maxSize
@@ -26183,11 +27036,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1243
-            schema: *ref_1199
+          - !<!Parameter> &ref_1244
+            schema: *ref_1200
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_1231
+              x-ms-parameter-grouping: *ref_1232
             language: !<!Languages> 
               default:
                 name: appendPosition
@@ -26198,11 +27051,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1244
-            schema: *ref_237
+          - !<!Parameter> &ref_1245
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -26211,11 +27064,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1245
-            schema: *ref_237
+          - !<!Parameter> &ref_1246
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -26224,11 +27077,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1246
-            schema: *ref_393
+          - !<!Parameter> &ref_1247
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -26237,11 +27090,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1247
-            schema: *ref_393
+          - !<!Parameter> &ref_1248
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -26250,11 +27103,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1248
-            schema: *ref_427
+          - !<!Parameter> &ref_1249
+            schema: *ref_428
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_684
+              x-ms-parameter-grouping: *ref_685
             language: !<!Languages> 
               default:
                 name: sourceIfModifiedSince
@@ -26263,11 +27116,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1249
-            schema: *ref_427
+          - !<!Parameter> &ref_1250
+            schema: *ref_428
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_685
+              x-ms-parameter-grouping: *ref_686
             language: !<!Languages> 
               default:
                 name: sourceIfUnmodifiedSince
@@ -26276,11 +27129,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1250
-            schema: *ref_418
+          - !<!Parameter> &ref_1251
+            schema: *ref_419
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_686
+              x-ms-parameter-grouping: *ref_687
             language: !<!Languages> 
               default:
                 name: sourceIfMatch
@@ -26289,11 +27142,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1251
-            schema: *ref_418
+          - !<!Parameter> &ref_1252
+            schema: *ref_419
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_687
+              x-ms-parameter-grouping: *ref_688
             language: !<!Languages> 
               default:
                 name: sourceIfNoneMatch
@@ -26303,7 +27156,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_1252
+          - !<!Parameter> &ref_1253
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -26316,6 +27169,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -26326,7 +27194,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1232
           - *ref_1233
           - *ref_1234
           - *ref_1235
@@ -26347,6 +27214,7 @@ operationGroups:
           - *ref_1250
           - *ref_1251
           - *ref_1252
+          - *ref_1253
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -26357,77 +27225,77 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1253
+                    schema: *ref_1254
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1254
+                    schema: *ref_1255
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1255
+                    schema: *ref_1256
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1256
+                    schema: *ref_1257
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1257
+                    schema: *ref_1258
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1258
+                    schema: *ref_1259
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1259
+                    schema: *ref_1260
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1260
+                    schema: *ref_1261
                     header: x-ms-blob-append-offset
                     language:
                       default:
                         name: BlobAppendOffset
                         description: 'This response header is returned only for append operations. It returns the offset at which the block was committed, in bytes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1261
+                    schema: *ref_1262
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_1262
+                    schema: *ref_1263
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
                         name: EncryptionKeySha256
                         description: The SHA-256 hash of the encryption key used to encrypt the block. This header is only returned when the block was encrypted with a customer-provided key.
                   - !<!HttpHeader> 
-                    schema: *ref_1263
+                    schema: *ref_1264
                     header: x-ms-request-server-encrypted
                     language:
                       default:
@@ -26437,7 +27305,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -26446,7 +27314,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1264
+                    schema: *ref_1265
                     header: x-ms-error-code
                     language:
                       default:
@@ -26479,7 +27347,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_1265
+            schema: *ref_1266
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26490,7 +27358,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1268
+          - !<!Parameter> &ref_1269
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -26503,8 +27371,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1269
-            schema: *ref_987
+          - !<!Parameter> &ref_1270
+            schema: *ref_988
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26514,8 +27382,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1270
-            schema: *ref_200
+          - !<!Parameter> &ref_1271
+            schema: *ref_201
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26526,11 +27394,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1271
-            schema: *ref_727
+          - !<!Parameter> &ref_1272
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_949
+              x-ms-parameter-grouping: *ref_950
             language: !<!Languages> 
               default:
                 name: blobContentType
@@ -26539,29 +27407,16 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1272
-            schema: *ref_727
-            implementation: Method
-            extensions:
-              x-ms-parameter-grouping: *ref_950
-            language: !<!Languages> 
-              default:
-                name: blobContentEncoding
-                description: 'Optional. Sets the blob''s content encoding. If specified, this property is stored with the blob and returned with a read request.'
-                serializedName: x-ms-blob-content-encoding
-            protocol: !<!Protocols> 
-              http: !<!HttpParameter> 
-                in: header
           - !<!Parameter> &ref_1273
-            schema: *ref_727
+            schema: *ref_728
             implementation: Method
             extensions:
               x-ms-parameter-grouping: *ref_951
             language: !<!Languages> 
               default:
-                name: blobContentLanguage
-                description: 'Optional. Set the blob''s content language. If specified, this property is stored with the blob and returned with a read request.'
-                serializedName: x-ms-blob-content-language
+                name: blobContentEncoding
+                description: 'Optional. Sets the blob''s content encoding. If specified, this property is stored with the blob and returned with a read request.'
+                serializedName: x-ms-blob-content-encoding
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
@@ -26572,17 +27427,30 @@ operationGroups:
               x-ms-parameter-grouping: *ref_952
             language: !<!Languages> 
               default:
+                name: blobContentLanguage
+                description: 'Optional. Set the blob''s content language. If specified, this property is stored with the blob and returned with a read request.'
+                serializedName: x-ms-blob-content-language
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: header
+          - !<!Parameter> &ref_1275
+            schema: *ref_729
+            implementation: Method
+            extensions:
+              x-ms-parameter-grouping: *ref_953
+            language: !<!Languages> 
+              default:
                 name: blobContentMD5
                 description: 'Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks were validated when each was uploaded.'
                 serializedName: x-ms-blob-content-md5
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1275
-            schema: *ref_727
+          - !<!Parameter> &ref_1276
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_953
+              x-ms-parameter-grouping: *ref_954
             language: !<!Languages> 
               default:
                 name: blobCacheControl
@@ -26591,8 +27459,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1276
-            schema: *ref_212
+          - !<!Parameter> &ref_1277
+            schema: *ref_213
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -26607,11 +27475,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1277
-            schema: *ref_223
+          - !<!Parameter> &ref_1278
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -26620,11 +27488,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1278
-            schema: *ref_727
+          - !<!Parameter> &ref_1279
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_954
+              x-ms-parameter-grouping: *ref_955
             language: !<!Languages> 
               default:
                 name: blobContentDisposition
@@ -26633,11 +27501,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1279
-            schema: *ref_518
+          - !<!Parameter> &ref_1280
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_585
+              x-ms-parameter-grouping: *ref_586
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -26648,11 +27516,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1280
-            schema: *ref_518
+          - !<!Parameter> &ref_1281
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_586
+              x-ms-parameter-grouping: *ref_587
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -26662,10 +27530,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_519
+            schema: *ref_520
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_587
+              x-ms-parameter-grouping: *ref_588
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -26674,7 +27542,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1281
+          - !<!Parameter> &ref_1282
             schema: *ref_86
             implementation: Method
             language: !<!Languages> 
@@ -26685,11 +27553,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1282
-            schema: *ref_237
+          - !<!Parameter> &ref_1283
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -26698,11 +27566,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1283
-            schema: *ref_237
+          - !<!Parameter> &ref_1284
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -26711,11 +27579,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1284
-            schema: *ref_393
+          - !<!Parameter> &ref_1285
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -26724,11 +27592,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1285
-            schema: *ref_393
+          - !<!Parameter> &ref_1286
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -26738,7 +27606,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_1286
+          - !<!Parameter> &ref_1287
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -26752,8 +27620,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1267
-                schema: *ref_1266
+              - !<!Parameter> &ref_1268
+                schema: *ref_1267
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -26764,8 +27632,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_1267
+              - *ref_1268
             language: !<!Languages> 
               default:
                 name: ''
@@ -26780,7 +27661,6 @@ operationGroups:
                   - application/octet-stream
                 uri: '{url}'
         signatureParameters:
-          - *ref_1268
           - *ref_1269
           - *ref_1270
           - *ref_1271
@@ -26799,6 +27679,7 @@ operationGroups:
           - *ref_1284
           - *ref_1285
           - *ref_1286
+          - *ref_1287
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -26809,63 +27690,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1287
+                    schema: *ref_1288
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1288
+                    schema: *ref_1289
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1289
+                    schema: *ref_1290
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1290
+                    schema: *ref_1291
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1291
+                    schema: *ref_1292
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1292
+                    schema: *ref_1293
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1293
+                    schema: *ref_1294
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1294
+                    schema: *ref_1295
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1295
+                    schema: *ref_1296
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -26875,7 +27756,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -26884,7 +27765,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1296
+                    schema: *ref_1297
                     header: x-ms-error-code
                     language:
                       default:
@@ -26909,7 +27790,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_1297
+            schema: *ref_1298
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26920,8 +27801,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1301
-            schema: *ref_1298
+          - !<!Parameter> &ref_1302
+            schema: *ref_1299
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26934,8 +27815,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1302
-            schema: *ref_200
+          - !<!Parameter> &ref_1303
+            schema: *ref_201
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26946,8 +27827,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1303
-            schema: *ref_987
+          - !<!Parameter> &ref_1304
+            schema: *ref_988
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26957,8 +27838,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1304
-            schema: *ref_988
+          - !<!Parameter> &ref_1305
+            schema: *ref_989
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26968,7 +27849,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1305
+          - !<!Parameter> &ref_1306
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -26981,11 +27862,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1306
-            schema: *ref_223
+          - !<!Parameter> &ref_1307
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -26994,11 +27875,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1307
-            schema: *ref_518
+          - !<!Parameter> &ref_1308
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_585
+              x-ms-parameter-grouping: *ref_586
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -27009,11 +27890,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1308
-            schema: *ref_518
+          - !<!Parameter> &ref_1309
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_586
+              x-ms-parameter-grouping: *ref_587
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -27023,10 +27904,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_519
+            schema: *ref_520
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_587
+              x-ms-parameter-grouping: *ref_588
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -27036,7 +27917,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_1309
+          - !<!Parameter> &ref_1310
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -27050,8 +27931,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1300
-                schema: *ref_1299
+              - !<!Parameter> &ref_1301
+                schema: *ref_1300
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -27062,8 +27943,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_1300
+              - *ref_1301
             language: !<!Languages> 
               default:
                 name: ''
@@ -27078,7 +27972,6 @@ operationGroups:
                   - application/octet-stream
                 uri: '{url}'
         signatureParameters:
-          - *ref_1301
           - *ref_1302
           - *ref_1303
           - *ref_1304
@@ -27087,6 +27980,7 @@ operationGroups:
           - *ref_1307
           - *ref_1308
           - *ref_1309
+          - *ref_1310
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -27097,56 +27991,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1310
+                    schema: *ref_1311
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1298
+                    schema: *ref_1299
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1311
+                    schema: *ref_1312
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1312
+                    schema: *ref_1313
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1313
+                    schema: *ref_1314
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1314
+                    schema: *ref_1315
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1315
+                    schema: *ref_1316
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1316
+                    schema: *ref_1317
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -27156,7 +28050,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -27165,7 +28059,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1317
+                    schema: *ref_1318
                     header: x-ms-error-code
                     language:
                       default:
@@ -27188,7 +28082,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_1297
+            schema: *ref_1298
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27199,8 +28093,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1318
-            schema: *ref_1298
+          - !<!Parameter> &ref_1319
+            schema: *ref_1299
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27213,8 +28107,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1319
-            schema: *ref_200
+          - !<!Parameter> &ref_1320
+            schema: *ref_201
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27225,8 +28119,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1320
-            schema: *ref_866
+          - !<!Parameter> &ref_1321
+            schema: *ref_867
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27237,8 +28131,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1321
-            schema: *ref_1229
+          - !<!Parameter> &ref_1322
+            schema: *ref_1230
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27248,8 +28142,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1322
-            schema: *ref_891
+          - !<!Parameter> &ref_1323
+            schema: *ref_892
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27259,8 +28153,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1323
-            schema: *ref_1048
+          - !<!Parameter> &ref_1324
+            schema: *ref_1049
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27270,7 +28164,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1324
+          - !<!Parameter> &ref_1325
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -27283,11 +28177,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1325
-            schema: *ref_518
+          - !<!Parameter> &ref_1326
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_585
+              x-ms-parameter-grouping: *ref_586
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -27298,11 +28192,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1326
-            schema: *ref_518
+          - !<!Parameter> &ref_1327
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_586
+              x-ms-parameter-grouping: *ref_587
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -27312,10 +28206,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_519
+            schema: *ref_520
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_587
+              x-ms-parameter-grouping: *ref_588
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -27324,11 +28218,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1327
-            schema: *ref_223
+          - !<!Parameter> &ref_1328
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -27337,11 +28231,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1328
-            schema: *ref_427
+          - !<!Parameter> &ref_1329
+            schema: *ref_428
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_684
+              x-ms-parameter-grouping: *ref_685
             language: !<!Languages> 
               default:
                 name: sourceIfModifiedSince
@@ -27350,11 +28244,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1329
-            schema: *ref_427
+          - !<!Parameter> &ref_1330
+            schema: *ref_428
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_685
+              x-ms-parameter-grouping: *ref_686
             language: !<!Languages> 
               default:
                 name: sourceIfUnmodifiedSince
@@ -27363,11 +28257,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1330
-            schema: *ref_418
+          - !<!Parameter> &ref_1331
+            schema: *ref_419
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_686
+              x-ms-parameter-grouping: *ref_687
             language: !<!Languages> 
               default:
                 name: sourceIfMatch
@@ -27376,11 +28270,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1331
-            schema: *ref_418
+          - !<!Parameter> &ref_1332
+            schema: *ref_419
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_687
+              x-ms-parameter-grouping: *ref_688
             language: !<!Languages> 
               default:
                 name: sourceIfNoneMatch
@@ -27390,7 +28284,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_1332
+          - !<!Parameter> &ref_1333
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -27403,6 +28297,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -27413,7 +28322,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1318
           - *ref_1319
           - *ref_1320
           - *ref_1321
@@ -27428,6 +28336,7 @@ operationGroups:
           - *ref_1330
           - *ref_1331
           - *ref_1332
+          - *ref_1333
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -27438,56 +28347,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1333
+                    schema: *ref_1334
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1334
+                    schema: *ref_1335
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1229
+                    schema: *ref_1230
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1335
+                    schema: *ref_1336
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1336
+                    schema: *ref_1337
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1337
+                    schema: *ref_1338
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1338
+                    schema: *ref_1339
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1339
+                    schema: *ref_1340
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -27497,7 +28406,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -27506,7 +28415,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1340
+                    schema: *ref_1341
                     header: x-ms-error-code
                     language:
                       default:
@@ -27529,7 +28438,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_1341
+            schema: *ref_1342
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27540,7 +28449,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1344
+          - !<!Parameter> &ref_1345
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -27553,11 +28462,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1345
-            schema: *ref_727
+          - !<!Parameter> &ref_1346
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_953
+              x-ms-parameter-grouping: *ref_954
             language: !<!Languages> 
               default:
                 name: blobCacheControl
@@ -27566,11 +28475,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1346
-            schema: *ref_727
+          - !<!Parameter> &ref_1347
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_949
+              x-ms-parameter-grouping: *ref_950
             language: !<!Languages> 
               default:
                 name: blobContentType
@@ -27579,29 +28488,16 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1347
-            schema: *ref_727
-            implementation: Method
-            extensions:
-              x-ms-parameter-grouping: *ref_950
-            language: !<!Languages> 
-              default:
-                name: blobContentEncoding
-                description: 'Optional. Sets the blob''s content encoding. If specified, this property is stored with the blob and returned with a read request.'
-                serializedName: x-ms-blob-content-encoding
-            protocol: !<!Protocols> 
-              http: !<!HttpParameter> 
-                in: header
           - !<!Parameter> &ref_1348
-            schema: *ref_727
+            schema: *ref_728
             implementation: Method
             extensions:
               x-ms-parameter-grouping: *ref_951
             language: !<!Languages> 
               default:
-                name: blobContentLanguage
-                description: 'Optional. Set the blob''s content language. If specified, this property is stored with the blob and returned with a read request.'
-                serializedName: x-ms-blob-content-language
+                name: blobContentEncoding
+                description: 'Optional. Sets the blob''s content encoding. If specified, this property is stored with the blob and returned with a read request.'
+                serializedName: x-ms-blob-content-encoding
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
@@ -27612,14 +28508,27 @@ operationGroups:
               x-ms-parameter-grouping: *ref_952
             language: !<!Languages> 
               default:
+                name: blobContentLanguage
+                description: 'Optional. Set the blob''s content language. If specified, this property is stored with the blob and returned with a read request.'
+                serializedName: x-ms-blob-content-language
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: header
+          - !<!Parameter> &ref_1350
+            schema: *ref_729
+            implementation: Method
+            extensions:
+              x-ms-parameter-grouping: *ref_953
+            language: !<!Languages> 
+              default:
                 name: blobContentMD5
                 description: 'Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks were validated when each was uploaded.'
                 serializedName: x-ms-blob-content-md5
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1350
-            schema: *ref_987
+          - !<!Parameter> &ref_1351
+            schema: *ref_988
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27629,8 +28538,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1351
-            schema: *ref_988
+          - !<!Parameter> &ref_1352
+            schema: *ref_989
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27640,8 +28549,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1352
-            schema: *ref_212
+          - !<!Parameter> &ref_1353
+            schema: *ref_213
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -27656,11 +28565,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1353
-            schema: *ref_223
+          - !<!Parameter> &ref_1354
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -27669,11 +28578,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1354
-            schema: *ref_727
+          - !<!Parameter> &ref_1355
+            schema: *ref_728
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_954
+              x-ms-parameter-grouping: *ref_955
             language: !<!Languages> 
               default:
                 name: blobContentDisposition
@@ -27682,11 +28591,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1355
-            schema: *ref_518
+          - !<!Parameter> &ref_1356
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_585
+              x-ms-parameter-grouping: *ref_586
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -27697,11 +28606,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1356
-            schema: *ref_518
+          - !<!Parameter> &ref_1357
+            schema: *ref_519
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_586
+              x-ms-parameter-grouping: *ref_587
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -27711,10 +28620,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_519
+            schema: *ref_520
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_587
+              x-ms-parameter-grouping: *ref_588
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -27723,7 +28632,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1357
+          - !<!Parameter> &ref_1358
             schema: *ref_86
             implementation: Method
             language: !<!Languages> 
@@ -27734,11 +28643,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1358
-            schema: *ref_237
+          - !<!Parameter> &ref_1359
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_248
+              x-ms-parameter-grouping: *ref_249
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -27747,11 +28656,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1359
-            schema: *ref_237
+          - !<!Parameter> &ref_1360
+            schema: *ref_238
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_273
+              x-ms-parameter-grouping: *ref_274
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -27760,11 +28669,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1360
-            schema: *ref_393
+          - !<!Parameter> &ref_1361
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_425
+              x-ms-parameter-grouping: *ref_426
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -27773,11 +28682,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1361
-            schema: *ref_393
+          - !<!Parameter> &ref_1362
+            schema: *ref_394
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_426
+              x-ms-parameter-grouping: *ref_427
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -27787,7 +28696,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_1362
+          - !<!Parameter> &ref_1363
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -27801,8 +28710,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1343
-                schema: *ref_1342
+              - !<!Parameter> &ref_1344
+                schema: *ref_1343
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -27813,8 +28722,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_1343
+              - *ref_1344
             language: !<!Languages> 
               default:
                 name: ''
@@ -27828,7 +28750,6 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_1344
           - *ref_1345
           - *ref_1346
           - *ref_1347
@@ -27847,6 +28768,7 @@ operationGroups:
           - *ref_1360
           - *ref_1361
           - *ref_1362
+          - *ref_1363
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -27857,21 +28779,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1363
+                    schema: *ref_1364
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1364
+                    schema: *ref_1365
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1365
+                    schema: *ref_1366
                     header: Content-MD5
                     language:
                       default:
@@ -27880,7 +28802,7 @@ operationGroups:
                           This header is returned so that the client can check for message content integrity. This header refers to the content of the request, meaning, in this case, the list of blocks, and not the content of the blob
                           itself.
                   - !<!HttpHeader> 
-                    schema: *ref_1366
+                    schema: *ref_1367
                     header: x-ms-content-crc64
                     language:
                       default:
@@ -27889,42 +28811,42 @@ operationGroups:
                           This header is returned so that the client can check for message content integrity. This header refers to the content of the request, meaning, in this case, the list of blocks, and not the content of the blob
                           itself.
                   - !<!HttpHeader> 
-                    schema: *ref_1367
+                    schema: *ref_1368
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1368
+                    schema: *ref_1369
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1369
+                    schema: *ref_1370
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1370
+                    schema: *ref_1371
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1371
+                    schema: *ref_1372
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1372
+                    schema: *ref_1373
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -27934,7 +28856,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -27943,7 +28865,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1373
+                    schema: *ref_1374
                     header: x-ms-error-code
                     language:
                       default:
@@ -27969,7 +28891,7 @@ operationGroups:
         parameters:
           - *ref_135
           - !<!Parameter> 
-            schema: *ref_1341
+            schema: *ref_1342
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27980,8 +28902,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1375
-            schema: *ref_518
+          - !<!Parameter> &ref_1376
+            schema: *ref_519
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27993,8 +28915,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1376
-            schema: *ref_1374
+          - !<!Parameter> &ref_1377
+            schema: *ref_1375
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28005,7 +28927,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1377
+          - !<!Parameter> &ref_1378
             schema: *ref_138
             implementation: Method
             language: !<!Languages> 
@@ -28018,11 +28940,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1378
-            schema: *ref_223
+          - !<!Parameter> &ref_1379
+            schema: *ref_224
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_236
+              x-ms-parameter-grouping: *ref_237
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -28032,7 +28954,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_139
-          - !<!Parameter> &ref_1379
+          - !<!Parameter> &ref_1380
             schema: *ref_140
             implementation: Method
             language: !<!Languages> 
@@ -28045,6 +28967,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_142
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -28055,14 +28992,14 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_1375
           - *ref_1376
           - *ref_1377
           - *ref_1378
           - *ref_1379
+          - *ref_1380
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1380
+            schema: *ref_1381
             language: !<!Languages> 
               default:
                 name: ''
@@ -28071,56 +29008,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1381
+                    schema: *ref_1382
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1382
+                    schema: *ref_1383
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1383
+                    schema: *ref_1384
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The media type of the body of the response. For Get Block List this is 'application/xml'
                   - !<!HttpHeader> 
-                    schema: *ref_1384
+                    schema: *ref_1385
                     header: x-ms-blob-content-length
                     language:
                       default:
                         name: BlobContentLength
                         description: The size of the blob in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_1385
+                    schema: *ref_1386
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1386
+                    schema: *ref_1387
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1387
+                    schema: *ref_1388
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1388
+                    schema: *ref_1389
                     header: Date
                     language:
                       default:
@@ -28133,7 +29070,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -28142,7 +29079,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1389
+                    schema: *ref_1390
                     header: x-ms-error-code
                     language:
                       default:

--- a/modelerfour/test/scenarios/blob-storage/grouped.yaml
+++ b/modelerfour/test/scenarios/blob-storage/grouped.yaml
@@ -59,7 +59,7 @@ schemas: !<!Schemas>
           name: boolean
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_329
+    - !<!BooleanSchema> &ref_330
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -70,7 +70,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-has-immutability-policy
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_330
+    - !<!BooleanSchema> &ref_331
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -81,7 +81,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-has-legal-hold
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_548
+    - !<!BooleanSchema> &ref_549
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -92,7 +92,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_673
+    - !<!BooleanSchema> &ref_674
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -103,7 +103,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_697
+    - !<!BooleanSchema> &ref_698
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -114,7 +114,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-incremental-copy
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_714
+    - !<!BooleanSchema> &ref_715
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -125,7 +125,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_717
+    - !<!BooleanSchema> &ref_718
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -136,7 +136,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-access-tier-inferred
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1073
+    - !<!BooleanSchema> &ref_1074
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -147,7 +147,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1290
+    - !<!BooleanSchema> &ref_1291
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -158,7 +158,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1389
+    - !<!BooleanSchema> &ref_1390
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -169,7 +169,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_857
+    - !<!BooleanSchema> &ref_858
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -180,7 +180,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_955
+    - !<!BooleanSchema> &ref_956
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -191,7 +191,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1411
+    - !<!BooleanSchema> &ref_1412
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -202,7 +202,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1435
+    - !<!BooleanSchema> &ref_1436
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -213,7 +213,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1469
+    - !<!BooleanSchema> &ref_1470
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -224,7 +224,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1107
+    - !<!BooleanSchema> &ref_1108
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -235,7 +235,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1168
+    - !<!BooleanSchema> &ref_1169
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -246,7 +246,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1321
+    - !<!BooleanSchema> &ref_1322
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -257,7 +257,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1357
+    - !<!BooleanSchema> &ref_1358
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -299,7 +299,7 @@ schemas: !<!Schemas>
           name: integer
           description: The maximum amount time that a browser should cache the preflight OPTIONS request.
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_262
+    - !<!NumberSchema> &ref_263
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -319,7 +319,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_296
+    - !<!NumberSchema> &ref_297
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -331,7 +331,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_387
+    - !<!NumberSchema> &ref_388
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -359,7 +359,7 @@ schemas: !<!Schemas>
           name: blobSequenceNumber
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_543
+    - !<!NumberSchema> &ref_544
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -371,7 +371,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_626
+    - !<!NumberSchema> &ref_627
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -383,7 +383,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_635
+    - !<!NumberSchema> &ref_636
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -395,7 +395,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_646
+    - !<!NumberSchema> &ref_647
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -407,7 +407,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-committed-block-count
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_651
+    - !<!NumberSchema> &ref_652
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -419,7 +419,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_660
+    - !<!NumberSchema> &ref_661
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -431,7 +431,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_672
+    - !<!NumberSchema> &ref_673
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -443,7 +443,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-committed-block-count
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_699
+    - !<!NumberSchema> &ref_700
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -455,7 +455,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_707
+    - !<!NumberSchema> &ref_708
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -467,7 +467,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_713
+    - !<!NumberSchema> &ref_714
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -479,7 +479,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-committed-block-count
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_805
+    - !<!NumberSchema> &ref_806
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -491,7 +491,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_834
+    - !<!NumberSchema> &ref_835
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -503,7 +503,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1058
+    - !<!NumberSchema> &ref_1059
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -515,7 +515,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_930
+    - !<!NumberSchema> &ref_931
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -527,7 +527,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-lease-time
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1483
+    - !<!NumberSchema> &ref_1484
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -559,7 +559,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1130
+    - !<!NumberSchema> &ref_1131
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -571,7 +571,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1164
+    - !<!NumberSchema> &ref_1165
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -583,7 +583,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1185
+    - !<!NumberSchema> &ref_1186
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -623,7 +623,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1204
+    - !<!NumberSchema> &ref_1205
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -635,7 +635,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-content-length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1223
+    - !<!NumberSchema> &ref_1224
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -647,7 +647,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1242
+    - !<!NumberSchema> &ref_1243
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -670,7 +670,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1320
+    - !<!NumberSchema> &ref_1321
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -682,7 +682,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-committed-block-count
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1355
+    - !<!NumberSchema> &ref_1356
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -805,7 +805,7 @@ schemas: !<!Schemas>
           name: StaticWebsite-ErrorDocument404Path
           description: The absolute path of the custom 404 page
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_241
+    - !<!StringSchema> &ref_242
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -816,7 +816,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_242
+    - !<!StringSchema> &ref_243
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -827,7 +827,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_244
+    - !<!StringSchema> &ref_245
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -848,17 +848,6 @@ schemas: !<!Schemas>
           name: StorageError-Message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_247
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_248
       type: string
       apiVersions:
@@ -868,7 +857,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_249
       type: string
@@ -879,7 +868,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_250
       type: string
@@ -890,9 +879,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_255
+    - !<!StringSchema> &ref_251
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -901,7 +890,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_256
       type: string
@@ -912,7 +901,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_257
       type: string
@@ -923,9 +912,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_258
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_259
+    - !<!StringSchema> &ref_260
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -936,7 +936,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_261
+    - !<!StringSchema> &ref_262
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -947,7 +947,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_270
+    - !<!StringSchema> &ref_271
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -958,7 +958,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_271
+    - !<!StringSchema> &ref_272
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1065,7 +1065,7 @@ schemas: !<!Schemas>
           name: KeyInfo-Expiry
           description: The date-time the key expires in ISO 8601 UTC time
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_282
+    - !<!StringSchema> &ref_283
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1076,7 +1076,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_283
+    - !<!StringSchema> &ref_284
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1087,7 +1087,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_284
+    - !<!StringSchema> &ref_285
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1148,7 +1148,7 @@ schemas: !<!Schemas>
           name: UserDelegationKey-Value
           description: The key as a base64 string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_286
+    - !<!StringSchema> &ref_287
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1158,17 +1158,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_288
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_289
       type: string
@@ -1179,7 +1168,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_290
       type: string
@@ -1190,9 +1179,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_291
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_294
+    - !<!StringSchema> &ref_295
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1203,7 +1203,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_297
+    - !<!StringSchema> &ref_298
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1214,17 +1214,6 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_304
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_305
       type: string
       apiVersions:
@@ -1234,7 +1223,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_306
       type: string
@@ -1245,9 +1234,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_307
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_308
+    - !<!StringSchema> &ref_309
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1258,7 +1258,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_314
+    - !<!StringSchema> &ref_315
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1269,7 +1269,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_315
+    - !<!StringSchema> &ref_316
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1280,7 +1280,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_316
+    - !<!StringSchema> &ref_317
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1291,7 +1291,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_318
+    - !<!StringSchema> &ref_319
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1313,7 +1313,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-meta
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_323
+    - !<!StringSchema> &ref_324
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1323,17 +1323,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_325
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_326
       type: string
@@ -1344,7 +1333,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_327
       type: string
@@ -1355,9 +1344,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_328
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_331
+    - !<!StringSchema> &ref_332
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1367,17 +1367,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_338
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_339
       type: string
@@ -1388,7 +1377,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_340
       type: string
@@ -1399,7 +1388,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_341
       type: string
@@ -1410,9 +1399,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_342
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_350
+    - !<!StringSchema> &ref_351
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1422,17 +1422,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_352
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_353
       type: string
@@ -1443,7 +1432,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_354
       type: string
@@ -1454,9 +1443,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_355
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_356
+    - !<!StringSchema> &ref_357
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1467,7 +1467,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_363
+    - !<!StringSchema> &ref_364
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1478,7 +1478,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_365
+    - !<!StringSchema> &ref_366
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1489,7 +1489,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_366
+    - !<!StringSchema> &ref_367
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1500,7 +1500,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_367
+    - !<!StringSchema> &ref_368
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1531,7 +1531,7 @@ schemas: !<!Schemas>
           name: AccessPolicy-Permission
           description: the permissions for the acl policy
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_369
+    - !<!StringSchema> &ref_370
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1542,7 +1542,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_378
+    - !<!StringSchema> &ref_379
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1552,17 +1552,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_380
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_381
       type: string
@@ -1573,7 +1562,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_382
       type: string
@@ -1584,9 +1573,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_383
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_384
+    - !<!StringSchema> &ref_385
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1597,7 +1597,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_388
+    - !<!StringSchema> &ref_389
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1607,17 +1607,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_396
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_397
       type: string
@@ -1628,7 +1617,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_398
       type: string
@@ -1639,7 +1628,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_399
       type: string
@@ -1650,9 +1639,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_400
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_401
+    - !<!StringSchema> &ref_402
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1663,7 +1663,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_403
+    - !<!StringSchema> &ref_404
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1673,17 +1673,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_410
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_411
       type: string
@@ -1694,7 +1683,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_412
       type: string
@@ -1705,9 +1694,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_413
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_414
+    - !<!StringSchema> &ref_415
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1718,7 +1718,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_421
+    - !<!StringSchema> &ref_422
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1728,17 +1728,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_423
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_424
       type: string
@@ -1749,7 +1738,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_425
       type: string
@@ -1760,7 +1749,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_426
       type: string
@@ -1771,9 +1760,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_427
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_428
+    - !<!StringSchema> &ref_429
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1784,7 +1784,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_435
+    - !<!StringSchema> &ref_436
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1794,17 +1794,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_437
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_438
       type: string
@@ -1815,7 +1804,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_439
       type: string
@@ -1826,9 +1815,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_440
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_441
+    - !<!StringSchema> &ref_442
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1839,7 +1839,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_443
+    - !<!StringSchema> &ref_444
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1850,7 +1850,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_451
+    - !<!StringSchema> &ref_452
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1861,17 +1861,6 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-lease-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_452
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_453
       type: string
       apiVersions:
@@ -1881,7 +1870,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_454
       type: string
@@ -1892,9 +1881,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_455
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_456
+    - !<!StringSchema> &ref_457
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1905,7 +1905,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_465
+    - !<!StringSchema> &ref_466
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1916,7 +1916,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_466
+    - !<!StringSchema> &ref_467
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1927,7 +1927,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_467
+    - !<!StringSchema> &ref_468
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1938,7 +1938,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_468
+    - !<!StringSchema> &ref_469
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2175,7 +2175,7 @@ schemas: !<!Schemas>
           name: ListBlobsFlatSegmentResponse-NextMarker
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_470
+    - !<!StringSchema> &ref_471
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2186,7 +2186,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_479
+    - !<!StringSchema> &ref_480
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2197,7 +2197,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_480
+    - !<!StringSchema> &ref_481
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2208,7 +2208,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_481
+    - !<!StringSchema> &ref_482
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2299,7 +2299,7 @@ schemas: !<!Schemas>
           name: ListBlobsHierarchySegmentResponse-NextMarker
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_483
+    - !<!StringSchema> &ref_484
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2310,7 +2310,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_484
+    - !<!StringSchema> &ref_485
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2321,7 +2321,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_485
+    - !<!StringSchema> &ref_486
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2332,7 +2332,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_486
+    - !<!StringSchema> &ref_487
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2343,7 +2343,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_488
+    - !<!StringSchema> &ref_489
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2365,17 +2365,6 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_507
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_508
       type: string
       apiVersions:
@@ -2385,7 +2374,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_509
       type: string
@@ -2396,9 +2385,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_512
+    - !<!StringSchema> &ref_510
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2407,7 +2396,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_513
       type: string
@@ -2418,9 +2407,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_514
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_515
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2462,17 +2462,6 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-continuation
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_539
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_540
       type: string
       apiVersions:
@@ -2482,7 +2471,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_541
       type: string
@@ -2493,7 +2482,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_542
       type: string
@@ -2504,9 +2493,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_545
+    - !<!StringSchema> &ref_543
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2515,7 +2504,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_546
       type: string
@@ -2526,7 +2515,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_547
       type: string
@@ -2537,9 +2526,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_559
+    - !<!StringSchema> &ref_548
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2548,7 +2537,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-continuation
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_560
       type: string
@@ -2559,7 +2548,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-continuation
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_561
       type: string
@@ -2570,7 +2559,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_562
       type: string
@@ -2581,9 +2570,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_564
+    - !<!StringSchema> &ref_563
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2592,7 +2581,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_565
       type: string
@@ -2603,7 +2592,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_566
       type: string
@@ -2614,9 +2603,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_567
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_569
+    - !<!StringSchema> &ref_570
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2626,17 +2626,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_583
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_584
       type: string
@@ -2647,7 +2636,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_585
       type: string
@@ -2658,7 +2647,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_586
       type: string
@@ -2669,7 +2658,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_587
       type: string
@@ -2680,9 +2669,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_588
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_599
+    - !<!StringSchema> &ref_600
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2693,7 +2693,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_601
+    - !<!StringSchema> &ref_602
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2704,7 +2704,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-owner
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_602
+    - !<!StringSchema> &ref_603
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2715,7 +2715,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-group
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_603
+    - !<!StringSchema> &ref_604
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2726,7 +2726,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-permissions
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_604
+    - !<!StringSchema> &ref_605
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2737,17 +2737,6 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-acl
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_605
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_606
       type: string
       apiVersions:
@@ -2757,7 +2746,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_607
       type: string
@@ -2768,7 +2757,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_608
       type: string
@@ -2779,9 +2768,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_609
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_610
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2803,17 +2803,6 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-meta
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_627
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Type
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_628
       type: string
       apiVersions:
@@ -2823,7 +2812,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Range
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_629
       type: string
@@ -2834,9 +2823,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Content-Range
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_631
+    - !<!StringSchema> &ref_630
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2845,7 +2834,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Encoding
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_632
       type: string
@@ -2856,7 +2845,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Cache-Control
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_633
       type: string
@@ -2867,7 +2856,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Disposition
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_634
       type: string
@@ -2878,9 +2867,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
+          header: Content-Disposition
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_637
+    - !<!StringSchema> &ref_635
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2889,7 +2878,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-status-description
+          header: Content-Language
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_638
       type: string
@@ -2900,7 +2889,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-id
+          header: x-ms-copy-status-description
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_639
       type: string
@@ -2911,7 +2900,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-progress
+          header: x-ms-copy-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_640
       type: string
@@ -2922,7 +2911,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-source
+          header: x-ms-copy-progress
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_641
       type: string
@@ -2933,7 +2922,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-copy-source
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_642
       type: string
@@ -2944,7 +2933,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_643
       type: string
@@ -2955,7 +2944,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_644
       type: string
@@ -2966,9 +2955,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_645
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: Accept-Ranges
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_647
+    - !<!StringSchema> &ref_648
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2979,7 +2979,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_650
+    - !<!StringSchema> &ref_651
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2989,17 +2989,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-meta
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_652
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_653
       type: string
@@ -3010,7 +2999,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Range
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_654
       type: string
@@ -3021,9 +3010,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Content-Range
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_656
+    - !<!StringSchema> &ref_655
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3032,7 +3021,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Encoding
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_657
       type: string
@@ -3043,7 +3032,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Cache-Control
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_658
       type: string
@@ -3054,7 +3043,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Disposition
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_659
       type: string
@@ -3065,9 +3054,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
+          header: Content-Disposition
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_663
+    - !<!StringSchema> &ref_660
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3076,7 +3065,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-status-description
+          header: Content-Language
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_664
       type: string
@@ -3087,7 +3076,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-id
+          header: x-ms-copy-status-description
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_665
       type: string
@@ -3098,7 +3087,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-progress
+          header: x-ms-copy-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_666
       type: string
@@ -3109,7 +3098,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-source
+          header: x-ms-copy-progress
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_667
       type: string
@@ -3120,7 +3109,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-copy-source
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_668
       type: string
@@ -3131,7 +3120,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_669
       type: string
@@ -3142,7 +3131,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_670
       type: string
@@ -3153,9 +3142,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_671
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: Accept-Ranges
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_674
+    - !<!StringSchema> &ref_675
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3166,7 +3166,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_676
+    - !<!StringSchema> &ref_677
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3177,7 +3177,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_691
+    - !<!StringSchema> &ref_692
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3188,7 +3188,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-meta
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_693
+    - !<!StringSchema> &ref_694
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3199,7 +3199,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-status-description
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_694
+    - !<!StringSchema> &ref_695
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3210,7 +3210,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_695
+    - !<!StringSchema> &ref_696
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3221,7 +3221,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-progress
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_696
+    - !<!StringSchema> &ref_697
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3232,7 +3232,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-source
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_698
+    - !<!StringSchema> &ref_699
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3243,7 +3243,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-destination-snapshot
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_700
+    - !<!StringSchema> &ref_701
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3254,7 +3254,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_701
+    - !<!StringSchema> &ref_702
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3264,17 +3264,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_703
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_704
       type: string
@@ -3285,7 +3274,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Disposition
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_705
       type: string
@@ -3296,7 +3285,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
+          header: Content-Disposition
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_706
       type: string
@@ -3307,9 +3296,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Cache-Control
+          header: Content-Language
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_708
+    - !<!StringSchema> &ref_707
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3318,7 +3307,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_709
       type: string
@@ -3329,7 +3318,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_710
       type: string
@@ -3340,9 +3329,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_711
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_712
+    - !<!StringSchema> &ref_713
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3353,7 +3353,7 @@ schemas: !<!Schemas>
           description: ''
           header: Accept-Ranges
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_715
+    - !<!StringSchema> &ref_716
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3364,7 +3364,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_716
+    - !<!StringSchema> &ref_717
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3375,7 +3375,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-access-tier
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_718
+    - !<!StringSchema> &ref_719
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3386,7 +3386,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-archive-status
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_720
+    - !<!StringSchema> &ref_721
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3396,17 +3396,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_732
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_733
       type: string
@@ -3417,7 +3406,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_734
       type: string
@@ -3428,9 +3417,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_735
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_736
+    - !<!StringSchema> &ref_737
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3441,7 +3441,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_750
+    - !<!StringSchema> &ref_751
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3451,17 +3451,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_752
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_753
       type: string
@@ -3472,7 +3461,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_754
       type: string
@@ -3483,7 +3472,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_755
       type: string
@@ -3494,7 +3483,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_756
       type: string
@@ -3505,9 +3494,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_757
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_767
+    - !<!StringSchema> &ref_768
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3517,17 +3517,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_769
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-owner
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_770
       type: string
@@ -3538,7 +3527,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-group
+          header: x-ms-owner
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_771
       type: string
@@ -3549,7 +3538,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-permissions
+          header: x-ms-group
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_772
       type: string
@@ -3560,7 +3549,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-acl
+          header: x-ms-permissions
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_773
       type: string
@@ -3571,7 +3560,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-acl
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_774
       type: string
@@ -3582,7 +3571,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_775
       type: string
@@ -3593,7 +3582,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_776
       type: string
@@ -3604,7 +3593,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_777
       type: string
@@ -3615,9 +3604,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_778
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_800
+    - !<!StringSchema> &ref_801
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3628,17 +3628,6 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_802
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_803
       type: string
       apiVersions:
@@ -3648,7 +3637,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_804
       type: string
@@ -3659,9 +3648,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_807
+    - !<!StringSchema> &ref_805
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3670,7 +3659,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_808
       type: string
@@ -3681,9 +3670,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_809
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_810
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3705,17 +3705,6 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1069
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1070
       type: string
       apiVersions:
@@ -3725,7 +3714,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1071
       type: string
@@ -3736,9 +3725,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1074
+    - !<!StringSchema> &ref_1072
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3747,7 +3736,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1075
       type: string
@@ -3758,9 +3747,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1076
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1283
+    - !<!StringSchema> &ref_1284
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3770,17 +3770,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1286
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1287
       type: string
@@ -3791,7 +3780,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1288
       type: string
@@ -3802,9 +3791,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1291
+    - !<!StringSchema> &ref_1289
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3813,7 +3802,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1292
       type: string
@@ -3824,9 +3813,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1293
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1382
+    - !<!StringSchema> &ref_1383
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3836,17 +3836,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1385
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1386
       type: string
@@ -3857,7 +3846,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1387
       type: string
@@ -3868,9 +3857,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1390
+    - !<!StringSchema> &ref_1388
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3879,7 +3868,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1391
       type: string
@@ -3890,9 +3879,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_813
+    - !<!StringSchema> &ref_1392
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3901,7 +3890,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_814
       type: string
@@ -3912,7 +3901,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_815
       type: string
@@ -3923,9 +3912,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_816
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_817
+    - !<!StringSchema> &ref_818
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3936,7 +3936,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_832
+    - !<!StringSchema> &ref_833
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3946,17 +3946,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_835
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_836
       type: string
@@ -3967,7 +3956,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_837
       type: string
@@ -3978,9 +3967,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_838
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_839
+    - !<!StringSchema> &ref_840
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3991,7 +3991,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_851
+    - !<!StringSchema> &ref_852
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4001,17 +4001,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_853
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_854
       type: string
@@ -4022,7 +4011,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_855
       type: string
@@ -4033,9 +4022,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_858
+    - !<!StringSchema> &ref_856
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4044,7 +4033,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_859
       type: string
@@ -4055,9 +4044,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_860
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_868
+    - !<!StringSchema> &ref_869
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4067,17 +4067,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_870
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_871
       type: string
@@ -4088,7 +4077,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_872
       type: string
@@ -4099,7 +4088,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_873
       type: string
@@ -4110,9 +4099,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_874
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_875
+    - !<!StringSchema> &ref_876
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4123,7 +4123,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_883
+    - !<!StringSchema> &ref_884
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4133,17 +4133,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_885
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_886
       type: string
@@ -4154,7 +4143,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_887
       type: string
@@ -4165,9 +4154,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_888
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_889
+    - !<!StringSchema> &ref_890
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4178,7 +4178,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_897
+    - !<!StringSchema> &ref_898
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4188,17 +4188,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_899
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_900
       type: string
@@ -4209,7 +4198,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_901
       type: string
@@ -4220,7 +4209,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_902
       type: string
@@ -4231,9 +4220,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_903
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_904
+    - !<!StringSchema> &ref_905
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4244,7 +4244,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_913
+    - !<!StringSchema> &ref_914
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4254,17 +4254,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_915
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_916
       type: string
@@ -4275,7 +4264,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_917
       type: string
@@ -4286,7 +4275,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-lease-id
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_918
       type: string
@@ -4297,9 +4286,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-lease-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_919
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_920
+    - !<!StringSchema> &ref_921
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4310,7 +4310,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_928
+    - !<!StringSchema> &ref_929
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4320,17 +4320,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_931
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_932
       type: string
@@ -4341,7 +4330,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_933
       type: string
@@ -4352,9 +4341,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_934
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_935
+    - !<!StringSchema> &ref_936
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4364,17 +4364,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_948
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-snapshot
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_949
       type: string
@@ -4385,9 +4374,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: x-ms-snapshot
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_951
+    - !<!StringSchema> &ref_950
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4396,7 +4385,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_952
       type: string
@@ -4407,7 +4396,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_953
       type: string
@@ -4418,9 +4407,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_954
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_956
+    - !<!StringSchema> &ref_957
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4431,7 +4431,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_975
+    - !<!StringSchema> &ref_976
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4441,17 +4441,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_977
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_978
       type: string
@@ -4462,7 +4451,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_979
       type: string
@@ -4473,9 +4462,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_981
+    - !<!StringSchema> &ref_980
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4484,7 +4473,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_982
       type: string
@@ -4495,9 +4484,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-copy-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_983
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1001
+    - !<!StringSchema> &ref_1002
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4508,17 +4508,6 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1003
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1004
       type: string
       apiVersions:
@@ -4528,7 +4517,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1005
       type: string
@@ -4539,9 +4528,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1006
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1007
+    - !<!StringSchema> &ref_1008
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4552,7 +4552,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1011
+    - !<!StringSchema> &ref_1012
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4563,7 +4563,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1014
+    - !<!StringSchema> &ref_1015
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4573,17 +4573,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1020
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1021
       type: string
@@ -4594,9 +4583,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1022
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1023
+    - !<!StringSchema> &ref_1024
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4606,17 +4606,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1031
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1032
       type: string
@@ -4627,7 +4616,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1033
       type: string
@@ -4638,7 +4627,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1034
       type: string
@@ -4649,7 +4638,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1035
       type: string
@@ -4660,7 +4649,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1036
       type: string
@@ -4671,7 +4660,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1037
       type: string
@@ -4682,7 +4671,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1038
       type: string
@@ -4693,7 +4682,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1039
       type: string
@@ -4704,7 +4693,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1040
       type: string
@@ -4715,9 +4704,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1041
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1042
+    - !<!StringSchema> &ref_1043
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4728,7 +4728,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1393
+    - !<!StringSchema> &ref_1394
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4738,17 +4738,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1407
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1408
       type: string
@@ -4759,9 +4748,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1412
+    - !<!StringSchema> &ref_1409
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4770,7 +4759,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1413
       type: string
@@ -4781,9 +4770,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1414
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1324
+    - !<!StringSchema> &ref_1325
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4794,7 +4794,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1432
+    - !<!StringSchema> &ref_1433
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4805,7 +4805,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1433
+    - !<!StringSchema> &ref_1434
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4816,7 +4816,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1436
+    - !<!StringSchema> &ref_1437
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4827,7 +4827,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1437
+    - !<!StringSchema> &ref_1438
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4886,7 +4886,7 @@ schemas: !<!Schemas>
           name: BlockLookupList-LatestItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1461
+    - !<!StringSchema> &ref_1462
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4896,17 +4896,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1465
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1466
       type: string
@@ -4917,7 +4906,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1467
       type: string
@@ -4928,9 +4917,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1470
+    - !<!StringSchema> &ref_1468
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4939,7 +4928,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1471
       type: string
@@ -4950,9 +4939,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1481
+    - !<!StringSchema> &ref_1472
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4961,7 +4950,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1482
       type: string
@@ -4972,9 +4961,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Type
+          header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1484
+    - !<!StringSchema> &ref_1483
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4983,7 +4972,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1485
       type: string
@@ -4994,9 +4983,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1486
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1487
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5017,7 +5017,7 @@ schemas: !<!Schemas>
           name: Block-Name
           description: The base64 encoded block ID.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1488
+    - !<!StringSchema> &ref_1489
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5028,7 +5028,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1099
+    - !<!StringSchema> &ref_1100
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5038,17 +5038,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1103
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1104
       type: string
@@ -5059,7 +5048,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1105
       type: string
@@ -5070,9 +5059,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1108
+    - !<!StringSchema> &ref_1106
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5081,7 +5070,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1109
       type: string
@@ -5092,9 +5081,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1110
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1126
+    - !<!StringSchema> &ref_1127
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5104,17 +5104,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1131
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1132
       type: string
@@ -5125,7 +5114,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1133
       type: string
@@ -5136,9 +5125,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1135
+    - !<!StringSchema> &ref_1134
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5147,7 +5136,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1136
       type: string
@@ -5158,9 +5147,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1165
+    - !<!StringSchema> &ref_1137
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5169,7 +5158,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1166
       type: string
@@ -5180,9 +5169,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1169
+    - !<!StringSchema> &ref_1167
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5191,7 +5180,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1170
       type: string
@@ -5202,9 +5191,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1171
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1184
+    - !<!StringSchema> &ref_1185
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5214,17 +5214,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1186
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1187
       type: string
@@ -5235,7 +5224,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1188
       type: string
@@ -5246,9 +5235,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1190
+    - !<!StringSchema> &ref_1189
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5257,7 +5246,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1191
       type: string
@@ -5268,9 +5257,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1205
+    - !<!StringSchema> &ref_1192
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5279,7 +5268,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1206
       type: string
@@ -5290,7 +5279,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1207
       type: string
@@ -5301,9 +5290,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1208
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1209
+    - !<!StringSchema> &ref_1210
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5314,7 +5314,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1221
+    - !<!StringSchema> &ref_1222
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5324,17 +5324,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1224
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1225
       type: string
@@ -5345,7 +5334,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1226
       type: string
@@ -5356,9 +5345,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1227
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1228
+    - !<!StringSchema> &ref_1229
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5369,7 +5369,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1240
+    - !<!StringSchema> &ref_1241
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5379,17 +5379,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1243
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1244
       type: string
@@ -5400,7 +5389,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1245
       type: string
@@ -5411,9 +5400,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1246
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1247
+    - !<!StringSchema> &ref_1248
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5424,7 +5424,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1256
+    - !<!StringSchema> &ref_1257
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5434,17 +5434,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1258
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1259
       type: string
@@ -5455,7 +5444,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1260
       type: string
@@ -5466,9 +5455,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1262
+    - !<!StringSchema> &ref_1261
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5477,7 +5466,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1263
       type: string
@@ -5488,9 +5477,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-copy-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1264
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1311
+    - !<!StringSchema> &ref_1312
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5500,17 +5500,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1315
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1316
       type: string
@@ -5521,7 +5510,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1317
       type: string
@@ -5532,9 +5521,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1318
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1319
+    - !<!StringSchema> &ref_1320
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5544,17 +5544,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-blob-append-offset
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1322
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1323
       type: string
@@ -5565,9 +5554,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1324
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1347
+    - !<!StringSchema> &ref_1348
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5578,7 +5578,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1351
+    - !<!StringSchema> &ref_1352
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5589,7 +5589,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1352
+    - !<!StringSchema> &ref_1353
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5600,7 +5600,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1354
+    - !<!StringSchema> &ref_1355
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5611,7 +5611,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-append-offset
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1356
+    - !<!StringSchema> &ref_1357
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5622,7 +5622,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1358
+    - !<!StringSchema> &ref_1359
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5832,7 +5832,7 @@ schemas: !<!Schemas>
           name: ArchiveStatus
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_1044
+    - !<!ChoiceSchema> &ref_1045
       choices:
         - !<!ChoiceValue> 
           value: P4
@@ -5910,7 +5910,7 @@ schemas: !<!Schemas>
           name: PremiumPageBlobAccessTier
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_957
+    - !<!ChoiceSchema> &ref_958
       choices:
         - !<!ChoiceValue> 
           value: High
@@ -6700,7 +6700,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-lease-duration
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_292
+    - !<!SealedChoiceSchema> &ref_293
       choices:
         - !<!ChoiceValue> 
           value: Standard_LRS
@@ -6743,7 +6743,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-sku-name
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_293
+    - !<!SealedChoiceSchema> &ref_294
       choices:
         - !<!ChoiceValue> 
           value: Storage
@@ -6908,7 +6908,7 @@ schemas: !<!Schemas>
           name: PathRenameMode
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_722
+    - !<!SealedChoiceSchema> &ref_723
       choices:
         - !<!ChoiceValue> 
           value: include
@@ -6932,7 +6932,7 @@ schemas: !<!Schemas>
           name: DeleteSnapshotsOptionType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_1472
+    - !<!SealedChoiceSchema> &ref_1473
       choices:
         - !<!ChoiceValue> 
           value: committed
@@ -6963,7 +6963,7 @@ schemas: !<!Schemas>
           name: BlockListType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_1234
+    - !<!SealedChoiceSchema> &ref_1235
       choices:
         - !<!ChoiceValue> 
           value: max
@@ -7024,7 +7024,17 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_251
+    - !<!ConstantSchema> &ref_238
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/xml
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/xml'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_252
       type: constant
       value: !<!ConstantValue> 
         value: stats
@@ -7034,7 +7044,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_260
+    - !<!ConstantSchema> &ref_261
       type: constant
       value: !<!ConstantValue> 
         value: list
@@ -7044,7 +7054,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_263
+    - !<!ConstantSchema> &ref_264
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -7057,7 +7067,7 @@ schemas: !<!Schemas>
           name: ListContainersIncludeType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_272
+    - !<!ConstantSchema> &ref_273
       type: constant
       value: !<!ConstantValue> 
         value: userdelegationkey
@@ -7067,7 +7077,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_287
+    - !<!ConstantSchema> &ref_288
       type: constant
       value: !<!ConstantValue> 
         value: account
@@ -7077,7 +7087,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_295
+    - !<!ConstantSchema> &ref_296
       type: constant
       value: !<!ConstantValue> 
         value: batch
@@ -7087,7 +7097,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_307
+    - !<!ConstantSchema> &ref_308
       type: constant
       value: !<!ConstantValue> 
         value: container
@@ -7097,7 +7107,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_342
+    - !<!ConstantSchema> &ref_343
       type: constant
       value: !<!ConstantValue> 
         value: metadata
@@ -7107,7 +7117,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_357
+    - !<!ConstantSchema> &ref_358
       type: constant
       value: !<!ConstantValue> 
         value: acl
@@ -7117,7 +7127,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_385
+    - !<!ConstantSchema> &ref_386
       type: constant
       value: !<!ConstantValue> 
         value: lease
@@ -7127,7 +7137,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_386
+    - !<!ConstantSchema> &ref_387
       type: constant
       value: !<!ConstantValue> 
         value: acquire
@@ -7137,7 +7147,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_402
+    - !<!ConstantSchema> &ref_403
       type: constant
       value: !<!ConstantValue> 
         value: release
@@ -7147,7 +7157,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_415
+    - !<!ConstantSchema> &ref_416
       type: constant
       value: !<!ConstantValue> 
         value: renew
@@ -7157,7 +7167,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_429
+    - !<!ConstantSchema> &ref_430
       type: constant
       value: !<!ConstantValue> 
         value: break
@@ -7167,7 +7177,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_442
+    - !<!ConstantSchema> &ref_443
       type: constant
       value: !<!ConstantValue> 
         value: change
@@ -7177,7 +7187,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_489
+    - !<!ConstantSchema> &ref_490
       type: constant
       value: !<!ConstantValue> 
         value: directory
@@ -7187,7 +7197,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_567
+    - !<!ConstantSchema> &ref_568
       type: constant
       value: !<!ConstantValue> 
         value: setAccessControl
@@ -7197,7 +7207,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_588
+    - !<!ConstantSchema> &ref_589
       type: constant
       value: !<!ConstantValue> 
         value: getAccessControl
@@ -7207,7 +7217,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_613
+    - !<!ConstantSchema> &ref_614
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -7220,7 +7230,7 @@ schemas: !<!Schemas>
           name: EncryptionAlgorithmType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1043
+    - !<!ConstantSchema> &ref_1044
       type: constant
       value: !<!ConstantValue> 
         value: PageBlob
@@ -7230,7 +7240,7 @@ schemas: !<!Schemas>
           name: BlobType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1264
+    - !<!ConstantSchema> &ref_1265
       type: constant
       value: !<!ConstantValue> 
         value: AppendBlob
@@ -7240,7 +7250,7 @@ schemas: !<!Schemas>
           name: BlobType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1359
+    - !<!ConstantSchema> &ref_1360
       type: constant
       value: !<!ConstantValue> 
         value: BlockBlob
@@ -7250,7 +7260,7 @@ schemas: !<!Schemas>
           name: BlobType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_810
+    - !<!ConstantSchema> &ref_811
       type: constant
       value: !<!ConstantValue> 
         value: undelete
@@ -7260,7 +7270,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_936
+    - !<!ConstantSchema> &ref_937
       type: constant
       value: !<!ConstantValue> 
         value: snapshot
@@ -7270,7 +7280,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_983
+    - !<!ConstantSchema> &ref_984
       type: constant
       value: !<!ConstantValue> 
         value: 'true'
@@ -7280,7 +7290,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1008
+    - !<!ConstantSchema> &ref_1009
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -7294,7 +7304,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-status
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1012
+    - !<!ConstantSchema> &ref_1013
       type: constant
       value: !<!ConstantValue> 
         value: copy
@@ -7304,7 +7314,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1013
+    - !<!ConstantSchema> &ref_1014
       type: constant
       value: !<!ConstantValue> 
         value: abort
@@ -7314,7 +7324,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1024
+    - !<!ConstantSchema> &ref_1025
       type: constant
       value: !<!ConstantValue> 
         value: tier
@@ -7324,7 +7334,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1392
+    - !<!ConstantSchema> &ref_1393
       type: constant
       value: !<!ConstantValue> 
         value: block
@@ -7334,7 +7344,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1438
+    - !<!ConstantSchema> &ref_1439
       type: constant
       value: !<!ConstantValue> 
         value: blocklist
@@ -7344,7 +7354,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1076
+    - !<!ConstantSchema> &ref_1077
       type: constant
       value: !<!ConstantValue> 
         value: page
@@ -7354,7 +7364,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1077
+    - !<!ConstantSchema> &ref_1078
       type: constant
       value: !<!ConstantValue> 
         value: update
@@ -7364,7 +7374,7 @@ schemas: !<!Schemas>
           name: PageWriteType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1110
+    - !<!ConstantSchema> &ref_1111
       type: constant
       value: !<!ConstantValue> 
         value: clear
@@ -7374,7 +7384,7 @@ schemas: !<!Schemas>
           name: PageWriteType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1171
+    - !<!ConstantSchema> &ref_1172
       type: constant
       value: !<!ConstantValue> 
         value: pagelist
@@ -7384,7 +7394,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1248
+    - !<!ConstantSchema> &ref_1249
       type: constant
       value: !<!ConstantValue> 
         value: incrementalcopy
@@ -7394,7 +7404,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1293
+    - !<!ConstantSchema> &ref_1294
       type: constant
       value: !<!ConstantValue> 
         value: appendblock
@@ -7422,7 +7432,7 @@ schemas: !<!Schemas>
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
   binaries:
-    - !<!BinarySchema> &ref_298
+    - !<!BinarySchema> &ref_299
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7432,7 +7442,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_1373
+    - !<!BinarySchema> &ref_1374
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7442,7 +7452,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_1397
+    - !<!BinarySchema> &ref_1398
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7452,7 +7462,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_1090
+    - !<!BinarySchema> &ref_1091
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7462,7 +7472,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_1303
+    - !<!BinarySchema> &ref_1304
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7484,7 +7494,7 @@ schemas: !<!Schemas>
           name: BlobProperties-Content-MD5
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_630
+    - !<!ByteArraySchema> &ref_631
       type: byte-array
       format: byte
       apiVersions:
@@ -7496,7 +7506,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_648
+    - !<!ByteArraySchema> &ref_649
       type: byte-array
       format: byte
       apiVersions:
@@ -7508,7 +7518,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-content-md5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_655
+    - !<!ByteArraySchema> &ref_656
       type: byte-array
       format: byte
       apiVersions:
@@ -7520,7 +7530,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_661
+    - !<!ByteArraySchema> &ref_662
       type: byte-array
       format: byte
       apiVersions:
@@ -7532,7 +7542,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_675
+    - !<!ByteArraySchema> &ref_676
       type: byte-array
       format: byte
       apiVersions:
@@ -7544,7 +7554,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-content-md5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_702
+    - !<!ByteArraySchema> &ref_703
       type: byte-array
       format: byte
       apiVersions:
@@ -7567,7 +7577,7 @@ schemas: !<!Schemas>
           name: components·16jr1zi·parameters·blobcontentmd5·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1068
+    - !<!ByteArraySchema> &ref_1069
       type: byte-array
       format: byte
       apiVersions:
@@ -7579,7 +7589,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1285
+    - !<!ByteArraySchema> &ref_1286
       type: byte-array
       format: byte
       apiVersions:
@@ -7591,7 +7601,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1078
+    - !<!ByteArraySchema> &ref_1079
       type: byte-array
       format: byte
       apiVersions:
@@ -7602,7 +7612,7 @@ schemas: !<!Schemas>
           name: components·18jrsfm·parameters·contentmd5·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1384
+    - !<!ByteArraySchema> &ref_1385
       type: byte-array
       format: byte
       apiVersions:
@@ -7614,7 +7624,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_993
+    - !<!ByteArraySchema> &ref_994
       type: byte-array
       format: byte
       apiVersions:
@@ -7625,7 +7635,7 @@ schemas: !<!Schemas>
           name: components·1t0oq3p·parameters·sourcecontentmd5·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1009
+    - !<!ByteArraySchema> &ref_1010
       type: byte-array
       format: byte
       apiVersions:
@@ -7637,7 +7647,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1010
+    - !<!ByteArraySchema> &ref_1011
       type: byte-array
       format: byte
       apiVersions:
@@ -7649,7 +7659,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1079
+    - !<!ByteArraySchema> &ref_1080
       type: byte-array
       format: byte
       apiVersions:
@@ -7660,7 +7670,7 @@ schemas: !<!Schemas>
           name: components·rar3zb·parameters·contentcrc64·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1406
+    - !<!ByteArraySchema> &ref_1407
       type: byte-array
       format: byte
       apiVersions:
@@ -7672,7 +7682,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1410
+    - !<!ByteArraySchema> &ref_1411
       type: byte-array
       format: byte
       apiVersions:
@@ -7684,7 +7694,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1137
+    - !<!ByteArraySchema> &ref_1138
       type: byte-array
       format: byte
       apiVersions:
@@ -7695,7 +7705,7 @@ schemas: !<!Schemas>
           name: components·1rd7mnm·parameters·sourcecontentcrc64·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1430
+    - !<!ByteArraySchema> &ref_1431
       type: byte-array
       format: byte
       apiVersions:
@@ -7707,7 +7717,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1431
+    - !<!ByteArraySchema> &ref_1432
       type: byte-array
       format: byte
       apiVersions:
@@ -7719,7 +7729,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1463
+    - !<!ByteArraySchema> &ref_1464
       type: byte-array
       format: byte
       apiVersions:
@@ -7731,7 +7741,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1464
+    - !<!ByteArraySchema> &ref_1465
       type: byte-array
       format: byte
       apiVersions:
@@ -7743,7 +7753,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1101
+    - !<!ByteArraySchema> &ref_1102
       type: byte-array
       format: byte
       apiVersions:
@@ -7755,7 +7765,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1102
+    - !<!ByteArraySchema> &ref_1103
       type: byte-array
       format: byte
       apiVersions:
@@ -7767,7 +7777,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1128
+    - !<!ByteArraySchema> &ref_1129
       type: byte-array
       format: byte
       apiVersions:
@@ -7779,7 +7789,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1129
+    - !<!ByteArraySchema> &ref_1130
       type: byte-array
       format: byte
       apiVersions:
@@ -7791,7 +7801,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1162
+    - !<!ByteArraySchema> &ref_1163
       type: byte-array
       format: byte
       apiVersions:
@@ -7803,7 +7813,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1163
+    - !<!ByteArraySchema> &ref_1164
       type: byte-array
       format: byte
       apiVersions:
@@ -7815,7 +7825,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1313
+    - !<!ByteArraySchema> &ref_1314
       type: byte-array
       format: byte
       apiVersions:
@@ -7827,7 +7837,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1314
+    - !<!ByteArraySchema> &ref_1315
       type: byte-array
       format: byte
       apiVersions:
@@ -7839,7 +7849,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1349
+    - !<!ByteArraySchema> &ref_1350
       type: byte-array
       format: byte
       apiVersions:
@@ -7851,7 +7861,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1350
+    - !<!ByteArraySchema> &ref_1351
       type: byte-array
       format: byte
       apiVersions:
@@ -7864,7 +7874,7 @@ schemas: !<!Schemas>
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
   dateTimes:
-    - !<!DateTimeSchema> &ref_258
+    - !<!DateTimeSchema> &ref_259
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7898,7 +7908,7 @@ schemas: !<!Schemas>
           name: ContainerProperties-Last-Modified
           description: ''
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_285
+    - !<!DateTimeSchema> &ref_286
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7932,7 +7942,7 @@ schemas: !<!Schemas>
           name: UserDelegationKey-SignedExpiry
           description: The date-time the key expires
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_291
+    - !<!DateTimeSchema> &ref_292
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7944,7 +7954,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_313
+    - !<!DateTimeSchema> &ref_314
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7956,7 +7966,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_317
+    - !<!DateTimeSchema> &ref_318
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7968,7 +7978,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_324
+    - !<!DateTimeSchema> &ref_325
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7980,7 +7990,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_328
+    - !<!DateTimeSchema> &ref_329
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8004,7 +8014,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_351
+    - !<!DateTimeSchema> &ref_352
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8016,7 +8026,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_355
+    - !<!DateTimeSchema> &ref_356
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8028,7 +8038,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_364
+    - !<!DateTimeSchema> &ref_365
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8040,7 +8050,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_368
+    - !<!DateTimeSchema> &ref_369
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8074,7 +8084,7 @@ schemas: !<!Schemas>
           name: AccessPolicy-Expiry
           description: the date-time the policy expires
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_379
+    - !<!DateTimeSchema> &ref_380
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8086,7 +8096,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_383
+    - !<!DateTimeSchema> &ref_384
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8098,7 +8108,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_395
+    - !<!DateTimeSchema> &ref_396
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8110,7 +8120,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_400
+    - !<!DateTimeSchema> &ref_401
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8122,7 +8132,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_409
+    - !<!DateTimeSchema> &ref_410
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8134,7 +8144,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_413
+    - !<!DateTimeSchema> &ref_414
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8146,7 +8156,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_422
+    - !<!DateTimeSchema> &ref_423
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8158,7 +8168,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_427
+    - !<!DateTimeSchema> &ref_428
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8170,7 +8180,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_436
+    - !<!DateTimeSchema> &ref_437
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8182,7 +8192,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_440
+    - !<!DateTimeSchema> &ref_441
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8194,7 +8204,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_450
+    - !<!DateTimeSchema> &ref_451
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8206,7 +8216,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_455
+    - !<!DateTimeSchema> &ref_456
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8218,7 +8228,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_469
+    - !<!DateTimeSchema> &ref_470
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8285,7 +8295,7 @@ schemas: !<!Schemas>
           name: BlobProperties-AccessTierChangeTime
           description: ''
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_482
+    - !<!DateTimeSchema> &ref_483
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8297,7 +8307,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_487
+    - !<!DateTimeSchema> &ref_488
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8309,7 +8319,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_506
+    - !<!DateTimeSchema> &ref_507
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8321,7 +8331,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_510
+    - !<!DateTimeSchema> &ref_511
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8345,7 +8355,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_544
+    - !<!DateTimeSchema> &ref_545
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8357,19 +8367,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_563
-      type: date-time
-      format: date-time-rfc1123
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: date-time
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_581
+    - !<!DateTimeSchema> &ref_564
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8391,9 +8389,21 @@ schemas: !<!Schemas>
         default:
           name: date-time
           description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!DateTimeSchema> &ref_583
+      type: date-time
+      format: date-time-rfc1123
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: date-time
+          description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_598
+    - !<!DateTimeSchema> &ref_599
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8405,7 +8415,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_600
+    - !<!DateTimeSchema> &ref_601
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8417,7 +8427,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_625
+    - !<!DateTimeSchema> &ref_626
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8429,7 +8439,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_636
+    - !<!DateTimeSchema> &ref_637
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8441,7 +8451,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-completion-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_645
+    - !<!DateTimeSchema> &ref_646
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8453,7 +8463,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_649
+    - !<!DateTimeSchema> &ref_650
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8465,7 +8475,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_662
+    - !<!DateTimeSchema> &ref_663
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8477,7 +8487,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-completion-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_671
+    - !<!DateTimeSchema> &ref_672
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8488,18 +8498,6 @@ schemas: !<!Schemas>
           name: date-time
           description: ''
           header: Date
-      protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_689
-      type: date-time
-      format: date-time-rfc1123
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: date-time
-          description: ''
-          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!DateTimeSchema> &ref_690
       type: date-time
@@ -8511,9 +8509,21 @@ schemas: !<!Schemas>
         default:
           name: date-time
           description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!DateTimeSchema> &ref_691
+      type: date-time
+      format: date-time-rfc1123
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: date-time
+          description: ''
           header: x-ms-creation-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_692
+    - !<!DateTimeSchema> &ref_693
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8525,7 +8535,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-completion-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_711
+    - !<!DateTimeSchema> &ref_712
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8537,7 +8547,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_719
+    - !<!DateTimeSchema> &ref_720
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8549,7 +8559,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-access-tier-change-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_735
+    - !<!DateTimeSchema> &ref_736
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8561,7 +8571,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_749
+    - !<!DateTimeSchema> &ref_750
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8573,7 +8583,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_751
+    - !<!DateTimeSchema> &ref_752
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8585,7 +8595,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_766
+    - !<!DateTimeSchema> &ref_767
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8597,7 +8607,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_768
+    - !<!DateTimeSchema> &ref_769
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8609,7 +8619,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_801
+    - !<!DateTimeSchema> &ref_802
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8621,7 +8631,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_806
+    - !<!DateTimeSchema> &ref_807
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8633,7 +8643,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1067
+    - !<!DateTimeSchema> &ref_1068
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8645,7 +8655,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1072
+    - !<!DateTimeSchema> &ref_1073
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8657,7 +8667,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1284
+    - !<!DateTimeSchema> &ref_1285
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8669,7 +8679,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1289
+    - !<!DateTimeSchema> &ref_1290
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8681,7 +8691,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1383
+    - !<!DateTimeSchema> &ref_1384
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8693,7 +8703,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1388
+    - !<!DateTimeSchema> &ref_1389
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8705,7 +8715,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_816
+    - !<!DateTimeSchema> &ref_817
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8717,7 +8727,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_833
+    - !<!DateTimeSchema> &ref_834
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8729,7 +8739,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_838
+    - !<!DateTimeSchema> &ref_839
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8741,7 +8751,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_852
+    - !<!DateTimeSchema> &ref_853
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8753,7 +8763,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_856
+    - !<!DateTimeSchema> &ref_857
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8765,7 +8775,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_869
+    - !<!DateTimeSchema> &ref_870
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8777,7 +8787,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_874
+    - !<!DateTimeSchema> &ref_875
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8789,7 +8799,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_884
+    - !<!DateTimeSchema> &ref_885
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8801,7 +8811,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_888
+    - !<!DateTimeSchema> &ref_889
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8813,7 +8823,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_898
+    - !<!DateTimeSchema> &ref_899
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8825,7 +8835,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_903
+    - !<!DateTimeSchema> &ref_904
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8837,7 +8847,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_914
+    - !<!DateTimeSchema> &ref_915
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8849,7 +8859,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_919
+    - !<!DateTimeSchema> &ref_920
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8861,7 +8871,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_929
+    - !<!DateTimeSchema> &ref_930
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8873,7 +8883,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_934
+    - !<!DateTimeSchema> &ref_935
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8885,7 +8895,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_950
+    - !<!DateTimeSchema> &ref_951
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8897,7 +8907,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_954
+    - !<!DateTimeSchema> &ref_955
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8909,7 +8919,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_976
+    - !<!DateTimeSchema> &ref_977
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8921,7 +8931,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_980
+    - !<!DateTimeSchema> &ref_981
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8933,7 +8943,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1002
+    - !<!DateTimeSchema> &ref_1003
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8945,7 +8955,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1006
+    - !<!DateTimeSchema> &ref_1007
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8957,7 +8967,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1022
+    - !<!DateTimeSchema> &ref_1023
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8969,7 +8979,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1041
+    - !<!DateTimeSchema> &ref_1042
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8981,7 +8991,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1409
+    - !<!DateTimeSchema> &ref_1410
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8993,7 +9003,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1434
+    - !<!DateTimeSchema> &ref_1435
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9005,7 +9015,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1462
+    - !<!DateTimeSchema> &ref_1463
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9017,7 +9027,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1468
+    - !<!DateTimeSchema> &ref_1469
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9029,7 +9039,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1480
+    - !<!DateTimeSchema> &ref_1481
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9041,7 +9051,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1487
+    - !<!DateTimeSchema> &ref_1488
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9053,7 +9063,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1100
+    - !<!DateTimeSchema> &ref_1101
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9065,7 +9075,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1106
+    - !<!DateTimeSchema> &ref_1107
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9077,7 +9087,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1127
+    - !<!DateTimeSchema> &ref_1128
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9089,7 +9099,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1134
+    - !<!DateTimeSchema> &ref_1135
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9101,7 +9111,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1161
+    - !<!DateTimeSchema> &ref_1162
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9113,7 +9123,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1167
+    - !<!DateTimeSchema> &ref_1168
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9125,7 +9135,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1183
+    - !<!DateTimeSchema> &ref_1184
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9137,7 +9147,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1189
+    - !<!DateTimeSchema> &ref_1190
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9149,7 +9159,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1203
+    - !<!DateTimeSchema> &ref_1204
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9161,7 +9171,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1208
+    - !<!DateTimeSchema> &ref_1209
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9173,7 +9183,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1222
+    - !<!DateTimeSchema> &ref_1223
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9185,7 +9195,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1227
+    - !<!DateTimeSchema> &ref_1228
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9197,7 +9207,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1241
+    - !<!DateTimeSchema> &ref_1242
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9209,7 +9219,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1246
+    - !<!DateTimeSchema> &ref_1247
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9221,7 +9231,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1257
+    - !<!DateTimeSchema> &ref_1258
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9233,7 +9243,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1261
+    - !<!DateTimeSchema> &ref_1262
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9245,7 +9255,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1312
+    - !<!DateTimeSchema> &ref_1313
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9257,7 +9267,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1318
+    - !<!DateTimeSchema> &ref_1319
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9269,7 +9279,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1348
+    - !<!DateTimeSchema> &ref_1349
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9281,7 +9291,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1353
+    - !<!DateTimeSchema> &ref_1354
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9300,9 +9310,9 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_133
           originalParameter:
-            - !<!Parameter> &ref_319
+            - !<!Parameter> &ref_320
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_320
+              groupedBy: !<!Parameter> &ref_321
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9319,9 +9329,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_332
+            - !<!Parameter> &ref_333
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_335
+              groupedBy: !<!Parameter> &ref_336
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9338,9 +9348,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_343
+            - !<!Parameter> &ref_344
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_345
+              groupedBy: !<!Parameter> &ref_346
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9357,9 +9367,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_358
+            - !<!Parameter> &ref_359
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_359
+              groupedBy: !<!Parameter> &ref_360
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9376,9 +9386,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_370
+            - !<!Parameter> &ref_371
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_373
+              groupedBy: !<!Parameter> &ref_374
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9395,9 +9405,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_495
+            - !<!Parameter> &ref_496
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_500
+              groupedBy: !<!Parameter> &ref_501
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9414,9 +9424,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_521
+            - !<!Parameter> &ref_522
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_530
+              groupedBy: !<!Parameter> &ref_531
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9433,9 +9443,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_549
+            - !<!Parameter> &ref_550
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_554
+              groupedBy: !<!Parameter> &ref_555
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9452,9 +9462,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_568
+            - !<!Parameter> &ref_569
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_574
+              groupedBy: !<!Parameter> &ref_575
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9471,9 +9481,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_589
+            - !<!Parameter> &ref_590
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_594
+              groupedBy: !<!Parameter> &ref_595
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9490,9 +9500,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_610
+            - !<!Parameter> &ref_611
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_618
+              groupedBy: !<!Parameter> &ref_619
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9509,9 +9519,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_677
+            - !<!Parameter> &ref_678
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_685
+              groupedBy: !<!Parameter> &ref_686
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9528,9 +9538,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_721
+            - !<!Parameter> &ref_722
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_727
+              groupedBy: !<!Parameter> &ref_728
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9547,9 +9557,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_737
+            - !<!Parameter> &ref_738
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_742
+              groupedBy: !<!Parameter> &ref_743
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9566,9 +9576,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_757
+            - !<!Parameter> &ref_758
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_762
+              groupedBy: !<!Parameter> &ref_763
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9585,9 +9595,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_783
+            - !<!Parameter> &ref_784
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_792
+              groupedBy: !<!Parameter> &ref_793
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9604,9 +9614,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_823
+            - !<!Parameter> &ref_824
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_829
+              groupedBy: !<!Parameter> &ref_830
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9623,9 +9633,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_840
+            - !<!Parameter> &ref_841
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_847
+              groupedBy: !<!Parameter> &ref_848
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9642,9 +9652,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_943
+            - !<!Parameter> &ref_944
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_944
+              groupedBy: !<!Parameter> &ref_945
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9661,9 +9671,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_967
+            - !<!Parameter> &ref_968
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_968
+              groupedBy: !<!Parameter> &ref_969
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9680,9 +9690,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_992
+            - !<!Parameter> &ref_993
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_994
+              groupedBy: !<!Parameter> &ref_995
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9699,9 +9709,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1015
+            - !<!Parameter> &ref_1016
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1016
+              groupedBy: !<!Parameter> &ref_1017
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9718,9 +9728,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1025
+            - !<!Parameter> &ref_1026
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1026
+              groupedBy: !<!Parameter> &ref_1027
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9737,9 +9747,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1050
+            - !<!Parameter> &ref_1051
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1059
+              groupedBy: !<!Parameter> &ref_1060
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9756,9 +9766,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1080
+            - !<!Parameter> &ref_1081
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1091
+              groupedBy: !<!Parameter> &ref_1092
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9775,9 +9785,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1111
+            - !<!Parameter> &ref_1112
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1121
+              groupedBy: !<!Parameter> &ref_1122
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9794,9 +9804,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1140
+            - !<!Parameter> &ref_1141
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1152
+              groupedBy: !<!Parameter> &ref_1153
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9813,9 +9823,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1172
+            - !<!Parameter> &ref_1173
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1177
+              groupedBy: !<!Parameter> &ref_1178
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9832,9 +9842,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1192
+            - !<!Parameter> &ref_1193
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1197
+              groupedBy: !<!Parameter> &ref_1198
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9851,9 +9861,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1210
+            - !<!Parameter> &ref_1211
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1217
+              groupedBy: !<!Parameter> &ref_1218
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9870,9 +9880,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1229
+            - !<!Parameter> &ref_1230
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1235
+              groupedBy: !<!Parameter> &ref_1236
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9889,9 +9899,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1270
+            - !<!Parameter> &ref_1271
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1278
+              groupedBy: !<!Parameter> &ref_1279
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9908,9 +9918,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1294
+            - !<!Parameter> &ref_1295
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1304
+              groupedBy: !<!Parameter> &ref_1305
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9927,9 +9937,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1327
+            - !<!Parameter> &ref_1328
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1338
+              groupedBy: !<!Parameter> &ref_1339
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9946,9 +9956,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1365
+            - !<!Parameter> &ref_1366
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1374
+              groupedBy: !<!Parameter> &ref_1375
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9965,9 +9975,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1394
+            - !<!Parameter> &ref_1395
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1398
+              groupedBy: !<!Parameter> &ref_1399
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -9984,9 +9994,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1416
+            - !<!Parameter> &ref_1417
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1421
+              groupedBy: !<!Parameter> &ref_1422
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -10003,9 +10013,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1444
+            - !<!Parameter> &ref_1445
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1453
+              groupedBy: !<!Parameter> &ref_1454
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -10022,9 +10032,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1473
+            - !<!Parameter> &ref_1474
               schema: *ref_133
-              groupedBy: !<!Parameter> &ref_1474
+              groupedBy: !<!Parameter> &ref_1475
                 schema: *ref_134
                 implementation: Method
                 language: !<!Languages> 
@@ -10060,7 +10070,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_135
           originalParameter:
-            - !<!Parameter> &ref_333
+            - !<!Parameter> &ref_334
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_137
                 schema: *ref_136
@@ -10079,9 +10089,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_344
+            - !<!Parameter> &ref_345
               schema: *ref_135
-              groupedBy: !<!Parameter> &ref_346
+              groupedBy: !<!Parameter> &ref_347
                 schema: *ref_136
                 implementation: Method
                 language: !<!Languages> 
@@ -10098,7 +10108,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_371
+            - !<!Parameter> &ref_372
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_138
                 schema: *ref_136
@@ -10117,7 +10127,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_389
+            - !<!Parameter> &ref_390
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_139
                 schema: *ref_136
@@ -10136,7 +10146,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_404
+            - !<!Parameter> &ref_405
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_140
                 schema: *ref_136
@@ -10155,7 +10165,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_416
+            - !<!Parameter> &ref_417
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_141
                 schema: *ref_136
@@ -10174,7 +10184,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_430
+            - !<!Parameter> &ref_431
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_142
                 schema: *ref_136
@@ -10193,7 +10203,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_444
+            - !<!Parameter> &ref_445
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_143
                 schema: *ref_136
@@ -10212,7 +10222,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_496
+            - !<!Parameter> &ref_497
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_144
                 schema: *ref_136
@@ -10231,7 +10241,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_522
+            - !<!Parameter> &ref_523
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_145
                 schema: *ref_136
@@ -10250,7 +10260,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_550
+            - !<!Parameter> &ref_551
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_146
                 schema: *ref_136
@@ -10269,7 +10279,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_572
+            - !<!Parameter> &ref_573
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_147
                 schema: *ref_136
@@ -10288,7 +10298,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_592
+            - !<!Parameter> &ref_593
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_148
                 schema: *ref_136
@@ -10307,7 +10317,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_614
+            - !<!Parameter> &ref_615
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_149
                 schema: *ref_136
@@ -10326,7 +10336,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_681
+            - !<!Parameter> &ref_682
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_150
                 schema: *ref_136
@@ -10345,7 +10355,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_723
+            - !<!Parameter> &ref_724
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_151
                 schema: *ref_136
@@ -10364,7 +10374,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_740
+            - !<!Parameter> &ref_741
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_152
                 schema: *ref_136
@@ -10383,7 +10393,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_760
+            - !<!Parameter> &ref_761
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_153
                 schema: *ref_136
@@ -10402,7 +10412,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_784
+            - !<!Parameter> &ref_785
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_154
                 schema: *ref_136
@@ -10421,7 +10431,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_824
+            - !<!Parameter> &ref_825
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_155
                 schema: *ref_136
@@ -10440,7 +10450,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_843
+            - !<!Parameter> &ref_844
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_156
                 schema: *ref_136
@@ -10459,7 +10469,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_860
+            - !<!Parameter> &ref_861
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_157
                 schema: *ref_136
@@ -10478,7 +10488,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_876
+            - !<!Parameter> &ref_877
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_158
                 schema: *ref_136
@@ -10497,7 +10507,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_890
+            - !<!Parameter> &ref_891
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_159
                 schema: *ref_136
@@ -10516,7 +10526,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_905
+            - !<!Parameter> &ref_906
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_160
                 schema: *ref_136
@@ -10535,7 +10545,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_921
+            - !<!Parameter> &ref_922
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_161
                 schema: *ref_136
@@ -10554,7 +10564,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_939
+            - !<!Parameter> &ref_940
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_162
                 schema: *ref_136
@@ -10573,7 +10583,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_962
+            - !<!Parameter> &ref_963
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_163
                 schema: *ref_136
@@ -10592,7 +10602,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_988
+            - !<!Parameter> &ref_989
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_164
                 schema: *ref_136
@@ -10611,7 +10621,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1054
+            - !<!Parameter> &ref_1055
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_165
                 schema: *ref_136
@@ -10630,7 +10640,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1086
+            - !<!Parameter> &ref_1087
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_166
                 schema: *ref_136
@@ -10649,7 +10659,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1117
+            - !<!Parameter> &ref_1118
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_167
                 schema: *ref_136
@@ -10668,7 +10678,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1144
+            - !<!Parameter> &ref_1145
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_168
                 schema: *ref_136
@@ -10687,7 +10697,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1173
+            - !<!Parameter> &ref_1174
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_169
                 schema: *ref_136
@@ -10706,7 +10716,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1193
+            - !<!Parameter> &ref_1194
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_170
                 schema: *ref_136
@@ -10725,7 +10735,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1213
+            - !<!Parameter> &ref_1214
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_171
                 schema: *ref_136
@@ -10744,7 +10754,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1230
+            - !<!Parameter> &ref_1231
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_172
                 schema: *ref_136
@@ -10763,7 +10773,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1249
+            - !<!Parameter> &ref_1250
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_173
                 schema: *ref_136
@@ -10782,7 +10792,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1274
+            - !<!Parameter> &ref_1275
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_174
                 schema: *ref_136
@@ -10801,7 +10811,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1299
+            - !<!Parameter> &ref_1300
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_175
                 schema: *ref_136
@@ -10820,7 +10830,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1330
+            - !<!Parameter> &ref_1331
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_176
                 schema: *ref_136
@@ -10839,7 +10849,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1369
+            - !<!Parameter> &ref_1370
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_177
                 schema: *ref_136
@@ -10858,7 +10868,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1448
+            - !<!Parameter> &ref_1449
               schema: *ref_135
               groupedBy: !<!Parameter> &ref_178
                 schema: *ref_136
@@ -10886,7 +10896,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_135
           originalParameter:
-            - !<!Parameter> &ref_334
+            - !<!Parameter> &ref_335
               schema: *ref_135
               groupedBy: *ref_137
               implementation: Method
@@ -10898,7 +10908,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_372
+            - !<!Parameter> &ref_373
               schema: *ref_135
               groupedBy: *ref_138
               implementation: Method
@@ -10910,7 +10920,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_390
+            - !<!Parameter> &ref_391
               schema: *ref_135
               groupedBy: *ref_139
               implementation: Method
@@ -10922,7 +10932,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_405
+            - !<!Parameter> &ref_406
               schema: *ref_135
               groupedBy: *ref_140
               implementation: Method
@@ -10934,7 +10944,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_417
+            - !<!Parameter> &ref_418
               schema: *ref_135
               groupedBy: *ref_141
               implementation: Method
@@ -10946,7 +10956,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_431
+            - !<!Parameter> &ref_432
               schema: *ref_135
               groupedBy: *ref_142
               implementation: Method
@@ -10958,7 +10968,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_445
+            - !<!Parameter> &ref_446
               schema: *ref_135
               groupedBy: *ref_143
               implementation: Method
@@ -10970,7 +10980,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_497
+            - !<!Parameter> &ref_498
               schema: *ref_135
               groupedBy: *ref_144
               implementation: Method
@@ -10982,7 +10992,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_523
+            - !<!Parameter> &ref_524
               schema: *ref_135
               groupedBy: *ref_145
               implementation: Method
@@ -10994,7 +11004,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_551
+            - !<!Parameter> &ref_552
               schema: *ref_135
               groupedBy: *ref_146
               implementation: Method
@@ -11006,7 +11016,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_573
+            - !<!Parameter> &ref_574
               schema: *ref_135
               groupedBy: *ref_147
               implementation: Method
@@ -11018,7 +11028,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_593
+            - !<!Parameter> &ref_594
               schema: *ref_135
               groupedBy: *ref_148
               implementation: Method
@@ -11030,7 +11040,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_615
+            - !<!Parameter> &ref_616
               schema: *ref_135
               groupedBy: *ref_149
               implementation: Method
@@ -11042,7 +11052,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_682
+            - !<!Parameter> &ref_683
               schema: *ref_135
               groupedBy: *ref_150
               implementation: Method
@@ -11054,7 +11064,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_724
+            - !<!Parameter> &ref_725
               schema: *ref_135
               groupedBy: *ref_151
               implementation: Method
@@ -11066,7 +11076,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_741
+            - !<!Parameter> &ref_742
               schema: *ref_135
               groupedBy: *ref_152
               implementation: Method
@@ -11078,7 +11088,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_761
+            - !<!Parameter> &ref_762
               schema: *ref_135
               groupedBy: *ref_153
               implementation: Method
@@ -11090,7 +11100,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_785
+            - !<!Parameter> &ref_786
               schema: *ref_135
               groupedBy: *ref_154
               implementation: Method
@@ -11102,7 +11112,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_825
+            - !<!Parameter> &ref_826
               schema: *ref_135
               groupedBy: *ref_155
               implementation: Method
@@ -11114,7 +11124,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_844
+            - !<!Parameter> &ref_845
               schema: *ref_135
               groupedBy: *ref_156
               implementation: Method
@@ -11126,7 +11136,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_861
+            - !<!Parameter> &ref_862
               schema: *ref_135
               groupedBy: *ref_157
               implementation: Method
@@ -11138,7 +11148,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_877
+            - !<!Parameter> &ref_878
               schema: *ref_135
               groupedBy: *ref_158
               implementation: Method
@@ -11150,7 +11160,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_891
+            - !<!Parameter> &ref_892
               schema: *ref_135
               groupedBy: *ref_159
               implementation: Method
@@ -11162,7 +11172,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_906
+            - !<!Parameter> &ref_907
               schema: *ref_135
               groupedBy: *ref_160
               implementation: Method
@@ -11174,7 +11184,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_922
+            - !<!Parameter> &ref_923
               schema: *ref_135
               groupedBy: *ref_161
               implementation: Method
@@ -11186,7 +11196,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_940
+            - !<!Parameter> &ref_941
               schema: *ref_135
               groupedBy: *ref_162
               implementation: Method
@@ -11198,7 +11208,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_963
+            - !<!Parameter> &ref_964
               schema: *ref_135
               groupedBy: *ref_163
               implementation: Method
@@ -11210,7 +11220,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_989
+            - !<!Parameter> &ref_990
               schema: *ref_135
               groupedBy: *ref_164
               implementation: Method
@@ -11222,7 +11232,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1055
+            - !<!Parameter> &ref_1056
               schema: *ref_135
               groupedBy: *ref_165
               implementation: Method
@@ -11234,7 +11244,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1087
+            - !<!Parameter> &ref_1088
               schema: *ref_135
               groupedBy: *ref_166
               implementation: Method
@@ -11246,7 +11256,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1118
+            - !<!Parameter> &ref_1119
               schema: *ref_135
               groupedBy: *ref_167
               implementation: Method
@@ -11258,7 +11268,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1145
+            - !<!Parameter> &ref_1146
               schema: *ref_135
               groupedBy: *ref_168
               implementation: Method
@@ -11270,7 +11280,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1174
+            - !<!Parameter> &ref_1175
               schema: *ref_135
               groupedBy: *ref_169
               implementation: Method
@@ -11282,7 +11292,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1194
+            - !<!Parameter> &ref_1195
               schema: *ref_135
               groupedBy: *ref_170
               implementation: Method
@@ -11294,7 +11304,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1214
+            - !<!Parameter> &ref_1215
               schema: *ref_135
               groupedBy: *ref_171
               implementation: Method
@@ -11306,7 +11316,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1231
+            - !<!Parameter> &ref_1232
               schema: *ref_135
               groupedBy: *ref_172
               implementation: Method
@@ -11318,7 +11328,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1250
+            - !<!Parameter> &ref_1251
               schema: *ref_135
               groupedBy: *ref_173
               implementation: Method
@@ -11330,7 +11340,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1275
+            - !<!Parameter> &ref_1276
               schema: *ref_135
               groupedBy: *ref_174
               implementation: Method
@@ -11342,7 +11352,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1300
+            - !<!Parameter> &ref_1301
               schema: *ref_135
               groupedBy: *ref_175
               implementation: Method
@@ -11354,7 +11364,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1331
+            - !<!Parameter> &ref_1332
               schema: *ref_135
               groupedBy: *ref_176
               implementation: Method
@@ -11366,7 +11376,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1370
+            - !<!Parameter> &ref_1371
               schema: *ref_135
               groupedBy: *ref_177
               implementation: Method
@@ -11378,7 +11388,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1449
+            - !<!Parameter> &ref_1450
               schema: *ref_135
               groupedBy: *ref_178
               implementation: Method
@@ -11399,7 +11409,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_179
           originalParameter:
-            - !<!Parameter> &ref_498
+            - !<!Parameter> &ref_499
               schema: *ref_179
               groupedBy: *ref_144
               implementation: Method
@@ -11411,7 +11421,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_524
+            - !<!Parameter> &ref_525
               schema: *ref_179
               groupedBy: *ref_145
               implementation: Method
@@ -11423,7 +11433,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_552
+            - !<!Parameter> &ref_553
               schema: *ref_179
               groupedBy: *ref_146
               implementation: Method
@@ -11435,7 +11445,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_570
+            - !<!Parameter> &ref_571
               schema: *ref_179
               groupedBy: *ref_147
               implementation: Method
@@ -11447,7 +11457,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_590
+            - !<!Parameter> &ref_591
               schema: *ref_179
               groupedBy: *ref_148
               implementation: Method
@@ -11459,7 +11469,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_616
+            - !<!Parameter> &ref_617
               schema: *ref_179
               groupedBy: *ref_149
               implementation: Method
@@ -11471,7 +11481,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_683
+            - !<!Parameter> &ref_684
               schema: *ref_179
               groupedBy: *ref_150
               implementation: Method
@@ -11483,7 +11493,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_725
+            - !<!Parameter> &ref_726
               schema: *ref_179
               groupedBy: *ref_151
               implementation: Method
@@ -11495,7 +11505,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_738
+            - !<!Parameter> &ref_739
               schema: *ref_179
               groupedBy: *ref_152
               implementation: Method
@@ -11507,7 +11517,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_758
+            - !<!Parameter> &ref_759
               schema: *ref_179
               groupedBy: *ref_153
               implementation: Method
@@ -11519,7 +11529,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_786
+            - !<!Parameter> &ref_787
               schema: *ref_179
               groupedBy: *ref_154
               implementation: Method
@@ -11531,7 +11541,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_826
+            - !<!Parameter> &ref_827
               schema: *ref_179
               groupedBy: *ref_155
               implementation: Method
@@ -11543,7 +11553,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_845
+            - !<!Parameter> &ref_846
               schema: *ref_179
               groupedBy: *ref_156
               implementation: Method
@@ -11555,7 +11565,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_862
+            - !<!Parameter> &ref_863
               schema: *ref_179
               groupedBy: *ref_157
               implementation: Method
@@ -11567,7 +11577,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_878
+            - !<!Parameter> &ref_879
               schema: *ref_179
               groupedBy: *ref_158
               implementation: Method
@@ -11579,7 +11589,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_892
+            - !<!Parameter> &ref_893
               schema: *ref_179
               groupedBy: *ref_159
               implementation: Method
@@ -11591,7 +11601,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_907
+            - !<!Parameter> &ref_908
               schema: *ref_179
               groupedBy: *ref_160
               implementation: Method
@@ -11603,7 +11613,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_923
+            - !<!Parameter> &ref_924
               schema: *ref_179
               groupedBy: *ref_161
               implementation: Method
@@ -11615,7 +11625,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_941
+            - !<!Parameter> &ref_942
               schema: *ref_179
               groupedBy: *ref_162
               implementation: Method
@@ -11627,7 +11637,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_964
+            - !<!Parameter> &ref_965
               schema: *ref_179
               groupedBy: *ref_163
               implementation: Method
@@ -11639,7 +11649,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_990
+            - !<!Parameter> &ref_991
               schema: *ref_179
               groupedBy: *ref_164
               implementation: Method
@@ -11651,7 +11661,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1056
+            - !<!Parameter> &ref_1057
               schema: *ref_179
               groupedBy: *ref_165
               implementation: Method
@@ -11663,7 +11673,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1088
+            - !<!Parameter> &ref_1089
               schema: *ref_179
               groupedBy: *ref_166
               implementation: Method
@@ -11675,7 +11685,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1119
+            - !<!Parameter> &ref_1120
               schema: *ref_179
               groupedBy: *ref_167
               implementation: Method
@@ -11687,7 +11697,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1146
+            - !<!Parameter> &ref_1147
               schema: *ref_179
               groupedBy: *ref_168
               implementation: Method
@@ -11699,7 +11709,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1175
+            - !<!Parameter> &ref_1176
               schema: *ref_179
               groupedBy: *ref_169
               implementation: Method
@@ -11711,7 +11721,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1195
+            - !<!Parameter> &ref_1196
               schema: *ref_179
               groupedBy: *ref_170
               implementation: Method
@@ -11723,7 +11733,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1215
+            - !<!Parameter> &ref_1216
               schema: *ref_179
               groupedBy: *ref_171
               implementation: Method
@@ -11735,7 +11745,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1232
+            - !<!Parameter> &ref_1233
               schema: *ref_179
               groupedBy: *ref_172
               implementation: Method
@@ -11747,7 +11757,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1251
+            - !<!Parameter> &ref_1252
               schema: *ref_179
               groupedBy: *ref_173
               implementation: Method
@@ -11759,7 +11769,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1276
+            - !<!Parameter> &ref_1277
               schema: *ref_179
               groupedBy: *ref_174
               implementation: Method
@@ -11771,7 +11781,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1301
+            - !<!Parameter> &ref_1302
               schema: *ref_179
               groupedBy: *ref_175
               implementation: Method
@@ -11783,7 +11793,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1332
+            - !<!Parameter> &ref_1333
               schema: *ref_179
               groupedBy: *ref_176
               implementation: Method
@@ -11795,7 +11805,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1371
+            - !<!Parameter> &ref_1372
               schema: *ref_179
               groupedBy: *ref_177
               implementation: Method
@@ -11807,7 +11817,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1450
+            - !<!Parameter> &ref_1451
               schema: *ref_179
               groupedBy: *ref_178
               implementation: Method
@@ -11828,7 +11838,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_179
           originalParameter:
-            - !<!Parameter> &ref_499
+            - !<!Parameter> &ref_500
               schema: *ref_179
               groupedBy: *ref_144
               implementation: Method
@@ -11840,7 +11850,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_525
+            - !<!Parameter> &ref_526
               schema: *ref_179
               groupedBy: *ref_145
               implementation: Method
@@ -11852,7 +11862,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_553
+            - !<!Parameter> &ref_554
               schema: *ref_179
               groupedBy: *ref_146
               implementation: Method
@@ -11864,7 +11874,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_571
+            - !<!Parameter> &ref_572
               schema: *ref_179
               groupedBy: *ref_147
               implementation: Method
@@ -11876,7 +11886,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_591
+            - !<!Parameter> &ref_592
               schema: *ref_179
               groupedBy: *ref_148
               implementation: Method
@@ -11888,7 +11898,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_617
+            - !<!Parameter> &ref_618
               schema: *ref_179
               groupedBy: *ref_149
               implementation: Method
@@ -11900,7 +11910,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_684
+            - !<!Parameter> &ref_685
               schema: *ref_179
               groupedBy: *ref_150
               implementation: Method
@@ -11912,7 +11922,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_726
+            - !<!Parameter> &ref_727
               schema: *ref_179
               groupedBy: *ref_151
               implementation: Method
@@ -11924,7 +11934,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_739
+            - !<!Parameter> &ref_740
               schema: *ref_179
               groupedBy: *ref_152
               implementation: Method
@@ -11936,7 +11946,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_759
+            - !<!Parameter> &ref_760
               schema: *ref_179
               groupedBy: *ref_153
               implementation: Method
@@ -11948,7 +11958,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_787
+            - !<!Parameter> &ref_788
               schema: *ref_179
               groupedBy: *ref_154
               implementation: Method
@@ -11960,7 +11970,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_827
+            - !<!Parameter> &ref_828
               schema: *ref_179
               groupedBy: *ref_155
               implementation: Method
@@ -11972,7 +11982,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_846
+            - !<!Parameter> &ref_847
               schema: *ref_179
               groupedBy: *ref_156
               implementation: Method
@@ -11984,7 +11994,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_863
+            - !<!Parameter> &ref_864
               schema: *ref_179
               groupedBy: *ref_157
               implementation: Method
@@ -11996,7 +12006,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_879
+            - !<!Parameter> &ref_880
               schema: *ref_179
               groupedBy: *ref_158
               implementation: Method
@@ -12008,7 +12018,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_893
+            - !<!Parameter> &ref_894
               schema: *ref_179
               groupedBy: *ref_159
               implementation: Method
@@ -12020,7 +12030,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_908
+            - !<!Parameter> &ref_909
               schema: *ref_179
               groupedBy: *ref_160
               implementation: Method
@@ -12032,7 +12042,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_924
+            - !<!Parameter> &ref_925
               schema: *ref_179
               groupedBy: *ref_161
               implementation: Method
@@ -12044,7 +12054,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_942
+            - !<!Parameter> &ref_943
               schema: *ref_179
               groupedBy: *ref_162
               implementation: Method
@@ -12056,7 +12066,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_965
+            - !<!Parameter> &ref_966
               schema: *ref_179
               groupedBy: *ref_163
               implementation: Method
@@ -12068,7 +12078,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_991
+            - !<!Parameter> &ref_992
               schema: *ref_179
               groupedBy: *ref_164
               implementation: Method
@@ -12080,7 +12090,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1057
+            - !<!Parameter> &ref_1058
               schema: *ref_179
               groupedBy: *ref_165
               implementation: Method
@@ -12092,7 +12102,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1089
+            - !<!Parameter> &ref_1090
               schema: *ref_179
               groupedBy: *ref_166
               implementation: Method
@@ -12104,7 +12114,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1120
+            - !<!Parameter> &ref_1121
               schema: *ref_179
               groupedBy: *ref_167
               implementation: Method
@@ -12116,7 +12126,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1147
+            - !<!Parameter> &ref_1148
               schema: *ref_179
               groupedBy: *ref_168
               implementation: Method
@@ -12128,7 +12138,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1176
+            - !<!Parameter> &ref_1177
               schema: *ref_179
               groupedBy: *ref_169
               implementation: Method
@@ -12140,7 +12150,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1196
+            - !<!Parameter> &ref_1197
               schema: *ref_179
               groupedBy: *ref_170
               implementation: Method
@@ -12152,7 +12162,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1216
+            - !<!Parameter> &ref_1217
               schema: *ref_179
               groupedBy: *ref_171
               implementation: Method
@@ -12164,7 +12174,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1233
+            - !<!Parameter> &ref_1234
               schema: *ref_179
               groupedBy: *ref_172
               implementation: Method
@@ -12176,7 +12186,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1252
+            - !<!Parameter> &ref_1253
               schema: *ref_179
               groupedBy: *ref_173
               implementation: Method
@@ -12188,7 +12198,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1277
+            - !<!Parameter> &ref_1278
               schema: *ref_179
               groupedBy: *ref_174
               implementation: Method
@@ -12200,7 +12210,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1302
+            - !<!Parameter> &ref_1303
               schema: *ref_179
               groupedBy: *ref_175
               implementation: Method
@@ -12212,7 +12222,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1333
+            - !<!Parameter> &ref_1334
               schema: *ref_179
               groupedBy: *ref_176
               implementation: Method
@@ -12224,7 +12234,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1372
+            - !<!Parameter> &ref_1373
               schema: *ref_179
               groupedBy: *ref_177
               implementation: Method
@@ -12236,7 +12246,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1451
+            - !<!Parameter> &ref_1452
               schema: *ref_179
               groupedBy: *ref_178
               implementation: Method
@@ -12267,7 +12277,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_179
           originalParameter:
-            - !<!Parameter> &ref_490
+            - !<!Parameter> &ref_491
               schema: *ref_179
               groupedBy: !<!Parameter> &ref_181
                 schema: *ref_180
@@ -12286,7 +12296,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_516
+            - !<!Parameter> &ref_517
               schema: *ref_179
               groupedBy: !<!Parameter> &ref_182
                 schema: *ref_180
@@ -12305,7 +12315,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_778
+            - !<!Parameter> &ref_779
               schema: *ref_179
               groupedBy: !<!Parameter> &ref_183
                 schema: *ref_180
@@ -12333,7 +12343,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_179
           originalParameter:
-            - !<!Parameter> &ref_491
+            - !<!Parameter> &ref_492
               schema: *ref_179
               groupedBy: *ref_181
               implementation: Method
@@ -12345,7 +12355,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_517
+            - !<!Parameter> &ref_518
               schema: *ref_179
               groupedBy: *ref_182
               implementation: Method
@@ -12357,7 +12367,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_779
+            - !<!Parameter> &ref_780
               schema: *ref_179
               groupedBy: *ref_183
               implementation: Method
@@ -12378,7 +12388,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_179
           originalParameter:
-            - !<!Parameter> &ref_492
+            - !<!Parameter> &ref_493
               schema: *ref_179
               groupedBy: *ref_181
               implementation: Method
@@ -12390,7 +12400,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_518
+            - !<!Parameter> &ref_519
               schema: *ref_179
               groupedBy: *ref_182
               implementation: Method
@@ -12402,7 +12412,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_780
+            - !<!Parameter> &ref_781
               schema: *ref_179
               groupedBy: *ref_183
               implementation: Method
@@ -12423,7 +12433,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_179
           originalParameter:
-            - !<!Parameter> &ref_493
+            - !<!Parameter> &ref_494
               schema: *ref_179
               groupedBy: *ref_181
               implementation: Method
@@ -12435,7 +12445,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_519
+            - !<!Parameter> &ref_520
               schema: *ref_179
               groupedBy: *ref_182
               implementation: Method
@@ -12447,7 +12457,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_781
+            - !<!Parameter> &ref_782
               schema: *ref_179
               groupedBy: *ref_183
               implementation: Method
@@ -12468,7 +12478,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_179
           originalParameter:
-            - !<!Parameter> &ref_494
+            - !<!Parameter> &ref_495
               schema: *ref_179
               groupedBy: *ref_181
               implementation: Method
@@ -12480,7 +12490,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_520
+            - !<!Parameter> &ref_521
               schema: *ref_179
               groupedBy: *ref_182
               implementation: Method
@@ -12492,7 +12502,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_782
+            - !<!Parameter> &ref_783
               schema: *ref_179
               groupedBy: *ref_183
               implementation: Method
@@ -12523,7 +12533,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_184
           originalParameter:
-            - !<!Parameter> &ref_526
+            - !<!Parameter> &ref_527
               schema: *ref_184
               groupedBy: !<!Parameter> &ref_186
                 schema: *ref_185
@@ -12542,7 +12552,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_788
+            - !<!Parameter> &ref_789
               schema: *ref_184
               groupedBy: !<!Parameter> &ref_187
                 schema: *ref_185
@@ -12561,7 +12571,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_958
+            - !<!Parameter> &ref_959
               schema: *ref_184
               groupedBy: !<!Parameter> &ref_188
                 schema: *ref_185
@@ -12580,7 +12590,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_984
+            - !<!Parameter> &ref_985
               schema: *ref_184
               groupedBy: !<!Parameter> &ref_189
                 schema: *ref_185
@@ -12599,7 +12609,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1148
+            - !<!Parameter> &ref_1149
               schema: *ref_184
               groupedBy: !<!Parameter> &ref_190
                 schema: *ref_185
@@ -12618,7 +12628,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1334
+            - !<!Parameter> &ref_1335
               schema: *ref_184
               groupedBy: !<!Parameter> &ref_191
                 schema: *ref_185
@@ -12637,7 +12647,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1417
+            - !<!Parameter> &ref_1418
               schema: *ref_184
               groupedBy: !<!Parameter> &ref_192
                 schema: *ref_185
@@ -12665,7 +12675,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_184
           originalParameter:
-            - !<!Parameter> &ref_527
+            - !<!Parameter> &ref_528
               schema: *ref_184
               groupedBy: *ref_186
               implementation: Method
@@ -12677,7 +12687,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_789
+            - !<!Parameter> &ref_790
               schema: *ref_184
               groupedBy: *ref_187
               implementation: Method
@@ -12689,7 +12699,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_959
+            - !<!Parameter> &ref_960
               schema: *ref_184
               groupedBy: *ref_188
               implementation: Method
@@ -12701,7 +12711,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_985
+            - !<!Parameter> &ref_986
               schema: *ref_184
               groupedBy: *ref_189
               implementation: Method
@@ -12713,7 +12723,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1149
+            - !<!Parameter> &ref_1150
               schema: *ref_184
               groupedBy: *ref_190
               implementation: Method
@@ -12725,7 +12735,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1335
+            - !<!Parameter> &ref_1336
               schema: *ref_184
               groupedBy: *ref_191
               implementation: Method
@@ -12737,7 +12747,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1418
+            - !<!Parameter> &ref_1419
               schema: *ref_184
               groupedBy: *ref_192
               implementation: Method
@@ -12758,7 +12768,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_193
           originalParameter:
-            - !<!Parameter> &ref_528
+            - !<!Parameter> &ref_529
               schema: *ref_193
               groupedBy: *ref_186
               implementation: Method
@@ -12770,7 +12780,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_790
+            - !<!Parameter> &ref_791
               schema: *ref_193
               groupedBy: *ref_187
               implementation: Method
@@ -12782,7 +12792,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_960
+            - !<!Parameter> &ref_961
               schema: *ref_193
               groupedBy: *ref_188
               implementation: Method
@@ -12794,7 +12804,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_986
+            - !<!Parameter> &ref_987
               schema: *ref_193
               groupedBy: *ref_189
               implementation: Method
@@ -12806,7 +12816,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1150
+            - !<!Parameter> &ref_1151
               schema: *ref_193
               groupedBy: *ref_190
               implementation: Method
@@ -12818,7 +12828,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1336
+            - !<!Parameter> &ref_1337
               schema: *ref_193
               groupedBy: *ref_191
               implementation: Method
@@ -12830,7 +12840,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1419
+            - !<!Parameter> &ref_1420
               schema: *ref_193
               groupedBy: *ref_192
               implementation: Method
@@ -12851,7 +12861,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_193
           originalParameter:
-            - !<!Parameter> &ref_529
+            - !<!Parameter> &ref_530
               schema: *ref_193
               groupedBy: *ref_186
               implementation: Method
@@ -12863,7 +12873,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_791
+            - !<!Parameter> &ref_792
               schema: *ref_193
               groupedBy: *ref_187
               implementation: Method
@@ -12875,7 +12885,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_961
+            - !<!Parameter> &ref_962
               schema: *ref_193
               groupedBy: *ref_188
               implementation: Method
@@ -12887,7 +12897,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_987
+            - !<!Parameter> &ref_988
               schema: *ref_193
               groupedBy: *ref_189
               implementation: Method
@@ -12899,7 +12909,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1151
+            - !<!Parameter> &ref_1152
               schema: *ref_193
               groupedBy: *ref_190
               implementation: Method
@@ -12911,7 +12921,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1337
+            - !<!Parameter> &ref_1338
               schema: *ref_193
               groupedBy: *ref_191
               implementation: Method
@@ -12923,7 +12933,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1420
+            - !<!Parameter> &ref_1421
               schema: *ref_193
               groupedBy: *ref_192
               implementation: Method
@@ -12954,7 +12964,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_194
           originalParameter:
-            - !<!Parameter> &ref_611
+            - !<!Parameter> &ref_612
               schema: *ref_194
               groupedBy: !<!Parameter> &ref_196
                 schema: *ref_195
@@ -12975,7 +12985,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_678
+            - !<!Parameter> &ref_679
               schema: *ref_194
               groupedBy: !<!Parameter> &ref_197
                 schema: *ref_195
@@ -12996,7 +13006,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_841
+            - !<!Parameter> &ref_842
               schema: *ref_194
               groupedBy: !<!Parameter> &ref_198
                 schema: *ref_195
@@ -13017,7 +13027,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_937
+            - !<!Parameter> &ref_938
               schema: *ref_194
               groupedBy: !<!Parameter> &ref_199
                 schema: *ref_195
@@ -13038,7 +13048,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1052
+            - !<!Parameter> &ref_1053
               schema: *ref_194
               groupedBy: !<!Parameter> &ref_200
                 schema: *ref_195
@@ -13059,7 +13069,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1081
+            - !<!Parameter> &ref_1082
               schema: *ref_194
               groupedBy: !<!Parameter> &ref_201
                 schema: *ref_195
@@ -13080,7 +13090,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1112
+            - !<!Parameter> &ref_1113
               schema: *ref_194
               groupedBy: !<!Parameter> &ref_202
                 schema: *ref_195
@@ -13101,7 +13111,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1138
+            - !<!Parameter> &ref_1139
               schema: *ref_194
               groupedBy: !<!Parameter> &ref_203
                 schema: *ref_195
@@ -13122,7 +13132,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1211
+            - !<!Parameter> &ref_1212
               schema: *ref_194
               groupedBy: !<!Parameter> &ref_204
                 schema: *ref_195
@@ -13143,7 +13153,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1272
+            - !<!Parameter> &ref_1273
               schema: *ref_194
               groupedBy: !<!Parameter> &ref_205
                 schema: *ref_195
@@ -13164,7 +13174,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1297
+            - !<!Parameter> &ref_1298
               schema: *ref_194
               groupedBy: !<!Parameter> &ref_206
                 schema: *ref_195
@@ -13185,7 +13195,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1325
+            - !<!Parameter> &ref_1326
               schema: *ref_194
               groupedBy: !<!Parameter> &ref_207
                 schema: *ref_195
@@ -13206,7 +13216,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1367
+            - !<!Parameter> &ref_1368
               schema: *ref_194
               groupedBy: !<!Parameter> &ref_208
                 schema: *ref_195
@@ -13227,7 +13237,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1395
+            - !<!Parameter> &ref_1396
               schema: *ref_194
               groupedBy: !<!Parameter> &ref_209
                 schema: *ref_195
@@ -13248,7 +13258,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1414
+            - !<!Parameter> &ref_1415
               schema: *ref_194
               groupedBy: !<!Parameter> &ref_210
                 schema: *ref_195
@@ -13269,7 +13279,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1446
+            - !<!Parameter> &ref_1447
               schema: *ref_194
               groupedBy: !<!Parameter> &ref_211
                 schema: *ref_195
@@ -13301,7 +13311,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_194
           originalParameter:
-            - !<!Parameter> &ref_612
+            - !<!Parameter> &ref_613
               schema: *ref_194
               groupedBy: *ref_196
               implementation: Method
@@ -13313,7 +13323,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_679
+            - !<!Parameter> &ref_680
               schema: *ref_194
               groupedBy: *ref_197
               implementation: Method
@@ -13325,7 +13335,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_842
+            - !<!Parameter> &ref_843
               schema: *ref_194
               groupedBy: *ref_198
               implementation: Method
@@ -13337,7 +13347,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_938
+            - !<!Parameter> &ref_939
               schema: *ref_194
               groupedBy: *ref_199
               implementation: Method
@@ -13349,7 +13359,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1053
+            - !<!Parameter> &ref_1054
               schema: *ref_194
               groupedBy: *ref_200
               implementation: Method
@@ -13361,7 +13371,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1082
+            - !<!Parameter> &ref_1083
               schema: *ref_194
               groupedBy: *ref_201
               implementation: Method
@@ -13373,7 +13383,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1113
+            - !<!Parameter> &ref_1114
               schema: *ref_194
               groupedBy: *ref_202
               implementation: Method
@@ -13385,7 +13395,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1139
+            - !<!Parameter> &ref_1140
               schema: *ref_194
               groupedBy: *ref_203
               implementation: Method
@@ -13397,7 +13407,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1212
+            - !<!Parameter> &ref_1213
               schema: *ref_194
               groupedBy: *ref_204
               implementation: Method
@@ -13409,7 +13419,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1273
+            - !<!Parameter> &ref_1274
               schema: *ref_194
               groupedBy: *ref_205
               implementation: Method
@@ -13421,7 +13431,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1298
+            - !<!Parameter> &ref_1299
               schema: *ref_194
               groupedBy: *ref_206
               implementation: Method
@@ -13433,7 +13443,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1326
+            - !<!Parameter> &ref_1327
               schema: *ref_194
               groupedBy: *ref_207
               implementation: Method
@@ -13445,7 +13455,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1368
+            - !<!Parameter> &ref_1369
               schema: *ref_194
               groupedBy: *ref_208
               implementation: Method
@@ -13457,7 +13467,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1396
+            - !<!Parameter> &ref_1397
               schema: *ref_194
               groupedBy: *ref_209
               implementation: Method
@@ -13469,7 +13479,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1415
+            - !<!Parameter> &ref_1416
               schema: *ref_194
               groupedBy: *ref_210
               implementation: Method
@@ -13481,7 +13491,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1447
+            - !<!Parameter> &ref_1448
               schema: *ref_194
               groupedBy: *ref_211
               implementation: Method
@@ -13512,7 +13522,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_212
           originalParameter:
-            - !<!Parameter> &ref_818
+            - !<!Parameter> &ref_819
               schema: *ref_212
               groupedBy: !<!Parameter> &ref_214
                 schema: *ref_213
@@ -13531,7 +13541,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1049
+            - !<!Parameter> &ref_1050
               schema: *ref_212
               groupedBy: !<!Parameter> &ref_215
                 schema: *ref_213
@@ -13550,7 +13560,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1269
+            - !<!Parameter> &ref_1270
               schema: *ref_212
               groupedBy: !<!Parameter> &ref_216
                 schema: *ref_213
@@ -13569,7 +13579,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1364
+            - !<!Parameter> &ref_1365
               schema: *ref_212
               groupedBy: !<!Parameter> &ref_217
                 schema: *ref_213
@@ -13588,7 +13598,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1439
+            - !<!Parameter> &ref_1440
               schema: *ref_212
               groupedBy: !<!Parameter> &ref_218
                 schema: *ref_213
@@ -13616,7 +13626,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_212
           originalParameter:
-            - !<!Parameter> &ref_819
+            - !<!Parameter> &ref_820
               schema: *ref_212
               groupedBy: *ref_214
               implementation: Method
@@ -13628,7 +13638,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1045
+            - !<!Parameter> &ref_1046
               schema: *ref_212
               groupedBy: *ref_215
               implementation: Method
@@ -13640,7 +13650,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1265
+            - !<!Parameter> &ref_1266
               schema: *ref_212
               groupedBy: *ref_216
               implementation: Method
@@ -13652,7 +13662,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1360
+            - !<!Parameter> &ref_1361
               schema: *ref_212
               groupedBy: *ref_217
               implementation: Method
@@ -13664,7 +13674,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1440
+            - !<!Parameter> &ref_1441
               schema: *ref_212
               groupedBy: *ref_218
               implementation: Method
@@ -13685,7 +13695,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_219
           originalParameter:
-            - !<!Parameter> &ref_820
+            - !<!Parameter> &ref_821
               schema: *ref_219
               groupedBy: *ref_214
               implementation: Method
@@ -13697,7 +13707,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1048
+            - !<!Parameter> &ref_1049
               schema: *ref_219
               groupedBy: *ref_215
               implementation: Method
@@ -13709,7 +13719,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1268
+            - !<!Parameter> &ref_1269
               schema: *ref_219
               groupedBy: *ref_216
               implementation: Method
@@ -13721,7 +13731,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1363
+            - !<!Parameter> &ref_1364
               schema: *ref_219
               groupedBy: *ref_217
               implementation: Method
@@ -13733,7 +13743,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1443
+            - !<!Parameter> &ref_1444
               schema: *ref_219
               groupedBy: *ref_218
               implementation: Method
@@ -13754,7 +13764,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_212
           originalParameter:
-            - !<!Parameter> &ref_821
+            - !<!Parameter> &ref_822
               schema: *ref_212
               groupedBy: *ref_214
               implementation: Method
@@ -13766,7 +13776,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1046
+            - !<!Parameter> &ref_1047
               schema: *ref_212
               groupedBy: *ref_215
               implementation: Method
@@ -13778,7 +13788,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1266
+            - !<!Parameter> &ref_1267
               schema: *ref_212
               groupedBy: *ref_216
               implementation: Method
@@ -13790,7 +13800,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1361
+            - !<!Parameter> &ref_1362
               schema: *ref_212
               groupedBy: *ref_217
               implementation: Method
@@ -13802,7 +13812,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1441
+            - !<!Parameter> &ref_1442
               schema: *ref_212
               groupedBy: *ref_218
               implementation: Method
@@ -13823,7 +13833,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_212
           originalParameter:
-            - !<!Parameter> &ref_822
+            - !<!Parameter> &ref_823
               schema: *ref_212
               groupedBy: *ref_214
               implementation: Method
@@ -13835,7 +13845,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1047
+            - !<!Parameter> &ref_1048
               schema: *ref_212
               groupedBy: *ref_215
               implementation: Method
@@ -13847,7 +13857,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1267
+            - !<!Parameter> &ref_1268
               schema: *ref_212
               groupedBy: *ref_216
               implementation: Method
@@ -13859,7 +13869,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1362
+            - !<!Parameter> &ref_1363
               schema: *ref_212
               groupedBy: *ref_217
               implementation: Method
@@ -13871,7 +13881,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1442
+            - !<!Parameter> &ref_1443
               schema: *ref_212
               groupedBy: *ref_218
               implementation: Method
@@ -13892,7 +13902,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_212
           originalParameter:
-            - !<!Parameter> &ref_828
+            - !<!Parameter> &ref_829
               schema: *ref_212
               groupedBy: *ref_214
               implementation: Method
@@ -13904,7 +13914,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1051
+            - !<!Parameter> &ref_1052
               schema: *ref_212
               groupedBy: *ref_215
               implementation: Method
@@ -13916,7 +13926,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1271
+            - !<!Parameter> &ref_1272
               schema: *ref_212
               groupedBy: *ref_216
               implementation: Method
@@ -13928,7 +13938,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1366
+            - !<!Parameter> &ref_1367
               schema: *ref_212
               groupedBy: *ref_217
               implementation: Method
@@ -13940,7 +13950,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1445
+            - !<!Parameter> &ref_1446
               schema: *ref_212
               groupedBy: *ref_218
               implementation: Method
@@ -13971,7 +13981,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_220
           originalParameter:
-            - !<!Parameter> &ref_1083
+            - !<!Parameter> &ref_1084
               schema: *ref_220
               groupedBy: !<!Parameter> &ref_222
                 schema: *ref_221
@@ -13990,7 +14000,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1114
+            - !<!Parameter> &ref_1115
               schema: *ref_220
               groupedBy: !<!Parameter> &ref_223
                 schema: *ref_221
@@ -14009,7 +14019,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1141
+            - !<!Parameter> &ref_1142
               schema: *ref_220
               groupedBy: !<!Parameter> &ref_224
                 schema: *ref_221
@@ -14037,7 +14047,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_220
           originalParameter:
-            - !<!Parameter> &ref_1084
+            - !<!Parameter> &ref_1085
               schema: *ref_220
               groupedBy: *ref_222
               implementation: Method
@@ -14049,7 +14059,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1115
+            - !<!Parameter> &ref_1116
               schema: *ref_220
               groupedBy: *ref_223
               implementation: Method
@@ -14061,7 +14071,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1142
+            - !<!Parameter> &ref_1143
               schema: *ref_220
               groupedBy: *ref_224
               implementation: Method
@@ -14082,7 +14092,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_220
           originalParameter:
-            - !<!Parameter> &ref_1085
+            - !<!Parameter> &ref_1086
               schema: *ref_220
               groupedBy: *ref_222
               implementation: Method
@@ -14094,7 +14104,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1116
+            - !<!Parameter> &ref_1117
               schema: *ref_220
               groupedBy: *ref_223
               implementation: Method
@@ -14106,7 +14116,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1143
+            - !<!Parameter> &ref_1144
               schema: *ref_220
               groupedBy: *ref_224
               implementation: Method
@@ -14137,7 +14147,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_225
           originalParameter:
-            - !<!Parameter> &ref_1295
+            - !<!Parameter> &ref_1296
               schema: *ref_225
               groupedBy: !<!Parameter> &ref_227
                 schema: *ref_226
@@ -14158,7 +14168,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1328
+            - !<!Parameter> &ref_1329
               schema: *ref_225
               groupedBy: !<!Parameter> &ref_228
                 schema: *ref_226
@@ -14190,7 +14200,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_225
           originalParameter:
-            - !<!Parameter> &ref_1296
+            - !<!Parameter> &ref_1297
               schema: *ref_225
               groupedBy: *ref_227
               implementation: Method
@@ -14204,7 +14214,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1329
+            - !<!Parameter> &ref_1330
               schema: *ref_225
               groupedBy: *ref_228
               implementation: Method
@@ -14234,7 +14244,7 @@ schemas: !<!Schemas>
           description: Parameter group
       protocol: !<!Protocols> {}
   uris:
-    - !<!UriSchema> &ref_966
+    - !<!UriSchema> &ref_967
       type: uri
       apiVersions:
         - !<!ApiVersion> 
@@ -14593,7 +14603,7 @@ schemas: !<!Schemas>
     - *ref_13
     - *ref_24
     - *ref_25
-    - !<!ObjectSchema> &ref_243
+    - !<!ObjectSchema> &ref_244
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -14617,7 +14627,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_254
+    - !<!ObjectSchema> &ref_255
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -14677,7 +14687,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_29
-    - !<!ObjectSchema> &ref_269
+    - !<!ObjectSchema> &ref_270
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -14906,13 +14916,13 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_44
     - *ref_45
-    - !<!ObjectSchema> &ref_273
+    - !<!ObjectSchema> &ref_274
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
       properties:
-        - !<!Property> &ref_275
+        - !<!Property> &ref_276
           schema: *ref_46
           required: true
           serializedName: Start
@@ -14921,7 +14931,7 @@ schemas: !<!Schemas>
               name: Start
               description: The date-time the key is active in ISO 8601 UTC time
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_276
+        - !<!Property> &ref_277
           schema: *ref_47
           required: true
           serializedName: Expiry
@@ -14940,7 +14950,7 @@ schemas: !<!Schemas>
           description: Key information
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_281
+    - !<!ObjectSchema> &ref_282
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -15104,7 +15114,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_59
-    - !<!ObjectSchema> &ref_464
+    - !<!ObjectSchema> &ref_465
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -15633,7 +15643,7 @@ schemas: !<!Schemas>
     - *ref_94
     - *ref_95
     - *ref_96
-    - !<!ObjectSchema> &ref_478
+    - !<!ObjectSchema> &ref_479
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -15812,7 +15822,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_104
     - *ref_105
-    - !<!ObjectSchema> &ref_511
+    - !<!ObjectSchema> &ref_512
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -15868,7 +15878,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_108
-    - !<!ObjectSchema> &ref_1452
+    - !<!ObjectSchema> &ref_1453
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -15944,7 +15954,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_1479
+    - !<!ObjectSchema> &ref_1480
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -16040,7 +16050,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_114
-    - !<!ObjectSchema> &ref_1182
+    - !<!ObjectSchema> &ref_1183
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -16175,7 +16185,7 @@ schemas: !<!Schemas>
   arrays:
     - *ref_119
     - *ref_120
-    - !<!ArraySchema> &ref_362
+    - !<!ArraySchema> &ref_363
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -16192,7 +16202,7 @@ schemas: !<!Schemas>
           name: SignedIdentifiers
           description: a collection of signed identifiers
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_457
+    - !<!ArraySchema> &ref_458
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -16247,7 +16257,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: header
-  - !<!Parameter> &ref_515
+  - !<!Parameter> &ref_516
     schema: *ref_230
     implementation: Client
     extensions:
@@ -16294,7 +16304,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_239
+          - !<!Parameter> &ref_240
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -16308,7 +16318,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_240
+          - !<!Parameter> &ref_241
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -16322,7 +16332,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_238
+              - !<!Parameter> &ref_239
                 schema: *ref_237
                 implementation: Method
                 required: true
@@ -16334,8 +16344,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_238
+              - *ref_239
             language: !<!Languages> 
               default:
                 name: ''
@@ -16349,8 +16372,8 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_239
           - *ref_240
+          - *ref_241
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -16368,14 +16391,14 @@ operationGroups:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_241
+                    schema: *ref_242
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_242
+                    schema: *ref_243
                     header: x-ms-version
                     language:
                       default:
@@ -16385,7 +16408,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -16394,7 +16417,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_244
+                    schema: *ref_245
                     header: x-ms-error-code
                     language:
                       default:
@@ -16440,7 +16463,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_245
+          - !<!Parameter> &ref_246
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -16454,7 +16477,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_246
+          - !<!Parameter> &ref_247
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -16467,6 +16490,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16477,8 +16515,8 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_245
           - *ref_246
+          - *ref_247
         responses:
           - !<!SchemaResponse> 
             schema: *ref_237
@@ -16490,21 +16528,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_247
+                    schema: *ref_248
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_248
+                    schema: *ref_249
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_249
+                    schema: *ref_250
                     header: x-ms-version
                     language:
                       default:
@@ -16517,7 +16555,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -16526,7 +16564,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_250
+                    schema: *ref_251
                     header: x-ms-error-code
                     language:
                       default:
@@ -16561,7 +16599,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_251
+            schema: *ref_252
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16572,7 +16610,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_252
+          - !<!Parameter> &ref_253
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -16586,7 +16624,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_253
+          - !<!Parameter> &ref_254
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -16599,6 +16637,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16609,11 +16662,11 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_252
           - *ref_253
+          - *ref_254
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_254
+            schema: *ref_255
             language: !<!Languages> 
               default:
                 name: ''
@@ -16622,28 +16675,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_255
+                    schema: *ref_256
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_256
+                    schema: *ref_257
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_257
+                    schema: *ref_258
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_258
+                    schema: *ref_259
                     header: Date
                     language:
                       default:
@@ -16656,7 +16709,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -16665,7 +16718,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_259
+                    schema: *ref_260
                     header: x-ms-error-code
                     language:
                       default:
@@ -16688,7 +16741,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_260
+            schema: *ref_261
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16699,8 +16752,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_264
-            schema: *ref_261
+          - !<!Parameter> &ref_265
+            schema: *ref_262
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16710,8 +16763,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_265
-            schema: *ref_261
+          - !<!Parameter> &ref_266
+            schema: *ref_262
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16724,8 +16777,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_266
-            schema: *ref_262
+          - !<!Parameter> &ref_267
+            schema: *ref_263
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16739,7 +16792,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_263
+            schema: *ref_264
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16749,7 +16802,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_267
+          - !<!Parameter> &ref_268
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -16763,7 +16816,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_268
+          - !<!Parameter> &ref_269
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -16776,6 +16829,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16786,14 +16854,14 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_264
           - *ref_265
           - *ref_266
           - *ref_267
           - *ref_268
+          - *ref_269
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_269
+            schema: *ref_270
             language: !<!Languages> 
               default:
                 name: ''
@@ -16802,21 +16870,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_261
+                    schema: *ref_262
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_270
+                    schema: *ref_271
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_271
+                    schema: *ref_272
                     header: x-ms-version
                     language:
                       default:
@@ -16829,7 +16897,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -16878,7 +16946,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_272
+            schema: *ref_273
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16889,7 +16957,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_279
+          - !<!Parameter> &ref_280
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -16903,7 +16971,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_280
+          - !<!Parameter> &ref_281
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -16917,8 +16985,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_274
-                schema: *ref_273
+              - !<!Parameter> &ref_275
+                schema: *ref_274
                 flattened: true
                 implementation: Method
                 required: true
@@ -16930,33 +16998,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - !<!VirtualParameter> &ref_277
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_278
                 schema: *ref_46
                 implementation: Method
-                originalParameter: *ref_274
+                originalParameter: *ref_275
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_275
+                targetProperty: *ref_276
                 language: !<!Languages> 
                   default:
                     name: Start
                     description: The date-time the key is active in ISO 8601 UTC time
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_278
+              - !<!VirtualParameter> &ref_279
                 schema: *ref_47
                 implementation: Method
-                originalParameter: *ref_274
+                originalParameter: *ref_275
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_276
+                targetProperty: *ref_277
                 language: !<!Languages> 
                   default:
                     name: Expiry
                     description: The date-time the key expires in ISO 8601 UTC time
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_277
               - *ref_278
+              - *ref_279
             language: !<!Languages> 
               default:
                 name: ''
@@ -16970,11 +17051,11 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_279
           - *ref_280
+          - *ref_281
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_281
+            schema: *ref_282
             language: !<!Languages> 
               default:
                 name: ''
@@ -16983,28 +17064,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_282
+                    schema: *ref_283
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_283
+                    schema: *ref_284
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_284
+                    schema: *ref_285
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_285
+                    schema: *ref_286
                     header: Date
                     language:
                       default:
@@ -17017,7 +17098,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -17026,7 +17107,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_286
+                    schema: *ref_287
                     header: x-ms-error-code
                     language:
                       default:
@@ -17049,7 +17130,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_287
+            schema: *ref_288
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17075,6 +17156,21 @@ operationGroups:
           - *ref_235
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -17095,42 +17191,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_288
+                    schema: *ref_289
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_289
+                    schema: *ref_290
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_290
+                    schema: *ref_291
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_291
+                    schema: *ref_292
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_292
+                    schema: *ref_293
                     header: x-ms-sku-name
                     language:
                       default:
                         name: SkuName
                         description: Identifies the sku name of the account
                   - !<!HttpHeader> 
-                    schema: *ref_293
+                    schema: *ref_294
                     header: x-ms-account-kind
                     language:
                       default:
@@ -17140,7 +17236,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -17149,7 +17245,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_294
+                    schema: *ref_295
                     header: x-ms-error-code
                     language:
                       default:
@@ -17172,7 +17268,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_295
+            schema: *ref_296
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17183,8 +17279,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_300
-            schema: *ref_296
+          - !<!Parameter> &ref_301
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17195,8 +17291,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_301
-            schema: *ref_297
+          - !<!Parameter> &ref_302
+            schema: *ref_298
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17207,7 +17303,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_302
+          - !<!Parameter> &ref_303
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -17221,7 +17317,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_303
+          - !<!Parameter> &ref_304
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -17235,8 +17331,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_299
-                schema: *ref_298
+              - !<!Parameter> &ref_300
+                schema: *ref_299
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -17247,8 +17343,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_299
+              - *ref_300
             language: !<!Languages> 
               default:
                 name: ''
@@ -17262,10 +17371,10 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_300
           - *ref_301
           - *ref_302
           - *ref_303
+          - *ref_304
         responses:
           - !<!BinaryResponse> 
             binary: true
@@ -17277,21 +17386,21 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_297
+                    schema: *ref_298
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The media type of the body of the response. For batch requests, this is multipart/mixed; boundary=batchresponse_GUID'
                   - !<!HttpHeader> 
-                    schema: *ref_304
+                    schema: *ref_305
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_305
+                    schema: *ref_306
                     header: x-ms-version
                     language:
                       default:
@@ -17304,7 +17413,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -17313,7 +17422,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_306
+                    schema: *ref_307
                     header: x-ms-error-code
                     language:
                       default:
@@ -17344,7 +17453,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17355,7 +17464,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_309
+          - !<!Parameter> &ref_310
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -17368,8 +17477,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_310
-            schema: *ref_308
+          - !<!Parameter> &ref_311
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -17384,7 +17493,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_311
+          - !<!Parameter> &ref_312
             schema: *ref_40
             implementation: Method
             language: !<!Languages> 
@@ -17396,7 +17505,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_235
-          - !<!Parameter> &ref_312
+          - !<!Parameter> &ref_313
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -17409,6 +17518,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -17419,10 +17543,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_309
           - *ref_310
           - *ref_311
           - *ref_312
+          - *ref_313
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -17433,42 +17557,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_308
+                    schema: *ref_309
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_313
+                    schema: *ref_314
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_314
+                    schema: *ref_315
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_315
+                    schema: *ref_316
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_316
+                    schema: *ref_317
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_317
+                    schema: *ref_318
                     header: Date
                     language:
                       default:
@@ -17478,7 +17602,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -17487,7 +17611,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_318
+                    schema: *ref_319
                     header: x-ms-error-code
                     language:
                       default:
@@ -17510,7 +17634,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17521,7 +17645,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_321
+          - !<!Parameter> &ref_322
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -17534,9 +17658,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_319
+          - *ref_320
           - *ref_235
-          - !<!Parameter> &ref_322
+          - !<!Parameter> &ref_323
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -17550,9 +17674,22 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_320
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_321
             signatureParameters:
-              - *ref_320
+              - *ref_321
             language: !<!Languages> 
               default:
                 name: ''
@@ -17563,8 +17700,8 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_321
           - *ref_322
+          - *ref_323
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -17582,14 +17719,14 @@ operationGroups:
                         name: Metadata
                         description: ''
                   - !<!HttpHeader> 
-                    schema: *ref_323
+                    schema: *ref_324
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_324
+                    schema: *ref_325
                     header: Last-Modified
                     language:
                       default:
@@ -17617,28 +17754,28 @@ operationGroups:
                         name: LeaseStatus
                         description: The current lease status of the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_325
+                    schema: *ref_326
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_326
+                    schema: *ref_327
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_327
+                    schema: *ref_328
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_328
+                    schema: *ref_329
                     header: Date
                     language:
                       default:
@@ -17652,14 +17789,14 @@ operationGroups:
                         name: BlobPublicAccess
                         description: Indicated whether data in the container may be accessed publicly and the level of access
                   - !<!HttpHeader> 
-                    schema: *ref_329
+                    schema: *ref_330
                     header: x-ms-has-immutability-policy
                     language:
                       default:
                         name: HasImmutabilityPolicy
                         description: Indicates whether the container has an immutability policy set on it.
                   - !<!HttpHeader> 
-                    schema: *ref_330
+                    schema: *ref_331
                     header: x-ms-has-legal-hold
                     language:
                       default:
@@ -17669,7 +17806,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -17678,7 +17815,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_331
+                    schema: *ref_332
                     header: x-ms-error-code
                     language:
                       default:
@@ -17701,7 +17838,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17712,7 +17849,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_336
+          - !<!Parameter> &ref_337
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -17725,11 +17862,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_332
           - *ref_333
           - *ref_334
+          - *ref_335
           - *ref_235
-          - !<!Parameter> &ref_337
+          - !<!Parameter> &ref_338
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -17743,10 +17880,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_335
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_336
               - *ref_137
             signatureParameters:
-              - *ref_335
+              - *ref_336
               - *ref_137
             language: !<!Languages> 
               default:
@@ -17758,8 +17908,8 @@ operationGroups:
                 method: delete
                 uri: '{url}'
         signatureParameters:
-          - *ref_336
           - *ref_337
+          - *ref_338
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -17770,21 +17920,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_338
+                    schema: *ref_339
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_339
+                    schema: *ref_340
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_340
+                    schema: *ref_341
                     header: x-ms-version
                     language:
                       default:
@@ -17801,7 +17951,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -17810,7 +17960,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_341
+                    schema: *ref_342
                     header: x-ms-error-code
                     language:
                       default:
@@ -17833,7 +17983,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17845,7 +17995,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_342
+            schema: *ref_343
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17856,7 +18006,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_347
+          - !<!Parameter> &ref_348
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -17869,9 +18019,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_343
-          - !<!Parameter> &ref_348
-            schema: *ref_308
+          - *ref_344
+          - !<!Parameter> &ref_349
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -17886,9 +18036,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_344
+          - *ref_345
           - *ref_235
-          - !<!Parameter> &ref_349
+          - !<!Parameter> &ref_350
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -17902,11 +18052,24 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_345
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_346
+              - *ref_347
             signatureParameters:
-              - *ref_345
               - *ref_346
+              - *ref_347
             language: !<!Languages> 
               default:
                 name: ''
@@ -17917,9 +18080,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_347
           - *ref_348
           - *ref_349
+          - *ref_350
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -17930,42 +18093,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_350
+                    schema: *ref_351
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_351
+                    schema: *ref_352
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_352
+                    schema: *ref_353
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_353
+                    schema: *ref_354
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_354
+                    schema: *ref_355
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_355
+                    schema: *ref_356
                     header: Date
                     language:
                       default:
@@ -17975,7 +18138,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -17984,7 +18147,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_356
+                    schema: *ref_357
                     header: x-ms-error-code
                     language:
                       default:
@@ -18007,7 +18170,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18019,7 +18182,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_357
+            schema: *ref_358
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18030,7 +18193,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_360
+          - !<!Parameter> &ref_361
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -18043,9 +18206,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_358
+          - *ref_359
           - *ref_235
-          - !<!Parameter> &ref_361
+          - !<!Parameter> &ref_362
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -18059,9 +18222,22 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_359
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_360
             signatureParameters:
-              - *ref_359
+              - *ref_360
             language: !<!Languages> 
               default:
                 name: ''
@@ -18072,11 +18248,11 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_360
           - *ref_361
+          - *ref_362
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_362
+            schema: *ref_363
             language: !<!Languages> 
               default:
                 name: ''
@@ -18092,42 +18268,42 @@ operationGroups:
                         name: BlobPublicAccess
                         description: Indicated whether data in the container may be accessed publicly and the level of access
                   - !<!HttpHeader> 
-                    schema: *ref_363
+                    schema: *ref_364
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_364
+                    schema: *ref_365
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_365
+                    schema: *ref_366
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_366
+                    schema: *ref_367
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_367
+                    schema: *ref_368
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_368
+                    schema: *ref_369
                     header: Date
                     language:
                       default:
@@ -18140,7 +18316,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -18149,7 +18325,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_369
+                    schema: *ref_370
                     header: x-ms-error-code
                     language:
                       default:
@@ -18172,7 +18348,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18184,7 +18360,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_357
+            schema: *ref_358
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18195,7 +18371,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_375
+          - !<!Parameter> &ref_376
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -18208,8 +18384,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_370
-          - !<!Parameter> &ref_376
+          - *ref_371
+          - !<!Parameter> &ref_377
             schema: *ref_40
             implementation: Method
             language: !<!Languages> 
@@ -18220,10 +18396,10 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_371
           - *ref_372
+          - *ref_373
           - *ref_235
-          - !<!Parameter> &ref_377
+          - !<!Parameter> &ref_378
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -18237,8 +18413,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_374
-                schema: *ref_362
+              - !<!Parameter> &ref_375
+                schema: *ref_363
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -18249,11 +18425,24 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - *ref_373
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_374
               - *ref_138
             signatureParameters:
+              - *ref_375
               - *ref_374
-              - *ref_373
               - *ref_138
             language: !<!Languages> 
               default:
@@ -18268,9 +18457,9 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_375
           - *ref_376
           - *ref_377
+          - *ref_378
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -18281,42 +18470,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_378
+                    schema: *ref_379
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_379
+                    schema: *ref_380
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_380
+                    schema: *ref_381
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_381
+                    schema: *ref_382
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_382
+                    schema: *ref_383
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_383
+                    schema: *ref_384
                     header: Date
                     language:
                       default:
@@ -18326,7 +18515,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -18335,7 +18524,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_384
+                    schema: *ref_385
                     header: x-ms-error-code
                     language:
                       default:
@@ -18358,7 +18547,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18370,7 +18559,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18382,7 +18571,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_386
+            schema: *ref_387
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18393,7 +18582,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_391
+          - !<!Parameter> &ref_392
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -18406,8 +18595,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_392
-            schema: *ref_387
+          - !<!Parameter> &ref_393
+            schema: *ref_388
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18417,8 +18606,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_393
-            schema: *ref_388
+          - !<!Parameter> &ref_394
+            schema: *ref_389
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18428,10 +18617,10 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_389
           - *ref_390
+          - *ref_391
           - *ref_235
-          - !<!Parameter> &ref_394
+          - !<!Parameter> &ref_395
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -18445,6 +18634,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_139
             signatureParameters:
               - *ref_139
@@ -18458,10 +18660,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_391
           - *ref_392
           - *ref_393
           - *ref_394
+          - *ref_395
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -18472,49 +18674,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_388
+                    schema: *ref_389
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_395
+                    schema: *ref_396
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_396
+                    schema: *ref_397
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a container's lease
                   - !<!HttpHeader> 
-                    schema: *ref_397
+                    schema: *ref_398
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_398
+                    schema: *ref_399
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_399
+                    schema: *ref_400
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_400
+                    schema: *ref_401
                     header: Date
                     language:
                       default:
@@ -18524,7 +18726,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -18533,7 +18735,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_401
+                    schema: *ref_402
                     header: x-ms-error-code
                     language:
                       default:
@@ -18556,7 +18758,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18568,7 +18770,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18580,7 +18782,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_402
+            schema: *ref_403
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18591,7 +18793,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_406
+          - !<!Parameter> &ref_407
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -18604,8 +18806,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_407
-            schema: *ref_403
+          - !<!Parameter> &ref_408
+            schema: *ref_404
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18616,10 +18818,10 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_404
           - *ref_405
+          - *ref_406
           - *ref_235
-          - !<!Parameter> &ref_408
+          - !<!Parameter> &ref_409
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -18633,6 +18835,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_140
             signatureParameters:
               - *ref_140
@@ -18646,9 +18861,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_406
           - *ref_407
           - *ref_408
+          - *ref_409
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -18659,42 +18874,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_403
+                    schema: *ref_404
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_409
+                    schema: *ref_410
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_410
+                    schema: *ref_411
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_411
+                    schema: *ref_412
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_412
+                    schema: *ref_413
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_413
+                    schema: *ref_414
                     header: Date
                     language:
                       default:
@@ -18704,7 +18919,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -18713,7 +18928,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_414
+                    schema: *ref_415
                     header: x-ms-error-code
                     language:
                       default:
@@ -18736,7 +18951,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18748,7 +18963,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18760,7 +18975,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_415
+            schema: *ref_416
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18771,7 +18986,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_418
+          - !<!Parameter> &ref_419
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -18784,8 +18999,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_419
-            schema: *ref_403
+          - !<!Parameter> &ref_420
+            schema: *ref_404
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18796,10 +19011,10 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_416
           - *ref_417
+          - *ref_418
           - *ref_235
-          - !<!Parameter> &ref_420
+          - !<!Parameter> &ref_421
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -18813,6 +19028,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_141
             signatureParameters:
               - *ref_141
@@ -18826,9 +19054,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_418
           - *ref_419
           - *ref_420
+          - *ref_421
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -18839,49 +19067,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_421
+                    schema: *ref_422
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_422
+                    schema: *ref_423
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_423
+                    schema: *ref_424
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a container's lease
                   - !<!HttpHeader> 
-                    schema: *ref_424
+                    schema: *ref_425
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_425
+                    schema: *ref_426
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_426
+                    schema: *ref_427
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_427
+                    schema: *ref_428
                     header: Date
                     language:
                       default:
@@ -18891,7 +19119,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -18900,7 +19128,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_428
+                    schema: *ref_429
                     header: x-ms-error-code
                     language:
                       default:
@@ -18923,7 +19151,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18935,7 +19163,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18947,7 +19175,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_429
+            schema: *ref_430
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18958,7 +19186,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_432
+          - !<!Parameter> &ref_433
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -18971,8 +19199,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_433
-            schema: *ref_387
+          - !<!Parameter> &ref_434
+            schema: *ref_388
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18985,10 +19213,10 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_430
           - *ref_431
+          - *ref_432
           - *ref_235
-          - !<!Parameter> &ref_434
+          - !<!Parameter> &ref_435
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -19002,6 +19230,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_142
             signatureParameters:
               - *ref_142
@@ -19015,9 +19256,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_432
           - *ref_433
           - *ref_434
+          - *ref_435
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -19028,49 +19269,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_435
+                    schema: *ref_436
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_436
+                    schema: *ref_437
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_387
+                    schema: *ref_388
                     header: x-ms-lease-time
                     language:
                       default:
                         name: LeaseTime
                         description: 'Approximate time remaining in the lease period, in seconds.'
                   - !<!HttpHeader> 
-                    schema: *ref_437
+                    schema: *ref_438
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_438
+                    schema: *ref_439
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_439
+                    schema: *ref_440
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_440
+                    schema: *ref_441
                     header: Date
                     language:
                       default:
@@ -19080,7 +19321,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -19089,7 +19330,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_441
+                    schema: *ref_442
                     header: x-ms-error-code
                     language:
                       default:
@@ -19112,7 +19353,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19124,7 +19365,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19136,7 +19377,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_442
+            schema: *ref_443
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19147,7 +19388,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_446
+          - !<!Parameter> &ref_447
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -19160,8 +19401,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_447
-            schema: *ref_403
+          - !<!Parameter> &ref_448
+            schema: *ref_404
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19172,8 +19413,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_448
-            schema: *ref_443
+          - !<!Parameter> &ref_449
+            schema: *ref_444
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19184,10 +19425,10 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_444
           - *ref_445
+          - *ref_446
           - *ref_235
-          - !<!Parameter> &ref_449
+          - !<!Parameter> &ref_450
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -19201,6 +19442,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_143
             signatureParameters:
               - *ref_143
@@ -19214,10 +19468,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_446
           - *ref_447
           - *ref_448
           - *ref_449
+          - *ref_450
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -19228,49 +19482,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_443
+                    schema: *ref_444
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_450
+                    schema: *ref_451
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_451
+                    schema: *ref_452
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a container's lease
                   - !<!HttpHeader> 
-                    schema: *ref_452
+                    schema: *ref_453
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_453
+                    schema: *ref_454
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_454
+                    schema: *ref_455
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_455
+                    schema: *ref_456
                     header: Date
                     language:
                       default:
@@ -19280,7 +19534,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -19289,7 +19543,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_456
+                    schema: *ref_457
                     header: x-ms-error-code
                     language:
                       default:
@@ -19312,7 +19566,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19324,7 +19578,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_260
+            schema: *ref_261
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19335,8 +19589,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_458
-            schema: *ref_261
+          - !<!Parameter> &ref_459
+            schema: *ref_262
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19346,8 +19600,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_459
-            schema: *ref_261
+          - !<!Parameter> &ref_460
+            schema: *ref_262
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19360,8 +19614,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_460
-            schema: *ref_262
+          - !<!Parameter> &ref_461
+            schema: *ref_263
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19374,8 +19628,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_461
-            schema: *ref_457
+          - !<!Parameter> &ref_462
+            schema: *ref_458
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19386,7 +19640,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
                 style: form
-          - !<!Parameter> &ref_462
+          - !<!Parameter> &ref_463
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -19400,7 +19654,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_463
+          - !<!Parameter> &ref_464
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -19413,6 +19667,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -19423,15 +19692,15 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_458
           - *ref_459
           - *ref_460
           - *ref_461
           - *ref_462
           - *ref_463
+          - *ref_464
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_464
+            schema: *ref_465
             language: !<!Languages> 
               default:
                 name: ''
@@ -19440,35 +19709,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_465
+                    schema: *ref_466
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The media type of the body of the response. For List Blobs this is 'application/xml'
                   - !<!HttpHeader> 
-                    schema: *ref_466
+                    schema: *ref_467
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_467
+                    schema: *ref_468
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_468
+                    schema: *ref_469
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_469
+                    schema: *ref_470
                     header: Date
                     language:
                       default:
@@ -19481,7 +19750,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -19518,7 +19787,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19530,7 +19799,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_260
+            schema: *ref_261
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19541,8 +19810,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_471
-            schema: *ref_261
+          - !<!Parameter> &ref_472
+            schema: *ref_262
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19552,8 +19821,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_472
-            schema: *ref_470
+          - !<!Parameter> &ref_473
+            schema: *ref_471
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19566,8 +19835,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_473
-            schema: *ref_261
+          - !<!Parameter> &ref_474
+            schema: *ref_262
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19580,8 +19849,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_474
-            schema: *ref_262
+          - !<!Parameter> &ref_475
+            schema: *ref_263
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19594,8 +19863,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_475
-            schema: *ref_457
+          - !<!Parameter> &ref_476
+            schema: *ref_458
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19606,7 +19875,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
                 style: form
-          - !<!Parameter> &ref_476
+          - !<!Parameter> &ref_477
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -19620,7 +19889,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_477
+          - !<!Parameter> &ref_478
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -19633,6 +19902,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -19643,16 +19927,16 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_471
           - *ref_472
           - *ref_473
           - *ref_474
           - *ref_475
           - *ref_476
           - *ref_477
+          - *ref_478
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_478
+            schema: *ref_479
             language: !<!Languages> 
               default:
                 name: ''
@@ -19661,35 +19945,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_470
+                    schema: *ref_471
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The media type of the body of the response. For List Blobs this is 'application/xml'
                   - !<!HttpHeader> 
-                    schema: *ref_479
+                    schema: *ref_480
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_480
+                    schema: *ref_481
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_481
+                    schema: *ref_482
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_482
+                    schema: *ref_483
                     header: Date
                     language:
                       default:
@@ -19702,7 +19986,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -19711,7 +19995,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_483
+                    schema: *ref_484
                     header: x-ms-error-code
                     language:
                       default:
@@ -19739,7 +20023,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_287
+            schema: *ref_288
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19765,6 +20049,21 @@ operationGroups:
           - *ref_235
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -19785,42 +20084,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_484
+                    schema: *ref_485
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_485
+                    schema: *ref_486
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_486
+                    schema: *ref_487
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_487
+                    schema: *ref_488
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_292
+                    schema: *ref_293
                     header: x-ms-sku-name
                     language:
                       default:
                         name: SkuName
                         description: Identifies the sku name of the account
                   - !<!HttpHeader> 
-                    schema: *ref_293
+                    schema: *ref_294
                     header: x-ms-account-kind
                     language:
                       default:
@@ -19830,7 +20129,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -19839,7 +20138,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_488
+                    schema: *ref_489
                     header: x-ms-error-code
                     language:
                       default:
@@ -19870,7 +20169,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_489
+            schema: *ref_490
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19881,7 +20180,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_501
+          - !<!Parameter> &ref_502
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -19894,7 +20193,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_502
+          - !<!Parameter> &ref_503
             schema: *ref_179
             implementation: Method
             language: !<!Languages> 
@@ -19905,7 +20204,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_503
+          - !<!Parameter> &ref_504
             schema: *ref_179
             implementation: Method
             language: !<!Languages> 
@@ -19918,7 +20217,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_504
+          - !<!Parameter> &ref_505
             schema: *ref_179
             implementation: Method
             language: !<!Languages> 
@@ -19932,7 +20231,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_490
           - *ref_491
           - *ref_492
           - *ref_493
@@ -19942,8 +20240,9 @@ operationGroups:
           - *ref_497
           - *ref_498
           - *ref_499
+          - *ref_500
           - *ref_235
-          - !<!Parameter> &ref_505
+          - !<!Parameter> &ref_506
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -19957,12 +20256,25 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_181
-              - *ref_500
+              - *ref_501
               - *ref_144
             signatureParameters:
               - *ref_181
-              - *ref_500
+              - *ref_501
               - *ref_144
             language: !<!Languages> 
               default:
@@ -19974,11 +20286,11 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_501
           - *ref_502
           - *ref_503
           - *ref_504
           - *ref_505
+          - *ref_506
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -19996,42 +20308,42 @@ operationGroups:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_506
+                    schema: *ref_507
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_507
+                    schema: *ref_508
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_508
+                    schema: *ref_509
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_509
+                    schema: *ref_510
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_296
+                    schema: *ref_297
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_510
+                    schema: *ref_511
                     header: Date
                     language:
                       default:
@@ -20041,7 +20353,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_511
+            schema: *ref_512
             language: !<!Languages> 
               default:
                 name: ''
@@ -20050,21 +20362,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_512
+                    schema: *ref_513
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_513
+                    schema: *ref_514
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_514
+                    schema: *ref_515
                     header: x-ms-version
                     language:
                       default:
@@ -20089,7 +20401,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_231
-          - !<!Parameter> &ref_531
+          - !<!Parameter> &ref_532
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -20102,7 +20414,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_532
+          - !<!Parameter> &ref_533
             schema: *ref_193
             implementation: Method
             language: !<!Languages> 
@@ -20115,8 +20427,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_515
-          - !<!Parameter> &ref_533
+          - *ref_516
+          - !<!Parameter> &ref_534
             schema: *ref_193
             implementation: Method
             required: true
@@ -20130,7 +20442,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_534
+          - !<!Parameter> &ref_535
             schema: *ref_179
             implementation: Method
             language: !<!Languages> 
@@ -20141,7 +20453,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_535
+          - !<!Parameter> &ref_536
             schema: *ref_179
             implementation: Method
             language: !<!Languages> 
@@ -20154,7 +20466,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_536
+          - !<!Parameter> &ref_537
             schema: *ref_179
             implementation: Method
             language: !<!Languages> 
@@ -20168,13 +20480,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_516
           - *ref_517
           - *ref_518
           - *ref_519
           - *ref_520
           - *ref_521
-          - !<!Parameter> &ref_537
+          - *ref_522
+          - !<!Parameter> &ref_538
             schema: *ref_193
             implementation: Method
             language: !<!Languages> 
@@ -20185,7 +20497,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_522
           - *ref_523
           - *ref_524
           - *ref_525
@@ -20193,8 +20504,9 @@ operationGroups:
           - *ref_527
           - *ref_528
           - *ref_529
+          - *ref_530
           - *ref_235
-          - !<!Parameter> &ref_538
+          - !<!Parameter> &ref_539
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -20208,13 +20520,26 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_182
-              - *ref_530
+              - *ref_531
               - *ref_145
               - *ref_186
             signatureParameters:
               - *ref_182
-              - *ref_530
+              - *ref_531
               - *ref_145
               - *ref_186
             language: !<!Languages> 
@@ -20227,7 +20552,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_531
           - *ref_532
           - *ref_533
           - *ref_534
@@ -20235,6 +20559,7 @@ operationGroups:
           - *ref_536
           - *ref_537
           - *ref_538
+          - *ref_539
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -20254,7 +20579,7 @@ operationGroups:
                           When renaming a directory, the number of paths that are renamed with each invocation is limited. If the number of paths to be renamed exceeds this limit, a continuation token is returned in this response header.
                           When a continuation token is returned in the response, it must be specified in a subsequent invocation of the rename operation to continue renaming the directory.
                   - !<!HttpHeader> 
-                    schema: *ref_539
+                    schema: *ref_540
                     header: ETag
                     language:
                       default:
@@ -20268,35 +20593,35 @@ operationGroups:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_540
+                    schema: *ref_541
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_541
+                    schema: *ref_542
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_542
+                    schema: *ref_543
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_543
+                    schema: *ref_544
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_544
+                    schema: *ref_545
                     header: Date
                     language:
                       default:
@@ -20306,7 +20631,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_511
+            schema: *ref_512
             language: !<!Languages> 
               default:
                 name: ''
@@ -20315,21 +20640,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_545
+                    schema: *ref_546
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_546
+                    schema: *ref_547
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_547
+                    schema: *ref_548
                     header: x-ms-version
                     language:
                       default:
@@ -20354,7 +20679,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_231
-          - !<!Parameter> &ref_555
+          - !<!Parameter> &ref_556
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -20367,8 +20692,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_556
-            schema: *ref_548
+          - !<!Parameter> &ref_557
+            schema: *ref_549
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20379,7 +20704,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_557
+          - !<!Parameter> &ref_558
             schema: *ref_193
             implementation: Method
             language: !<!Languages> 
@@ -20392,13 +20717,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_549
           - *ref_550
           - *ref_551
           - *ref_552
           - *ref_553
+          - *ref_554
           - *ref_235
-          - !<!Parameter> &ref_558
+          - !<!Parameter> &ref_559
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -20412,10 +20737,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_554
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_555
               - *ref_146
             signatureParameters:
-              - *ref_554
+              - *ref_555
               - *ref_146
             language: !<!Languages> 
               default:
@@ -20427,10 +20765,10 @@ operationGroups:
                 method: delete
                 uri: '{url}'
         signatureParameters:
-          - *ref_555
           - *ref_556
           - *ref_557
           - *ref_558
+          - *ref_559
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -20441,7 +20779,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_559
+                    schema: *ref_560
                     header: x-ms-continuation
                     language:
                       default:
@@ -20450,28 +20788,28 @@ operationGroups:
                           When renaming a directory, the number of paths that are renamed with each invocation is limited. If the number of paths to be renamed exceeds this limit, a continuation token is returned in this response header.
                           When a continuation token is returned in the response, it must be specified in a subsequent invocation of the rename operation to continue renaming the directory.
                   - !<!HttpHeader> 
-                    schema: *ref_560
+                    schema: *ref_561
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_561
+                    schema: *ref_562
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_562
+                    schema: *ref_563
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_563
+                    schema: *ref_564
                     header: Date
                     language:
                       default:
@@ -20481,7 +20819,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_511
+            schema: *ref_512
             language: !<!Languages> 
               default:
                 name: ''
@@ -20490,21 +20828,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_564
+                    schema: *ref_565
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_565
+                    schema: *ref_566
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_566
+                    schema: *ref_567
                     header: x-ms-version
                     language:
                       default:
@@ -20527,7 +20865,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_567
+            schema: *ref_568
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20538,7 +20876,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_575
+          - !<!Parameter> &ref_576
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -20551,9 +20889,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_568
-          - !<!Parameter> &ref_576
-            schema: *ref_569
+          - *ref_569
+          - !<!Parameter> &ref_577
+            schema: *ref_570
             implementation: Method
             language: !<!Languages> 
               default:
@@ -20563,8 +20901,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_577
-            schema: *ref_569
+          - !<!Parameter> &ref_578
+            schema: *ref_570
             implementation: Method
             language: !<!Languages> 
               default:
@@ -20574,7 +20912,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_578
+          - !<!Parameter> &ref_579
             schema: *ref_179
             implementation: Method
             language: !<!Languages> 
@@ -20587,8 +20925,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_579
-            schema: *ref_569
+          - !<!Parameter> &ref_580
+            schema: *ref_570
             implementation: Method
             language: !<!Languages> 
               default:
@@ -20600,11 +20938,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_570
           - *ref_571
           - *ref_572
           - *ref_573
-          - !<!Parameter> &ref_580
+          - *ref_574
+          - !<!Parameter> &ref_581
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -20619,10 +20957,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_574
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_575
               - *ref_147
             signatureParameters:
-              - *ref_574
+              - *ref_575
               - *ref_147
             language: !<!Languages> 
               default:
@@ -20634,12 +20985,12 @@ operationGroups:
                 method: patch
                 uri: '{url}'
         signatureParameters:
-          - *ref_575
           - *ref_576
           - *ref_577
           - *ref_578
           - *ref_579
           - *ref_580
+          - *ref_581
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -20650,35 +21001,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_581
+                    schema: *ref_582
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_569
+                    schema: *ref_570
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_582
+                    schema: *ref_583
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_583
+                    schema: *ref_584
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_584
+                    schema: *ref_585
                     header: x-ms-version
                     language:
                       default:
@@ -20688,7 +21039,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_511
+            schema: *ref_512
             language: !<!Languages> 
               default:
                 name: ''
@@ -20697,21 +21048,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_585
+                    schema: *ref_586
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_586
+                    schema: *ref_587
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_587
+                    schema: *ref_588
                     header: x-ms-version
                     language:
                       default:
@@ -20734,7 +21085,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_588
+            schema: *ref_589
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20745,7 +21096,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_595
+          - !<!Parameter> &ref_596
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -20758,8 +21109,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_596
-            schema: *ref_548
+          - !<!Parameter> &ref_597
+            schema: *ref_549
             implementation: Method
             language: !<!Languages> 
               default:
@@ -20771,12 +21122,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_589
           - *ref_590
           - *ref_591
           - *ref_592
           - *ref_593
-          - !<!Parameter> &ref_597
+          - *ref_594
+          - !<!Parameter> &ref_598
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -20791,10 +21142,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_594
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_595
               - *ref_148
             signatureParameters:
-              - *ref_594
+              - *ref_595
               - *ref_148
             language: !<!Languages> 
               default:
@@ -20806,9 +21170,9 @@ operationGroups:
                 method: head
                 uri: '{url}'
         signatureParameters:
-          - *ref_595
           - *ref_596
           - *ref_597
+          - *ref_598
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -20819,63 +21183,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_598
+                    schema: *ref_599
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_599
+                    schema: *ref_600
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_600
+                    schema: *ref_601
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_601
+                    schema: *ref_602
                     header: x-ms-owner
                     language:
                       default:
                         name: x-ms-owner
                         description: The owner of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_602
+                    schema: *ref_603
                     header: x-ms-group
                     language:
                       default:
                         name: x-ms-group
                         description: The owning group of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_603
+                    schema: *ref_604
                     header: x-ms-permissions
                     language:
                       default:
                         name: x-ms-permissions
                         description: 'The POSIX access permissions for the file owner, the file owning group, and others. Included in the response if Hierarchical Namespace is enabled for the account.'
                   - !<!HttpHeader> 
-                    schema: *ref_604
+                    schema: *ref_605
                     header: x-ms-acl
                     language:
                       default:
                         name: x-ms-acl
                         description: The POSIX access control list for the file or directory.  Included in the response only if the action is "getAccessControl" and Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_605
+                    schema: *ref_606
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_606
+                    schema: *ref_607
                     header: x-ms-version
                     language:
                       default:
@@ -20885,7 +21249,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_511
+            schema: *ref_512
             language: !<!Languages> 
               default:
                 name: ''
@@ -20894,21 +21258,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_607
+                    schema: *ref_608
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_608
+                    schema: *ref_609
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_609
+                    schema: *ref_610
                     header: x-ms-version
                     language:
                       default:
@@ -20938,7 +21302,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_231
-          - !<!Parameter> &ref_619
+          - !<!Parameter> &ref_620
             schema: *ref_194
             implementation: Method
             language: !<!Languages> 
@@ -20951,7 +21315,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_620
+          - !<!Parameter> &ref_621
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -20964,7 +21328,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_621
+          - !<!Parameter> &ref_622
             schema: *ref_194
             implementation: Method
             language: !<!Languages> 
@@ -20975,9 +21339,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_610
-          - !<!Parameter> &ref_622
-            schema: *ref_548
+          - *ref_611
+          - !<!Parameter> &ref_623
+            schema: *ref_549
             implementation: Method
             language: !<!Languages> 
               default:
@@ -20987,8 +21351,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_623
-            schema: *ref_548
+          - !<!Parameter> &ref_624
+            schema: *ref_549
             implementation: Method
             language: !<!Languages> 
               default:
@@ -20998,13 +21362,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_611
           - *ref_612
+          - *ref_613
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_680
+              x-ms-parameter-grouping: &ref_681
                 name: cpk-info
             language: !<!Languages> 
               default:
@@ -21014,12 +21378,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_614
           - *ref_615
           - *ref_616
           - *ref_617
+          - *ref_618
           - *ref_235
-          - !<!Parameter> &ref_624
+          - !<!Parameter> &ref_625
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -21033,11 +21397,24 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_618
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_619
               - *ref_196
               - *ref_149
             signatureParameters:
-              - *ref_618
+              - *ref_619
               - *ref_196
               - *ref_149
             language: !<!Languages> 
@@ -21050,12 +21427,12 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_619
           - *ref_620
           - *ref_621
           - *ref_622
           - *ref_623
           - *ref_624
+          - *ref_625
         responses:
           - !<!BinaryResponse> 
             binary: true
@@ -21067,7 +21444,7 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_625
+                    schema: *ref_626
                     header: Last-Modified
                     language:
                       default:
@@ -21081,56 +21458,56 @@ operationGroups:
                         name: Metadata
                         description: ''
                   - !<!HttpHeader> 
-                    schema: *ref_626
+                    schema: *ref_627
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The number of bytes present in the response body.
                   - !<!HttpHeader> 
-                    schema: *ref_627
+                    schema: *ref_628
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The media type of the body of the response. For Download Blob this is 'application/octet-stream'
                   - !<!HttpHeader> 
-                    schema: *ref_628
+                    schema: *ref_629
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the blob by setting the 'Range' request header.
                   - !<!HttpHeader> 
-                    schema: *ref_629
+                    schema: *ref_630
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_630
+                    schema: *ref_631
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_631
+                    schema: *ref_632
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: This header returns the value that was specified for the Content-Encoding request header
                   - !<!HttpHeader> 
-                    schema: *ref_632
+                    schema: *ref_633
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: This header is returned if it was previously specified for the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_633
+                    schema: *ref_634
                     header: Content-Disposition
                     language:
                       default:
@@ -21140,14 +21517,14 @@ operationGroups:
                           payload, and also can be used to attach additional metadata. For example, if set to attachment, it indicates that the user-agent should not display the response, but instead show a Save As dialog with a filename
                           other than the blob name specified.
                   - !<!HttpHeader> 
-                    schema: *ref_634
+                    schema: *ref_635
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: This header returns the value that was specified for the Content-Language request header.
                   - !<!HttpHeader> 
-                    schema: *ref_635
+                    schema: *ref_636
                     header: x-ms-blob-sequence-number
                     language:
                       default:
@@ -21161,7 +21538,7 @@ operationGroups:
                         name: BlobType
                         description: The blob's type.
                   - !<!HttpHeader> 
-                    schema: *ref_636
+                    schema: *ref_637
                     header: x-ms-copy-completion-time
                     language:
                       default:
@@ -21170,7 +21547,7 @@ operationGroups:
                           Conclusion time of the last attempted Copy Blob operation where this blob was the destination blob. This value can specify the time of a completed, aborted, or failed copy attempt. This header does not appear if a
                           copy is pending, if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List.
                   - !<!HttpHeader> 
-                    schema: *ref_637
+                    schema: *ref_638
                     header: x-ms-copy-status-description
                     language:
                       default:
@@ -21179,14 +21556,14 @@ operationGroups:
                           Only appears when x-ms-copy-status is failed or pending. Describes the cause of the last fatal or non-fatal copy operation failure. This header does not appear if this blob has never been the destination in a Copy
                           Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List
                   - !<!HttpHeader> 
-                    schema: *ref_638
+                    schema: *ref_639
                     header: x-ms-copy-id
                     language:
                       default:
                         name: CopyId
                         description: 'String identifier for this copy operation. Use with Get Blob Properties to check the status of this copy operation, or pass to Abort Copy Blob to abort a pending copy.'
                   - !<!HttpHeader> 
-                    schema: *ref_639
+                    schema: *ref_640
                     header: x-ms-copy-progress
                     language:
                       default:
@@ -21196,7 +21573,7 @@ operationGroups:
                           header does not appear if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block
                           List
                   - !<!HttpHeader> 
-                    schema: *ref_640
+                    schema: *ref_641
                     header: x-ms-copy-source
                     language:
                       default:
@@ -21233,49 +21610,49 @@ operationGroups:
                         name: LeaseStatus
                         description: The current lease status of the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_641
+                    schema: *ref_642
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_642
+                    schema: *ref_643
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_643
+                    schema: *ref_644
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_644
+                    schema: *ref_645
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial blob content.
                   - !<!HttpHeader> 
-                    schema: *ref_645
+                    schema: *ref_646
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_646
+                    schema: *ref_647
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_548
+                    schema: *ref_549
                     header: x-ms-server-encrypted
                     language:
                       default:
@@ -21284,14 +21661,14 @@ operationGroups:
                           The value of this header is set to true if the blob data and application metadata are completely encrypted using the specified algorithm. Otherwise, the value is set to false (when the blob is unencrypted, or if
                           only parts of the blob/application metadata are encrypted).
                   - !<!HttpHeader> 
-                    schema: *ref_647
+                    schema: *ref_648
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
                         name: EncryptionKeySha256
                         description: The SHA-256 hash of the encryption key used to encrypt the blob. This header is only returned when the blob was encrypted with a customer-provided key.
                   - !<!HttpHeader> 
-                    schema: *ref_648
+                    schema: *ref_649
                     header: x-ms-blob-content-md5
                     language:
                       default:
@@ -21314,70 +21691,70 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_649
+                    schema: *ref_650
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_650
+                    schema: *ref_651
                     header: x-ms-meta
                     language:
                       default:
                         name: Metadata
                         description: ''
                   - !<!HttpHeader> 
-                    schema: *ref_651
+                    schema: *ref_652
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The number of bytes present in the response body.
                   - !<!HttpHeader> 
-                    schema: *ref_652
+                    schema: *ref_653
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The media type of the body of the response. For Download Blob this is 'application/octet-stream'
                   - !<!HttpHeader> 
-                    schema: *ref_653
+                    schema: *ref_654
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the blob by setting the 'Range' request header.
                   - !<!HttpHeader> 
-                    schema: *ref_654
+                    schema: *ref_655
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_655
+                    schema: *ref_656
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_656
+                    schema: *ref_657
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: This header returns the value that was specified for the Content-Encoding request header
                   - !<!HttpHeader> 
-                    schema: *ref_657
+                    schema: *ref_658
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: This header is returned if it was previously specified for the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_658
+                    schema: *ref_659
                     header: Content-Disposition
                     language:
                       default:
@@ -21387,14 +21764,14 @@ operationGroups:
                           payload, and also can be used to attach additional metadata. For example, if set to attachment, it indicates that the user-agent should not display the response, but instead show a Save As dialog with a filename
                           other than the blob name specified.
                   - !<!HttpHeader> 
-                    schema: *ref_659
+                    schema: *ref_660
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: This header returns the value that was specified for the Content-Language request header.
                   - !<!HttpHeader> 
-                    schema: *ref_660
+                    schema: *ref_661
                     header: x-ms-blob-sequence-number
                     language:
                       default:
@@ -21408,7 +21785,7 @@ operationGroups:
                         name: BlobType
                         description: The blob's type.
                   - !<!HttpHeader> 
-                    schema: *ref_661
+                    schema: *ref_662
                     header: x-ms-content-crc64
                     language:
                       default:
@@ -21417,7 +21794,7 @@ operationGroups:
                           If the request is to read a specified range and the x-ms-range-get-content-crc64 is set to true, then the request returns a crc64 for the range, as long as the range size is less than or equal to 4 MB. If both
                           x-ms-range-get-content-crc64 & x-ms-range-get-content-md5 is specified in the same request, it will fail with 400(Bad Request)
                   - !<!HttpHeader> 
-                    schema: *ref_662
+                    schema: *ref_663
                     header: x-ms-copy-completion-time
                     language:
                       default:
@@ -21426,7 +21803,7 @@ operationGroups:
                           Conclusion time of the last attempted Copy Blob operation where this blob was the destination blob. This value can specify the time of a completed, aborted, or failed copy attempt. This header does not appear if a
                           copy is pending, if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List.
                   - !<!HttpHeader> 
-                    schema: *ref_663
+                    schema: *ref_664
                     header: x-ms-copy-status-description
                     language:
                       default:
@@ -21435,14 +21812,14 @@ operationGroups:
                           Only appears when x-ms-copy-status is failed or pending. Describes the cause of the last fatal or non-fatal copy operation failure. This header does not appear if this blob has never been the destination in a Copy
                           Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List
                   - !<!HttpHeader> 
-                    schema: *ref_664
+                    schema: *ref_665
                     header: x-ms-copy-id
                     language:
                       default:
                         name: CopyId
                         description: 'String identifier for this copy operation. Use with Get Blob Properties to check the status of this copy operation, or pass to Abort Copy Blob to abort a pending copy.'
                   - !<!HttpHeader> 
-                    schema: *ref_665
+                    schema: *ref_666
                     header: x-ms-copy-progress
                     language:
                       default:
@@ -21452,7 +21829,7 @@ operationGroups:
                           header does not appear if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block
                           List
                   - !<!HttpHeader> 
-                    schema: *ref_666
+                    schema: *ref_667
                     header: x-ms-copy-source
                     language:
                       default:
@@ -21489,49 +21866,49 @@ operationGroups:
                         name: LeaseStatus
                         description: The current lease status of the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_667
+                    schema: *ref_668
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_668
+                    schema: *ref_669
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_669
+                    schema: *ref_670
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_670
+                    schema: *ref_671
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial blob content.
                   - !<!HttpHeader> 
-                    schema: *ref_671
+                    schema: *ref_672
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_672
+                    schema: *ref_673
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_673
+                    schema: *ref_674
                     header: x-ms-server-encrypted
                     language:
                       default:
@@ -21540,14 +21917,14 @@ operationGroups:
                           The value of this header is set to true if the blob data and application metadata are completely encrypted using the specified algorithm. Otherwise, the value is set to false (when the blob is unencrypted, or if
                           only parts of the blob/application metadata are encrypted).
                   - !<!HttpHeader> 
-                    schema: *ref_674
+                    schema: *ref_675
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
                         name: EncryptionKeySha256
                         description: The SHA-256 hash of the encryption key used to encrypt the blob. This header is only returned when the blob was encrypted with a customer-provided key.
                   - !<!HttpHeader> 
-                    schema: *ref_675
+                    schema: *ref_676
                     header: x-ms-blob-content-md5
                     language:
                       default:
@@ -21562,7 +21939,7 @@ operationGroups:
                   - '206'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -21571,7 +21948,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_676
+                    schema: *ref_677
                     header: x-ms-error-code
                     language:
                       default:
@@ -21593,7 +21970,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_231
-          - !<!Parameter> &ref_686
+          - !<!Parameter> &ref_687
             schema: *ref_194
             implementation: Method
             language: !<!Languages> 
@@ -21606,7 +21983,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_687
+          - !<!Parameter> &ref_688
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -21619,14 +21996,14 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_677
           - *ref_678
           - *ref_679
+          - *ref_680
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -21635,12 +22012,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_681
           - *ref_682
           - *ref_683
           - *ref_684
+          - *ref_685
           - *ref_235
-          - !<!Parameter> &ref_688
+          - !<!Parameter> &ref_689
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -21654,11 +22031,24 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_685
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_686
               - *ref_197
               - *ref_150
             signatureParameters:
-              - *ref_685
+              - *ref_686
               - *ref_197
               - *ref_150
             language: !<!Languages> 
@@ -21671,9 +22061,9 @@ operationGroups:
                 method: head
                 uri: '{url}'
         signatureParameters:
-          - *ref_686
           - *ref_687
           - *ref_688
+          - *ref_689
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -21684,21 +22074,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_689
+                    schema: *ref_690
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_690
+                    schema: *ref_691
                     header: x-ms-creation-time
                     language:
                       default:
                         name: CreationTime
                         description: Returns the date and time the blob was created.
                   - !<!HttpHeader> 
-                    schema: *ref_691
+                    schema: *ref_692
                     header: x-ms-meta
                     language:
                       default:
@@ -21712,7 +22102,7 @@ operationGroups:
                         name: BlobType
                         description: The blob's type.
                   - !<!HttpHeader> 
-                    schema: *ref_692
+                    schema: *ref_693
                     header: x-ms-copy-completion-time
                     language:
                       default:
@@ -21721,7 +22111,7 @@ operationGroups:
                           Conclusion time of the last attempted Copy Blob operation where this blob was the destination blob. This value can specify the time of a completed, aborted, or failed copy attempt. This header does not appear if a
                           copy is pending, if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List.
                   - !<!HttpHeader> 
-                    schema: *ref_693
+                    schema: *ref_694
                     header: x-ms-copy-status-description
                     language:
                       default:
@@ -21730,14 +22120,14 @@ operationGroups:
                           Only appears when x-ms-copy-status is failed or pending. Describes the cause of the last fatal or non-fatal copy operation failure. This header does not appear if this blob has never been the destination in a Copy
                           Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List
                   - !<!HttpHeader> 
-                    schema: *ref_694
+                    schema: *ref_695
                     header: x-ms-copy-id
                     language:
                       default:
                         name: CopyId
                         description: 'String identifier for this copy operation. Use with Get Blob Properties to check the status of this copy operation, or pass to Abort Copy Blob to abort a pending copy.'
                   - !<!HttpHeader> 
-                    schema: *ref_695
+                    schema: *ref_696
                     header: x-ms-copy-progress
                     language:
                       default:
@@ -21747,7 +22137,7 @@ operationGroups:
                           header does not appear if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block
                           List
                   - !<!HttpHeader> 
-                    schema: *ref_696
+                    schema: *ref_697
                     header: x-ms-copy-source
                     language:
                       default:
@@ -21763,14 +22153,14 @@ operationGroups:
                         name: CopyStatus
                         description: State of the copy operation identified by x-ms-copy-id.
                   - !<!HttpHeader> 
-                    schema: *ref_697
+                    schema: *ref_698
                     header: x-ms-incremental-copy
                     language:
                       default:
                         name: IsIncrementalCopy
                         description: Included if the blob is incremental copy blob.
                   - !<!HttpHeader> 
-                    schema: *ref_698
+                    schema: *ref_699
                     header: x-ms-copy-destination-snapshot
                     language:
                       default:
@@ -21798,42 +22188,42 @@ operationGroups:
                         name: LeaseStatus
                         description: The current lease status of the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_699
+                    schema: *ref_700
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The number of bytes present in the response body.
                   - !<!HttpHeader> 
-                    schema: *ref_700
+                    schema: *ref_701
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The content type specified for the blob. The default content type is 'application/octet-stream'
                   - !<!HttpHeader> 
-                    schema: *ref_701
+                    schema: *ref_702
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_702
+                    schema: *ref_703
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_703
+                    schema: *ref_704
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: This header returns the value that was specified for the Content-Encoding request header
                   - !<!HttpHeader> 
-                    schema: *ref_704
+                    schema: *ref_705
                     header: Content-Disposition
                     language:
                       default:
@@ -21843,70 +22233,70 @@ operationGroups:
                           payload, and also can be used to attach additional metadata. For example, if set to attachment, it indicates that the user-agent should not display the response, but instead show a Save As dialog with a filename
                           other than the blob name specified.
                   - !<!HttpHeader> 
-                    schema: *ref_705
+                    schema: *ref_706
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: This header returns the value that was specified for the Content-Language request header.
                   - !<!HttpHeader> 
-                    schema: *ref_706
+                    schema: *ref_707
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: This header is returned if it was previously specified for the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_707
+                    schema: *ref_708
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for a page blob. This header is not returned for block blobs or append blobs
                   - !<!HttpHeader> 
-                    schema: *ref_708
+                    schema: *ref_709
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_709
+                    schema: *ref_710
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_710
+                    schema: *ref_711
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_711
+                    schema: *ref_712
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_712
+                    schema: *ref_713
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial blob content.
                   - !<!HttpHeader> 
-                    schema: *ref_713
+                    schema: *ref_714
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_714
+                    schema: *ref_715
                     header: x-ms-server-encrypted
                     language:
                       default:
@@ -21915,14 +22305,14 @@ operationGroups:
                           The value of this header is set to true if the blob data and application metadata are completely encrypted using the specified algorithm. Otherwise, the value is set to false (when the blob is unencrypted, or if
                           only parts of the blob/application metadata are encrypted).
                   - !<!HttpHeader> 
-                    schema: *ref_715
+                    schema: *ref_716
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
                         name: EncryptionKeySha256
                         description: The SHA-256 hash of the encryption key used to encrypt the metadata. This header is only returned when the metadata was encrypted with a customer-provided key.
                   - !<!HttpHeader> 
-                    schema: *ref_716
+                    schema: *ref_717
                     header: x-ms-access-tier
                     language:
                       default:
@@ -21931,14 +22321,14 @@ operationGroups:
                           The tier of page blob on a premium storage account or tier of block blob on blob storage LRS accounts. For a list of allowed premium page blob tiers, see
                           https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage#features. For blob storage LRS accounts, valid values are Hot/Cool/Archive.
                   - !<!HttpHeader> 
-                    schema: *ref_717
+                    schema: *ref_718
                     header: x-ms-access-tier-inferred
                     language:
                       default:
                         name: AccessTierInferred
                         description: 'For page blobs on a premium storage account only. If the access tier is not explicitly set on the blob, the tier is inferred based on its content length and this header will be returned with true value.'
                   - !<!HttpHeader> 
-                    schema: *ref_718
+                    schema: *ref_719
                     header: x-ms-archive-status
                     language:
                       default:
@@ -21947,7 +22337,7 @@ operationGroups:
                           For blob storage LRS accounts, valid values are rehydrate-pending-to-hot/rehydrate-pending-to-cool. If the blob is being rehydrated and is not complete then this header is returned indicating that rehydrate is
                           pending and also tells the destination tier.
                   - !<!HttpHeader> 
-                    schema: *ref_719
+                    schema: *ref_720
                     header: x-ms-access-tier-change-time
                     language:
                       default:
@@ -21957,7 +22347,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -21966,7 +22356,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_720
+                    schema: *ref_721
                     header: x-ms-error-code
                     language:
                       default:
@@ -21988,7 +22378,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_231
-          - !<!Parameter> &ref_728
+          - !<!Parameter> &ref_729
             schema: *ref_194
             implementation: Method
             language: !<!Languages> 
@@ -22001,7 +22391,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_729
+          - !<!Parameter> &ref_730
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -22014,9 +22404,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_721
-          - !<!Parameter> &ref_730
-            schema: *ref_722
+          - *ref_722
+          - !<!Parameter> &ref_731
+            schema: *ref_723
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22026,12 +22416,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_723
           - *ref_724
           - *ref_725
           - *ref_726
+          - *ref_727
           - *ref_235
-          - !<!Parameter> &ref_731
+          - !<!Parameter> &ref_732
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -22045,10 +22435,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_727
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_728
               - *ref_151
             signatureParameters:
-              - *ref_727
+              - *ref_728
               - *ref_151
             language: !<!Languages> 
               default:
@@ -22060,10 +22463,10 @@ operationGroups:
                 method: delete
                 uri: '{url}'
         signatureParameters:
-          - *ref_728
           - *ref_729
           - *ref_730
           - *ref_731
+          - *ref_732
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -22074,28 +22477,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_732
+                    schema: *ref_733
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_733
+                    schema: *ref_734
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_734
+                    schema: *ref_735
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_735
+                    schema: *ref_736
                     header: Date
                     language:
                       default:
@@ -22105,7 +22508,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -22114,7 +22517,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_736
+                    schema: *ref_737
                     header: x-ms-error-code
                     language:
                       default:
@@ -22142,7 +22545,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_567
+            schema: *ref_568
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22153,7 +22556,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_743
+          - !<!Parameter> &ref_744
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -22166,9 +22569,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_737
-          - !<!Parameter> &ref_744
-            schema: *ref_569
+          - *ref_738
+          - !<!Parameter> &ref_745
+            schema: *ref_570
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22178,8 +22581,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_745
-            schema: *ref_569
+          - !<!Parameter> &ref_746
+            schema: *ref_570
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22189,7 +22592,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_746
+          - !<!Parameter> &ref_747
             schema: *ref_179
             implementation: Method
             language: !<!Languages> 
@@ -22202,8 +22605,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_747
-            schema: *ref_569
+          - !<!Parameter> &ref_748
+            schema: *ref_570
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22215,11 +22618,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_738
           - *ref_739
           - *ref_740
           - *ref_741
-          - !<!Parameter> &ref_748
+          - *ref_742
+          - !<!Parameter> &ref_749
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -22234,10 +22637,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_742
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_743
               - *ref_152
             signatureParameters:
-              - *ref_742
+              - *ref_743
               - *ref_152
             language: !<!Languages> 
               default:
@@ -22249,12 +22665,12 @@ operationGroups:
                 method: patch
                 uri: '{url}'
         signatureParameters:
-          - *ref_743
           - *ref_744
           - *ref_745
           - *ref_746
           - *ref_747
           - *ref_748
+          - *ref_749
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -22265,35 +22681,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_749
+                    schema: *ref_750
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_750
+                    schema: *ref_751
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_751
+                    schema: *ref_752
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_752
+                    schema: *ref_753
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_753
+                    schema: *ref_754
                     header: x-ms-version
                     language:
                       default:
@@ -22303,7 +22719,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_511
+            schema: *ref_512
             language: !<!Languages> 
               default:
                 name: ''
@@ -22312,21 +22728,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_754
+                    schema: *ref_755
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_755
+                    schema: *ref_756
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_756
+                    schema: *ref_757
                     header: x-ms-version
                     language:
                       default:
@@ -22349,7 +22765,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_588
+            schema: *ref_589
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22360,7 +22776,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_763
+          - !<!Parameter> &ref_764
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -22373,8 +22789,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_764
-            schema: *ref_548
+          - !<!Parameter> &ref_765
+            schema: *ref_549
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22386,12 +22802,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_757
           - *ref_758
           - *ref_759
           - *ref_760
           - *ref_761
-          - !<!Parameter> &ref_765
+          - *ref_762
+          - !<!Parameter> &ref_766
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -22406,10 +22822,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_762
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_763
               - *ref_153
             signatureParameters:
-              - *ref_762
+              - *ref_763
               - *ref_153
             language: !<!Languages> 
               default:
@@ -22421,9 +22850,9 @@ operationGroups:
                 method: head
                 uri: '{url}'
         signatureParameters:
-          - *ref_763
           - *ref_764
           - *ref_765
+          - *ref_766
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -22434,63 +22863,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_766
+                    schema: *ref_767
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_767
+                    schema: *ref_768
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_768
+                    schema: *ref_769
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_769
+                    schema: *ref_770
                     header: x-ms-owner
                     language:
                       default:
                         name: x-ms-owner
                         description: The owner of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_770
+                    schema: *ref_771
                     header: x-ms-group
                     language:
                       default:
                         name: x-ms-group
                         description: The owning group of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_771
+                    schema: *ref_772
                     header: x-ms-permissions
                     language:
                       default:
                         name: x-ms-permissions
                         description: 'The POSIX access permissions for the file owner, the file owning group, and others. Included in the response if Hierarchical Namespace is enabled for the account.'
                   - !<!HttpHeader> 
-                    schema: *ref_772
+                    schema: *ref_773
                     header: x-ms-acl
                     language:
                       default:
                         name: x-ms-acl
                         description: The POSIX access control list for the file or directory.  Included in the response only if the action is "getAccessControl" and Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_773
+                    schema: *ref_774
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_774
+                    schema: *ref_775
                     header: x-ms-version
                     language:
                       default:
@@ -22500,7 +22929,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_511
+            schema: *ref_512
             language: !<!Languages> 
               default:
                 name: ''
@@ -22509,21 +22938,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_775
+                    schema: *ref_776
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_776
+                    schema: *ref_777
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_777
+                    schema: *ref_778
                     header: x-ms-version
                     language:
                       default:
@@ -22545,7 +22974,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_231
-          - !<!Parameter> &ref_793
+          - !<!Parameter> &ref_794
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -22558,8 +22987,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_515
-          - !<!Parameter> &ref_794
+          - *ref_516
+          - !<!Parameter> &ref_795
             schema: *ref_193
             implementation: Method
             required: true
@@ -22573,7 +23002,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_795
+          - !<!Parameter> &ref_796
             schema: *ref_179
             implementation: Method
             language: !<!Languages> 
@@ -22584,7 +23013,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_796
+          - !<!Parameter> &ref_797
             schema: *ref_179
             implementation: Method
             language: !<!Languages> 
@@ -22597,7 +23026,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_797
+          - !<!Parameter> &ref_798
             schema: *ref_179
             implementation: Method
             language: !<!Languages> 
@@ -22611,13 +23040,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_778
           - *ref_779
           - *ref_780
           - *ref_781
           - *ref_782
           - *ref_783
-          - !<!Parameter> &ref_798
+          - *ref_784
+          - !<!Parameter> &ref_799
             schema: *ref_193
             implementation: Method
             language: !<!Languages> 
@@ -22628,7 +23057,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_784
           - *ref_785
           - *ref_786
           - *ref_787
@@ -22636,8 +23064,9 @@ operationGroups:
           - *ref_789
           - *ref_790
           - *ref_791
+          - *ref_792
           - *ref_235
-          - !<!Parameter> &ref_799
+          - !<!Parameter> &ref_800
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -22651,13 +23080,26 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_183
-              - *ref_792
+              - *ref_793
               - *ref_154
               - *ref_187
             signatureParameters:
               - *ref_183
-              - *ref_792
+              - *ref_793
               - *ref_154
               - *ref_187
             language: !<!Languages> 
@@ -22670,13 +23112,13 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_793
           - *ref_794
           - *ref_795
           - *ref_796
           - *ref_797
           - *ref_798
           - *ref_799
+          - *ref_800
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -22687,49 +23129,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_800
+                    schema: *ref_801
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_801
+                    schema: *ref_802
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_802
+                    schema: *ref_803
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_803
+                    schema: *ref_804
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_804
+                    schema: *ref_805
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_805
+                    schema: *ref_806
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_806
+                    schema: *ref_807
                     header: Date
                     language:
                       default:
@@ -22739,7 +23181,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_511
+            schema: *ref_512
             language: !<!Languages> 
               default:
                 name: ''
@@ -22748,21 +23190,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_807
+                    schema: *ref_808
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_808
+                    schema: *ref_809
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_809
+                    schema: *ref_810
                     header: x-ms-version
                     language:
                       default:
@@ -22788,7 +23230,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_810
+            schema: *ref_811
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22799,7 +23241,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_811
+          - !<!Parameter> &ref_812
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -22813,7 +23255,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_812
+          - !<!Parameter> &ref_813
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -22826,6 +23268,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -22836,8 +23293,8 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_811
           - *ref_812
+          - *ref_813
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -22848,28 +23305,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_813
+                    schema: *ref_814
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_814
+                    schema: *ref_815
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_815
+                    schema: *ref_816
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_816
+                    schema: *ref_817
                     header: Date
                     language:
                       default:
@@ -22879,7 +23336,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -22888,7 +23345,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_817
+                    schema: *ref_818
                     header: x-ms-error-code
                     language:
                       default:
@@ -22922,7 +23379,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_830
+          - !<!Parameter> &ref_831
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -22935,7 +23392,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_818
           - *ref_819
           - *ref_820
           - *ref_821
@@ -22946,8 +23402,9 @@ operationGroups:
           - *ref_826
           - *ref_827
           - *ref_828
+          - *ref_829
           - *ref_235
-          - !<!Parameter> &ref_831
+          - !<!Parameter> &ref_832
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -22961,12 +23418,25 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_214
-              - *ref_829
+              - *ref_830
               - *ref_155
             signatureParameters:
               - *ref_214
-              - *ref_829
+              - *ref_830
               - *ref_155
             language: !<!Languages> 
               default:
@@ -22978,8 +23448,8 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_830
           - *ref_831
+          - *ref_832
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -22990,49 +23460,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_832
+                    schema: *ref_833
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_833
+                    schema: *ref_834
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_834
+                    schema: *ref_835
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for a page blob. This header is not returned for block blobs or append blobs
                   - !<!HttpHeader> 
-                    schema: *ref_835
+                    schema: *ref_836
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_836
+                    schema: *ref_837
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_837
+                    schema: *ref_838
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_838
+                    schema: *ref_839
                     header: Date
                     language:
                       default:
@@ -23042,7 +23512,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -23051,7 +23521,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_839
+                    schema: *ref_840
                     header: x-ms-error-code
                     language:
                       default:
@@ -23074,7 +23544,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_342
+            schema: *ref_343
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23085,7 +23555,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_848
+          - !<!Parameter> &ref_849
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -23098,8 +23568,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_849
-            schema: *ref_308
+          - !<!Parameter> &ref_850
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -23114,14 +23584,14 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_840
           - *ref_841
           - *ref_842
+          - *ref_843
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -23130,12 +23600,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_843
           - *ref_844
           - *ref_845
           - *ref_846
+          - *ref_847
           - *ref_235
-          - !<!Parameter> &ref_850
+          - !<!Parameter> &ref_851
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -23149,11 +23619,24 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_847
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_848
               - *ref_198
               - *ref_156
             signatureParameters:
-              - *ref_847
+              - *ref_848
               - *ref_198
               - *ref_156
             language: !<!Languages> 
@@ -23166,9 +23649,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_848
           - *ref_849
           - *ref_850
+          - *ref_851
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -23179,56 +23662,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_851
+                    schema: *ref_852
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_852
+                    schema: *ref_853
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_853
+                    schema: *ref_854
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_854
+                    schema: *ref_855
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_855
+                    schema: *ref_856
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_856
+                    schema: *ref_857
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_857
+                    schema: *ref_858
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_858
+                    schema: *ref_859
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -23238,7 +23721,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -23247,7 +23730,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_859
+                    schema: *ref_860
                     header: x-ms-error-code
                     language:
                       default:
@@ -23270,7 +23753,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23282,7 +23765,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_386
+            schema: *ref_387
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23293,7 +23776,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_864
+          - !<!Parameter> &ref_865
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -23306,8 +23789,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_865
-            schema: *ref_387
+          - !<!Parameter> &ref_866
+            schema: *ref_388
             implementation: Method
             language: !<!Languages> 
               default:
@@ -23317,8 +23800,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_866
-            schema: *ref_388
+          - !<!Parameter> &ref_867
+            schema: *ref_389
             implementation: Method
             language: !<!Languages> 
               default:
@@ -23328,12 +23811,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_860
           - *ref_861
           - *ref_862
           - *ref_863
+          - *ref_864
           - *ref_235
-          - !<!Parameter> &ref_867
+          - !<!Parameter> &ref_868
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -23347,6 +23830,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_157
             signatureParameters:
               - *ref_157
@@ -23360,10 +23856,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_864
           - *ref_865
           - *ref_866
           - *ref_867
+          - *ref_868
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -23374,49 +23870,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_868
+                    schema: *ref_869
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_869
+                    schema: *ref_870
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_870
+                    schema: *ref_871
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a blobs's lease
                   - !<!HttpHeader> 
-                    schema: *ref_871
+                    schema: *ref_872
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_872
+                    schema: *ref_873
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_873
+                    schema: *ref_874
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_874
+                    schema: *ref_875
                     header: Date
                     language:
                       default:
@@ -23426,7 +23922,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -23435,7 +23931,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_875
+                    schema: *ref_876
                     header: x-ms-error-code
                     language:
                       default:
@@ -23458,7 +23954,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23470,7 +23966,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_402
+            schema: *ref_403
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23481,7 +23977,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_880
+          - !<!Parameter> &ref_881
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -23494,8 +23990,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_881
-            schema: *ref_403
+          - !<!Parameter> &ref_882
+            schema: *ref_404
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23506,12 +24002,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_876
           - *ref_877
           - *ref_878
           - *ref_879
+          - *ref_880
           - *ref_235
-          - !<!Parameter> &ref_882
+          - !<!Parameter> &ref_883
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -23525,6 +24021,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_158
             signatureParameters:
               - *ref_158
@@ -23538,9 +24047,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_880
           - *ref_881
           - *ref_882
+          - *ref_883
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -23551,42 +24060,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_883
+                    schema: *ref_884
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_884
+                    schema: *ref_885
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_885
+                    schema: *ref_886
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_886
+                    schema: *ref_887
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_887
+                    schema: *ref_888
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_888
+                    schema: *ref_889
                     header: Date
                     language:
                       default:
@@ -23596,7 +24105,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -23605,7 +24114,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_889
+                    schema: *ref_890
                     header: x-ms-error-code
                     language:
                       default:
@@ -23628,7 +24137,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23640,7 +24149,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_415
+            schema: *ref_416
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23651,7 +24160,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_894
+          - !<!Parameter> &ref_895
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -23664,8 +24173,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_895
-            schema: *ref_403
+          - !<!Parameter> &ref_896
+            schema: *ref_404
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23676,12 +24185,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_890
           - *ref_891
           - *ref_892
           - *ref_893
+          - *ref_894
           - *ref_235
-          - !<!Parameter> &ref_896
+          - !<!Parameter> &ref_897
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -23695,6 +24204,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_159
             signatureParameters:
               - *ref_159
@@ -23708,9 +24230,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_894
           - *ref_895
           - *ref_896
+          - *ref_897
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -23721,49 +24243,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_897
+                    schema: *ref_898
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_898
+                    schema: *ref_899
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_899
+                    schema: *ref_900
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a blobs's lease
                   - !<!HttpHeader> 
-                    schema: *ref_900
+                    schema: *ref_901
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_901
+                    schema: *ref_902
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_902
+                    schema: *ref_903
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_903
+                    schema: *ref_904
                     header: Date
                     language:
                       default:
@@ -23773,7 +24295,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -23782,7 +24304,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_904
+                    schema: *ref_905
                     header: x-ms-error-code
                     language:
                       default:
@@ -23805,7 +24327,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23817,7 +24339,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_442
+            schema: *ref_443
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23828,7 +24350,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_909
+          - !<!Parameter> &ref_910
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -23841,8 +24363,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_910
-            schema: *ref_403
+          - !<!Parameter> &ref_911
+            schema: *ref_404
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23853,8 +24375,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_911
-            schema: *ref_443
+          - !<!Parameter> &ref_912
+            schema: *ref_444
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23865,12 +24387,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_905
           - *ref_906
           - *ref_907
           - *ref_908
+          - *ref_909
           - *ref_235
-          - !<!Parameter> &ref_912
+          - !<!Parameter> &ref_913
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -23884,6 +24406,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_160
             signatureParameters:
               - *ref_160
@@ -23897,10 +24432,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_909
           - *ref_910
           - *ref_911
           - *ref_912
+          - *ref_913
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -23911,49 +24446,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_913
+                    schema: *ref_914
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_914
+                    schema: *ref_915
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_915
+                    schema: *ref_916
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_916
+                    schema: *ref_917
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_917
+                    schema: *ref_918
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a blobs's lease
                   - !<!HttpHeader> 
-                    schema: *ref_918
+                    schema: *ref_919
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_919
+                    schema: *ref_920
                     header: Date
                     language:
                       default:
@@ -23963,7 +24498,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -23972,7 +24507,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_920
+                    schema: *ref_921
                     header: x-ms-error-code
                     language:
                       default:
@@ -23995,7 +24530,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24007,7 +24542,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_429
+            schema: *ref_430
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24018,7 +24553,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_925
+          - !<!Parameter> &ref_926
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -24031,8 +24566,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_926
-            schema: *ref_387
+          - !<!Parameter> &ref_927
+            schema: *ref_388
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24045,12 +24580,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_921
           - *ref_922
           - *ref_923
           - *ref_924
+          - *ref_925
           - *ref_235
-          - !<!Parameter> &ref_927
+          - !<!Parameter> &ref_928
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -24064,6 +24599,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_161
             signatureParameters:
               - *ref_161
@@ -24077,9 +24625,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_925
           - *ref_926
           - *ref_927
+          - *ref_928
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -24090,49 +24638,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_928
+                    schema: *ref_929
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_929
+                    schema: *ref_930
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_930
+                    schema: *ref_931
                     header: x-ms-lease-time
                     language:
                       default:
                         name: LeaseTime
                         description: 'Approximate time remaining in the lease period, in seconds.'
                   - !<!HttpHeader> 
-                    schema: *ref_931
+                    schema: *ref_932
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_932
+                    schema: *ref_933
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_933
+                    schema: *ref_934
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_934
+                    schema: *ref_935
                     header: Date
                     language:
                       default:
@@ -24142,7 +24690,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -24151,7 +24699,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_935
+                    schema: *ref_936
                     header: x-ms-error-code
                     language:
                       default:
@@ -24174,7 +24722,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_936
+            schema: *ref_937
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24185,7 +24733,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_945
+          - !<!Parameter> &ref_946
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -24198,8 +24746,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_946
-            schema: *ref_308
+          - !<!Parameter> &ref_947
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -24214,13 +24762,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_937
           - *ref_938
+          - *ref_939
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -24229,13 +24777,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_939
           - *ref_940
           - *ref_941
           - *ref_942
           - *ref_943
+          - *ref_944
           - *ref_235
-          - !<!Parameter> &ref_947
+          - !<!Parameter> &ref_948
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -24249,13 +24797,26 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_199
               - *ref_162
-              - *ref_944
+              - *ref_945
             signatureParameters:
               - *ref_199
               - *ref_162
-              - *ref_944
+              - *ref_945
             language: !<!Languages> 
               default:
                 name: ''
@@ -24266,9 +24827,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_945
           - *ref_946
           - *ref_947
+          - *ref_948
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -24279,56 +24840,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_948
+                    schema: *ref_949
                     header: x-ms-snapshot
                     language:
                       default:
                         name: Snapshot
                         description: Uniquely identifies the snapshot and indicates the snapshot version. It may be used in subsequent requests to access the snapshot
                   - !<!HttpHeader> 
-                    schema: *ref_949
+                    schema: *ref_950
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_950
+                    schema: *ref_951
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_951
+                    schema: *ref_952
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_952
+                    schema: *ref_953
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_953
+                    schema: *ref_954
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_954
+                    schema: *ref_955
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_955
+                    schema: *ref_956
                     header: x-ms-request-server-encrypted
                     language:
                       default:
@@ -24340,7 +24901,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -24349,7 +24910,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_956
+                    schema: *ref_957
                     header: x-ms-error-code
                     language:
                       default:
@@ -24371,7 +24932,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_231
-          - !<!Parameter> &ref_969
+          - !<!Parameter> &ref_970
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -24384,8 +24945,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_970
-            schema: *ref_308
+          - !<!Parameter> &ref_971
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -24400,7 +24961,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_971
+          - !<!Parameter> &ref_972
             schema: *ref_86
             implementation: Method
             language: !<!Languages> 
@@ -24411,8 +24972,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_972
-            schema: *ref_957
+          - !<!Parameter> &ref_973
+            schema: *ref_958
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24422,7 +24983,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_958
           - *ref_959
           - *ref_960
           - *ref_961
@@ -24430,8 +24990,9 @@ operationGroups:
           - *ref_963
           - *ref_964
           - *ref_965
-          - !<!Parameter> &ref_973
-            schema: *ref_966
+          - *ref_966
+          - !<!Parameter> &ref_974
+            schema: *ref_967
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24444,9 +25005,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_967
+          - *ref_968
           - *ref_235
-          - !<!Parameter> &ref_974
+          - !<!Parameter> &ref_975
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -24460,13 +25021,26 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_188
               - *ref_163
-              - *ref_968
+              - *ref_969
             signatureParameters:
               - *ref_188
               - *ref_163
-              - *ref_968
+              - *ref_969
             language: !<!Languages> 
               default:
                 name: ''
@@ -24477,12 +25051,12 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_969
           - *ref_970
           - *ref_971
           - *ref_972
           - *ref_973
           - *ref_974
+          - *ref_975
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -24493,49 +25067,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_975
+                    schema: *ref_976
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_976
+                    schema: *ref_977
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_977
+                    schema: *ref_978
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_978
+                    schema: *ref_979
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_979
+                    schema: *ref_980
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_980
+                    schema: *ref_981
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_981
+                    schema: *ref_982
                     header: x-ms-copy-id
                     language:
                       default:
@@ -24552,7 +25126,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -24561,7 +25135,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_982
+                    schema: *ref_983
                     header: x-ms-error-code
                     language:
                       default:
@@ -24584,7 +25158,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_983
+            schema: *ref_984
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24595,7 +25169,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_995
+          - !<!Parameter> &ref_996
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -24608,8 +25182,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_996
-            schema: *ref_308
+          - !<!Parameter> &ref_997
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -24624,7 +25198,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_997
+          - !<!Parameter> &ref_998
             schema: *ref_86
             implementation: Method
             language: !<!Languages> 
@@ -24635,7 +25209,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_984
           - *ref_985
           - *ref_986
           - *ref_987
@@ -24643,8 +25216,9 @@ operationGroups:
           - *ref_989
           - *ref_990
           - *ref_991
-          - !<!Parameter> &ref_998
-            schema: *ref_966
+          - *ref_992
+          - !<!Parameter> &ref_999
+            schema: *ref_967
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24657,9 +25231,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_992
+          - *ref_993
           - *ref_235
-          - !<!Parameter> &ref_999
+          - !<!Parameter> &ref_1000
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -24670,8 +25244,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1000
-            schema: *ref_993
+          - !<!Parameter> &ref_1001
+            schema: *ref_994
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24684,13 +25258,26 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_189
               - *ref_164
-              - *ref_994
+              - *ref_995
             signatureParameters:
               - *ref_189
               - *ref_164
-              - *ref_994
+              - *ref_995
             language: !<!Languages> 
               default:
                 name: ''
@@ -24701,12 +25288,12 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_995
           - *ref_996
           - *ref_997
           - *ref_998
           - *ref_999
           - *ref_1000
+          - *ref_1001
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -24717,70 +25304,70 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1001
+                    schema: *ref_1002
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1002
+                    schema: *ref_1003
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1003
+                    schema: *ref_1004
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1004
+                    schema: *ref_1005
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1005
+                    schema: *ref_1006
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1006
+                    schema: *ref_1007
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1007
+                    schema: *ref_1008
                     header: x-ms-copy-id
                     language:
                       default:
                         name: CopyId
                         description: String identifier for this copy operation.
                   - !<!HttpHeader> 
-                    schema: *ref_1008
+                    schema: *ref_1009
                     header: x-ms-copy-status
                     language:
                       default:
                         name: CopyStatus
                         description: State of the copy operation identified by x-ms-copy-id.
                   - !<!HttpHeader> 
-                    schema: *ref_1009
+                    schema: *ref_1010
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: This response header is returned so that the client can check for the integrity of the copied content. This header is only returned if the source content MD5 was specified.
                   - !<!HttpHeader> 
-                    schema: *ref_1010
+                    schema: *ref_1011
                     header: x-ms-content-crc64
                     language:
                       default:
@@ -24790,7 +25377,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -24799,7 +25386,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1011
+                    schema: *ref_1012
                     header: x-ms-error-code
                     language:
                       default:
@@ -24822,7 +25409,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1012
+            schema: *ref_1013
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24834,7 +25421,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_1013
+            schema: *ref_1014
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24845,8 +25432,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1017
-            schema: *ref_1014
+          - !<!Parameter> &ref_1018
+            schema: *ref_1015
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24857,7 +25444,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1018
+          - !<!Parameter> &ref_1019
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -24870,9 +25457,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_1015
+          - *ref_1016
           - *ref_235
-          - !<!Parameter> &ref_1019
+          - !<!Parameter> &ref_1020
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -24886,9 +25473,22 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_1016
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1017
             signatureParameters:
-              - *ref_1016
+              - *ref_1017
             language: !<!Languages> 
               default:
                 name: ''
@@ -24899,9 +25499,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1017
           - *ref_1018
           - *ref_1019
+          - *ref_1020
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -24912,28 +25512,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1014
+                    schema: *ref_1015
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1020
+                    schema: *ref_1021
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1021
+                    schema: *ref_1022
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1022
+                    schema: *ref_1023
                     header: Date
                     language:
                       default:
@@ -24943,7 +25543,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -24952,7 +25552,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1023
+                    schema: *ref_1024
                     header: x-ms-error-code
                     language:
                       default:
@@ -24975,7 +25575,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1024
+            schema: *ref_1025
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24986,7 +25586,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1027
+          - !<!Parameter> &ref_1028
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -24999,7 +25599,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1028
+          - !<!Parameter> &ref_1029
             schema: *ref_86
             implementation: Method
             required: true
@@ -25011,8 +25611,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1029
-            schema: *ref_957
+          - !<!Parameter> &ref_1030
+            schema: *ref_958
             implementation: Method
             language: !<!Languages> 
               default:
@@ -25023,7 +25623,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_235
-          - !<!Parameter> &ref_1030
+          - !<!Parameter> &ref_1031
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -25034,13 +25634,26 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1025
+          - *ref_1026
         requests:
           - !<!Request> 
             parameters:
-              - *ref_1026
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1027
             signatureParameters:
-              - *ref_1026
+              - *ref_1027
             language: !<!Languages> 
               default:
                 name: ''
@@ -25051,10 +25664,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1027
           - *ref_1028
           - *ref_1029
           - *ref_1030
+          - *ref_1031
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -25065,21 +25678,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1031
+                    schema: *ref_1032
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1032
+                    schema: *ref_1033
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1033
+                    schema: *ref_1034
                     header: x-ms-version
                     language:
                       default:
@@ -25096,21 +25709,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1034
+                    schema: *ref_1035
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1035
+                    schema: *ref_1036
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1036
+                    schema: *ref_1037
                     header: x-ms-version
                     language:
                       default:
@@ -25120,7 +25733,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -25129,7 +25742,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1037
+                    schema: *ref_1038
                     header: x-ms-error-code
                     language:
                       default:
@@ -25154,7 +25767,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_287
+            schema: *ref_288
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25180,6 +25793,21 @@ operationGroups:
           - *ref_235
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -25200,42 +25828,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1038
+                    schema: *ref_1039
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1039
+                    schema: *ref_1040
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1040
+                    schema: *ref_1041
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1041
+                    schema: *ref_1042
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_292
+                    schema: *ref_293
                     header: x-ms-sku-name
                     language:
                       default:
                         name: SkuName
                         description: Identifies the sku name of the account
                   - !<!HttpHeader> 
-                    schema: *ref_293
+                    schema: *ref_294
                     header: x-ms-account-kind
                     language:
                       default:
@@ -25245,7 +25873,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -25254,7 +25882,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1042
+                    schema: *ref_1043
                     header: x-ms-error-code
                     language:
                       default:
@@ -25285,7 +25913,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1043
+            schema: *ref_1044
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25296,7 +25924,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1060
+          - !<!Parameter> &ref_1061
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -25309,8 +25937,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1061
-            schema: *ref_296
+          - !<!Parameter> &ref_1062
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25321,8 +25949,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1062
-            schema: *ref_1044
+          - !<!Parameter> &ref_1063
+            schema: *ref_1045
             implementation: Method
             language: !<!Languages> 
               default:
@@ -25332,13 +25960,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1045
           - *ref_1046
           - *ref_1047
           - *ref_1048
           - *ref_1049
-          - !<!Parameter> &ref_1063
-            schema: *ref_308
+          - *ref_1050
+          - !<!Parameter> &ref_1064
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -25353,15 +25981,15 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1050
           - *ref_1051
           - *ref_1052
           - *ref_1053
+          - *ref_1054
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -25370,12 +25998,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1054
           - *ref_1055
           - *ref_1056
           - *ref_1057
-          - !<!Parameter> &ref_1064
-            schema: *ref_834
+          - *ref_1058
+          - !<!Parameter> &ref_1065
+            schema: *ref_835
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25386,8 +26014,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1065
-            schema: *ref_1058
+          - !<!Parameter> &ref_1066
+            schema: *ref_1059
             implementation: Method
             language: !<!Languages> 
               default:
@@ -25398,7 +26026,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_235
-          - !<!Parameter> &ref_1066
+          - !<!Parameter> &ref_1067
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -25412,13 +26040,26 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_215
-              - *ref_1059
+              - *ref_1060
               - *ref_200
               - *ref_165
             signatureParameters:
               - *ref_215
-              - *ref_1059
+              - *ref_1060
               - *ref_200
               - *ref_165
             language: !<!Languages> 
@@ -25431,13 +26072,13 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1060
           - *ref_1061
           - *ref_1062
           - *ref_1063
           - *ref_1064
           - *ref_1065
           - *ref_1066
+          - *ref_1067
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -25455,56 +26096,56 @@ operationGroups:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1067
+                    schema: *ref_1068
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1068
+                    schema: *ref_1069
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1069
+                    schema: *ref_1070
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1070
+                    schema: *ref_1071
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1071
+                    schema: *ref_1072
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1072
+                    schema: *ref_1073
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1073
+                    schema: *ref_1074
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1074
+                    schema: *ref_1075
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -25514,7 +26155,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -25523,7 +26164,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1075
+                    schema: *ref_1076
                     header: x-ms-error-code
                     language:
                       default:
@@ -25546,7 +26187,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1076
+            schema: *ref_1077
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25558,7 +26199,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_1077
+            schema: *ref_1078
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25572,8 +26213,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1093
-            schema: *ref_296
+          - !<!Parameter> &ref_1094
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25584,8 +26225,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1094
-            schema: *ref_1078
+          - !<!Parameter> &ref_1095
+            schema: *ref_1079
             implementation: Method
             language: !<!Languages> 
               default:
@@ -25595,8 +26236,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1095
-            schema: *ref_1079
+          - !<!Parameter> &ref_1096
+            schema: *ref_1080
             implementation: Method
             language: !<!Languages> 
               default:
@@ -25606,7 +26247,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1096
+          - !<!Parameter> &ref_1097
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -25619,7 +26260,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1097
+          - !<!Parameter> &ref_1098
             schema: *ref_194
             implementation: Method
             language: !<!Languages> 
@@ -25630,14 +26271,14 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1080
           - *ref_1081
           - *ref_1082
+          - *ref_1083
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -25646,15 +26287,15 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1083
           - *ref_1084
           - *ref_1085
           - *ref_1086
           - *ref_1087
           - *ref_1088
           - *ref_1089
+          - *ref_1090
           - *ref_235
-          - !<!Parameter> &ref_1098
+          - !<!Parameter> &ref_1099
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -25668,8 +26309,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1092
-                schema: *ref_1090
+              - !<!Parameter> &ref_1093
+                schema: *ref_1091
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -25680,13 +26321,26 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
-              - *ref_1091
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1092
               - *ref_201
               - *ref_222
               - *ref_166
             signatureParameters:
+              - *ref_1093
               - *ref_1092
-              - *ref_1091
               - *ref_201
               - *ref_222
               - *ref_166
@@ -25704,12 +26358,12 @@ operationGroups:
                   - application/octet-stream
                 uri: '{url}'
         signatureParameters:
-          - *ref_1093
           - *ref_1094
           - *ref_1095
           - *ref_1096
           - *ref_1097
           - *ref_1098
+          - *ref_1099
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -25720,28 +26374,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1099
+                    schema: *ref_1100
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1100
+                    schema: *ref_1101
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1101
+                    schema: *ref_1102
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1102
+                    schema: *ref_1103
                     header: x-ms-content-crc64
                     language:
                       default:
@@ -25755,42 +26409,42 @@ operationGroups:
                         name: BlobSequenceNumber
                         description: The current sequence number for the page blob.
                   - !<!HttpHeader> 
-                    schema: *ref_1103
+                    schema: *ref_1104
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1104
+                    schema: *ref_1105
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1105
+                    schema: *ref_1106
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1106
+                    schema: *ref_1107
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1107
+                    schema: *ref_1108
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1108
+                    schema: *ref_1109
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -25800,7 +26454,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -25809,7 +26463,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1109
+                    schema: *ref_1110
                     header: x-ms-error-code
                     language:
                       default:
@@ -25832,7 +26486,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1076
+            schema: *ref_1077
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25844,7 +26498,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_1110
+            schema: *ref_1111
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25858,8 +26512,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1122
-            schema: *ref_296
+          - !<!Parameter> &ref_1123
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25870,7 +26524,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1123
+          - !<!Parameter> &ref_1124
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -25883,7 +26537,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1124
+          - !<!Parameter> &ref_1125
             schema: *ref_194
             implementation: Method
             language: !<!Languages> 
@@ -25894,14 +26548,14 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1111
           - *ref_1112
           - *ref_1113
+          - *ref_1114
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -25910,15 +26564,15 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1114
           - *ref_1115
           - *ref_1116
           - *ref_1117
           - *ref_1118
           - *ref_1119
           - *ref_1120
+          - *ref_1121
           - *ref_235
-          - !<!Parameter> &ref_1125
+          - !<!Parameter> &ref_1126
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -25932,12 +26586,25 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_1121
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1122
               - *ref_202
               - *ref_223
               - *ref_167
             signatureParameters:
-              - *ref_1121
+              - *ref_1122
               - *ref_202
               - *ref_223
               - *ref_167
@@ -25951,10 +26618,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1122
           - *ref_1123
           - *ref_1124
           - *ref_1125
+          - *ref_1126
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -25965,63 +26632,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1126
+                    schema: *ref_1127
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1127
+                    schema: *ref_1128
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1128
+                    schema: *ref_1129
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1129
+                    schema: *ref_1130
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1130
+                    schema: *ref_1131
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for the page blob.
                   - !<!HttpHeader> 
-                    schema: *ref_1131
+                    schema: *ref_1132
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1132
+                    schema: *ref_1133
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1133
+                    schema: *ref_1134
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1134
+                    schema: *ref_1135
                     header: Date
                     language:
                       default:
@@ -26031,7 +26698,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -26040,7 +26707,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1135
+                    schema: *ref_1136
                     header: x-ms-error-code
                     language:
                       default:
@@ -26063,7 +26730,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1076
+            schema: *ref_1077
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26075,7 +26742,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_1077
+            schema: *ref_1078
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26089,8 +26756,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1153
-            schema: *ref_966
+          - !<!Parameter> &ref_1154
+            schema: *ref_967
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26101,8 +26768,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1154
-            schema: *ref_1136
+          - !<!Parameter> &ref_1155
+            schema: *ref_1137
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26113,8 +26780,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1155
-            schema: *ref_993
+          - !<!Parameter> &ref_1156
+            schema: *ref_994
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26124,8 +26791,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1156
-            schema: *ref_1137
+          - !<!Parameter> &ref_1157
+            schema: *ref_1138
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26135,8 +26802,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1157
-            schema: *ref_296
+          - !<!Parameter> &ref_1158
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26147,7 +26814,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1158
+          - !<!Parameter> &ref_1159
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -26160,8 +26827,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1159
-            schema: *ref_1136
+          - !<!Parameter> &ref_1160
+            schema: *ref_1137
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26172,13 +26839,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1138
           - *ref_1139
+          - *ref_1140
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -26187,7 +26854,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1140
           - *ref_1141
           - *ref_1142
           - *ref_1143
@@ -26199,8 +26865,9 @@ operationGroups:
           - *ref_1149
           - *ref_1150
           - *ref_1151
+          - *ref_1152
           - *ref_235
-          - !<!Parameter> &ref_1160
+          - !<!Parameter> &ref_1161
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -26214,14 +26881,27 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_203
-              - *ref_1152
+              - *ref_1153
               - *ref_224
               - *ref_168
               - *ref_190
             signatureParameters:
               - *ref_203
-              - *ref_1152
+              - *ref_1153
               - *ref_224
               - *ref_168
               - *ref_190
@@ -26235,7 +26915,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1153
           - *ref_1154
           - *ref_1155
           - *ref_1156
@@ -26243,6 +26922,7 @@ operationGroups:
           - *ref_1158
           - *ref_1159
           - *ref_1160
+          - *ref_1161
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -26253,70 +26933,70 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1136
+                    schema: *ref_1137
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1161
+                    schema: *ref_1162
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1162
+                    schema: *ref_1163
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1163
+                    schema: *ref_1164
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1164
+                    schema: *ref_1165
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for the page blob.
                   - !<!HttpHeader> 
-                    schema: *ref_1165
+                    schema: *ref_1166
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1166
+                    schema: *ref_1167
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1167
+                    schema: *ref_1168
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1168
+                    schema: *ref_1169
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1169
+                    schema: *ref_1170
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -26326,7 +27006,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -26335,7 +27015,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1170
+                    schema: *ref_1171
                     header: x-ms-error-code
                     language:
                       default:
@@ -26358,7 +27038,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1171
+            schema: *ref_1172
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26369,7 +27049,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1178
+          - !<!Parameter> &ref_1179
             schema: *ref_194
             implementation: Method
             language: !<!Languages> 
@@ -26382,7 +27062,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1179
+          - !<!Parameter> &ref_1180
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -26395,7 +27075,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1180
+          - !<!Parameter> &ref_1181
             schema: *ref_194
             implementation: Method
             language: !<!Languages> 
@@ -26406,13 +27086,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1172
           - *ref_1173
           - *ref_1174
           - *ref_1175
           - *ref_1176
+          - *ref_1177
           - *ref_235
-          - !<!Parameter> &ref_1181
+          - !<!Parameter> &ref_1182
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -26426,10 +27106,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_1177
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1178
               - *ref_169
             signatureParameters:
-              - *ref_1177
+              - *ref_1178
               - *ref_169
             language: !<!Languages> 
               default:
@@ -26441,13 +27134,13 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_1178
           - *ref_1179
           - *ref_1180
           - *ref_1181
+          - *ref_1182
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1182
+            schema: *ref_1183
             language: !<!Languages> 
               default:
                 name: ''
@@ -26456,49 +27149,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1183
+                    schema: *ref_1184
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1184
+                    schema: *ref_1185
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1185
+                    schema: *ref_1186
                     header: x-ms-blob-content-length
                     language:
                       default:
                         name: BlobContentLength
                         description: The size of the blob in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_1186
+                    schema: *ref_1187
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1187
+                    schema: *ref_1188
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1188
+                    schema: *ref_1189
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1189
+                    schema: *ref_1190
                     header: Date
                     language:
                       default:
@@ -26511,7 +27204,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -26520,7 +27213,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1190
+                    schema: *ref_1191
                     header: x-ms-error-code
                     language:
                       default:
@@ -26543,7 +27236,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1171
+            schema: *ref_1172
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26554,7 +27247,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1198
+          - !<!Parameter> &ref_1199
             schema: *ref_194
             implementation: Method
             language: !<!Languages> 
@@ -26567,7 +27260,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1199
+          - !<!Parameter> &ref_1200
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -26580,8 +27273,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1200
-            schema: *ref_1191
+          - !<!Parameter> &ref_1201
+            schema: *ref_1192
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26594,7 +27287,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1201
+          - !<!Parameter> &ref_1202
             schema: *ref_194
             implementation: Method
             language: !<!Languages> 
@@ -26605,13 +27298,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1192
           - *ref_1193
           - *ref_1194
           - *ref_1195
           - *ref_1196
+          - *ref_1197
           - *ref_235
-          - !<!Parameter> &ref_1202
+          - !<!Parameter> &ref_1203
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -26625,10 +27318,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_1197
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1198
               - *ref_170
             signatureParameters:
-              - *ref_1197
+              - *ref_1198
               - *ref_170
             language: !<!Languages> 
               default:
@@ -26640,14 +27346,14 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_1198
           - *ref_1199
           - *ref_1200
           - *ref_1201
           - *ref_1202
+          - *ref_1203
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1182
+            schema: *ref_1183
             language: !<!Languages> 
               default:
                 name: ''
@@ -26656,49 +27362,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1203
+                    schema: *ref_1204
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1191
+                    schema: *ref_1192
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1204
+                    schema: *ref_1205
                     header: x-ms-blob-content-length
                     language:
                       default:
                         name: BlobContentLength
                         description: The size of the blob in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_1205
+                    schema: *ref_1206
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1206
+                    schema: *ref_1207
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1207
+                    schema: *ref_1208
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1208
+                    schema: *ref_1209
                     header: Date
                     language:
                       default:
@@ -26711,7 +27417,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -26720,7 +27426,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1209
+                    schema: *ref_1210
                     header: x-ms-error-code
                     language:
                       default:
@@ -26754,7 +27460,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1218
+          - !<!Parameter> &ref_1219
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -26767,14 +27473,14 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_1210
           - *ref_1211
           - *ref_1212
+          - *ref_1213
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -26783,12 +27489,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1213
           - *ref_1214
           - *ref_1215
           - *ref_1216
-          - !<!Parameter> &ref_1219
-            schema: *ref_834
+          - *ref_1217
+          - !<!Parameter> &ref_1220
+            schema: *ref_835
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26800,7 +27506,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_235
-          - !<!Parameter> &ref_1220
+          - !<!Parameter> &ref_1221
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -26814,11 +27520,24 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_1217
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1218
               - *ref_204
               - *ref_171
             signatureParameters:
-              - *ref_1217
+              - *ref_1218
               - *ref_204
               - *ref_171
             language: !<!Languages> 
@@ -26831,9 +27550,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1218
           - *ref_1219
           - *ref_1220
+          - *ref_1221
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -26844,49 +27563,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1221
+                    schema: *ref_1222
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1222
+                    schema: *ref_1223
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1223
+                    schema: *ref_1224
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for a page blob. This header is not returned for block blobs or append blobs
                   - !<!HttpHeader> 
-                    schema: *ref_1224
+                    schema: *ref_1225
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1225
+                    schema: *ref_1226
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1226
+                    schema: *ref_1227
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1227
+                    schema: *ref_1228
                     header: Date
                     language:
                       default:
@@ -26896,7 +27615,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -26905,7 +27624,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1228
+                    schema: *ref_1229
                     header: x-ms-error-code
                     language:
                       default:
@@ -26939,7 +27658,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1236
+          - !<!Parameter> &ref_1237
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -26952,13 +27671,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_1229
           - *ref_1230
           - *ref_1231
           - *ref_1232
           - *ref_1233
-          - !<!Parameter> &ref_1237
-            schema: *ref_1234
+          - *ref_1234
+          - !<!Parameter> &ref_1238
+            schema: *ref_1235
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26969,8 +27688,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1238
-            schema: *ref_1058
+          - !<!Parameter> &ref_1239
+            schema: *ref_1059
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26981,7 +27700,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_235
-          - !<!Parameter> &ref_1239
+          - !<!Parameter> &ref_1240
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -26995,10 +27714,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_1235
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1236
               - *ref_172
             signatureParameters:
-              - *ref_1235
+              - *ref_1236
               - *ref_172
             language: !<!Languages> 
               default:
@@ -27010,10 +27742,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1236
           - *ref_1237
           - *ref_1238
           - *ref_1239
+          - *ref_1240
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -27024,49 +27756,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1240
+                    schema: *ref_1241
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1241
+                    schema: *ref_1242
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1242
+                    schema: *ref_1243
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for a page blob. This header is not returned for block blobs or append blobs
                   - !<!HttpHeader> 
-                    schema: *ref_1243
+                    schema: *ref_1244
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1244
+                    schema: *ref_1245
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1245
+                    schema: *ref_1246
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1246
+                    schema: *ref_1247
                     header: Date
                     language:
                       default:
@@ -27076,7 +27808,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -27085,7 +27817,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1247
+                    schema: *ref_1248
                     header: x-ms-error-code
                     language:
                       default:
@@ -27108,7 +27840,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1248
+            schema: *ref_1249
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27119,7 +27851,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1253
+          - !<!Parameter> &ref_1254
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -27132,12 +27864,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_1249
           - *ref_1250
           - *ref_1251
           - *ref_1252
-          - !<!Parameter> &ref_1254
-            schema: *ref_966
+          - *ref_1253
+          - !<!Parameter> &ref_1255
+            schema: *ref_967
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27151,7 +27883,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_235
-          - !<!Parameter> &ref_1255
+          - !<!Parameter> &ref_1256
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -27165,6 +27897,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_173
             signatureParameters:
               - *ref_173
@@ -27178,9 +27923,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1253
           - *ref_1254
           - *ref_1255
+          - *ref_1256
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -27191,49 +27936,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1256
+                    schema: *ref_1257
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1257
+                    schema: *ref_1258
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1258
+                    schema: *ref_1259
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1259
+                    schema: *ref_1260
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1260
+                    schema: *ref_1261
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1261
+                    schema: *ref_1262
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1262
+                    schema: *ref_1263
                     header: x-ms-copy-id
                     language:
                       default:
@@ -27250,7 +27995,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -27259,7 +28004,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1263
+                    schema: *ref_1264
                     header: x-ms-error-code
                     language:
                       default:
@@ -27292,7 +28037,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1264
+            schema: *ref_1265
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27303,7 +28048,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1279
+          - !<!Parameter> &ref_1280
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -27316,8 +28061,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1280
-            schema: *ref_296
+          - !<!Parameter> &ref_1281
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27328,13 +28073,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1265
           - *ref_1266
           - *ref_1267
           - *ref_1268
           - *ref_1269
-          - !<!Parameter> &ref_1281
-            schema: *ref_308
+          - *ref_1270
+          - !<!Parameter> &ref_1282
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -27349,15 +28094,15 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1270
           - *ref_1271
           - *ref_1272
           - *ref_1273
+          - *ref_1274
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -27366,12 +28111,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1274
           - *ref_1275
           - *ref_1276
           - *ref_1277
+          - *ref_1278
           - *ref_235
-          - !<!Parameter> &ref_1282
+          - !<!Parameter> &ref_1283
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -27385,13 +28130,26 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_216
-              - *ref_1278
+              - *ref_1279
               - *ref_205
               - *ref_174
             signatureParameters:
               - *ref_216
-              - *ref_1278
+              - *ref_1279
               - *ref_205
               - *ref_174
             language: !<!Languages> 
@@ -27404,10 +28162,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1279
           - *ref_1280
           - *ref_1281
           - *ref_1282
+          - *ref_1283
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -27418,63 +28176,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1283
+                    schema: *ref_1284
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1284
+                    schema: *ref_1285
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1285
+                    schema: *ref_1286
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1286
+                    schema: *ref_1287
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1287
+                    schema: *ref_1288
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1288
+                    schema: *ref_1289
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1289
+                    schema: *ref_1290
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1290
+                    schema: *ref_1291
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1291
+                    schema: *ref_1292
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -27484,7 +28242,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -27493,7 +28251,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1292
+                    schema: *ref_1293
                     header: x-ms-error-code
                     language:
                       default:
@@ -27516,7 +28274,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1293
+            schema: *ref_1294
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27527,7 +28285,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1306
+          - !<!Parameter> &ref_1307
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -27540,8 +28298,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1307
-            schema: *ref_296
+          - !<!Parameter> &ref_1308
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27552,8 +28310,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1308
-            schema: *ref_1078
+          - !<!Parameter> &ref_1309
+            schema: *ref_1079
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27563,8 +28321,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1309
-            schema: *ref_1079
+          - !<!Parameter> &ref_1310
+            schema: *ref_1080
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27574,16 +28332,16 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1294
           - *ref_1295
           - *ref_1296
           - *ref_1297
           - *ref_1298
+          - *ref_1299
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -27592,12 +28350,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1299
           - *ref_1300
           - *ref_1301
           - *ref_1302
+          - *ref_1303
           - *ref_235
-          - !<!Parameter> &ref_1310
+          - !<!Parameter> &ref_1311
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -27611,8 +28369,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1305
-                schema: *ref_1303
+              - !<!Parameter> &ref_1306
+                schema: *ref_1304
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -27623,13 +28381,26 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
-              - *ref_1304
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1305
               - *ref_227
               - *ref_206
               - *ref_175
             signatureParameters:
+              - *ref_1306
               - *ref_1305
-              - *ref_1304
               - *ref_227
               - *ref_206
               - *ref_175
@@ -27647,11 +28418,11 @@ operationGroups:
                   - application/octet-stream
                 uri: '{url}'
         signatureParameters:
-          - *ref_1306
           - *ref_1307
           - *ref_1308
           - *ref_1309
           - *ref_1310
+          - *ref_1311
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -27662,84 +28433,84 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1311
+                    schema: *ref_1312
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1312
+                    schema: *ref_1313
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1313
+                    schema: *ref_1314
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1314
+                    schema: *ref_1315
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1315
+                    schema: *ref_1316
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1316
+                    schema: *ref_1317
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1317
+                    schema: *ref_1318
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1318
+                    schema: *ref_1319
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1319
+                    schema: *ref_1320
                     header: x-ms-blob-append-offset
                     language:
                       default:
                         name: BlobAppendOffset
                         description: 'This response header is returned only for append operations. It returns the offset at which the block was committed, in bytes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1320
+                    schema: *ref_1321
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_1321
+                    schema: *ref_1322
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1322
+                    schema: *ref_1323
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -27749,7 +28520,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -27758,7 +28529,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1323
+                    schema: *ref_1324
                     header: x-ms-error-code
                     language:
                       default:
@@ -27783,7 +28554,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1293
+            schema: *ref_1294
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27794,8 +28565,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1339
-            schema: *ref_966
+          - !<!Parameter> &ref_1340
+            schema: *ref_967
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27806,8 +28577,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1340
-            schema: *ref_1324
+          - !<!Parameter> &ref_1341
+            schema: *ref_1325
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27817,8 +28588,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1341
-            schema: *ref_993
+          - !<!Parameter> &ref_1342
+            schema: *ref_994
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27828,8 +28599,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1342
-            schema: *ref_1137
+          - !<!Parameter> &ref_1343
+            schema: *ref_1138
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27839,7 +28610,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1343
+          - !<!Parameter> &ref_1344
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -27852,8 +28623,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1344
-            schema: *ref_296
+          - !<!Parameter> &ref_1345
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27864,8 +28635,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1345
-            schema: *ref_1078
+          - !<!Parameter> &ref_1346
+            schema: *ref_1079
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27875,13 +28646,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1325
           - *ref_1326
+          - *ref_1327
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -27890,7 +28661,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1327
           - *ref_1328
           - *ref_1329
           - *ref_1330
@@ -27901,8 +28671,9 @@ operationGroups:
           - *ref_1335
           - *ref_1336
           - *ref_1337
+          - *ref_1338
           - *ref_235
-          - !<!Parameter> &ref_1346
+          - !<!Parameter> &ref_1347
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -27916,14 +28687,27 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_207
-              - *ref_1338
+              - *ref_1339
               - *ref_228
               - *ref_176
               - *ref_191
             signatureParameters:
               - *ref_207
-              - *ref_1338
+              - *ref_1339
               - *ref_228
               - *ref_176
               - *ref_191
@@ -27937,7 +28721,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1339
           - *ref_1340
           - *ref_1341
           - *ref_1342
@@ -27945,6 +28728,7 @@ operationGroups:
           - *ref_1344
           - *ref_1345
           - *ref_1346
+          - *ref_1347
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -27955,77 +28739,77 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1347
+                    schema: *ref_1348
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1348
+                    schema: *ref_1349
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1349
+                    schema: *ref_1350
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1350
+                    schema: *ref_1351
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1351
+                    schema: *ref_1352
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1352
+                    schema: *ref_1353
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1353
+                    schema: *ref_1354
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1354
+                    schema: *ref_1355
                     header: x-ms-blob-append-offset
                     language:
                       default:
                         name: BlobAppendOffset
                         description: 'This response header is returned only for append operations. It returns the offset at which the block was committed, in bytes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1355
+                    schema: *ref_1356
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_1356
+                    schema: *ref_1357
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
                         name: EncryptionKeySha256
                         description: The SHA-256 hash of the encryption key used to encrypt the block. This header is only returned when the block was encrypted with a customer-provided key.
                   - !<!HttpHeader> 
-                    schema: *ref_1357
+                    schema: *ref_1358
                     header: x-ms-request-server-encrypted
                     language:
                       default:
@@ -28035,7 +28819,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -28044,7 +28828,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1358
+                    schema: *ref_1359
                     header: x-ms-error-code
                     language:
                       default:
@@ -28077,7 +28861,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1359
+            schema: *ref_1360
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28088,7 +28872,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1376
+          - !<!Parameter> &ref_1377
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -28101,8 +28885,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1377
-            schema: *ref_1078
+          - !<!Parameter> &ref_1378
+            schema: *ref_1079
             implementation: Method
             language: !<!Languages> 
               default:
@@ -28112,8 +28896,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1378
-            schema: *ref_296
+          - !<!Parameter> &ref_1379
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28124,13 +28908,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1360
           - *ref_1361
           - *ref_1362
           - *ref_1363
           - *ref_1364
-          - !<!Parameter> &ref_1379
-            schema: *ref_308
+          - *ref_1365
+          - !<!Parameter> &ref_1380
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -28145,15 +28929,15 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1365
           - *ref_1366
           - *ref_1367
           - *ref_1368
+          - *ref_1369
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -28162,7 +28946,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1380
+          - !<!Parameter> &ref_1381
             schema: *ref_86
             implementation: Method
             language: !<!Languages> 
@@ -28173,12 +28957,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1369
           - *ref_1370
           - *ref_1371
           - *ref_1372
+          - *ref_1373
           - *ref_235
-          - !<!Parameter> &ref_1381
+          - !<!Parameter> &ref_1382
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -28192,8 +28976,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1375
-                schema: *ref_1373
+              - !<!Parameter> &ref_1376
+                schema: *ref_1374
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -28204,14 +28988,27 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_217
-              - *ref_1374
+              - *ref_1375
               - *ref_208
               - *ref_177
             signatureParameters:
-              - *ref_1375
+              - *ref_1376
               - *ref_217
-              - *ref_1374
+              - *ref_1375
               - *ref_208
               - *ref_177
             language: !<!Languages> 
@@ -28228,12 +29025,12 @@ operationGroups:
                   - application/octet-stream
                 uri: '{url}'
         signatureParameters:
-          - *ref_1376
           - *ref_1377
           - *ref_1378
           - *ref_1379
           - *ref_1380
           - *ref_1381
+          - *ref_1382
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -28244,63 +29041,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1382
+                    schema: *ref_1383
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1383
+                    schema: *ref_1384
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1384
+                    schema: *ref_1385
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1385
+                    schema: *ref_1386
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1386
+                    schema: *ref_1387
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1387
+                    schema: *ref_1388
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1388
+                    schema: *ref_1389
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1389
+                    schema: *ref_1390
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1390
+                    schema: *ref_1391
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -28310,7 +29107,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -28319,7 +29116,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1391
+                    schema: *ref_1392
                     header: x-ms-error-code
                     language:
                       default:
@@ -28344,7 +29141,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1392
+            schema: *ref_1393
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28355,8 +29152,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1400
-            schema: *ref_1393
+          - !<!Parameter> &ref_1401
+            schema: *ref_1394
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28369,8 +29166,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1401
-            schema: *ref_296
+          - !<!Parameter> &ref_1402
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28381,8 +29178,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1402
-            schema: *ref_1078
+          - !<!Parameter> &ref_1403
+            schema: *ref_1079
             implementation: Method
             language: !<!Languages> 
               default:
@@ -28392,8 +29189,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1403
-            schema: *ref_1079
+          - !<!Parameter> &ref_1404
+            schema: *ref_1080
             implementation: Method
             language: !<!Languages> 
               default:
@@ -28403,7 +29200,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1404
+          - !<!Parameter> &ref_1405
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -28416,14 +29213,14 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_1394
           - *ref_1395
           - *ref_1396
+          - *ref_1397
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -28433,7 +29230,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_235
-          - !<!Parameter> &ref_1405
+          - !<!Parameter> &ref_1406
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -28447,8 +29244,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1399
-                schema: *ref_1397
+              - !<!Parameter> &ref_1400
+                schema: *ref_1398
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -28459,11 +29256,24 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
-              - *ref_1398
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1399
               - *ref_209
             signatureParameters:
+              - *ref_1400
               - *ref_1399
-              - *ref_1398
               - *ref_209
             language: !<!Languages> 
               default:
@@ -28479,12 +29289,12 @@ operationGroups:
                   - application/octet-stream
                 uri: '{url}'
         signatureParameters:
-          - *ref_1400
           - *ref_1401
           - *ref_1402
           - *ref_1403
           - *ref_1404
           - *ref_1405
+          - *ref_1406
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -28495,56 +29305,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1406
+                    schema: *ref_1407
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1393
+                    schema: *ref_1394
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1407
+                    schema: *ref_1408
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1408
+                    schema: *ref_1409
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1409
+                    schema: *ref_1410
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1410
+                    schema: *ref_1411
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1411
+                    schema: *ref_1412
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1412
+                    schema: *ref_1413
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -28554,7 +29364,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -28563,7 +29373,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1413
+                    schema: *ref_1414
                     header: x-ms-error-code
                     language:
                       default:
@@ -28586,7 +29396,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1392
+            schema: *ref_1393
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28597,8 +29407,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1422
-            schema: *ref_1393
+          - !<!Parameter> &ref_1423
+            schema: *ref_1394
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28611,8 +29421,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1423
-            schema: *ref_296
+          - !<!Parameter> &ref_1424
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28623,8 +29433,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1424
-            schema: *ref_966
+          - !<!Parameter> &ref_1425
+            schema: *ref_967
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28635,8 +29445,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1425
-            schema: *ref_1324
+          - !<!Parameter> &ref_1426
+            schema: *ref_1325
             implementation: Method
             language: !<!Languages> 
               default:
@@ -28646,8 +29456,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1426
-            schema: *ref_993
+          - !<!Parameter> &ref_1427
+            schema: *ref_994
             implementation: Method
             language: !<!Languages> 
               default:
@@ -28657,8 +29467,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1427
-            schema: *ref_1137
+          - !<!Parameter> &ref_1428
+            schema: *ref_1138
             implementation: Method
             language: !<!Languages> 
               default:
@@ -28668,7 +29478,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1428
+          - !<!Parameter> &ref_1429
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -28681,13 +29491,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_1414
           - *ref_1415
+          - *ref_1416
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -28696,13 +29506,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1416
           - *ref_1417
           - *ref_1418
           - *ref_1419
           - *ref_1420
+          - *ref_1421
           - *ref_235
-          - !<!Parameter> &ref_1429
+          - !<!Parameter> &ref_1430
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -28716,12 +29526,25 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_210
-              - *ref_1421
+              - *ref_1422
               - *ref_192
             signatureParameters:
               - *ref_210
-              - *ref_1421
+              - *ref_1422
               - *ref_192
             language: !<!Languages> 
               default:
@@ -28733,7 +29556,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1422
           - *ref_1423
           - *ref_1424
           - *ref_1425
@@ -28741,6 +29563,7 @@ operationGroups:
           - *ref_1427
           - *ref_1428
           - *ref_1429
+          - *ref_1430
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -28751,56 +29574,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1430
+                    schema: *ref_1431
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1431
+                    schema: *ref_1432
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1324
+                    schema: *ref_1325
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1432
+                    schema: *ref_1433
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1433
+                    schema: *ref_1434
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1434
+                    schema: *ref_1435
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1435
+                    schema: *ref_1436
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1436
+                    schema: *ref_1437
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -28810,7 +29633,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -28819,7 +29642,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1437
+                    schema: *ref_1438
                     header: x-ms-error-code
                     language:
                       default:
@@ -28842,7 +29665,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1438
+            schema: *ref_1439
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28853,7 +29676,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1455
+          - !<!Parameter> &ref_1456
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -28866,13 +29689,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_1439
           - *ref_1440
           - *ref_1441
           - *ref_1442
           - *ref_1443
-          - !<!Parameter> &ref_1456
-            schema: *ref_1078
+          - *ref_1444
+          - !<!Parameter> &ref_1457
+            schema: *ref_1079
             implementation: Method
             language: !<!Languages> 
               default:
@@ -28882,8 +29705,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1457
-            schema: *ref_1079
+          - !<!Parameter> &ref_1458
+            schema: *ref_1080
             implementation: Method
             language: !<!Languages> 
               default:
@@ -28893,8 +29716,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1458
-            schema: *ref_308
+          - !<!Parameter> &ref_1459
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -28909,15 +29732,15 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1444
           - *ref_1445
           - *ref_1446
           - *ref_1447
+          - *ref_1448
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -28926,7 +29749,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1459
+          - !<!Parameter> &ref_1460
             schema: *ref_86
             implementation: Method
             language: !<!Languages> 
@@ -28937,12 +29760,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1448
           - *ref_1449
           - *ref_1450
           - *ref_1451
+          - *ref_1452
           - *ref_235
-          - !<!Parameter> &ref_1460
+          - !<!Parameter> &ref_1461
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -28956,8 +29779,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1454
-                schema: *ref_1452
+              - !<!Parameter> &ref_1455
+                schema: *ref_1453
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -28968,14 +29791,27 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_218
-              - *ref_1453
+              - *ref_1454
               - *ref_211
               - *ref_178
             signatureParameters:
-              - *ref_1454
+              - *ref_1455
               - *ref_218
-              - *ref_1453
+              - *ref_1454
               - *ref_211
               - *ref_178
             language: !<!Languages> 
@@ -28991,12 +29827,12 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_1455
           - *ref_1456
           - *ref_1457
           - *ref_1458
           - *ref_1459
           - *ref_1460
+          - *ref_1461
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -29007,21 +29843,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1461
+                    schema: *ref_1462
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1462
+                    schema: *ref_1463
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1463
+                    schema: *ref_1464
                     header: Content-MD5
                     language:
                       default:
@@ -29030,7 +29866,7 @@ operationGroups:
                           This header is returned so that the client can check for message content integrity. This header refers to the content of the request, meaning, in this case, the list of blocks, and not the content of the blob
                           itself.
                   - !<!HttpHeader> 
-                    schema: *ref_1464
+                    schema: *ref_1465
                     header: x-ms-content-crc64
                     language:
                       default:
@@ -29039,42 +29875,42 @@ operationGroups:
                           This header is returned so that the client can check for message content integrity. This header refers to the content of the request, meaning, in this case, the list of blocks, and not the content of the blob
                           itself.
                   - !<!HttpHeader> 
-                    schema: *ref_1465
+                    schema: *ref_1466
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1466
+                    schema: *ref_1467
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1467
+                    schema: *ref_1468
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1468
+                    schema: *ref_1469
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1469
+                    schema: *ref_1470
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1470
+                    schema: *ref_1471
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -29084,7 +29920,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -29093,7 +29929,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1471
+                    schema: *ref_1472
                     header: x-ms-error-code
                     language:
                       default:
@@ -29119,7 +29955,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1438
+            schema: *ref_1439
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -29130,7 +29966,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1475
+          - !<!Parameter> &ref_1476
             schema: *ref_194
             implementation: Method
             language: !<!Languages> 
@@ -29143,8 +29979,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1476
-            schema: *ref_1472
+          - !<!Parameter> &ref_1477
+            schema: *ref_1473
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -29155,7 +29991,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1477
+          - !<!Parameter> &ref_1478
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -29168,9 +30004,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_1473
+          - *ref_1474
           - *ref_235
-          - !<!Parameter> &ref_1478
+          - !<!Parameter> &ref_1479
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -29184,9 +30020,22 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_1474
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1475
             signatureParameters:
-              - *ref_1474
+              - *ref_1475
             language: !<!Languages> 
               default:
                 name: ''
@@ -29197,13 +30046,13 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_1475
           - *ref_1476
           - *ref_1477
           - *ref_1478
+          - *ref_1479
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1479
+            schema: *ref_1480
             language: !<!Languages> 
               default:
                 name: ''
@@ -29212,56 +30061,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1480
+                    schema: *ref_1481
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1481
+                    schema: *ref_1482
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1482
+                    schema: *ref_1483
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The media type of the body of the response. For Get Block List this is 'application/xml'
                   - !<!HttpHeader> 
-                    schema: *ref_1483
+                    schema: *ref_1484
                     header: x-ms-blob-content-length
                     language:
                       default:
                         name: BlobContentLength
                         description: The size of the blob in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_1484
+                    schema: *ref_1485
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1485
+                    schema: *ref_1486
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1486
+                    schema: *ref_1487
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1487
+                    schema: *ref_1488
                     header: Date
                     language:
                       default:
@@ -29274,7 +30123,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -29283,7 +30132,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1488
+                    schema: *ref_1489
                     header: x-ms-error-code
                     language:
                       default:

--- a/modelerfour/test/scenarios/blob-storage/modeler.yaml
+++ b/modelerfour/test/scenarios/blob-storage/modeler.yaml
@@ -59,7 +59,7 @@ schemas: !<!Schemas>
           name: boolean
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_228
+    - !<!BooleanSchema> &ref_229
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -70,7 +70,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-has-immutability-policy
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_229
+    - !<!BooleanSchema> &ref_230
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -81,7 +81,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-has-legal-hold
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_454
+    - !<!BooleanSchema> &ref_455
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -92,7 +92,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_576
+    - !<!BooleanSchema> &ref_577
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -103,7 +103,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_601
+    - !<!BooleanSchema> &ref_602
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -114,7 +114,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-incremental-copy
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_618
+    - !<!BooleanSchema> &ref_619
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -125,7 +125,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_621
+    - !<!BooleanSchema> &ref_622
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -136,7 +136,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-access-tier-inferred
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_978
+    - !<!BooleanSchema> &ref_979
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -147,7 +147,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1191
+    - !<!BooleanSchema> &ref_1192
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -158,7 +158,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1290
+    - !<!BooleanSchema> &ref_1291
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -169,7 +169,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_762
+    - !<!BooleanSchema> &ref_763
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -180,7 +180,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_859
+    - !<!BooleanSchema> &ref_860
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -191,7 +191,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1311
+    - !<!BooleanSchema> &ref_1312
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -202,7 +202,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1334
+    - !<!BooleanSchema> &ref_1335
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -213,7 +213,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1367
+    - !<!BooleanSchema> &ref_1368
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -224,7 +224,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1012
+    - !<!BooleanSchema> &ref_1013
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -235,7 +235,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1074
+    - !<!BooleanSchema> &ref_1075
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -246,7 +246,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1222
+    - !<!BooleanSchema> &ref_1223
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -257,7 +257,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1259
+    - !<!BooleanSchema> &ref_1260
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -299,7 +299,7 @@ schemas: !<!Schemas>
           name: integer
           description: The maximum amount time that a browser should cache the preflight OPTIONS request.
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_165
+    - !<!NumberSchema> &ref_166
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -319,7 +319,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_195
+    - !<!NumberSchema> &ref_196
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -331,7 +331,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_285
+    - !<!NumberSchema> &ref_286
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -359,7 +359,7 @@ schemas: !<!Schemas>
           name: blobSequenceNumber
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_449
+    - !<!NumberSchema> &ref_450
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -371,7 +371,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_529
+    - !<!NumberSchema> &ref_530
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -383,7 +383,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_538
+    - !<!NumberSchema> &ref_539
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -395,7 +395,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_549
+    - !<!NumberSchema> &ref_550
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -407,7 +407,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-committed-block-count
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_554
+    - !<!NumberSchema> &ref_555
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -419,7 +419,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_563
+    - !<!NumberSchema> &ref_564
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -431,7 +431,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_575
+    - !<!NumberSchema> &ref_576
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -443,7 +443,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-committed-block-count
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_603
+    - !<!NumberSchema> &ref_604
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -455,7 +455,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_611
+    - !<!NumberSchema> &ref_612
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -467,7 +467,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_617
+    - !<!NumberSchema> &ref_618
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -479,7 +479,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-committed-block-count
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_710
+    - !<!NumberSchema> &ref_711
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -491,7 +491,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_740
+    - !<!NumberSchema> &ref_741
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -503,7 +503,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_951
+    - !<!NumberSchema> &ref_952
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -515,7 +515,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_835
+    - !<!NumberSchema> &ref_836
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -527,7 +527,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-lease-time
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1379
+    - !<!NumberSchema> &ref_1380
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -547,7 +547,7 @@ schemas: !<!Schemas>
           name: integer
           description: The block size in bytes.
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_985
+    - !<!NumberSchema> &ref_986
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -559,7 +559,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1037
+    - !<!NumberSchema> &ref_1038
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -571,7 +571,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1070
+    - !<!NumberSchema> &ref_1071
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -583,7 +583,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1089
+    - !<!NumberSchema> &ref_1090
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -623,7 +623,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1108
+    - !<!NumberSchema> &ref_1109
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -635,7 +635,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-content-length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1126
+    - !<!NumberSchema> &ref_1127
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -647,7 +647,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1144
+    - !<!NumberSchema> &ref_1145
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -659,7 +659,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1195
+    - !<!NumberSchema> &ref_1196
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -670,7 +670,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1221
+    - !<!NumberSchema> &ref_1222
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -682,7 +682,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-committed-block-count
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1257
+    - !<!NumberSchema> &ref_1258
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -805,7 +805,7 @@ schemas: !<!Schemas>
           name: StaticWebsite-ErrorDocument404Path
           description: The absolute path of the custom 404 page
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_142
+    - !<!StringSchema> &ref_143
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -816,7 +816,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_143
+    - !<!StringSchema> &ref_144
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -827,7 +827,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_144
+    - !<!StringSchema> &ref_145
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -848,17 +848,6 @@ schemas: !<!Schemas>
           name: StorageError-Message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_150
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_151
       type: string
       apiVersions:
@@ -868,7 +857,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_152
       type: string
@@ -879,7 +868,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_153
       type: string
@@ -890,9 +879,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_157
+    - !<!StringSchema> &ref_154
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -901,7 +890,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_158
       type: string
@@ -912,7 +901,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_159
       type: string
@@ -923,9 +912,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_160
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_162
+    - !<!StringSchema> &ref_163
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -936,7 +936,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_164
+    - !<!StringSchema> &ref_165
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -947,7 +947,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_172
+    - !<!StringSchema> &ref_173
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -958,7 +958,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_173
+    - !<!StringSchema> &ref_174
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1065,7 +1065,7 @@ schemas: !<!Schemas>
           name: KeyInfo-Expiry
           description: The date-time the key expires in ISO 8601 UTC time
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_180
+    - !<!StringSchema> &ref_181
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1076,7 +1076,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_181
+    - !<!StringSchema> &ref_182
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1087,7 +1087,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_182
+    - !<!StringSchema> &ref_183
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1148,7 +1148,7 @@ schemas: !<!Schemas>
           name: UserDelegationKey-Value
           description: The key as a base64 string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_185
+    - !<!StringSchema> &ref_186
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1158,17 +1158,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_187
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_188
       type: string
@@ -1179,7 +1168,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_189
       type: string
@@ -1190,9 +1179,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_190
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_193
+    - !<!StringSchema> &ref_194
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1203,7 +1203,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_196
+    - !<!StringSchema> &ref_197
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1214,17 +1214,6 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_203
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_204
       type: string
       apiVersions:
@@ -1234,7 +1223,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_205
       type: string
@@ -1245,9 +1234,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_206
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_207
+    - !<!StringSchema> &ref_208
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1257,17 +1257,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_213
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_214
       type: string
@@ -1278,7 +1267,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_215
       type: string
@@ -1289,9 +1278,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_217
+    - !<!StringSchema> &ref_216
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1300,7 +1289,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_218
       type: string
@@ -1311,9 +1300,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-error-code
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_219
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-meta
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_222
+    - !<!StringSchema> &ref_223
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1323,17 +1323,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_224
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_225
       type: string
@@ -1344,7 +1333,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_226
       type: string
@@ -1355,9 +1344,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_227
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_230
+    - !<!StringSchema> &ref_231
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1367,17 +1367,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_238
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_239
       type: string
@@ -1388,7 +1377,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_240
       type: string
@@ -1399,7 +1388,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_241
       type: string
@@ -1410,9 +1399,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_242
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_249
+    - !<!StringSchema> &ref_250
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1422,17 +1422,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_251
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_252
       type: string
@@ -1443,7 +1432,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_253
       type: string
@@ -1454,9 +1443,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_254
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_255
+    - !<!StringSchema> &ref_256
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1467,7 +1467,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_260
+    - !<!StringSchema> &ref_261
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1478,7 +1478,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_262
+    - !<!StringSchema> &ref_263
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1489,7 +1489,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_263
+    - !<!StringSchema> &ref_264
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1500,7 +1500,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_264
+    - !<!StringSchema> &ref_265
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1531,7 +1531,7 @@ schemas: !<!Schemas>
           name: AccessPolicy-Permission
           description: the permissions for the acl policy
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_267
+    - !<!StringSchema> &ref_268
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1542,7 +1542,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_276
+    - !<!StringSchema> &ref_277
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1552,17 +1552,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_278
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_279
       type: string
@@ -1573,7 +1562,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_280
       type: string
@@ -1584,9 +1573,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_281
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_282
+    - !<!StringSchema> &ref_283
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1597,7 +1597,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_286
+    - !<!StringSchema> &ref_287
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1607,17 +1607,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_294
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_295
       type: string
@@ -1628,7 +1617,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_296
       type: string
@@ -1639,7 +1628,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_297
       type: string
@@ -1650,9 +1639,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_298
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_299
+    - !<!StringSchema> &ref_300
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1663,7 +1663,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_301
+    - !<!StringSchema> &ref_302
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1673,17 +1673,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_308
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_309
       type: string
@@ -1694,7 +1683,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_310
       type: string
@@ -1705,9 +1694,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_311
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_312
+    - !<!StringSchema> &ref_313
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1718,7 +1718,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_319
+    - !<!StringSchema> &ref_320
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1728,17 +1728,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_321
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_322
       type: string
@@ -1749,7 +1738,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_323
       type: string
@@ -1760,7 +1749,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_324
       type: string
@@ -1771,9 +1760,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_325
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_326
+    - !<!StringSchema> &ref_327
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1784,7 +1784,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_333
+    - !<!StringSchema> &ref_334
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1794,17 +1794,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_335
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_336
       type: string
@@ -1815,7 +1804,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_337
       type: string
@@ -1826,9 +1815,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_338
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_339
+    - !<!StringSchema> &ref_340
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1839,7 +1839,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_341
+    - !<!StringSchema> &ref_342
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1850,7 +1850,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_349
+    - !<!StringSchema> &ref_350
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1861,17 +1861,6 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-lease-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_350
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_351
       type: string
       apiVersions:
@@ -1881,7 +1870,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_352
       type: string
@@ -1892,9 +1881,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_353
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_354
+    - !<!StringSchema> &ref_355
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1905,7 +1905,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_362
+    - !<!StringSchema> &ref_363
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1916,7 +1916,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_363
+    - !<!StringSchema> &ref_364
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1927,7 +1927,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_364
+    - !<!StringSchema> &ref_365
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1938,7 +1938,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_365
+    - !<!StringSchema> &ref_366
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2175,7 +2175,7 @@ schemas: !<!Schemas>
           name: ListBlobsFlatSegmentResponse-NextMarker
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_368
+    - !<!StringSchema> &ref_369
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2186,7 +2186,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_376
+    - !<!StringSchema> &ref_377
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2197,7 +2197,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_377
+    - !<!StringSchema> &ref_378
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2208,7 +2208,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_378
+    - !<!StringSchema> &ref_379
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2299,17 +2299,6 @@ schemas: !<!Schemas>
           name: ListBlobsHierarchySegmentResponse-NextMarker
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_381
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-error-code
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_382
       type: string
       apiVersions:
@@ -2319,7 +2308,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_383
       type: string
@@ -2330,7 +2319,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_384
       type: string
@@ -2341,9 +2330,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_385
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_386
+    - !<!StringSchema> &ref_387
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2354,7 +2354,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_388
+    - !<!StringSchema> &ref_389
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2365,17 +2365,6 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_405
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_406
       type: string
       apiVersions:
@@ -2385,7 +2374,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_407
       type: string
@@ -2396,9 +2385,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_409
+    - !<!StringSchema> &ref_408
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2407,7 +2396,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_410
       type: string
@@ -2418,9 +2407,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_411
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_412
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2451,7 +2451,7 @@ schemas: !<!Schemas>
           name: DataLakeStorageError-error-Message
           description: The service error message.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_413
+    - !<!StringSchema> &ref_414
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2461,17 +2461,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-continuation
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_445
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_446
       type: string
@@ -2482,7 +2471,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_447
       type: string
@@ -2493,7 +2482,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_448
       type: string
@@ -2504,9 +2493,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_451
+    - !<!StringSchema> &ref_449
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2515,7 +2504,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_452
       type: string
@@ -2526,7 +2515,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_453
       type: string
@@ -2537,9 +2526,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_464
+    - !<!StringSchema> &ref_454
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2548,7 +2537,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-continuation
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_465
       type: string
@@ -2559,7 +2548,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-continuation
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_466
       type: string
@@ -2570,7 +2559,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_467
       type: string
@@ -2581,9 +2570,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_469
+    - !<!StringSchema> &ref_468
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2592,7 +2581,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_470
       type: string
@@ -2603,7 +2592,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_471
       type: string
@@ -2614,9 +2603,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_472
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_473
+    - !<!StringSchema> &ref_474
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2626,17 +2626,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_487
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_488
       type: string
@@ -2647,7 +2636,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_489
       type: string
@@ -2658,7 +2647,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_490
       type: string
@@ -2669,7 +2658,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_491
       type: string
@@ -2680,9 +2669,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_492
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_502
+    - !<!StringSchema> &ref_503
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2692,17 +2692,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_504
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-owner
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_505
       type: string
@@ -2713,7 +2702,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-group
+          header: x-ms-owner
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_506
       type: string
@@ -2724,7 +2713,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-permissions
+          header: x-ms-group
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_507
       type: string
@@ -2735,7 +2724,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-acl
+          header: x-ms-permissions
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_508
       type: string
@@ -2746,7 +2735,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-acl
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_509
       type: string
@@ -2757,7 +2746,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_510
       type: string
@@ -2768,7 +2757,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_511
       type: string
@@ -2779,7 +2768,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_512
       type: string
@@ -2790,7 +2779,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_513
       type: string
@@ -2801,9 +2790,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-meta
+          header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_530
+    - !<!StringSchema> &ref_514
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2812,7 +2801,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Type
+          header: x-ms-meta
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_531
       type: string
@@ -2823,7 +2812,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Range
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_532
       type: string
@@ -2834,9 +2823,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Content-Range
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_534
+    - !<!StringSchema> &ref_533
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2845,7 +2834,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Encoding
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_535
       type: string
@@ -2856,7 +2845,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Cache-Control
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_536
       type: string
@@ -2867,7 +2856,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Disposition
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_537
       type: string
@@ -2878,9 +2867,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
+          header: Content-Disposition
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_540
+    - !<!StringSchema> &ref_538
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2889,7 +2878,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-status-description
+          header: Content-Language
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_541
       type: string
@@ -2900,7 +2889,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-id
+          header: x-ms-copy-status-description
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_542
       type: string
@@ -2911,7 +2900,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-progress
+          header: x-ms-copy-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_543
       type: string
@@ -2922,7 +2911,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-source
+          header: x-ms-copy-progress
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_544
       type: string
@@ -2933,7 +2922,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-copy-source
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_545
       type: string
@@ -2944,7 +2933,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_546
       type: string
@@ -2955,7 +2944,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_547
       type: string
@@ -2966,9 +2955,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_548
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: Accept-Ranges
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_550
+    - !<!StringSchema> &ref_551
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2979,7 +2979,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_553
+    - !<!StringSchema> &ref_554
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2989,17 +2989,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-meta
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_555
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_556
       type: string
@@ -3010,7 +2999,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Range
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_557
       type: string
@@ -3021,9 +3010,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Content-Range
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_559
+    - !<!StringSchema> &ref_558
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3032,7 +3021,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Encoding
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_560
       type: string
@@ -3043,7 +3032,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Cache-Control
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_561
       type: string
@@ -3054,7 +3043,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Disposition
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_562
       type: string
@@ -3065,9 +3054,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
+          header: Content-Disposition
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_566
+    - !<!StringSchema> &ref_563
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3076,7 +3065,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-status-description
+          header: Content-Language
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_567
       type: string
@@ -3087,7 +3076,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-id
+          header: x-ms-copy-status-description
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_568
       type: string
@@ -3098,7 +3087,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-progress
+          header: x-ms-copy-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_569
       type: string
@@ -3109,7 +3098,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-source
+          header: x-ms-copy-progress
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_570
       type: string
@@ -3120,7 +3109,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-copy-source
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_571
       type: string
@@ -3131,7 +3120,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_572
       type: string
@@ -3142,7 +3131,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_573
       type: string
@@ -3153,9 +3142,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_574
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: Accept-Ranges
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_577
+    - !<!StringSchema> &ref_578
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3166,7 +3166,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_579
+    - !<!StringSchema> &ref_580
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3177,7 +3177,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_595
+    - !<!StringSchema> &ref_596
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3188,7 +3188,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-meta
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_597
+    - !<!StringSchema> &ref_598
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3199,7 +3199,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-status-description
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_598
+    - !<!StringSchema> &ref_599
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3210,7 +3210,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_599
+    - !<!StringSchema> &ref_600
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3221,7 +3221,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-progress
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_600
+    - !<!StringSchema> &ref_601
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3232,7 +3232,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-source
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_602
+    - !<!StringSchema> &ref_603
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3243,7 +3243,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-destination-snapshot
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_604
+    - !<!StringSchema> &ref_605
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3254,7 +3254,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_605
+    - !<!StringSchema> &ref_606
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3264,17 +3264,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_607
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_608
       type: string
@@ -3285,7 +3274,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Disposition
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_609
       type: string
@@ -3296,7 +3285,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
+          header: Content-Disposition
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_610
       type: string
@@ -3307,9 +3296,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Cache-Control
+          header: Content-Language
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_612
+    - !<!StringSchema> &ref_611
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3318,7 +3307,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_613
       type: string
@@ -3329,7 +3318,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_614
       type: string
@@ -3340,9 +3329,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_615
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_616
+    - !<!StringSchema> &ref_617
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3353,7 +3353,7 @@ schemas: !<!Schemas>
           description: ''
           header: Accept-Ranges
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_619
+    - !<!StringSchema> &ref_620
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3364,7 +3364,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_620
+    - !<!StringSchema> &ref_621
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3375,7 +3375,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-access-tier
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_622
+    - !<!StringSchema> &ref_623
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3386,7 +3386,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-archive-status
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_624
+    - !<!StringSchema> &ref_625
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3396,17 +3396,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_635
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_636
       type: string
@@ -3417,7 +3406,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_637
       type: string
@@ -3428,9 +3417,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_638
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_639
+    - !<!StringSchema> &ref_640
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3441,7 +3441,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_652
+    - !<!StringSchema> &ref_653
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3451,17 +3451,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_654
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_655
       type: string
@@ -3472,7 +3461,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_656
       type: string
@@ -3483,7 +3472,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_657
       type: string
@@ -3494,7 +3483,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_658
       type: string
@@ -3505,9 +3494,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_659
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_668
+    - !<!StringSchema> &ref_669
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3517,17 +3517,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_670
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-owner
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_671
       type: string
@@ -3538,7 +3527,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-group
+          header: x-ms-owner
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_672
       type: string
@@ -3549,7 +3538,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-permissions
+          header: x-ms-group
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_673
       type: string
@@ -3560,7 +3549,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-acl
+          header: x-ms-permissions
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_674
       type: string
@@ -3571,7 +3560,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-acl
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_675
       type: string
@@ -3582,7 +3571,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_676
       type: string
@@ -3593,7 +3582,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_677
       type: string
@@ -3604,7 +3593,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_678
       type: string
@@ -3615,9 +3604,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_679
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_705
+    - !<!StringSchema> &ref_706
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3628,17 +3628,6 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_707
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_708
       type: string
       apiVersions:
@@ -3648,7 +3637,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_709
       type: string
@@ -3659,9 +3648,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_712
+    - !<!StringSchema> &ref_710
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3670,7 +3659,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_713
       type: string
@@ -3681,9 +3670,251 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_714
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_715
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_724
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: ETag
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_975
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-client-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_976
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_977
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_980
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_981
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-error-code
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1185
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: ETag
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1188
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-client-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1189
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1190
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1193
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1194
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-error-code
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1284
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: ETag
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1287
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-client-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1288
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1289
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1292
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1293
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-error-code
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_719
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-client-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_720
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_721
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3703,64 +3934,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_974
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_975
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_976
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_979
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-encryption-key-sha256
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_980
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1184
+    - !<!StringSchema> &ref_739
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3770,193 +3946,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1187
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1188
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1189
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1192
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-encryption-key-sha256
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1193
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1283
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1286
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1287
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1288
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1291
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-encryption-key-sha256
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1292
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_718
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_719
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_720
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_722
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_738
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_741
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_742
       type: string
@@ -3967,7 +3956,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_743
       type: string
@@ -3978,9 +3967,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_744
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_745
+    - !<!StringSchema> &ref_746
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3991,7 +3991,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_756
+    - !<!StringSchema> &ref_757
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4001,17 +4001,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_758
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_759
       type: string
@@ -4022,7 +4011,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_760
       type: string
@@ -4033,9 +4022,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_763
+    - !<!StringSchema> &ref_761
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4044,7 +4033,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_764
       type: string
@@ -4055,9 +4044,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_765
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_773
+    - !<!StringSchema> &ref_774
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4067,17 +4067,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_775
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_776
       type: string
@@ -4088,7 +4077,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_777
       type: string
@@ -4099,7 +4088,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_778
       type: string
@@ -4110,9 +4099,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_779
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_780
+    - !<!StringSchema> &ref_781
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4123,7 +4123,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_788
+    - !<!StringSchema> &ref_789
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4133,17 +4133,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_790
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_791
       type: string
@@ -4154,7 +4143,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_792
       type: string
@@ -4165,9 +4154,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_793
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_794
+    - !<!StringSchema> &ref_795
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4178,7 +4178,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_802
+    - !<!StringSchema> &ref_803
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4188,17 +4188,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_804
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_805
       type: string
@@ -4209,7 +4198,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_806
       type: string
@@ -4220,7 +4209,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_807
       type: string
@@ -4231,9 +4220,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_808
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_809
+    - !<!StringSchema> &ref_810
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4244,7 +4244,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_818
+    - !<!StringSchema> &ref_819
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4254,17 +4254,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_820
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_821
       type: string
@@ -4275,7 +4264,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_822
       type: string
@@ -4286,7 +4275,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-lease-id
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_823
       type: string
@@ -4297,9 +4286,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-lease-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_824
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_825
+    - !<!StringSchema> &ref_826
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4310,7 +4310,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_833
+    - !<!StringSchema> &ref_834
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4320,17 +4320,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_836
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_837
       type: string
@@ -4341,7 +4330,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_838
       type: string
@@ -4352,9 +4341,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_839
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_840
+    - !<!StringSchema> &ref_841
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4364,17 +4364,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_852
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-snapshot
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_853
       type: string
@@ -4385,9 +4374,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: x-ms-snapshot
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_855
+    - !<!StringSchema> &ref_854
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4396,7 +4385,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_856
       type: string
@@ -4407,7 +4396,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_857
       type: string
@@ -4418,9 +4407,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_858
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_860
+    - !<!StringSchema> &ref_861
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4431,7 +4431,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_878
+    - !<!StringSchema> &ref_879
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4441,17 +4441,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_880
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_881
       type: string
@@ -4462,7 +4451,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_882
       type: string
@@ -4473,9 +4462,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_884
+    - !<!StringSchema> &ref_883
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4484,7 +4473,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_885
       type: string
@@ -4495,9 +4484,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-copy-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_886
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_903
+    - !<!StringSchema> &ref_904
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4508,17 +4508,6 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_905
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_906
       type: string
       apiVersions:
@@ -4528,7 +4517,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_907
       type: string
@@ -4539,9 +4528,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_908
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_909
+    - !<!StringSchema> &ref_910
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4552,7 +4552,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_913
+    - !<!StringSchema> &ref_914
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4563,7 +4563,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_916
+    - !<!StringSchema> &ref_917
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4573,17 +4573,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_921
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_922
       type: string
@@ -4594,9 +4583,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_923
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_924
+    - !<!StringSchema> &ref_925
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4606,17 +4606,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_931
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_932
       type: string
@@ -4627,7 +4616,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_933
       type: string
@@ -4638,7 +4627,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_934
       type: string
@@ -4649,7 +4638,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_935
       type: string
@@ -4660,7 +4649,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_936
       type: string
@@ -4671,7 +4660,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_937
       type: string
@@ -4682,7 +4671,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_938
       type: string
@@ -4693,7 +4682,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_939
       type: string
@@ -4704,7 +4693,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_940
       type: string
@@ -4715,9 +4704,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_941
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_942
+    - !<!StringSchema> &ref_943
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4728,7 +4728,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1294
+    - !<!StringSchema> &ref_1295
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4738,17 +4738,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1307
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1308
       type: string
@@ -4759,9 +4748,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1312
+    - !<!StringSchema> &ref_1309
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4770,7 +4759,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1313
       type: string
@@ -4781,9 +4770,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1314
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1225
+    - !<!StringSchema> &ref_1226
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4794,7 +4794,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1331
+    - !<!StringSchema> &ref_1332
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4805,7 +4805,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1332
+    - !<!StringSchema> &ref_1333
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4816,7 +4816,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1335
+    - !<!StringSchema> &ref_1336
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4827,7 +4827,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1336
+    - !<!StringSchema> &ref_1337
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4886,7 +4886,7 @@ schemas: !<!Schemas>
           name: BlockLookupList-LatestItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1359
+    - !<!StringSchema> &ref_1360
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4896,17 +4896,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1363
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1364
       type: string
@@ -4917,7 +4906,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1365
       type: string
@@ -4928,9 +4917,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1368
+    - !<!StringSchema> &ref_1366
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4939,7 +4928,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1369
       type: string
@@ -4950,9 +4939,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1377
+    - !<!StringSchema> &ref_1370
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4961,7 +4950,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1378
       type: string
@@ -4972,9 +4961,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Type
+          header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1380
+    - !<!StringSchema> &ref_1379
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4983,7 +4972,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1381
       type: string
@@ -4994,9 +4983,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1382
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1383
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5017,7 +5017,7 @@ schemas: !<!Schemas>
           name: Block-Name
           description: The base64 encoded block ID.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1385
+    - !<!StringSchema> &ref_1386
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5028,7 +5028,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1004
+    - !<!StringSchema> &ref_1005
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5038,17 +5038,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1008
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1009
       type: string
@@ -5059,7 +5048,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1010
       type: string
@@ -5070,9 +5059,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1013
+    - !<!StringSchema> &ref_1011
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5081,7 +5070,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1014
       type: string
@@ -5092,9 +5081,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1015
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1033
+    - !<!StringSchema> &ref_1034
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5104,17 +5104,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1038
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1039
       type: string
@@ -5125,7 +5114,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1040
       type: string
@@ -5136,9 +5125,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1042
+    - !<!StringSchema> &ref_1041
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5147,7 +5136,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1043
       type: string
@@ -5158,9 +5147,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1071
+    - !<!StringSchema> &ref_1044
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5169,7 +5158,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1072
       type: string
@@ -5180,9 +5169,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1075
+    - !<!StringSchema> &ref_1073
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5191,7 +5180,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1076
       type: string
@@ -5202,9 +5191,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1077
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1088
+    - !<!StringSchema> &ref_1089
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5214,17 +5214,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1090
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1091
       type: string
@@ -5235,7 +5224,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1092
       type: string
@@ -5246,9 +5235,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1095
+    - !<!StringSchema> &ref_1093
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5257,7 +5246,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1096
       type: string
@@ -5268,9 +5257,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1109
+    - !<!StringSchema> &ref_1097
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5279,7 +5268,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-client-request-id
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1110
       type: string
@@ -5290,7 +5279,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1111
       type: string
@@ -5301,9 +5290,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1112
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1113
+    - !<!StringSchema> &ref_1114
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5314,7 +5314,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1124
+    - !<!StringSchema> &ref_1125
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5324,17 +5324,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1127
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1128
       type: string
@@ -5345,7 +5334,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1129
       type: string
@@ -5356,9 +5345,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1130
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1131
+    - !<!StringSchema> &ref_1132
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5369,7 +5369,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1142
+    - !<!StringSchema> &ref_1143
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5379,17 +5379,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1145
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1146
       type: string
@@ -5400,7 +5389,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1147
       type: string
@@ -5411,9 +5400,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1148
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1149
+    - !<!StringSchema> &ref_1150
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5424,7 +5424,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1158
+    - !<!StringSchema> &ref_1159
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5434,17 +5434,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1160
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1161
       type: string
@@ -5455,7 +5444,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1162
       type: string
@@ -5466,9 +5455,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1164
+    - !<!StringSchema> &ref_1163
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5477,7 +5466,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-copy-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1165
       type: string
@@ -5488,9 +5477,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-copy-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1166
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1212
+    - !<!StringSchema> &ref_1213
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5500,17 +5500,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1216
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1217
       type: string
@@ -5521,7 +5510,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1218
       type: string
@@ -5532,9 +5521,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1219
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1220
+    - !<!StringSchema> &ref_1221
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5544,17 +5544,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-blob-append-offset
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1223
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1224
       type: string
@@ -5565,9 +5554,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1225
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1249
+    - !<!StringSchema> &ref_1250
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5578,7 +5578,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1253
+    - !<!StringSchema> &ref_1254
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5589,7 +5589,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1254
+    - !<!StringSchema> &ref_1255
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5600,7 +5600,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1256
+    - !<!StringSchema> &ref_1257
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5611,7 +5611,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-append-offset
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1258
+    - !<!StringSchema> &ref_1259
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5622,7 +5622,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1260
+    - !<!StringSchema> &ref_1261
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5832,7 +5832,7 @@ schemas: !<!Schemas>
           name: ArchiveStatus
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_944
+    - !<!ChoiceSchema> &ref_945
       choices:
         - !<!ChoiceValue> 
           value: P4
@@ -5910,7 +5910,7 @@ schemas: !<!Schemas>
           name: PremiumPageBlobAccessTier
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_861
+    - !<!ChoiceSchema> &ref_862
       choices:
         - !<!ChoiceValue> 
           value: High
@@ -6700,7 +6700,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-lease-duration
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_191
+    - !<!SealedChoiceSchema> &ref_192
       choices:
         - !<!ChoiceValue> 
           value: Standard_LRS
@@ -6743,7 +6743,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-sku-name
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_192
+    - !<!SealedChoiceSchema> &ref_193
       choices:
         - !<!ChoiceValue> 
           value: Storage
@@ -6884,7 +6884,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-status
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_414
+    - !<!SealedChoiceSchema> &ref_415
       choices:
         - !<!ChoiceValue> 
           value: legacy
@@ -6908,7 +6908,7 @@ schemas: !<!Schemas>
           name: PathRenameMode
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_625
+    - !<!SealedChoiceSchema> &ref_626
       choices:
         - !<!ChoiceValue> 
           value: include
@@ -6932,7 +6932,7 @@ schemas: !<!Schemas>
           name: DeleteSnapshotsOptionType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_1370
+    - !<!SealedChoiceSchema> &ref_1371
       choices:
         - !<!ChoiceValue> 
           value: committed
@@ -6963,7 +6963,7 @@ schemas: !<!Schemas>
           name: BlockListType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_1132
+    - !<!SealedChoiceSchema> &ref_1133
       choices:
         - !<!ChoiceValue> 
           value: max
@@ -7024,7 +7024,17 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_154
+    - !<!ConstantSchema> &ref_141
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/xml
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/xml'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_155
       type: constant
       value: !<!ConstantValue> 
         value: stats
@@ -7034,7 +7044,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_163
+    - !<!ConstantSchema> &ref_164
       type: constant
       value: !<!ConstantValue> 
         value: list
@@ -7044,7 +7054,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_166
+    - !<!ConstantSchema> &ref_167
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -7057,7 +7067,7 @@ schemas: !<!Schemas>
           name: ListContainersIncludeType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_175
+    - !<!ConstantSchema> &ref_176
       type: constant
       value: !<!ConstantValue> 
         value: userdelegationkey
@@ -7067,7 +7077,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_186
+    - !<!ConstantSchema> &ref_187
       type: constant
       value: !<!ConstantValue> 
         value: account
@@ -7077,7 +7087,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_194
+    - !<!ConstantSchema> &ref_195
       type: constant
       value: !<!ConstantValue> 
         value: batch
@@ -7087,7 +7097,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_206
+    - !<!ConstantSchema> &ref_207
       type: constant
       value: !<!ConstantValue> 
         value: container
@@ -7097,7 +7107,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_242
+    - !<!ConstantSchema> &ref_243
       type: constant
       value: !<!ConstantValue> 
         value: metadata
@@ -7107,7 +7117,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_256
+    - !<!ConstantSchema> &ref_257
       type: constant
       value: !<!ConstantValue> 
         value: acl
@@ -7117,7 +7127,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_283
+    - !<!ConstantSchema> &ref_284
       type: constant
       value: !<!ConstantValue> 
         value: lease
@@ -7127,7 +7137,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_284
+    - !<!ConstantSchema> &ref_285
       type: constant
       value: !<!ConstantValue> 
         value: acquire
@@ -7137,7 +7147,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_300
+    - !<!ConstantSchema> &ref_301
       type: constant
       value: !<!ConstantValue> 
         value: release
@@ -7147,7 +7157,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_313
+    - !<!ConstantSchema> &ref_314
       type: constant
       value: !<!ConstantValue> 
         value: renew
@@ -7157,7 +7167,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_327
+    - !<!ConstantSchema> &ref_328
       type: constant
       value: !<!ConstantValue> 
         value: break
@@ -7167,7 +7177,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_340
+    - !<!ConstantSchema> &ref_341
       type: constant
       value: !<!ConstantValue> 
         value: change
@@ -7177,7 +7187,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_387
+    - !<!ConstantSchema> &ref_388
       type: constant
       value: !<!ConstantValue> 
         value: directory
@@ -7187,7 +7197,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_472
+    - !<!ConstantSchema> &ref_473
       type: constant
       value: !<!ConstantValue> 
         value: setAccessControl
@@ -7197,7 +7207,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_492
+    - !<!ConstantSchema> &ref_493
       type: constant
       value: !<!ConstantValue> 
         value: getAccessControl
@@ -7207,7 +7217,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_514
+    - !<!ConstantSchema> &ref_515
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -7220,7 +7230,7 @@ schemas: !<!Schemas>
           name: EncryptionAlgorithmType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_943
+    - !<!ConstantSchema> &ref_944
       type: constant
       value: !<!ConstantValue> 
         value: PageBlob
@@ -7230,7 +7240,7 @@ schemas: !<!Schemas>
           name: BlobType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1166
+    - !<!ConstantSchema> &ref_1167
       type: constant
       value: !<!ConstantValue> 
         value: AppendBlob
@@ -7240,7 +7250,7 @@ schemas: !<!Schemas>
           name: BlobType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1261
+    - !<!ConstantSchema> &ref_1262
       type: constant
       value: !<!ConstantValue> 
         value: BlockBlob
@@ -7250,7 +7260,7 @@ schemas: !<!Schemas>
           name: BlobType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_715
+    - !<!ConstantSchema> &ref_716
       type: constant
       value: !<!ConstantValue> 
         value: undelete
@@ -7260,7 +7270,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_841
+    - !<!ConstantSchema> &ref_842
       type: constant
       value: !<!ConstantValue> 
         value: snapshot
@@ -7270,7 +7280,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_886
+    - !<!ConstantSchema> &ref_887
       type: constant
       value: !<!ConstantValue> 
         value: 'true'
@@ -7280,7 +7290,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_910
+    - !<!ConstantSchema> &ref_911
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -7294,7 +7304,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-status
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_914
+    - !<!ConstantSchema> &ref_915
       type: constant
       value: !<!ConstantValue> 
         value: copy
@@ -7304,7 +7314,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_915
+    - !<!ConstantSchema> &ref_916
       type: constant
       value: !<!ConstantValue> 
         value: abort
@@ -7314,7 +7324,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_925
+    - !<!ConstantSchema> &ref_926
       type: constant
       value: !<!ConstantValue> 
         value: tier
@@ -7324,7 +7334,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1293
+    - !<!ConstantSchema> &ref_1294
       type: constant
       value: !<!ConstantValue> 
         value: block
@@ -7334,7 +7344,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1337
+    - !<!ConstantSchema> &ref_1338
       type: constant
       value: !<!ConstantValue> 
         value: blocklist
@@ -7344,7 +7354,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_981
+    - !<!ConstantSchema> &ref_982
       type: constant
       value: !<!ConstantValue> 
         value: page
@@ -7354,7 +7364,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_982
+    - !<!ConstantSchema> &ref_983
       type: constant
       value: !<!ConstantValue> 
         value: update
@@ -7364,7 +7374,7 @@ schemas: !<!Schemas>
           name: PageWriteType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1015
+    - !<!ConstantSchema> &ref_1016
       type: constant
       value: !<!ConstantValue> 
         value: clear
@@ -7374,7 +7384,7 @@ schemas: !<!Schemas>
           name: PageWriteType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1077
+    - !<!ConstantSchema> &ref_1078
       type: constant
       value: !<!ConstantValue> 
         value: pagelist
@@ -7384,7 +7394,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1150
+    - !<!ConstantSchema> &ref_1151
       type: constant
       value: !<!ConstantValue> 
         value: incrementalcopy
@@ -7394,7 +7404,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1194
+    - !<!ConstantSchema> &ref_1195
       type: constant
       value: !<!ConstantValue> 
         value: appendblock
@@ -7422,7 +7432,7 @@ schemas: !<!Schemas>
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
   binaries:
-    - !<!BinarySchema> &ref_201
+    - !<!BinarySchema> &ref_202
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7432,7 +7442,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_1281
+    - !<!BinarySchema> &ref_1282
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7442,7 +7452,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_1304
+    - !<!BinarySchema> &ref_1305
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7452,7 +7462,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_1002
+    - !<!BinarySchema> &ref_1003
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7462,7 +7472,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_1210
+    - !<!BinarySchema> &ref_1211
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7484,7 +7494,7 @@ schemas: !<!Schemas>
           name: BlobProperties-Content-MD5
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_533
+    - !<!ByteArraySchema> &ref_534
       type: byte-array
       format: byte
       apiVersions:
@@ -7496,7 +7506,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_551
+    - !<!ByteArraySchema> &ref_552
       type: byte-array
       format: byte
       apiVersions:
@@ -7508,7 +7518,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-content-md5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_558
+    - !<!ByteArraySchema> &ref_559
       type: byte-array
       format: byte
       apiVersions:
@@ -7520,7 +7530,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_564
+    - !<!ByteArraySchema> &ref_565
       type: byte-array
       format: byte
       apiVersions:
@@ -7532,7 +7542,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_578
+    - !<!ByteArraySchema> &ref_579
       type: byte-array
       format: byte
       apiVersions:
@@ -7544,7 +7554,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-content-md5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_606
+    - !<!ByteArraySchema> &ref_607
       type: byte-array
       format: byte
       apiVersions:
@@ -7556,7 +7566,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_724
+    - !<!ByteArraySchema> &ref_725
       type: byte-array
       format: byte
       apiVersions:
@@ -7567,7 +7577,7 @@ schemas: !<!Schemas>
           name: components·16jr1zi·parameters·blobcontentmd5·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_973
+    - !<!ByteArraySchema> &ref_974
       type: byte-array
       format: byte
       apiVersions:
@@ -7579,7 +7589,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1186
+    - !<!ByteArraySchema> &ref_1187
       type: byte-array
       format: byte
       apiVersions:
@@ -7591,7 +7601,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_983
+    - !<!ByteArraySchema> &ref_984
       type: byte-array
       format: byte
       apiVersions:
@@ -7602,7 +7612,7 @@ schemas: !<!Schemas>
           name: components·18jrsfm·parameters·contentmd5·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1285
+    - !<!ByteArraySchema> &ref_1286
       type: byte-array
       format: byte
       apiVersions:
@@ -7614,7 +7624,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_887
+    - !<!ByteArraySchema> &ref_888
       type: byte-array
       format: byte
       apiVersions:
@@ -7625,7 +7635,7 @@ schemas: !<!Schemas>
           name: components·1t0oq3p·parameters·sourcecontentmd5·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_911
+    - !<!ByteArraySchema> &ref_912
       type: byte-array
       format: byte
       apiVersions:
@@ -7637,7 +7647,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_912
+    - !<!ByteArraySchema> &ref_913
       type: byte-array
       format: byte
       apiVersions:
@@ -7649,7 +7659,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_984
+    - !<!ByteArraySchema> &ref_985
       type: byte-array
       format: byte
       apiVersions:
@@ -7660,7 +7670,7 @@ schemas: !<!Schemas>
           name: components·rar3zb·parameters·contentcrc64·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1306
+    - !<!ByteArraySchema> &ref_1307
       type: byte-array
       format: byte
       apiVersions:
@@ -7672,7 +7682,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1310
+    - !<!ByteArraySchema> &ref_1311
       type: byte-array
       format: byte
       apiVersions:
@@ -7684,7 +7694,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1044
+    - !<!ByteArraySchema> &ref_1045
       type: byte-array
       format: byte
       apiVersions:
@@ -7695,7 +7705,7 @@ schemas: !<!Schemas>
           name: components·1rd7mnm·parameters·sourcecontentcrc64·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1329
+    - !<!ByteArraySchema> &ref_1330
       type: byte-array
       format: byte
       apiVersions:
@@ -7707,7 +7717,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1330
+    - !<!ByteArraySchema> &ref_1331
       type: byte-array
       format: byte
       apiVersions:
@@ -7719,7 +7729,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1361
+    - !<!ByteArraySchema> &ref_1362
       type: byte-array
       format: byte
       apiVersions:
@@ -7731,7 +7741,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1362
+    - !<!ByteArraySchema> &ref_1363
       type: byte-array
       format: byte
       apiVersions:
@@ -7743,7 +7753,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1006
+    - !<!ByteArraySchema> &ref_1007
       type: byte-array
       format: byte
       apiVersions:
@@ -7755,7 +7765,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1007
+    - !<!ByteArraySchema> &ref_1008
       type: byte-array
       format: byte
       apiVersions:
@@ -7767,7 +7777,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1035
+    - !<!ByteArraySchema> &ref_1036
       type: byte-array
       format: byte
       apiVersions:
@@ -7779,7 +7789,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1036
+    - !<!ByteArraySchema> &ref_1037
       type: byte-array
       format: byte
       apiVersions:
@@ -7791,7 +7801,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1068
+    - !<!ByteArraySchema> &ref_1069
       type: byte-array
       format: byte
       apiVersions:
@@ -7803,7 +7813,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1069
+    - !<!ByteArraySchema> &ref_1070
       type: byte-array
       format: byte
       apiVersions:
@@ -7815,7 +7825,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1214
+    - !<!ByteArraySchema> &ref_1215
       type: byte-array
       format: byte
       apiVersions:
@@ -7827,7 +7837,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1215
+    - !<!ByteArraySchema> &ref_1216
       type: byte-array
       format: byte
       apiVersions:
@@ -7839,7 +7849,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1251
+    - !<!ByteArraySchema> &ref_1252
       type: byte-array
       format: byte
       apiVersions:
@@ -7851,7 +7861,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1252
+    - !<!ByteArraySchema> &ref_1253
       type: byte-array
       format: byte
       apiVersions:
@@ -7864,7 +7874,7 @@ schemas: !<!Schemas>
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
   dateTimes:
-    - !<!DateTimeSchema> &ref_160
+    - !<!DateTimeSchema> &ref_161
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7898,7 +7908,7 @@ schemas: !<!Schemas>
           name: ContainerProperties-Last-Modified
           description: ''
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_183
+    - !<!DateTimeSchema> &ref_184
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7932,7 +7942,7 @@ schemas: !<!Schemas>
           name: UserDelegationKey-SignedExpiry
           description: The date-time the key expires
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_190
+    - !<!DateTimeSchema> &ref_191
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7944,7 +7954,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_212
+    - !<!DateTimeSchema> &ref_213
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7956,7 +7966,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_216
+    - !<!DateTimeSchema> &ref_217
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7968,7 +7978,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_223
+    - !<!DateTimeSchema> &ref_224
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7980,7 +7990,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_227
+    - !<!DateTimeSchema> &ref_228
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7992,7 +8002,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_232
+    - !<!DateTimeSchema> &ref_233
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8004,7 +8014,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_250
+    - !<!DateTimeSchema> &ref_251
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8016,7 +8026,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_254
+    - !<!DateTimeSchema> &ref_255
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8028,7 +8038,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_261
+    - !<!DateTimeSchema> &ref_262
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8040,7 +8050,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_265
+    - !<!DateTimeSchema> &ref_266
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8074,7 +8084,7 @@ schemas: !<!Schemas>
           name: AccessPolicy-Expiry
           description: the date-time the policy expires
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_277
+    - !<!DateTimeSchema> &ref_278
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8086,7 +8096,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_281
+    - !<!DateTimeSchema> &ref_282
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8098,7 +8108,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_293
+    - !<!DateTimeSchema> &ref_294
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8110,7 +8120,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_298
+    - !<!DateTimeSchema> &ref_299
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8122,7 +8132,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_307
+    - !<!DateTimeSchema> &ref_308
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8134,7 +8144,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_311
+    - !<!DateTimeSchema> &ref_312
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8146,7 +8156,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_320
+    - !<!DateTimeSchema> &ref_321
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8158,7 +8168,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_325
+    - !<!DateTimeSchema> &ref_326
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8170,7 +8180,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_334
+    - !<!DateTimeSchema> &ref_335
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8182,7 +8192,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_338
+    - !<!DateTimeSchema> &ref_339
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8194,7 +8204,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_348
+    - !<!DateTimeSchema> &ref_349
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8206,7 +8216,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_353
+    - !<!DateTimeSchema> &ref_354
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8218,7 +8228,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_366
+    - !<!DateTimeSchema> &ref_367
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8285,7 +8295,7 @@ schemas: !<!Schemas>
           name: BlobProperties-AccessTierChangeTime
           description: ''
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_379
+    - !<!DateTimeSchema> &ref_380
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8297,7 +8307,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_385
+    - !<!DateTimeSchema> &ref_386
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8309,7 +8319,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_404
+    - !<!DateTimeSchema> &ref_405
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8321,7 +8331,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_408
+    - !<!DateTimeSchema> &ref_409
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8333,7 +8343,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_422
+    - !<!DateTimeSchema> &ref_423
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8345,7 +8355,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_450
+    - !<!DateTimeSchema> &ref_451
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8357,19 +8367,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_468
-      type: date-time
-      format: date-time-rfc1123
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: date-time
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_485
+    - !<!DateTimeSchema> &ref_469
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8391,9 +8389,21 @@ schemas: !<!Schemas>
         default:
           name: date-time
           description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!DateTimeSchema> &ref_487
+      type: date-time
+      format: date-time-rfc1123
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: date-time
+          description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_501
+    - !<!DateTimeSchema> &ref_502
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8405,7 +8415,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_503
+    - !<!DateTimeSchema> &ref_504
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8417,7 +8427,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_528
+    - !<!DateTimeSchema> &ref_529
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8429,7 +8439,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_539
+    - !<!DateTimeSchema> &ref_540
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8441,7 +8451,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-completion-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_548
+    - !<!DateTimeSchema> &ref_549
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8453,7 +8463,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_552
+    - !<!DateTimeSchema> &ref_553
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8465,7 +8475,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_565
+    - !<!DateTimeSchema> &ref_566
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8477,7 +8487,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-completion-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_574
+    - !<!DateTimeSchema> &ref_575
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8488,18 +8498,6 @@ schemas: !<!Schemas>
           name: date-time
           description: ''
           header: Date
-      protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_593
-      type: date-time
-      format: date-time-rfc1123
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: date-time
-          description: ''
-          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!DateTimeSchema> &ref_594
       type: date-time
@@ -8511,9 +8509,21 @@ schemas: !<!Schemas>
         default:
           name: date-time
           description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!DateTimeSchema> &ref_595
+      type: date-time
+      format: date-time-rfc1123
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: date-time
+          description: ''
           header: x-ms-creation-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_596
+    - !<!DateTimeSchema> &ref_597
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8525,7 +8535,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-completion-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_615
+    - !<!DateTimeSchema> &ref_616
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8537,7 +8547,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_623
+    - !<!DateTimeSchema> &ref_624
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8549,7 +8559,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-access-tier-change-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_638
+    - !<!DateTimeSchema> &ref_639
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8561,7 +8571,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_651
+    - !<!DateTimeSchema> &ref_652
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8573,7 +8583,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_653
+    - !<!DateTimeSchema> &ref_654
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8585,7 +8595,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_667
+    - !<!DateTimeSchema> &ref_668
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8597,7 +8607,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_669
+    - !<!DateTimeSchema> &ref_670
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8609,7 +8619,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_706
+    - !<!DateTimeSchema> &ref_707
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8621,7 +8631,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_711
+    - !<!DateTimeSchema> &ref_712
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8633,7 +8643,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_972
+    - !<!DateTimeSchema> &ref_973
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8645,7 +8655,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_977
+    - !<!DateTimeSchema> &ref_978
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8657,7 +8667,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1185
+    - !<!DateTimeSchema> &ref_1186
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8669,7 +8679,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1190
+    - !<!DateTimeSchema> &ref_1191
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8681,7 +8691,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1284
+    - !<!DateTimeSchema> &ref_1285
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8693,7 +8703,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1289
+    - !<!DateTimeSchema> &ref_1290
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8705,7 +8715,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_721
+    - !<!DateTimeSchema> &ref_722
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8717,7 +8727,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_739
+    - !<!DateTimeSchema> &ref_740
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8729,7 +8739,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_744
+    - !<!DateTimeSchema> &ref_745
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8741,7 +8751,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_757
+    - !<!DateTimeSchema> &ref_758
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8753,7 +8763,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_761
+    - !<!DateTimeSchema> &ref_762
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8765,7 +8775,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_774
+    - !<!DateTimeSchema> &ref_775
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8777,7 +8787,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_779
+    - !<!DateTimeSchema> &ref_780
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8789,7 +8799,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_789
+    - !<!DateTimeSchema> &ref_790
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8801,7 +8811,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_793
+    - !<!DateTimeSchema> &ref_794
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8813,7 +8823,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_803
+    - !<!DateTimeSchema> &ref_804
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8825,7 +8835,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_808
+    - !<!DateTimeSchema> &ref_809
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8837,7 +8847,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_819
+    - !<!DateTimeSchema> &ref_820
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8849,7 +8859,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_824
+    - !<!DateTimeSchema> &ref_825
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8861,7 +8871,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_834
+    - !<!DateTimeSchema> &ref_835
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8873,7 +8883,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_839
+    - !<!DateTimeSchema> &ref_840
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8885,7 +8895,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_854
+    - !<!DateTimeSchema> &ref_855
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8897,7 +8907,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_858
+    - !<!DateTimeSchema> &ref_859
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8909,7 +8919,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_879
+    - !<!DateTimeSchema> &ref_880
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8921,7 +8931,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_883
+    - !<!DateTimeSchema> &ref_884
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8933,7 +8943,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_904
+    - !<!DateTimeSchema> &ref_905
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8945,7 +8955,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_908
+    - !<!DateTimeSchema> &ref_909
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8957,7 +8967,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_923
+    - !<!DateTimeSchema> &ref_924
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8969,7 +8979,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_941
+    - !<!DateTimeSchema> &ref_942
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8981,7 +8991,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1309
+    - !<!DateTimeSchema> &ref_1310
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8993,7 +9003,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1333
+    - !<!DateTimeSchema> &ref_1334
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9005,7 +9015,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1360
+    - !<!DateTimeSchema> &ref_1361
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9017,7 +9027,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1366
+    - !<!DateTimeSchema> &ref_1367
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9029,7 +9039,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1376
+    - !<!DateTimeSchema> &ref_1377
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9041,7 +9051,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1383
+    - !<!DateTimeSchema> &ref_1384
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9053,7 +9063,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1005
+    - !<!DateTimeSchema> &ref_1006
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9065,7 +9075,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1011
+    - !<!DateTimeSchema> &ref_1012
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9077,7 +9087,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1034
+    - !<!DateTimeSchema> &ref_1035
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9089,7 +9099,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1041
+    - !<!DateTimeSchema> &ref_1042
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9101,7 +9111,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1067
+    - !<!DateTimeSchema> &ref_1068
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9113,7 +9123,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1073
+    - !<!DateTimeSchema> &ref_1074
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9125,7 +9135,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1087
+    - !<!DateTimeSchema> &ref_1088
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9137,7 +9147,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1093
+    - !<!DateTimeSchema> &ref_1094
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9149,7 +9159,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1107
+    - !<!DateTimeSchema> &ref_1108
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9161,7 +9171,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1112
+    - !<!DateTimeSchema> &ref_1113
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9173,7 +9183,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1125
+    - !<!DateTimeSchema> &ref_1126
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9185,7 +9195,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1130
+    - !<!DateTimeSchema> &ref_1131
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9197,7 +9207,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1143
+    - !<!DateTimeSchema> &ref_1144
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9209,7 +9219,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1148
+    - !<!DateTimeSchema> &ref_1149
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9221,7 +9231,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1159
+    - !<!DateTimeSchema> &ref_1160
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9233,7 +9243,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1163
+    - !<!DateTimeSchema> &ref_1164
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9245,7 +9255,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1213
+    - !<!DateTimeSchema> &ref_1214
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9257,7 +9267,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1219
+    - !<!DateTimeSchema> &ref_1220
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9269,7 +9279,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1250
+    - !<!DateTimeSchema> &ref_1251
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9281,7 +9291,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1255
+    - !<!DateTimeSchema> &ref_1256
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9294,7 +9304,7 @@ schemas: !<!Schemas>
           header: Date
       protocol: !<!Protocols> {}
   uris:
-    - !<!UriSchema> &ref_862
+    - !<!UriSchema> &ref_863
       type: uri
       apiVersions:
         - !<!ApiVersion> 
@@ -9653,7 +9663,7 @@ schemas: !<!Schemas>
     - *ref_5
     - *ref_15
     - *ref_16
-    - !<!ObjectSchema> &ref_145
+    - !<!ObjectSchema> &ref_146
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -9677,7 +9687,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_161
+    - !<!ObjectSchema> &ref_162
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -9737,7 +9747,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_18
-    - !<!ObjectSchema> &ref_174
+    - !<!ObjectSchema> &ref_175
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -9966,7 +9976,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_28
     - *ref_29
-    - !<!ObjectSchema> &ref_178
+    - !<!ObjectSchema> &ref_179
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -10000,7 +10010,7 @@ schemas: !<!Schemas>
           description: Key information
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_184
+    - !<!ObjectSchema> &ref_185
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -10164,7 +10174,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_39
-    - !<!ObjectSchema> &ref_367
+    - !<!ObjectSchema> &ref_368
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -10693,7 +10703,7 @@ schemas: !<!Schemas>
     - *ref_68
     - *ref_69
     - *ref_70
-    - !<!ObjectSchema> &ref_380
+    - !<!ObjectSchema> &ref_381
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -10872,7 +10882,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_78
     - *ref_79
-    - !<!ObjectSchema> &ref_412
+    - !<!ObjectSchema> &ref_413
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -10928,7 +10938,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_82
-    - !<!ObjectSchema> &ref_1357
+    - !<!ObjectSchema> &ref_1358
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -11004,7 +11014,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_1384
+    - !<!ObjectSchema> &ref_1385
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -11100,7 +11110,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_88
-    - !<!ObjectSchema> &ref_1094
+    - !<!ObjectSchema> &ref_1095
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -11235,7 +11245,7 @@ schemas: !<!Schemas>
   arrays:
     - *ref_100
     - *ref_101
-    - !<!ArraySchema> &ref_266
+    - !<!ArraySchema> &ref_267
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -11252,7 +11262,7 @@ schemas: !<!Schemas>
           name: SignedIdentifiers
           description: a collection of signed identifiers
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_355
+    - !<!ArraySchema> &ref_356
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -11274,7 +11284,7 @@ schemas: !<!Schemas>
     - *ref_111
     - *ref_112
 globalParameters:
-  - !<!Parameter> &ref_146
+  - !<!Parameter> &ref_147
     schema: *ref_0
     implementation: Client
     required: true
@@ -11293,7 +11303,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_147
+  - !<!Parameter> &ref_148
     schema: *ref_136
     implementation: Client
     required: true
@@ -11307,8 +11317,8 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: header
-  - !<!Parameter> &ref_679
-    schema: *ref_414
+  - !<!Parameter> &ref_680
+    schema: *ref_415
     implementation: Client
     extensions:
       x-ms-priority: 2
@@ -11329,7 +11339,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
             schema: *ref_133
             implementation: Method
@@ -11367,7 +11377,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_147
+          - *ref_148
           - !<!Parameter> &ref_139
             schema: *ref_137
             implementation: Method
@@ -11382,7 +11392,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_141
+              - !<!Parameter> &ref_142
                 schema: *ref_140
                 implementation: Method
                 required: true
@@ -11394,8 +11404,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_141
+              - *ref_142
             language: !<!Languages> 
               default:
                 name: ''
@@ -11428,14 +11451,14 @@ operationGroups:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_142
+                    schema: *ref_143
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_143
+                    schema: *ref_144
                     header: x-ms-version
                     language:
                       default:
@@ -11445,7 +11468,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -11454,7 +11477,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_144
+                    schema: *ref_145
                     header: x-ms-error-code
                     language:
                       default:
@@ -11475,7 +11498,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
             schema: *ref_133
             implementation: Method
@@ -11500,7 +11523,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_148
+          - !<!Parameter> &ref_149
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -11513,8 +11536,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_147
-          - !<!Parameter> &ref_149
+          - *ref_148
+          - !<!Parameter> &ref_150
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -11527,6 +11550,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11537,8 +11575,8 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_148
           - *ref_149
+          - *ref_150
         responses:
           - !<!SchemaResponse> 
             schema: *ref_140
@@ -11550,21 +11588,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_150
+                    schema: *ref_151
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_151
+                    schema: *ref_152
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_152
+                    schema: *ref_153
                     header: x-ms-version
                     language:
                       default:
@@ -11577,7 +11615,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -11586,7 +11624,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_153
+                    schema: *ref_154
                     header: x-ms-error-code
                     language:
                       default:
@@ -11607,7 +11645,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
             schema: *ref_133
             implementation: Method
@@ -11621,7 +11659,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_154
+            schema: *ref_155
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -11632,7 +11670,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_155
+          - !<!Parameter> &ref_156
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -11645,8 +11683,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_147
-          - !<!Parameter> &ref_156
+          - *ref_148
+          - !<!Parameter> &ref_157
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -11659,6 +11697,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11669,11 +11722,11 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_155
           - *ref_156
+          - *ref_157
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_161
+            schema: *ref_162
             language: !<!Languages> 
               default:
                 name: ''
@@ -11682,28 +11735,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_157
+                    schema: *ref_158
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_158
+                    schema: *ref_159
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_159
+                    schema: *ref_160
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_160
+                    schema: *ref_161
                     header: Date
                     language:
                       default:
@@ -11716,7 +11769,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -11725,7 +11778,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_162
+                    schema: *ref_163
                     header: x-ms-error-code
                     language:
                       default:
@@ -11746,9 +11799,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_163
+            schema: *ref_164
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -11759,8 +11812,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_167
-            schema: *ref_164
+          - !<!Parameter> &ref_168
+            schema: *ref_165
             implementation: Method
             language: !<!Languages> 
               default:
@@ -11770,8 +11823,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_168
-            schema: *ref_164
+          - !<!Parameter> &ref_169
+            schema: *ref_165
             implementation: Method
             language: !<!Languages> 
               default:
@@ -11784,8 +11837,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_169
-            schema: *ref_165
+          - !<!Parameter> &ref_170
+            schema: *ref_166
             implementation: Method
             language: !<!Languages> 
               default:
@@ -11799,7 +11852,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_166
+            schema: *ref_167
             implementation: Method
             language: !<!Languages> 
               default:
@@ -11809,7 +11862,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_170
+          - !<!Parameter> &ref_171
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -11822,8 +11875,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_147
-          - !<!Parameter> &ref_171
+          - *ref_148
+          - !<!Parameter> &ref_172
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -11836,6 +11889,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11846,14 +11914,14 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_167
           - *ref_168
           - *ref_169
           - *ref_170
           - *ref_171
+          - *ref_172
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_174
+            schema: *ref_175
             language: !<!Languages> 
               default:
                 name: ''
@@ -11862,21 +11930,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_164
+                    schema: *ref_165
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_172
+                    schema: *ref_173
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_173
+                    schema: *ref_174
                     header: x-ms-version
                     language:
                       default:
@@ -11889,7 +11957,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -11924,7 +11992,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
             schema: *ref_133
             implementation: Method
@@ -11938,7 +12006,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_175
+            schema: *ref_176
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -11949,7 +12017,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_176
+          - !<!Parameter> &ref_177
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -11962,8 +12030,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_147
-          - !<!Parameter> &ref_177
+          - *ref_148
+          - !<!Parameter> &ref_178
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -11977,8 +12045,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_179
-                schema: *ref_178
+              - !<!Parameter> &ref_180
+                schema: *ref_179
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -11989,8 +12057,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_179
+              - *ref_180
             language: !<!Languages> 
               default:
                 name: ''
@@ -12004,11 +12085,11 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_176
           - *ref_177
+          - *ref_178
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_184
+            schema: *ref_185
             language: !<!Languages> 
               default:
                 name: ''
@@ -12017,28 +12098,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_180
+                    schema: *ref_181
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_181
+                    schema: *ref_182
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_182
+                    schema: *ref_183
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_183
+                    schema: *ref_184
                     header: Date
                     language:
                       default:
@@ -12051,7 +12132,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -12060,7 +12141,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_185
+                    schema: *ref_186
                     header: x-ms-error-code
                     language:
                       default:
@@ -12081,9 +12162,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_186
+            schema: *ref_187
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12106,9 +12187,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_147
+          - *ref_148
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12129,42 +12225,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_187
+                    schema: *ref_188
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_188
+                    schema: *ref_189
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_189
+                    schema: *ref_190
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_190
+                    schema: *ref_191
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_191
+                    schema: *ref_192
                     header: x-ms-sku-name
                     language:
                       default:
                         name: SkuName
                         description: Identifies the sku name of the account
                   - !<!HttpHeader> 
-                    schema: *ref_192
+                    schema: *ref_193
                     header: x-ms-account-kind
                     language:
                       default:
@@ -12174,7 +12270,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -12183,7 +12279,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_193
+                    schema: *ref_194
                     header: x-ms-error-code
                     language:
                       default:
@@ -12204,9 +12300,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_194
+            schema: *ref_195
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12217,8 +12313,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_197
-            schema: *ref_195
+          - !<!Parameter> &ref_198
+            schema: *ref_196
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12229,8 +12325,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_198
-            schema: *ref_196
+          - !<!Parameter> &ref_199
+            schema: *ref_197
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12241,7 +12337,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_199
+          - !<!Parameter> &ref_200
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -12254,8 +12350,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_147
-          - !<!Parameter> &ref_200
+          - *ref_148
+          - !<!Parameter> &ref_201
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -12269,8 +12365,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_202
-                schema: *ref_201
+              - !<!Parameter> &ref_203
+                schema: *ref_202
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -12281,8 +12377,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_202
+              - *ref_203
             language: !<!Languages> 
               default:
                 name: ''
@@ -12296,10 +12405,10 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_197
           - *ref_198
           - *ref_199
           - *ref_200
+          - *ref_201
         responses:
           - !<!BinaryResponse> 
             binary: true
@@ -12311,21 +12420,21 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_196
+                    schema: *ref_197
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The media type of the body of the response. For batch requests, this is multipart/mixed; boundary=batchresponse_GUID'
                   - !<!HttpHeader> 
-                    schema: *ref_203
+                    schema: *ref_204
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_204
+                    schema: *ref_205
                     header: x-ms-version
                     language:
                       default:
@@ -12338,7 +12447,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -12347,7 +12456,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_205
+                    schema: *ref_206
                     header: x-ms-error-code
                     language:
                       default:
@@ -12376,9 +12485,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_206
+            schema: *ref_207
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12389,7 +12498,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_208
+          - !<!Parameter> &ref_209
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -12402,8 +12511,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_209
-            schema: *ref_207
+          - !<!Parameter> &ref_210
+            schema: *ref_208
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -12418,7 +12527,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_210
+          - !<!Parameter> &ref_211
             schema: *ref_125
             implementation: Method
             language: !<!Languages> 
@@ -12429,8 +12538,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_211
+          - *ref_148
+          - !<!Parameter> &ref_212
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -12443,6 +12552,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12453,10 +12577,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_208
           - *ref_209
           - *ref_210
           - *ref_211
+          - *ref_212
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -12467,42 +12591,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_207
+                    schema: *ref_208
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_212
+                    schema: *ref_213
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_213
+                    schema: *ref_214
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_214
+                    schema: *ref_215
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_215
+                    schema: *ref_216
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_216
+                    schema: *ref_217
                     header: Date
                     language:
                       default:
@@ -12512,7 +12636,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -12521,7 +12645,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_217
+                    schema: *ref_218
                     header: x-ms-error-code
                     language:
                       default:
@@ -12542,9 +12666,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_206
+            schema: *ref_207
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12555,7 +12679,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_219
+          - !<!Parameter> &ref_220
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -12568,11 +12692,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_220
-            schema: *ref_218
+          - !<!Parameter> &ref_221
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_231
+              x-ms-parameter-grouping: &ref_232
                 name: lease-access-conditions
             language: !<!Languages> 
               default:
@@ -12582,8 +12706,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_221
+          - *ref_148
+          - !<!Parameter> &ref_222
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -12596,6 +12720,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12606,9 +12745,9 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_219
           - *ref_220
           - *ref_221
+          - *ref_222
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -12619,21 +12758,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_218
+                    schema: *ref_219
                     header: x-ms-meta
                     language:
                       default:
                         name: Metadata
                         description: ''
                   - !<!HttpHeader> 
-                    schema: *ref_222
+                    schema: *ref_223
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_223
+                    schema: *ref_224
                     header: Last-Modified
                     language:
                       default:
@@ -12661,28 +12800,28 @@ operationGroups:
                         name: LeaseStatus
                         description: The current lease status of the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_224
+                    schema: *ref_225
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_225
+                    schema: *ref_226
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_226
+                    schema: *ref_227
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_227
+                    schema: *ref_228
                     header: Date
                     language:
                       default:
@@ -12696,14 +12835,14 @@ operationGroups:
                         name: BlobPublicAccess
                         description: Indicated whether data in the container may be accessed publicly and the level of access
                   - !<!HttpHeader> 
-                    schema: *ref_228
+                    schema: *ref_229
                     header: x-ms-has-immutability-policy
                     language:
                       default:
                         name: HasImmutabilityPolicy
                         description: Indicates whether the container has an immutability policy set on it.
                   - !<!HttpHeader> 
-                    schema: *ref_229
+                    schema: *ref_230
                     header: x-ms-has-legal-hold
                     language:
                       default:
@@ -12713,7 +12852,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -12722,7 +12861,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_230
+                    schema: *ref_231
                     header: x-ms-error-code
                     language:
                       default:
@@ -12743,9 +12882,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_206
+            schema: *ref_207
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12756,7 +12895,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_233
+          - !<!Parameter> &ref_234
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -12769,11 +12908,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_234
-            schema: *ref_218
+          - !<!Parameter> &ref_235
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -12782,11 +12921,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_235
-            schema: *ref_232
+          - !<!Parameter> &ref_236
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_243
+              x-ms-parameter-grouping: &ref_244
                 name: modified-access-conditions
             language: !<!Languages> 
               default:
@@ -12796,11 +12935,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_236
-            schema: *ref_232
+          - !<!Parameter> &ref_237
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_268
+              x-ms-parameter-grouping: &ref_269
                 name: modified-access-conditions
             language: !<!Languages> 
               default:
@@ -12810,8 +12949,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_237
+          - *ref_148
+          - !<!Parameter> &ref_238
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -12824,6 +12963,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12834,11 +12988,11 @@ operationGroups:
                 method: delete
                 uri: '{url}'
         signatureParameters:
-          - *ref_233
           - *ref_234
           - *ref_235
           - *ref_236
           - *ref_237
+          - *ref_238
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -12849,28 +13003,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_238
+                    schema: *ref_239
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_239
+                    schema: *ref_240
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_240
+                    schema: *ref_241
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_232
+                    schema: *ref_233
                     header: Date
                     language:
                       default:
@@ -12880,7 +13034,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -12889,7 +13043,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_241
+                    schema: *ref_242
                     header: x-ms-error-code
                     language:
                       default:
@@ -12910,9 +13064,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_206
+            schema: *ref_207
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12924,7 +13078,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_242
+            schema: *ref_243
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -12935,7 +13089,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_244
+          - !<!Parameter> &ref_245
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -12948,11 +13102,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_245
-            schema: *ref_218
+          - !<!Parameter> &ref_246
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -12961,8 +13115,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_246
-            schema: *ref_207
+          - !<!Parameter> &ref_247
+            schema: *ref_208
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -12977,11 +13131,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_247
-            schema: *ref_232
+          - !<!Parameter> &ref_248
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -12990,8 +13144,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_248
+          - *ref_148
+          - !<!Parameter> &ref_249
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -13004,6 +13158,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13014,11 +13183,11 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_244
           - *ref_245
           - *ref_246
           - *ref_247
           - *ref_248
+          - *ref_249
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -13029,42 +13198,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_249
+                    schema: *ref_250
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_250
+                    schema: *ref_251
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_251
+                    schema: *ref_252
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_252
+                    schema: *ref_253
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_253
+                    schema: *ref_254
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_254
+                    schema: *ref_255
                     header: Date
                     language:
                       default:
@@ -13074,7 +13243,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -13083,7 +13252,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_255
+                    schema: *ref_256
                     header: x-ms-error-code
                     language:
                       default:
@@ -13104,9 +13273,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_206
+            schema: *ref_207
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13118,7 +13287,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_256
+            schema: *ref_257
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13129,7 +13298,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_257
+          - !<!Parameter> &ref_258
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -13142,11 +13311,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_258
-            schema: *ref_218
+          - !<!Parameter> &ref_259
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -13155,8 +13324,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_259
+          - *ref_148
+          - !<!Parameter> &ref_260
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -13169,6 +13338,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13179,12 +13363,12 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_257
           - *ref_258
           - *ref_259
+          - *ref_260
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_266
+            schema: *ref_267
             language: !<!Languages> 
               default:
                 name: ''
@@ -13200,42 +13384,42 @@ operationGroups:
                         name: BlobPublicAccess
                         description: Indicated whether data in the container may be accessed publicly and the level of access
                   - !<!HttpHeader> 
-                    schema: *ref_260
+                    schema: *ref_261
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_261
+                    schema: *ref_262
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_262
+                    schema: *ref_263
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_263
+                    schema: *ref_264
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_264
+                    schema: *ref_265
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_265
+                    schema: *ref_266
                     header: Date
                     language:
                       default:
@@ -13248,7 +13432,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -13257,7 +13441,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_267
+                    schema: *ref_268
                     header: x-ms-error-code
                     language:
                       default:
@@ -13278,9 +13462,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_206
+            schema: *ref_207
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13292,7 +13476,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_256
+            schema: *ref_257
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13303,7 +13487,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_269
+          - !<!Parameter> &ref_270
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -13316,11 +13500,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_270
-            schema: *ref_218
+          - !<!Parameter> &ref_271
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -13329,7 +13513,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_271
+          - !<!Parameter> &ref_272
             schema: *ref_125
             implementation: Method
             language: !<!Languages> 
@@ -13340,11 +13524,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_272
-            schema: *ref_232
+          - !<!Parameter> &ref_273
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -13353,11 +13537,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_273
-            schema: *ref_232
+          - !<!Parameter> &ref_274
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -13366,8 +13550,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_274
+          - *ref_148
+          - !<!Parameter> &ref_275
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -13381,8 +13565,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_275
-                schema: *ref_266
+              - !<!Parameter> &ref_276
+                schema: *ref_267
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -13393,8 +13577,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_275
+              - *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13408,12 +13605,12 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_269
           - *ref_270
           - *ref_271
           - *ref_272
           - *ref_273
           - *ref_274
+          - *ref_275
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -13424,42 +13621,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_276
+                    schema: *ref_277
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_277
+                    schema: *ref_278
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_278
+                    schema: *ref_279
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_279
+                    schema: *ref_280
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_280
+                    schema: *ref_281
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_281
+                    schema: *ref_282
                     header: Date
                     language:
                       default:
@@ -13469,7 +13666,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -13478,7 +13675,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_282
+                    schema: *ref_283
                     header: x-ms-error-code
                     language:
                       default:
@@ -13499,9 +13696,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_283
+            schema: *ref_284
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13513,7 +13710,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_206
+            schema: *ref_207
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13525,7 +13722,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_284
+            schema: *ref_285
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13536,7 +13733,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_287
+          - !<!Parameter> &ref_288
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -13549,8 +13746,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_288
-            schema: *ref_285
+          - !<!Parameter> &ref_289
+            schema: *ref_286
             implementation: Method
             language: !<!Languages> 
               default:
@@ -13560,8 +13757,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_289
-            schema: *ref_286
+          - !<!Parameter> &ref_290
+            schema: *ref_287
             implementation: Method
             language: !<!Languages> 
               default:
@@ -13571,11 +13768,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_290
-            schema: *ref_232
+          - !<!Parameter> &ref_291
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -13584,11 +13781,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_291
-            schema: *ref_232
+          - !<!Parameter> &ref_292
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -13597,8 +13794,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_292
+          - *ref_148
+          - !<!Parameter> &ref_293
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -13611,6 +13808,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13621,12 +13833,12 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_287
           - *ref_288
           - *ref_289
           - *ref_290
           - *ref_291
           - *ref_292
+          - *ref_293
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -13637,49 +13849,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_286
+                    schema: *ref_287
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_293
+                    schema: *ref_294
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_294
+                    schema: *ref_295
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a container's lease
                   - !<!HttpHeader> 
-                    schema: *ref_295
+                    schema: *ref_296
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_296
+                    schema: *ref_297
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_297
+                    schema: *ref_298
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_298
+                    schema: *ref_299
                     header: Date
                     language:
                       default:
@@ -13689,7 +13901,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -13698,7 +13910,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_299
+                    schema: *ref_300
                     header: x-ms-error-code
                     language:
                       default:
@@ -13719,9 +13931,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_283
+            schema: *ref_284
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13733,7 +13945,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_206
+            schema: *ref_207
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13745,7 +13957,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_300
+            schema: *ref_301
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13756,7 +13968,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_302
+          - !<!Parameter> &ref_303
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -13769,8 +13981,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_303
-            schema: *ref_301
+          - !<!Parameter> &ref_304
+            schema: *ref_302
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13781,11 +13993,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_304
-            schema: *ref_232
+          - !<!Parameter> &ref_305
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -13794,11 +14006,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_305
-            schema: *ref_232
+          - !<!Parameter> &ref_306
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -13807,8 +14019,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_306
+          - *ref_148
+          - !<!Parameter> &ref_307
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -13821,6 +14033,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13831,11 +14058,11 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_302
           - *ref_303
           - *ref_304
           - *ref_305
           - *ref_306
+          - *ref_307
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -13846,42 +14073,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_301
+                    schema: *ref_302
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_307
+                    schema: *ref_308
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_308
+                    schema: *ref_309
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_309
+                    schema: *ref_310
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_310
+                    schema: *ref_311
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_311
+                    schema: *ref_312
                     header: Date
                     language:
                       default:
@@ -13891,7 +14118,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -13900,7 +14127,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_312
+                    schema: *ref_313
                     header: x-ms-error-code
                     language:
                       default:
@@ -13921,9 +14148,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_283
+            schema: *ref_284
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13935,7 +14162,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_206
+            schema: *ref_207
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13947,7 +14174,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_313
+            schema: *ref_314
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13958,7 +14185,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_314
+          - !<!Parameter> &ref_315
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -13971,8 +14198,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_315
-            schema: *ref_301
+          - !<!Parameter> &ref_316
+            schema: *ref_302
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13983,11 +14210,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_316
-            schema: *ref_232
+          - !<!Parameter> &ref_317
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -13996,11 +14223,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_317
-            schema: *ref_232
+          - !<!Parameter> &ref_318
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -14009,8 +14236,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_318
+          - *ref_148
+          - !<!Parameter> &ref_319
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -14023,6 +14250,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14033,11 +14275,11 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_314
           - *ref_315
           - *ref_316
           - *ref_317
           - *ref_318
+          - *ref_319
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -14048,49 +14290,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_319
+                    schema: *ref_320
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_320
+                    schema: *ref_321
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_321
+                    schema: *ref_322
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a container's lease
                   - !<!HttpHeader> 
-                    schema: *ref_322
+                    schema: *ref_323
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_323
+                    schema: *ref_324
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_324
+                    schema: *ref_325
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_325
+                    schema: *ref_326
                     header: Date
                     language:
                       default:
@@ -14100,7 +14342,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -14109,7 +14351,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_326
+                    schema: *ref_327
                     header: x-ms-error-code
                     language:
                       default:
@@ -14130,9 +14372,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_283
+            schema: *ref_284
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14144,7 +14386,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_206
+            schema: *ref_207
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14156,7 +14398,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_327
+            schema: *ref_328
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14167,7 +14409,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_328
+          - !<!Parameter> &ref_329
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -14180,8 +14422,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_329
-            schema: *ref_285
+          - !<!Parameter> &ref_330
+            schema: *ref_286
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14194,11 +14436,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_330
-            schema: *ref_232
+          - !<!Parameter> &ref_331
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -14207,11 +14449,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_331
-            schema: *ref_232
+          - !<!Parameter> &ref_332
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -14220,8 +14462,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_332
+          - *ref_148
+          - !<!Parameter> &ref_333
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -14234,6 +14476,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14244,11 +14501,11 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_328
           - *ref_329
           - *ref_330
           - *ref_331
           - *ref_332
+          - *ref_333
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -14259,49 +14516,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_333
+                    schema: *ref_334
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_334
+                    schema: *ref_335
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_285
+                    schema: *ref_286
                     header: x-ms-lease-time
                     language:
                       default:
                         name: LeaseTime
                         description: 'Approximate time remaining in the lease period, in seconds.'
                   - !<!HttpHeader> 
-                    schema: *ref_335
+                    schema: *ref_336
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_336
+                    schema: *ref_337
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_337
+                    schema: *ref_338
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_338
+                    schema: *ref_339
                     header: Date
                     language:
                       default:
@@ -14311,7 +14568,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -14320,7 +14577,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_339
+                    schema: *ref_340
                     header: x-ms-error-code
                     language:
                       default:
@@ -14341,9 +14598,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_283
+            schema: *ref_284
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14355,7 +14612,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_206
+            schema: *ref_207
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14367,7 +14624,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_340
+            schema: *ref_341
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14378,7 +14635,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_342
+          - !<!Parameter> &ref_343
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -14391,8 +14648,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_343
-            schema: *ref_301
+          - !<!Parameter> &ref_344
+            schema: *ref_302
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14403,8 +14660,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_344
-            schema: *ref_341
+          - !<!Parameter> &ref_345
+            schema: *ref_342
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14415,11 +14672,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_345
-            schema: *ref_232
+          - !<!Parameter> &ref_346
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -14428,11 +14685,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_346
-            schema: *ref_232
+          - !<!Parameter> &ref_347
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -14441,8 +14698,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_347
+          - *ref_148
+          - !<!Parameter> &ref_348
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -14455,6 +14712,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14465,12 +14737,12 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_342
           - *ref_343
           - *ref_344
           - *ref_345
           - *ref_346
           - *ref_347
+          - *ref_348
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -14481,49 +14753,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_341
+                    schema: *ref_342
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_348
+                    schema: *ref_349
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_349
+                    schema: *ref_350
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a container's lease
                   - !<!HttpHeader> 
-                    schema: *ref_350
+                    schema: *ref_351
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_351
+                    schema: *ref_352
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_352
+                    schema: *ref_353
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_353
+                    schema: *ref_354
                     header: Date
                     language:
                       default:
@@ -14533,7 +14805,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -14542,7 +14814,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_354
+                    schema: *ref_355
                     header: x-ms-error-code
                     language:
                       default:
@@ -14563,9 +14835,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_206
+            schema: *ref_207
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14577,7 +14849,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_163
+            schema: *ref_164
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14588,8 +14860,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_356
-            schema: *ref_164
+          - !<!Parameter> &ref_357
+            schema: *ref_165
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14599,8 +14871,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_357
-            schema: *ref_164
+          - !<!Parameter> &ref_358
+            schema: *ref_165
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14613,8 +14885,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_358
-            schema: *ref_165
+          - !<!Parameter> &ref_359
+            schema: *ref_166
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14627,8 +14899,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_359
-            schema: *ref_355
+          - !<!Parameter> &ref_360
+            schema: *ref_356
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14639,7 +14911,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
                 style: form
-          - !<!Parameter> &ref_360
+          - !<!Parameter> &ref_361
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -14652,8 +14924,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_147
-          - !<!Parameter> &ref_361
+          - *ref_148
+          - !<!Parameter> &ref_362
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -14666,6 +14938,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14676,15 +14963,15 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_356
           - *ref_357
           - *ref_358
           - *ref_359
           - *ref_360
           - *ref_361
+          - *ref_362
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_367
+            schema: *ref_368
             language: !<!Languages> 
               default:
                 name: ''
@@ -14693,35 +14980,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_362
+                    schema: *ref_363
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The media type of the body of the response. For List Blobs this is 'application/xml'
                   - !<!HttpHeader> 
-                    schema: *ref_363
+                    schema: *ref_364
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_364
+                    schema: *ref_365
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_365
+                    schema: *ref_366
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_366
+                    schema: *ref_367
                     header: Date
                     language:
                       default:
@@ -14734,7 +15021,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -14769,9 +15056,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_206
+            schema: *ref_207
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14783,7 +15070,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_163
+            schema: *ref_164
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14794,8 +15081,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_369
-            schema: *ref_164
+          - !<!Parameter> &ref_370
+            schema: *ref_165
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14805,8 +15092,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_370
-            schema: *ref_368
+          - !<!Parameter> &ref_371
+            schema: *ref_369
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14819,8 +15106,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_371
-            schema: *ref_164
+          - !<!Parameter> &ref_372
+            schema: *ref_165
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14833,8 +15120,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_372
-            schema: *ref_165
+          - !<!Parameter> &ref_373
+            schema: *ref_166
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14847,8 +15134,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_373
-            schema: *ref_355
+          - !<!Parameter> &ref_374
+            schema: *ref_356
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14859,7 +15146,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
                 style: form
-          - !<!Parameter> &ref_374
+          - !<!Parameter> &ref_375
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -14872,8 +15159,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_147
-          - !<!Parameter> &ref_375
+          - *ref_148
+          - !<!Parameter> &ref_376
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -14886,6 +15173,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14896,16 +15198,16 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_369
           - *ref_370
           - *ref_371
           - *ref_372
           - *ref_373
           - *ref_374
           - *ref_375
+          - *ref_376
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_380
+            schema: *ref_381
             language: !<!Languages> 
               default:
                 name: ''
@@ -14914,35 +15216,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_368
+                    schema: *ref_369
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The media type of the body of the response. For List Blobs this is 'application/xml'
                   - !<!HttpHeader> 
-                    schema: *ref_376
+                    schema: *ref_377
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_377
+                    schema: *ref_378
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_378
+                    schema: *ref_379
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_379
+                    schema: *ref_380
                     header: Date
                     language:
                       default:
@@ -14955,7 +15257,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -14964,7 +15266,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_381
+                    schema: *ref_382
                     header: x-ms-error-code
                     language:
                       default:
@@ -14990,9 +15292,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_186
+            schema: *ref_187
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15015,9 +15317,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_147
+          - *ref_148
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15038,42 +15355,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_382
+                    schema: *ref_383
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_383
+                    schema: *ref_384
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_384
+                    schema: *ref_385
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_385
+                    schema: *ref_386
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_191
+                    schema: *ref_192
                     header: x-ms-sku-name
                     language:
                       default:
                         name: SkuName
                         description: Identifies the sku name of the account
                   - !<!HttpHeader> 
-                    schema: *ref_192
+                    schema: *ref_193
                     header: x-ms-account-kind
                     language:
                       default:
@@ -15083,7 +15400,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -15092,7 +15409,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_386
+                    schema: *ref_387
                     header: x-ms-error-code
                     language:
                       default:
@@ -15121,9 +15438,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_387
+            schema: *ref_388
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15134,7 +15451,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_389
+          - !<!Parameter> &ref_390
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -15147,8 +15464,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_390
-            schema: *ref_388
+          - !<!Parameter> &ref_391
+            schema: *ref_389
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15158,8 +15475,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_391
-            schema: *ref_388
+          - !<!Parameter> &ref_392
+            schema: *ref_389
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15171,8 +15488,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_392
-            schema: *ref_388
+          - !<!Parameter> &ref_393
+            schema: *ref_389
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15185,11 +15502,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_393
-            schema: *ref_388
+          - !<!Parameter> &ref_394
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_415
+              x-ms-parameter-grouping: &ref_416
                 name: directory-http-headers
             language: !<!Languages> 
               default:
@@ -15199,11 +15516,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_394
-            schema: *ref_388
+          - !<!Parameter> &ref_395
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_416
+              x-ms-parameter-grouping: &ref_417
                 name: directory-http-headers
             language: !<!Languages> 
               default:
@@ -15213,11 +15530,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_395
-            schema: *ref_388
+          - !<!Parameter> &ref_396
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_417
+              x-ms-parameter-grouping: &ref_418
                 name: directory-http-headers
             language: !<!Languages> 
               default:
@@ -15227,11 +15544,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_396
-            schema: *ref_388
+          - !<!Parameter> &ref_397
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_418
+              x-ms-parameter-grouping: &ref_419
                 name: directory-http-headers
             language: !<!Languages> 
               default:
@@ -15241,11 +15558,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_397
-            schema: *ref_388
+          - !<!Parameter> &ref_398
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_419
+              x-ms-parameter-grouping: &ref_420
                 name: directory-http-headers
             language: !<!Languages> 
               default:
@@ -15255,11 +15572,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_398
-            schema: *ref_218
+          - !<!Parameter> &ref_399
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -15268,11 +15585,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_399
-            schema: *ref_232
+          - !<!Parameter> &ref_400
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -15281,11 +15598,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_400
-            schema: *ref_232
+          - !<!Parameter> &ref_401
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -15294,11 +15611,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_401
-            schema: *ref_388
+          - !<!Parameter> &ref_402
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_420
+              x-ms-parameter-grouping: &ref_421
                 name: modified-access-conditions
             language: !<!Languages> 
               default:
@@ -15308,11 +15625,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_402
-            schema: *ref_388
+          - !<!Parameter> &ref_403
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_421
+              x-ms-parameter-grouping: &ref_422
                 name: modified-access-conditions
             language: !<!Languages> 
               default:
@@ -15322,8 +15639,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_403
+          - *ref_148
+          - !<!Parameter> &ref_404
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -15336,6 +15653,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15346,7 +15678,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_389
           - *ref_390
           - *ref_391
           - *ref_392
@@ -15361,6 +15692,7 @@ operationGroups:
           - *ref_401
           - *ref_402
           - *ref_403
+          - *ref_404
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -15371,49 +15703,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_388
+                    schema: *ref_389
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_404
+                    schema: *ref_405
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_405
+                    schema: *ref_406
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_406
+                    schema: *ref_407
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_407
+                    schema: *ref_408
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_195
+                    schema: *ref_196
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_408
+                    schema: *ref_409
                     header: Date
                     language:
                       default:
@@ -15423,7 +15755,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_412
+            schema: *ref_413
             language: !<!Languages> 
               default:
                 name: ''
@@ -15432,21 +15764,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_409
+                    schema: *ref_410
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_410
+                    schema: *ref_411
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_411
+                    schema: *ref_412
                     header: x-ms-version
                     language:
                       default:
@@ -15470,8 +15802,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
-          - !<!Parameter> &ref_423
+          - *ref_147
+          - !<!Parameter> &ref_424
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -15484,8 +15816,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_424
-            schema: *ref_413
+          - !<!Parameter> &ref_425
+            schema: *ref_414
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15497,9 +15829,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_679
-          - !<!Parameter> &ref_425
-            schema: *ref_413
+          - *ref_680
+          - !<!Parameter> &ref_426
+            schema: *ref_414
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15512,8 +15844,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_426
-            schema: *ref_388
+          - !<!Parameter> &ref_427
+            schema: *ref_389
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15523,8 +15855,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_427
-            schema: *ref_388
+          - !<!Parameter> &ref_428
+            schema: *ref_389
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15536,8 +15868,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_428
-            schema: *ref_388
+          - !<!Parameter> &ref_429
+            schema: *ref_389
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15550,11 +15882,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_429
-            schema: *ref_388
+          - !<!Parameter> &ref_430
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_415
+              x-ms-parameter-grouping: *ref_416
             language: !<!Languages> 
               default:
                 name: cacheControl
@@ -15563,11 +15895,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_430
-            schema: *ref_388
+          - !<!Parameter> &ref_431
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_416
+              x-ms-parameter-grouping: *ref_417
             language: !<!Languages> 
               default:
                 name: contentType
@@ -15576,11 +15908,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_431
-            schema: *ref_388
+          - !<!Parameter> &ref_432
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_417
+              x-ms-parameter-grouping: *ref_418
             language: !<!Languages> 
               default:
                 name: contentEncoding
@@ -15589,11 +15921,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_432
-            schema: *ref_388
+          - !<!Parameter> &ref_433
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_418
+              x-ms-parameter-grouping: *ref_419
             language: !<!Languages> 
               default:
                 name: contentLanguage
@@ -15602,11 +15934,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_433
-            schema: *ref_388
+          - !<!Parameter> &ref_434
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_419
+              x-ms-parameter-grouping: *ref_420
             language: !<!Languages> 
               default:
                 name: contentDisposition
@@ -15615,11 +15947,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_434
-            schema: *ref_218
+          - !<!Parameter> &ref_435
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -15628,8 +15960,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_435
-            schema: *ref_413
+          - !<!Parameter> &ref_436
+            schema: *ref_414
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15639,11 +15971,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_436
-            schema: *ref_232
+          - !<!Parameter> &ref_437
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -15652,11 +15984,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_437
-            schema: *ref_232
+          - !<!Parameter> &ref_438
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -15665,11 +15997,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_438
-            schema: *ref_388
+          - !<!Parameter> &ref_439
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -15678,11 +16010,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_439
-            schema: *ref_388
+          - !<!Parameter> &ref_440
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -15691,11 +16023,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_440
-            schema: *ref_422
+          - !<!Parameter> &ref_441
+            schema: *ref_423
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_680
+              x-ms-parameter-grouping: &ref_681
                 name: source-modified-access-conditions
             language: !<!Languages> 
               default:
@@ -15705,11 +16037,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_441
-            schema: *ref_422
+          - !<!Parameter> &ref_442
+            schema: *ref_423
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_681
+              x-ms-parameter-grouping: &ref_682
                 name: source-modified-access-conditions
             language: !<!Languages> 
               default:
@@ -15719,11 +16051,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_442
-            schema: *ref_413
+          - !<!Parameter> &ref_443
+            schema: *ref_414
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_682
+              x-ms-parameter-grouping: &ref_683
                 name: source-modified-access-conditions
             language: !<!Languages> 
               default:
@@ -15733,11 +16065,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_443
-            schema: *ref_413
+          - !<!Parameter> &ref_444
+            schema: *ref_414
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_683
+              x-ms-parameter-grouping: &ref_684
                 name: source-modified-access-conditions
             language: !<!Languages> 
               default:
@@ -15747,8 +16079,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_444
+          - *ref_148
+          - !<!Parameter> &ref_445
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -15761,6 +16093,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15771,7 +16118,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_423
           - *ref_424
           - *ref_425
           - *ref_426
@@ -15793,6 +16139,7 @@ operationGroups:
           - *ref_442
           - *ref_443
           - *ref_444
+          - *ref_445
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -15803,7 +16150,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_413
+                    schema: *ref_414
                     header: x-ms-continuation
                     language:
                       default:
@@ -15812,49 +16159,49 @@ operationGroups:
                           When renaming a directory, the number of paths that are renamed with each invocation is limited. If the number of paths to be renamed exceeds this limit, a continuation token is returned in this response header.
                           When a continuation token is returned in the response, it must be specified in a subsequent invocation of the rename operation to continue renaming the directory.
                   - !<!HttpHeader> 
-                    schema: *ref_445
+                    schema: *ref_446
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_422
+                    schema: *ref_423
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_446
+                    schema: *ref_447
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_447
+                    schema: *ref_448
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_448
+                    schema: *ref_449
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_449
+                    schema: *ref_450
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_450
+                    schema: *ref_451
                     header: Date
                     language:
                       default:
@@ -15864,7 +16211,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_412
+            schema: *ref_413
             language: !<!Languages> 
               default:
                 name: ''
@@ -15873,21 +16220,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_451
+                    schema: *ref_452
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_452
+                    schema: *ref_453
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_453
+                    schema: *ref_454
                     header: x-ms-version
                     language:
                       default:
@@ -15911,8 +16258,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
-          - !<!Parameter> &ref_455
+          - *ref_147
+          - !<!Parameter> &ref_456
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -15925,8 +16272,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_456
-            schema: *ref_454
+          - !<!Parameter> &ref_457
+            schema: *ref_455
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15937,8 +16284,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_457
-            schema: *ref_413
+          - !<!Parameter> &ref_458
+            schema: *ref_414
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15950,11 +16297,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_458
-            schema: *ref_218
+          - !<!Parameter> &ref_459
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -15963,11 +16310,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_459
-            schema: *ref_232
+          - !<!Parameter> &ref_460
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -15976,11 +16323,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_460
-            schema: *ref_232
+          - !<!Parameter> &ref_461
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -15989,11 +16336,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_461
-            schema: *ref_388
+          - !<!Parameter> &ref_462
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -16002,11 +16349,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_462
-            schema: *ref_388
+          - !<!Parameter> &ref_463
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -16015,8 +16362,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_463
+          - *ref_148
+          - !<!Parameter> &ref_464
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -16029,6 +16376,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16039,7 +16401,6 @@ operationGroups:
                 method: delete
                 uri: '{url}'
         signatureParameters:
-          - *ref_455
           - *ref_456
           - *ref_457
           - *ref_458
@@ -16048,6 +16409,7 @@ operationGroups:
           - *ref_461
           - *ref_462
           - *ref_463
+          - *ref_464
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -16058,7 +16420,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_464
+                    schema: *ref_465
                     header: x-ms-continuation
                     language:
                       default:
@@ -16067,28 +16429,28 @@ operationGroups:
                           When renaming a directory, the number of paths that are renamed with each invocation is limited. If the number of paths to be renamed exceeds this limit, a continuation token is returned in this response header.
                           When a continuation token is returned in the response, it must be specified in a subsequent invocation of the rename operation to continue renaming the directory.
                   - !<!HttpHeader> 
-                    schema: *ref_465
+                    schema: *ref_466
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_466
+                    schema: *ref_467
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_467
+                    schema: *ref_468
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_468
+                    schema: *ref_469
                     header: Date
                     language:
                       default:
@@ -16098,7 +16460,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_412
+            schema: *ref_413
             language: !<!Languages> 
               default:
                 name: ''
@@ -16107,21 +16469,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_469
+                    schema: *ref_470
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_470
+                    schema: *ref_471
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_471
+                    schema: *ref_472
                     header: x-ms-version
                     language:
                       default:
@@ -16142,9 +16504,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_472
+            schema: *ref_473
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16155,7 +16517,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_474
+          - !<!Parameter> &ref_475
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -16168,11 +16530,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_475
-            schema: *ref_218
+          - !<!Parameter> &ref_476
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -16181,8 +16543,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_476
-            schema: *ref_473
+          - !<!Parameter> &ref_477
+            schema: *ref_474
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16192,8 +16554,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_477
-            schema: *ref_473
+          - !<!Parameter> &ref_478
+            schema: *ref_474
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16203,8 +16565,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_478
-            schema: *ref_388
+          - !<!Parameter> &ref_479
+            schema: *ref_389
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16216,8 +16578,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_479
-            schema: *ref_473
+          - !<!Parameter> &ref_480
+            schema: *ref_474
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16229,11 +16591,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_480
-            schema: *ref_388
+          - !<!Parameter> &ref_481
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -16242,11 +16604,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_481
-            schema: *ref_388
+          - !<!Parameter> &ref_482
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -16255,11 +16617,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_482
-            schema: *ref_232
+          - !<!Parameter> &ref_483
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -16268,11 +16630,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_483
-            schema: *ref_232
+          - !<!Parameter> &ref_484
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -16281,7 +16643,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_484
+          - !<!Parameter> &ref_485
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -16292,9 +16654,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
+          - *ref_148
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16305,7 +16682,6 @@ operationGroups:
                 method: patch
                 uri: '{url}'
         signatureParameters:
-          - *ref_474
           - *ref_475
           - *ref_476
           - *ref_477
@@ -16316,6 +16692,7 @@ operationGroups:
           - *ref_482
           - *ref_483
           - *ref_484
+          - *ref_485
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -16326,35 +16703,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_485
+                    schema: *ref_486
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_473
+                    schema: *ref_474
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_486
+                    schema: *ref_487
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_487
+                    schema: *ref_488
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_488
+                    schema: *ref_489
                     header: x-ms-version
                     language:
                       default:
@@ -16364,7 +16741,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_412
+            schema: *ref_413
             language: !<!Languages> 
               default:
                 name: ''
@@ -16373,21 +16750,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_489
+                    schema: *ref_490
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_490
+                    schema: *ref_491
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_491
+                    schema: *ref_492
                     header: x-ms-version
                     language:
                       default:
@@ -16408,9 +16785,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_492
+            schema: *ref_493
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16421,7 +16798,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_493
+          - !<!Parameter> &ref_494
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -16434,8 +16811,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_494
-            schema: *ref_454
+          - !<!Parameter> &ref_495
+            schema: *ref_455
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16447,11 +16824,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_495
-            schema: *ref_218
+          - !<!Parameter> &ref_496
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -16460,11 +16837,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_496
-            schema: *ref_388
+          - !<!Parameter> &ref_497
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -16473,11 +16850,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_497
-            schema: *ref_388
+          - !<!Parameter> &ref_498
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -16486,11 +16863,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_498
-            schema: *ref_232
+          - !<!Parameter> &ref_499
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -16499,11 +16876,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_499
-            schema: *ref_232
+          - !<!Parameter> &ref_500
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -16512,7 +16889,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_500
+          - !<!Parameter> &ref_501
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -16523,9 +16900,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
+          - *ref_148
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16536,7 +16928,6 @@ operationGroups:
                 method: head
                 uri: '{url}'
         signatureParameters:
-          - *ref_493
           - *ref_494
           - *ref_495
           - *ref_496
@@ -16544,6 +16935,7 @@ operationGroups:
           - *ref_498
           - *ref_499
           - *ref_500
+          - *ref_501
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -16554,63 +16946,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_501
+                    schema: *ref_502
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_502
+                    schema: *ref_503
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_503
+                    schema: *ref_504
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_504
+                    schema: *ref_505
                     header: x-ms-owner
                     language:
                       default:
                         name: x-ms-owner
                         description: The owner of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_505
+                    schema: *ref_506
                     header: x-ms-group
                     language:
                       default:
                         name: x-ms-group
                         description: The owning group of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_506
+                    schema: *ref_507
                     header: x-ms-permissions
                     language:
                       default:
                         name: x-ms-permissions
                         description: 'The POSIX access permissions for the file owner, the file owning group, and others. Included in the response if Hierarchical Namespace is enabled for the account.'
                   - !<!HttpHeader> 
-                    schema: *ref_507
+                    schema: *ref_508
                     header: x-ms-acl
                     language:
                       default:
                         name: x-ms-acl
                         description: The POSIX access control list for the file or directory.  Included in the response only if the action is "getAccessControl" and Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_508
+                    schema: *ref_509
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_509
+                    schema: *ref_510
                     header: x-ms-version
                     language:
                       default:
@@ -16620,7 +17012,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_412
+            schema: *ref_413
             language: !<!Languages> 
               default:
                 name: ''
@@ -16629,21 +17021,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_510
+                    schema: *ref_511
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_511
+                    schema: *ref_512
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_512
+                    schema: *ref_513
                     header: x-ms-version
                     language:
                       default:
@@ -16672,9 +17064,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
-          - !<!Parameter> &ref_515
-            schema: *ref_513
+          - *ref_147
+          - !<!Parameter> &ref_516
+            schema: *ref_514
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16686,7 +17078,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_516
+          - !<!Parameter> &ref_517
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -16699,8 +17091,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_517
-            schema: *ref_513
+          - !<!Parameter> &ref_518
+            schema: *ref_514
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16710,11 +17102,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_518
-            schema: *ref_218
+          - !<!Parameter> &ref_519
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -16723,8 +17115,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_519
-            schema: *ref_454
+          - !<!Parameter> &ref_520
+            schema: *ref_455
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16734,8 +17126,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_520
-            schema: *ref_454
+          - !<!Parameter> &ref_521
+            schema: *ref_455
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16745,11 +17137,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_521
-            schema: *ref_513
+          - !<!Parameter> &ref_522
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_580
+              x-ms-parameter-grouping: &ref_581
                 name: cpk-info
             language: !<!Languages> 
               default:
@@ -16761,11 +17153,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_522
-            schema: *ref_513
+          - !<!Parameter> &ref_523
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_581
+              x-ms-parameter-grouping: &ref_582
                 name: cpk-info
             language: !<!Languages> 
               default:
@@ -16776,10 +17168,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_514
+            schema: *ref_515
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_582
+              x-ms-parameter-grouping: &ref_583
                 name: cpk-info
             language: !<!Languages> 
               default:
@@ -16789,11 +17181,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_523
-            schema: *ref_232
+          - !<!Parameter> &ref_524
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -16802,11 +17194,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_524
-            schema: *ref_232
+          - !<!Parameter> &ref_525
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -16815,11 +17207,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_525
-            schema: *ref_388
+          - !<!Parameter> &ref_526
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -16828,11 +17220,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_526
-            schema: *ref_388
+          - !<!Parameter> &ref_527
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -16841,8 +17233,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_527
+          - *ref_148
+          - !<!Parameter> &ref_528
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -16855,6 +17247,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16865,7 +17272,6 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_515
           - *ref_516
           - *ref_517
           - *ref_518
@@ -16878,6 +17284,7 @@ operationGroups:
           - *ref_525
           - *ref_526
           - *ref_527
+          - *ref_528
         responses:
           - !<!BinaryResponse> 
             binary: true
@@ -16889,70 +17296,70 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_528
+                    schema: *ref_529
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_513
+                    schema: *ref_514
                     header: x-ms-meta
                     language:
                       default:
                         name: Metadata
                         description: ''
                   - !<!HttpHeader> 
-                    schema: *ref_529
+                    schema: *ref_530
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The number of bytes present in the response body.
                   - !<!HttpHeader> 
-                    schema: *ref_530
+                    schema: *ref_531
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The media type of the body of the response. For Download Blob this is 'application/octet-stream'
                   - !<!HttpHeader> 
-                    schema: *ref_531
+                    schema: *ref_532
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the blob by setting the 'Range' request header.
                   - !<!HttpHeader> 
-                    schema: *ref_532
+                    schema: *ref_533
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_533
+                    schema: *ref_534
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_534
+                    schema: *ref_535
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: This header returns the value that was specified for the Content-Encoding request header
                   - !<!HttpHeader> 
-                    schema: *ref_535
+                    schema: *ref_536
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: This header is returned if it was previously specified for the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_536
+                    schema: *ref_537
                     header: Content-Disposition
                     language:
                       default:
@@ -16962,14 +17369,14 @@ operationGroups:
                           payload, and also can be used to attach additional metadata. For example, if set to attachment, it indicates that the user-agent should not display the response, but instead show a Save As dialog with a filename
                           other than the blob name specified.
                   - !<!HttpHeader> 
-                    schema: *ref_537
+                    schema: *ref_538
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: This header returns the value that was specified for the Content-Language request header.
                   - !<!HttpHeader> 
-                    schema: *ref_538
+                    schema: *ref_539
                     header: x-ms-blob-sequence-number
                     language:
                       default:
@@ -16983,7 +17390,7 @@ operationGroups:
                         name: BlobType
                         description: The blob's type.
                   - !<!HttpHeader> 
-                    schema: *ref_539
+                    schema: *ref_540
                     header: x-ms-copy-completion-time
                     language:
                       default:
@@ -16992,7 +17399,7 @@ operationGroups:
                           Conclusion time of the last attempted Copy Blob operation where this blob was the destination blob. This value can specify the time of a completed, aborted, or failed copy attempt. This header does not appear if a
                           copy is pending, if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List.
                   - !<!HttpHeader> 
-                    schema: *ref_540
+                    schema: *ref_541
                     header: x-ms-copy-status-description
                     language:
                       default:
@@ -17001,14 +17408,14 @@ operationGroups:
                           Only appears when x-ms-copy-status is failed or pending. Describes the cause of the last fatal or non-fatal copy operation failure. This header does not appear if this blob has never been the destination in a Copy
                           Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List
                   - !<!HttpHeader> 
-                    schema: *ref_541
+                    schema: *ref_542
                     header: x-ms-copy-id
                     language:
                       default:
                         name: CopyId
                         description: 'String identifier for this copy operation. Use with Get Blob Properties to check the status of this copy operation, or pass to Abort Copy Blob to abort a pending copy.'
                   - !<!HttpHeader> 
-                    schema: *ref_542
+                    schema: *ref_543
                     header: x-ms-copy-progress
                     language:
                       default:
@@ -17018,7 +17425,7 @@ operationGroups:
                           header does not appear if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block
                           List
                   - !<!HttpHeader> 
-                    schema: *ref_543
+                    schema: *ref_544
                     header: x-ms-copy-source
                     language:
                       default:
@@ -17055,49 +17462,49 @@ operationGroups:
                         name: LeaseStatus
                         description: The current lease status of the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_544
+                    schema: *ref_545
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_545
+                    schema: *ref_546
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_546
+                    schema: *ref_547
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_547
+                    schema: *ref_548
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial blob content.
                   - !<!HttpHeader> 
-                    schema: *ref_548
+                    schema: *ref_549
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_549
+                    schema: *ref_550
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_454
+                    schema: *ref_455
                     header: x-ms-server-encrypted
                     language:
                       default:
@@ -17106,14 +17513,14 @@ operationGroups:
                           The value of this header is set to true if the blob data and application metadata are completely encrypted using the specified algorithm. Otherwise, the value is set to false (when the blob is unencrypted, or if
                           only parts of the blob/application metadata are encrypted).
                   - !<!HttpHeader> 
-                    schema: *ref_550
+                    schema: *ref_551
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
                         name: EncryptionKeySha256
                         description: The SHA-256 hash of the encryption key used to encrypt the blob. This header is only returned when the blob was encrypted with a customer-provided key.
                   - !<!HttpHeader> 
-                    schema: *ref_551
+                    schema: *ref_552
                     header: x-ms-blob-content-md5
                     language:
                       default:
@@ -17136,70 +17543,70 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_552
+                    schema: *ref_553
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_553
+                    schema: *ref_554
                     header: x-ms-meta
                     language:
                       default:
                         name: Metadata
                         description: ''
                   - !<!HttpHeader> 
-                    schema: *ref_554
+                    schema: *ref_555
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The number of bytes present in the response body.
                   - !<!HttpHeader> 
-                    schema: *ref_555
+                    schema: *ref_556
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The media type of the body of the response. For Download Blob this is 'application/octet-stream'
                   - !<!HttpHeader> 
-                    schema: *ref_556
+                    schema: *ref_557
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the blob by setting the 'Range' request header.
                   - !<!HttpHeader> 
-                    schema: *ref_557
+                    schema: *ref_558
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_558
+                    schema: *ref_559
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_559
+                    schema: *ref_560
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: This header returns the value that was specified for the Content-Encoding request header
                   - !<!HttpHeader> 
-                    schema: *ref_560
+                    schema: *ref_561
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: This header is returned if it was previously specified for the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_561
+                    schema: *ref_562
                     header: Content-Disposition
                     language:
                       default:
@@ -17209,14 +17616,14 @@ operationGroups:
                           payload, and also can be used to attach additional metadata. For example, if set to attachment, it indicates that the user-agent should not display the response, but instead show a Save As dialog with a filename
                           other than the blob name specified.
                   - !<!HttpHeader> 
-                    schema: *ref_562
+                    schema: *ref_563
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: This header returns the value that was specified for the Content-Language request header.
                   - !<!HttpHeader> 
-                    schema: *ref_563
+                    schema: *ref_564
                     header: x-ms-blob-sequence-number
                     language:
                       default:
@@ -17230,7 +17637,7 @@ operationGroups:
                         name: BlobType
                         description: The blob's type.
                   - !<!HttpHeader> 
-                    schema: *ref_564
+                    schema: *ref_565
                     header: x-ms-content-crc64
                     language:
                       default:
@@ -17239,7 +17646,7 @@ operationGroups:
                           If the request is to read a specified range and the x-ms-range-get-content-crc64 is set to true, then the request returns a crc64 for the range, as long as the range size is less than or equal to 4 MB. If both
                           x-ms-range-get-content-crc64 & x-ms-range-get-content-md5 is specified in the same request, it will fail with 400(Bad Request)
                   - !<!HttpHeader> 
-                    schema: *ref_565
+                    schema: *ref_566
                     header: x-ms-copy-completion-time
                     language:
                       default:
@@ -17248,7 +17655,7 @@ operationGroups:
                           Conclusion time of the last attempted Copy Blob operation where this blob was the destination blob. This value can specify the time of a completed, aborted, or failed copy attempt. This header does not appear if a
                           copy is pending, if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List.
                   - !<!HttpHeader> 
-                    schema: *ref_566
+                    schema: *ref_567
                     header: x-ms-copy-status-description
                     language:
                       default:
@@ -17257,14 +17664,14 @@ operationGroups:
                           Only appears when x-ms-copy-status is failed or pending. Describes the cause of the last fatal or non-fatal copy operation failure. This header does not appear if this blob has never been the destination in a Copy
                           Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List
                   - !<!HttpHeader> 
-                    schema: *ref_567
+                    schema: *ref_568
                     header: x-ms-copy-id
                     language:
                       default:
                         name: CopyId
                         description: 'String identifier for this copy operation. Use with Get Blob Properties to check the status of this copy operation, or pass to Abort Copy Blob to abort a pending copy.'
                   - !<!HttpHeader> 
-                    schema: *ref_568
+                    schema: *ref_569
                     header: x-ms-copy-progress
                     language:
                       default:
@@ -17274,7 +17681,7 @@ operationGroups:
                           header does not appear if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block
                           List
                   - !<!HttpHeader> 
-                    schema: *ref_569
+                    schema: *ref_570
                     header: x-ms-copy-source
                     language:
                       default:
@@ -17311,49 +17718,49 @@ operationGroups:
                         name: LeaseStatus
                         description: The current lease status of the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_570
+                    schema: *ref_571
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_571
+                    schema: *ref_572
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_572
+                    schema: *ref_573
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_573
+                    schema: *ref_574
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial blob content.
                   - !<!HttpHeader> 
-                    schema: *ref_574
+                    schema: *ref_575
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_575
+                    schema: *ref_576
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_576
+                    schema: *ref_577
                     header: x-ms-server-encrypted
                     language:
                       default:
@@ -17362,14 +17769,14 @@ operationGroups:
                           The value of this header is set to true if the blob data and application metadata are completely encrypted using the specified algorithm. Otherwise, the value is set to false (when the blob is unencrypted, or if
                           only parts of the blob/application metadata are encrypted).
                   - !<!HttpHeader> 
-                    schema: *ref_577
+                    schema: *ref_578
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
                         name: EncryptionKeySha256
                         description: The SHA-256 hash of the encryption key used to encrypt the blob. This header is only returned when the blob was encrypted with a customer-provided key.
                   - !<!HttpHeader> 
-                    schema: *ref_578
+                    schema: *ref_579
                     header: x-ms-blob-content-md5
                     language:
                       default:
@@ -17384,7 +17791,7 @@ operationGroups:
                   - '206'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -17393,7 +17800,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_579
+                    schema: *ref_580
                     header: x-ms-error-code
                     language:
                       default:
@@ -17414,9 +17821,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
-          - !<!Parameter> &ref_583
-            schema: *ref_513
+          - *ref_147
+          - !<!Parameter> &ref_584
+            schema: *ref_514
             implementation: Method
             language: !<!Languages> 
               default:
@@ -17428,7 +17835,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_584
+          - !<!Parameter> &ref_585
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -17441,11 +17848,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_585
-            schema: *ref_218
+          - !<!Parameter> &ref_586
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -17454,11 +17861,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_586
-            schema: *ref_513
+          - !<!Parameter> &ref_587
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_580
+              x-ms-parameter-grouping: *ref_581
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -17469,11 +17876,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_587
-            schema: *ref_513
+          - !<!Parameter> &ref_588
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_581
+              x-ms-parameter-grouping: *ref_582
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -17483,10 +17890,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_514
+            schema: *ref_515
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_582
+              x-ms-parameter-grouping: *ref_583
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -17495,11 +17902,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_588
-            schema: *ref_232
+          - !<!Parameter> &ref_589
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -17508,11 +17915,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_589
-            schema: *ref_232
+          - !<!Parameter> &ref_590
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -17521,11 +17928,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_590
-            schema: *ref_388
+          - !<!Parameter> &ref_591
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -17534,11 +17941,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_591
-            schema: *ref_388
+          - !<!Parameter> &ref_592
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -17547,8 +17954,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_592
+          - *ref_148
+          - !<!Parameter> &ref_593
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -17561,6 +17968,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -17571,7 +17993,6 @@ operationGroups:
                 method: head
                 uri: '{url}'
         signatureParameters:
-          - *ref_583
           - *ref_584
           - *ref_585
           - *ref_586
@@ -17581,6 +18002,7 @@ operationGroups:
           - *ref_590
           - *ref_591
           - *ref_592
+          - *ref_593
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -17591,21 +18013,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_593
+                    schema: *ref_594
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_594
+                    schema: *ref_595
                     header: x-ms-creation-time
                     language:
                       default:
                         name: CreationTime
                         description: Returns the date and time the blob was created.
                   - !<!HttpHeader> 
-                    schema: *ref_595
+                    schema: *ref_596
                     header: x-ms-meta
                     language:
                       default:
@@ -17619,7 +18041,7 @@ operationGroups:
                         name: BlobType
                         description: The blob's type.
                   - !<!HttpHeader> 
-                    schema: *ref_596
+                    schema: *ref_597
                     header: x-ms-copy-completion-time
                     language:
                       default:
@@ -17628,7 +18050,7 @@ operationGroups:
                           Conclusion time of the last attempted Copy Blob operation where this blob was the destination blob. This value can specify the time of a completed, aborted, or failed copy attempt. This header does not appear if a
                           copy is pending, if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List.
                   - !<!HttpHeader> 
-                    schema: *ref_597
+                    schema: *ref_598
                     header: x-ms-copy-status-description
                     language:
                       default:
@@ -17637,14 +18059,14 @@ operationGroups:
                           Only appears when x-ms-copy-status is failed or pending. Describes the cause of the last fatal or non-fatal copy operation failure. This header does not appear if this blob has never been the destination in a Copy
                           Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List
                   - !<!HttpHeader> 
-                    schema: *ref_598
+                    schema: *ref_599
                     header: x-ms-copy-id
                     language:
                       default:
                         name: CopyId
                         description: 'String identifier for this copy operation. Use with Get Blob Properties to check the status of this copy operation, or pass to Abort Copy Blob to abort a pending copy.'
                   - !<!HttpHeader> 
-                    schema: *ref_599
+                    schema: *ref_600
                     header: x-ms-copy-progress
                     language:
                       default:
@@ -17654,7 +18076,7 @@ operationGroups:
                           header does not appear if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block
                           List
                   - !<!HttpHeader> 
-                    schema: *ref_600
+                    schema: *ref_601
                     header: x-ms-copy-source
                     language:
                       default:
@@ -17670,14 +18092,14 @@ operationGroups:
                         name: CopyStatus
                         description: State of the copy operation identified by x-ms-copy-id.
                   - !<!HttpHeader> 
-                    schema: *ref_601
+                    schema: *ref_602
                     header: x-ms-incremental-copy
                     language:
                       default:
                         name: IsIncrementalCopy
                         description: Included if the blob is incremental copy blob.
                   - !<!HttpHeader> 
-                    schema: *ref_602
+                    schema: *ref_603
                     header: x-ms-copy-destination-snapshot
                     language:
                       default:
@@ -17705,42 +18127,42 @@ operationGroups:
                         name: LeaseStatus
                         description: The current lease status of the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_603
+                    schema: *ref_604
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The number of bytes present in the response body.
                   - !<!HttpHeader> 
-                    schema: *ref_604
+                    schema: *ref_605
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The content type specified for the blob. The default content type is 'application/octet-stream'
                   - !<!HttpHeader> 
-                    schema: *ref_605
+                    schema: *ref_606
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_606
+                    schema: *ref_607
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_607
+                    schema: *ref_608
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: This header returns the value that was specified for the Content-Encoding request header
                   - !<!HttpHeader> 
-                    schema: *ref_608
+                    schema: *ref_609
                     header: Content-Disposition
                     language:
                       default:
@@ -17750,70 +18172,70 @@ operationGroups:
                           payload, and also can be used to attach additional metadata. For example, if set to attachment, it indicates that the user-agent should not display the response, but instead show a Save As dialog with a filename
                           other than the blob name specified.
                   - !<!HttpHeader> 
-                    schema: *ref_609
+                    schema: *ref_610
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: This header returns the value that was specified for the Content-Language request header.
                   - !<!HttpHeader> 
-                    schema: *ref_610
+                    schema: *ref_611
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: This header is returned if it was previously specified for the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_611
+                    schema: *ref_612
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for a page blob. This header is not returned for block blobs or append blobs
                   - !<!HttpHeader> 
-                    schema: *ref_612
+                    schema: *ref_613
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_613
+                    schema: *ref_614
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_614
+                    schema: *ref_615
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_615
+                    schema: *ref_616
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_616
+                    schema: *ref_617
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial blob content.
                   - !<!HttpHeader> 
-                    schema: *ref_617
+                    schema: *ref_618
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_618
+                    schema: *ref_619
                     header: x-ms-server-encrypted
                     language:
                       default:
@@ -17822,14 +18244,14 @@ operationGroups:
                           The value of this header is set to true if the blob data and application metadata are completely encrypted using the specified algorithm. Otherwise, the value is set to false (when the blob is unencrypted, or if
                           only parts of the blob/application metadata are encrypted).
                   - !<!HttpHeader> 
-                    schema: *ref_619
+                    schema: *ref_620
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
                         name: EncryptionKeySha256
                         description: The SHA-256 hash of the encryption key used to encrypt the metadata. This header is only returned when the metadata was encrypted with a customer-provided key.
                   - !<!HttpHeader> 
-                    schema: *ref_620
+                    schema: *ref_621
                     header: x-ms-access-tier
                     language:
                       default:
@@ -17838,14 +18260,14 @@ operationGroups:
                           The tier of page blob on a premium storage account or tier of block blob on blob storage LRS accounts. For a list of allowed premium page blob tiers, see
                           https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage#features. For blob storage LRS accounts, valid values are Hot/Cool/Archive.
                   - !<!HttpHeader> 
-                    schema: *ref_621
+                    schema: *ref_622
                     header: x-ms-access-tier-inferred
                     language:
                       default:
                         name: AccessTierInferred
                         description: 'For page blobs on a premium storage account only. If the access tier is not explicitly set on the blob, the tier is inferred based on its content length and this header will be returned with true value.'
                   - !<!HttpHeader> 
-                    schema: *ref_622
+                    schema: *ref_623
                     header: x-ms-archive-status
                     language:
                       default:
@@ -17854,7 +18276,7 @@ operationGroups:
                           For blob storage LRS accounts, valid values are rehydrate-pending-to-hot/rehydrate-pending-to-cool. If the blob is being rehydrated and is not complete then this header is returned indicating that rehydrate is
                           pending and also tells the destination tier.
                   - !<!HttpHeader> 
-                    schema: *ref_623
+                    schema: *ref_624
                     header: x-ms-access-tier-change-time
                     language:
                       default:
@@ -17864,7 +18286,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -17873,7 +18295,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_624
+                    schema: *ref_625
                     header: x-ms-error-code
                     language:
                       default:
@@ -17894,9 +18316,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
-          - !<!Parameter> &ref_626
-            schema: *ref_513
+          - *ref_147
+          - !<!Parameter> &ref_627
+            schema: *ref_514
             implementation: Method
             language: !<!Languages> 
               default:
@@ -17908,7 +18330,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_627
+          - !<!Parameter> &ref_628
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -17921,11 +18343,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_628
-            schema: *ref_218
+          - !<!Parameter> &ref_629
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -17934,8 +18356,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_629
-            schema: *ref_625
+          - !<!Parameter> &ref_630
+            schema: *ref_626
             implementation: Method
             language: !<!Languages> 
               default:
@@ -17945,11 +18367,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_630
-            schema: *ref_232
+          - !<!Parameter> &ref_631
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -17958,11 +18380,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_631
-            schema: *ref_232
+          - !<!Parameter> &ref_632
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -17971,11 +18393,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_632
-            schema: *ref_388
+          - !<!Parameter> &ref_633
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -17984,11 +18406,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_633
-            schema: *ref_388
+          - !<!Parameter> &ref_634
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -17997,8 +18419,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_634
+          - *ref_148
+          - !<!Parameter> &ref_635
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -18011,6 +18433,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -18021,7 +18458,6 @@ operationGroups:
                 method: delete
                 uri: '{url}'
         signatureParameters:
-          - *ref_626
           - *ref_627
           - *ref_628
           - *ref_629
@@ -18030,6 +18466,7 @@ operationGroups:
           - *ref_632
           - *ref_633
           - *ref_634
+          - *ref_635
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -18040,28 +18477,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_635
+                    schema: *ref_636
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_636
+                    schema: *ref_637
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_637
+                    schema: *ref_638
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_638
+                    schema: *ref_639
                     header: Date
                     language:
                       default:
@@ -18071,7 +18508,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -18080,7 +18517,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_639
+                    schema: *ref_640
                     header: x-ms-error-code
                     language:
                       default:
@@ -18106,9 +18543,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_472
+            schema: *ref_473
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18119,7 +18556,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_640
+          - !<!Parameter> &ref_641
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -18132,11 +18569,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_641
-            schema: *ref_218
+          - !<!Parameter> &ref_642
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -18145,8 +18582,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_642
-            schema: *ref_473
+          - !<!Parameter> &ref_643
+            schema: *ref_474
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18156,8 +18593,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_643
-            schema: *ref_473
+          - !<!Parameter> &ref_644
+            schema: *ref_474
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18167,8 +18604,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_644
-            schema: *ref_388
+          - !<!Parameter> &ref_645
+            schema: *ref_389
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18180,8 +18617,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_645
-            schema: *ref_473
+          - !<!Parameter> &ref_646
+            schema: *ref_474
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18193,11 +18630,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_646
-            schema: *ref_388
+          - !<!Parameter> &ref_647
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -18206,11 +18643,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_647
-            schema: *ref_388
+          - !<!Parameter> &ref_648
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -18219,11 +18656,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_648
-            schema: *ref_232
+          - !<!Parameter> &ref_649
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -18232,11 +18669,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_649
-            schema: *ref_232
+          - !<!Parameter> &ref_650
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -18245,7 +18682,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_650
+          - !<!Parameter> &ref_651
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -18256,9 +18693,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
+          - *ref_148
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -18269,7 +18721,6 @@ operationGroups:
                 method: patch
                 uri: '{url}'
         signatureParameters:
-          - *ref_640
           - *ref_641
           - *ref_642
           - *ref_643
@@ -18280,6 +18731,7 @@ operationGroups:
           - *ref_648
           - *ref_649
           - *ref_650
+          - *ref_651
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -18290,35 +18742,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_651
+                    schema: *ref_652
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_652
+                    schema: *ref_653
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_653
+                    schema: *ref_654
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_654
+                    schema: *ref_655
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_655
+                    schema: *ref_656
                     header: x-ms-version
                     language:
                       default:
@@ -18328,7 +18780,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_412
+            schema: *ref_413
             language: !<!Languages> 
               default:
                 name: ''
@@ -18337,21 +18789,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_656
+                    schema: *ref_657
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_657
+                    schema: *ref_658
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_658
+                    schema: *ref_659
                     header: x-ms-version
                     language:
                       default:
@@ -18372,9 +18824,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_492
+            schema: *ref_493
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18385,7 +18837,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_659
+          - !<!Parameter> &ref_660
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -18398,8 +18850,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_660
-            schema: *ref_454
+          - !<!Parameter> &ref_661
+            schema: *ref_455
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18411,11 +18863,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_661
-            schema: *ref_218
+          - !<!Parameter> &ref_662
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -18424,11 +18876,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_662
-            schema: *ref_388
+          - !<!Parameter> &ref_663
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -18437,11 +18889,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_663
-            schema: *ref_388
+          - !<!Parameter> &ref_664
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -18450,11 +18902,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_664
-            schema: *ref_232
+          - !<!Parameter> &ref_665
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -18463,11 +18915,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_665
-            schema: *ref_232
+          - !<!Parameter> &ref_666
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -18476,7 +18928,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_666
+          - !<!Parameter> &ref_667
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -18487,9 +18939,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
+          - *ref_148
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -18500,7 +18967,6 @@ operationGroups:
                 method: head
                 uri: '{url}'
         signatureParameters:
-          - *ref_659
           - *ref_660
           - *ref_661
           - *ref_662
@@ -18508,6 +18974,7 @@ operationGroups:
           - *ref_664
           - *ref_665
           - *ref_666
+          - *ref_667
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -18518,63 +18985,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_667
+                    schema: *ref_668
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_668
+                    schema: *ref_669
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_669
+                    schema: *ref_670
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_670
+                    schema: *ref_671
                     header: x-ms-owner
                     language:
                       default:
                         name: x-ms-owner
                         description: The owner of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_671
+                    schema: *ref_672
                     header: x-ms-group
                     language:
                       default:
                         name: x-ms-group
                         description: The owning group of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_672
+                    schema: *ref_673
                     header: x-ms-permissions
                     language:
                       default:
                         name: x-ms-permissions
                         description: 'The POSIX access permissions for the file owner, the file owning group, and others. Included in the response if Hierarchical Namespace is enabled for the account.'
                   - !<!HttpHeader> 
-                    schema: *ref_673
+                    schema: *ref_674
                     header: x-ms-acl
                     language:
                       default:
                         name: x-ms-acl
                         description: The POSIX access control list for the file or directory.  Included in the response only if the action is "getAccessControl" and Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_674
+                    schema: *ref_675
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_675
+                    schema: *ref_676
                     header: x-ms-version
                     language:
                       default:
@@ -18584,7 +19051,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_412
+            schema: *ref_413
             language: !<!Languages> 
               default:
                 name: ''
@@ -18593,21 +19060,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_676
+                    schema: *ref_677
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_677
+                    schema: *ref_678
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_678
+                    schema: *ref_679
                     header: x-ms-version
                     language:
                       default:
@@ -18628,8 +19095,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
-          - !<!Parameter> &ref_684
+          - *ref_147
+          - !<!Parameter> &ref_685
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -18642,9 +19109,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_679
-          - !<!Parameter> &ref_685
-            schema: *ref_413
+          - *ref_680
+          - !<!Parameter> &ref_686
+            schema: *ref_414
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18657,8 +19124,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_686
-            schema: *ref_388
+          - !<!Parameter> &ref_687
+            schema: *ref_389
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18668,8 +19135,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_687
-            schema: *ref_388
+          - !<!Parameter> &ref_688
+            schema: *ref_389
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18681,8 +19148,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_688
-            schema: *ref_388
+          - !<!Parameter> &ref_689
+            schema: *ref_389
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18695,11 +19162,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_689
-            schema: *ref_388
+          - !<!Parameter> &ref_690
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_415
+              x-ms-parameter-grouping: *ref_416
             language: !<!Languages> 
               default:
                 name: cacheControl
@@ -18708,11 +19175,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_690
-            schema: *ref_388
+          - !<!Parameter> &ref_691
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_416
+              x-ms-parameter-grouping: *ref_417
             language: !<!Languages> 
               default:
                 name: contentType
@@ -18721,11 +19188,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_691
-            schema: *ref_388
+          - !<!Parameter> &ref_692
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_417
+              x-ms-parameter-grouping: *ref_418
             language: !<!Languages> 
               default:
                 name: contentEncoding
@@ -18734,11 +19201,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_692
-            schema: *ref_388
+          - !<!Parameter> &ref_693
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_418
+              x-ms-parameter-grouping: *ref_419
             language: !<!Languages> 
               default:
                 name: contentLanguage
@@ -18747,11 +19214,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_693
-            schema: *ref_388
+          - !<!Parameter> &ref_694
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_419
+              x-ms-parameter-grouping: *ref_420
             language: !<!Languages> 
               default:
                 name: contentDisposition
@@ -18760,11 +19227,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_694
-            schema: *ref_218
+          - !<!Parameter> &ref_695
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -18773,8 +19240,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_695
-            schema: *ref_413
+          - !<!Parameter> &ref_696
+            schema: *ref_414
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18784,11 +19251,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_696
-            schema: *ref_232
+          - !<!Parameter> &ref_697
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -18797,11 +19264,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_697
-            schema: *ref_232
+          - !<!Parameter> &ref_698
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -18810,11 +19277,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_698
-            schema: *ref_388
+          - !<!Parameter> &ref_699
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -18823,11 +19290,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_699
-            schema: *ref_388
+          - !<!Parameter> &ref_700
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -18836,11 +19303,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_700
-            schema: *ref_422
+          - !<!Parameter> &ref_701
+            schema: *ref_423
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: sourceIfModifiedSince
@@ -18849,11 +19316,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_701
-            schema: *ref_422
+          - !<!Parameter> &ref_702
+            schema: *ref_423
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_681
+              x-ms-parameter-grouping: *ref_682
             language: !<!Languages> 
               default:
                 name: sourceIfUnmodifiedSince
@@ -18862,11 +19329,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_702
-            schema: *ref_413
+          - !<!Parameter> &ref_703
+            schema: *ref_414
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_682
+              x-ms-parameter-grouping: *ref_683
             language: !<!Languages> 
               default:
                 name: sourceIfMatch
@@ -18875,11 +19342,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_703
-            schema: *ref_413
+          - !<!Parameter> &ref_704
+            schema: *ref_414
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_683
+              x-ms-parameter-grouping: *ref_684
             language: !<!Languages> 
               default:
                 name: sourceIfNoneMatch
@@ -18888,8 +19355,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_704
+          - *ref_148
+          - !<!Parameter> &ref_705
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -18902,6 +19369,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -18912,7 +19394,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_684
           - *ref_685
           - *ref_686
           - *ref_687
@@ -18933,6 +19414,7 @@ operationGroups:
           - *ref_702
           - *ref_703
           - *ref_704
+          - *ref_705
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -18943,49 +19425,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_705
+                    schema: *ref_706
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_706
+                    schema: *ref_707
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_707
+                    schema: *ref_708
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_708
+                    schema: *ref_709
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_709
+                    schema: *ref_710
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_710
+                    schema: *ref_711
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_711
+                    schema: *ref_712
                     header: Date
                     language:
                       default:
@@ -18995,7 +19477,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_412
+            schema: *ref_413
             language: !<!Languages> 
               default:
                 name: ''
@@ -19004,21 +19486,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_712
+                    schema: *ref_713
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_713
+                    schema: *ref_714
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_714
+                    schema: *ref_715
                     header: x-ms-version
                     language:
                       default:
@@ -19042,9 +19524,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_715
+            schema: *ref_716
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19055,7 +19537,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_716
+          - !<!Parameter> &ref_717
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -19068,8 +19550,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_147
-          - !<!Parameter> &ref_717
+          - *ref_148
+          - !<!Parameter> &ref_718
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -19082,6 +19564,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -19092,8 +19589,8 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_716
           - *ref_717
+          - *ref_718
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -19104,28 +19601,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_718
+                    schema: *ref_719
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_719
+                    schema: *ref_720
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_720
+                    schema: *ref_721
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_721
+                    schema: *ref_722
                     header: Date
                     language:
                       default:
@@ -19135,7 +19632,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -19144,7 +19641,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_722
+                    schema: *ref_723
                     header: x-ms-error-code
                     language:
                       default:
@@ -19165,7 +19662,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
             schema: *ref_134
             implementation: Method
@@ -19178,7 +19675,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_725
+          - !<!Parameter> &ref_726
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -19191,11 +19688,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_726
-            schema: *ref_723
+          - !<!Parameter> &ref_727
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_949
+              x-ms-parameter-grouping: &ref_950
                 name: blob-HTTP-headers
             language: !<!Languages> 
               default:
@@ -19205,11 +19702,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_727
-            schema: *ref_723
+          - !<!Parameter> &ref_728
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_945
+              x-ms-parameter-grouping: &ref_946
                 name: blob-HTTP-headers
             language: !<!Languages> 
               default:
@@ -19219,11 +19716,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_728
-            schema: *ref_724
+          - !<!Parameter> &ref_729
+            schema: *ref_725
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_948
+              x-ms-parameter-grouping: &ref_949
                 name: blob-HTTP-headers
             language: !<!Languages> 
               default:
@@ -19233,11 +19730,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_729
-            schema: *ref_723
+          - !<!Parameter> &ref_730
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_946
+              x-ms-parameter-grouping: &ref_947
                 name: blob-HTTP-headers
             language: !<!Languages> 
               default:
@@ -19247,11 +19744,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_730
-            schema: *ref_723
+          - !<!Parameter> &ref_731
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_947
+              x-ms-parameter-grouping: &ref_948
                 name: blob-HTTP-headers
             language: !<!Languages> 
               default:
@@ -19261,11 +19758,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_731
-            schema: *ref_218
+          - !<!Parameter> &ref_732
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -19274,11 +19771,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_732
-            schema: *ref_232
+          - !<!Parameter> &ref_733
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -19287,11 +19784,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_733
-            schema: *ref_232
+          - !<!Parameter> &ref_734
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -19300,11 +19797,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_734
-            schema: *ref_388
+          - !<!Parameter> &ref_735
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -19313,11 +19810,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_735
-            schema: *ref_388
+          - !<!Parameter> &ref_736
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -19326,11 +19823,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_736
-            schema: *ref_723
+          - !<!Parameter> &ref_737
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_950
+              x-ms-parameter-grouping: &ref_951
                 name: blob-HTTP-headers
             language: !<!Languages> 
               default:
@@ -19340,8 +19837,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_737
+          - *ref_148
+          - !<!Parameter> &ref_738
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -19354,6 +19851,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -19364,7 +19876,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_725
           - *ref_726
           - *ref_727
           - *ref_728
@@ -19377,6 +19888,7 @@ operationGroups:
           - *ref_735
           - *ref_736
           - *ref_737
+          - *ref_738
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -19387,49 +19899,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_738
+                    schema: *ref_739
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_739
+                    schema: *ref_740
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_740
+                    schema: *ref_741
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for a page blob. This header is not returned for block blobs or append blobs
                   - !<!HttpHeader> 
-                    schema: *ref_741
+                    schema: *ref_742
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_742
+                    schema: *ref_743
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_743
+                    schema: *ref_744
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_744
+                    schema: *ref_745
                     header: Date
                     language:
                       default:
@@ -19439,7 +19951,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -19448,7 +19960,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_745
+                    schema: *ref_746
                     header: x-ms-error-code
                     language:
                       default:
@@ -19469,9 +19981,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_242
+            schema: *ref_243
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19482,7 +19994,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_746
+          - !<!Parameter> &ref_747
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -19495,8 +20007,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_747
-            schema: *ref_207
+          - !<!Parameter> &ref_748
+            schema: *ref_208
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -19511,11 +20023,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_748
-            schema: *ref_218
+          - !<!Parameter> &ref_749
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -19524,11 +20036,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_749
-            schema: *ref_513
+          - !<!Parameter> &ref_750
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_580
+              x-ms-parameter-grouping: *ref_581
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -19539,11 +20051,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_750
-            schema: *ref_513
+          - !<!Parameter> &ref_751
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_581
+              x-ms-parameter-grouping: *ref_582
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -19553,10 +20065,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_514
+            schema: *ref_515
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_582
+              x-ms-parameter-grouping: *ref_583
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -19565,11 +20077,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_751
-            schema: *ref_232
+          - !<!Parameter> &ref_752
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -19578,11 +20090,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_752
-            schema: *ref_232
+          - !<!Parameter> &ref_753
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -19591,11 +20103,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_753
-            schema: *ref_388
+          - !<!Parameter> &ref_754
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -19604,11 +20116,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_754
-            schema: *ref_388
+          - !<!Parameter> &ref_755
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -19617,8 +20129,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_755
+          - *ref_148
+          - !<!Parameter> &ref_756
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -19631,6 +20143,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -19641,7 +20168,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_746
           - *ref_747
           - *ref_748
           - *ref_749
@@ -19651,6 +20177,7 @@ operationGroups:
           - *ref_753
           - *ref_754
           - *ref_755
+          - *ref_756
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -19661,56 +20188,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_756
+                    schema: *ref_757
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_757
+                    schema: *ref_758
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_758
+                    schema: *ref_759
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_759
+                    schema: *ref_760
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_760
+                    schema: *ref_761
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_761
+                    schema: *ref_762
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_762
+                    schema: *ref_763
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_763
+                    schema: *ref_764
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -19720,7 +20247,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -19729,7 +20256,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_764
+                    schema: *ref_765
                     header: x-ms-error-code
                     language:
                       default:
@@ -19750,9 +20277,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_283
+            schema: *ref_284
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19764,7 +20291,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_284
+            schema: *ref_285
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19775,7 +20302,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_765
+          - !<!Parameter> &ref_766
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -19788,8 +20315,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_766
-            schema: *ref_285
+          - !<!Parameter> &ref_767
+            schema: *ref_286
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19799,8 +20326,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_767
-            schema: *ref_286
+          - !<!Parameter> &ref_768
+            schema: *ref_287
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19810,11 +20337,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_768
-            schema: *ref_232
+          - !<!Parameter> &ref_769
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -19823,11 +20350,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_769
-            schema: *ref_232
+          - !<!Parameter> &ref_770
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -19836,11 +20363,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_770
-            schema: *ref_388
+          - !<!Parameter> &ref_771
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -19849,11 +20376,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_771
-            schema: *ref_388
+          - !<!Parameter> &ref_772
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -19862,8 +20389,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_772
+          - *ref_148
+          - !<!Parameter> &ref_773
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -19876,6 +20403,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -19886,7 +20428,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_765
           - *ref_766
           - *ref_767
           - *ref_768
@@ -19894,6 +20435,7 @@ operationGroups:
           - *ref_770
           - *ref_771
           - *ref_772
+          - *ref_773
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -19904,49 +20446,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_773
+                    schema: *ref_774
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_774
+                    schema: *ref_775
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_775
+                    schema: *ref_776
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a blobs's lease
                   - !<!HttpHeader> 
-                    schema: *ref_776
+                    schema: *ref_777
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_777
+                    schema: *ref_778
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_778
+                    schema: *ref_779
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_779
+                    schema: *ref_780
                     header: Date
                     language:
                       default:
@@ -19956,7 +20498,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -19965,7 +20507,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_780
+                    schema: *ref_781
                     header: x-ms-error-code
                     language:
                       default:
@@ -19986,9 +20528,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_283
+            schema: *ref_284
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20000,7 +20542,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_300
+            schema: *ref_301
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20011,7 +20553,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_781
+          - !<!Parameter> &ref_782
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -20024,8 +20566,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_782
-            schema: *ref_301
+          - !<!Parameter> &ref_783
+            schema: *ref_302
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20036,11 +20578,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_783
-            schema: *ref_232
+          - !<!Parameter> &ref_784
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -20049,11 +20591,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_784
-            schema: *ref_232
+          - !<!Parameter> &ref_785
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -20062,11 +20604,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_785
-            schema: *ref_388
+          - !<!Parameter> &ref_786
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -20075,11 +20617,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_786
-            schema: *ref_388
+          - !<!Parameter> &ref_787
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -20088,8 +20630,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_787
+          - *ref_148
+          - !<!Parameter> &ref_788
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -20102,6 +20644,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -20112,13 +20669,13 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_781
           - *ref_782
           - *ref_783
           - *ref_784
           - *ref_785
           - *ref_786
           - *ref_787
+          - *ref_788
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -20129,42 +20686,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_788
+                    schema: *ref_789
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_789
+                    schema: *ref_790
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_790
+                    schema: *ref_791
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_791
+                    schema: *ref_792
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_792
+                    schema: *ref_793
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_793
+                    schema: *ref_794
                     header: Date
                     language:
                       default:
@@ -20174,7 +20731,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -20183,7 +20740,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_794
+                    schema: *ref_795
                     header: x-ms-error-code
                     language:
                       default:
@@ -20204,9 +20761,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_283
+            schema: *ref_284
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20218,7 +20775,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_313
+            schema: *ref_314
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20229,7 +20786,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_795
+          - !<!Parameter> &ref_796
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -20242,8 +20799,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_796
-            schema: *ref_301
+          - !<!Parameter> &ref_797
+            schema: *ref_302
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20254,11 +20811,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_797
-            schema: *ref_232
+          - !<!Parameter> &ref_798
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -20267,11 +20824,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_798
-            schema: *ref_232
+          - !<!Parameter> &ref_799
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -20280,11 +20837,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_799
-            schema: *ref_388
+          - !<!Parameter> &ref_800
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -20293,11 +20850,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_800
-            schema: *ref_388
+          - !<!Parameter> &ref_801
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -20306,8 +20863,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_801
+          - *ref_148
+          - !<!Parameter> &ref_802
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -20320,6 +20877,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -20330,13 +20902,13 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_795
           - *ref_796
           - *ref_797
           - *ref_798
           - *ref_799
           - *ref_800
           - *ref_801
+          - *ref_802
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -20347,49 +20919,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_802
+                    schema: *ref_803
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_803
+                    schema: *ref_804
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_804
+                    schema: *ref_805
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a blobs's lease
                   - !<!HttpHeader> 
-                    schema: *ref_805
+                    schema: *ref_806
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_806
+                    schema: *ref_807
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_807
+                    schema: *ref_808
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_808
+                    schema: *ref_809
                     header: Date
                     language:
                       default:
@@ -20399,7 +20971,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -20408,7 +20980,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_809
+                    schema: *ref_810
                     header: x-ms-error-code
                     language:
                       default:
@@ -20429,9 +21001,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_283
+            schema: *ref_284
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20443,7 +21015,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_340
+            schema: *ref_341
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20454,7 +21026,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_810
+          - !<!Parameter> &ref_811
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -20467,8 +21039,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_811
-            schema: *ref_301
+          - !<!Parameter> &ref_812
+            schema: *ref_302
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20479,8 +21051,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_812
-            schema: *ref_341
+          - !<!Parameter> &ref_813
+            schema: *ref_342
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20491,11 +21063,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_813
-            schema: *ref_232
+          - !<!Parameter> &ref_814
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -20504,11 +21076,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_814
-            schema: *ref_232
+          - !<!Parameter> &ref_815
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -20517,11 +21089,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_815
-            schema: *ref_388
+          - !<!Parameter> &ref_816
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -20530,11 +21102,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_816
-            schema: *ref_388
+          - !<!Parameter> &ref_817
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -20543,8 +21115,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_817
+          - *ref_148
+          - !<!Parameter> &ref_818
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -20557,6 +21129,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -20567,7 +21154,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_810
           - *ref_811
           - *ref_812
           - *ref_813
@@ -20575,6 +21161,7 @@ operationGroups:
           - *ref_815
           - *ref_816
           - *ref_817
+          - *ref_818
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -20585,49 +21172,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_818
+                    schema: *ref_819
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_819
+                    schema: *ref_820
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_820
+                    schema: *ref_821
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_821
+                    schema: *ref_822
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_822
+                    schema: *ref_823
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a blobs's lease
                   - !<!HttpHeader> 
-                    schema: *ref_823
+                    schema: *ref_824
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_824
+                    schema: *ref_825
                     header: Date
                     language:
                       default:
@@ -20637,7 +21224,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -20646,7 +21233,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_825
+                    schema: *ref_826
                     header: x-ms-error-code
                     language:
                       default:
@@ -20667,9 +21254,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_283
+            schema: *ref_284
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20681,7 +21268,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_327
+            schema: *ref_328
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20692,7 +21279,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_826
+          - !<!Parameter> &ref_827
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -20705,8 +21292,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_827
-            schema: *ref_285
+          - !<!Parameter> &ref_828
+            schema: *ref_286
             implementation: Method
             language: !<!Languages> 
               default:
@@ -20719,11 +21306,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_828
-            schema: *ref_232
+          - !<!Parameter> &ref_829
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -20732,11 +21319,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_829
-            schema: *ref_232
+          - !<!Parameter> &ref_830
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -20745,11 +21332,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_830
-            schema: *ref_388
+          - !<!Parameter> &ref_831
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -20758,11 +21345,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_831
-            schema: *ref_388
+          - !<!Parameter> &ref_832
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -20771,8 +21358,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_832
+          - *ref_148
+          - !<!Parameter> &ref_833
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -20785,6 +21372,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -20795,13 +21397,13 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_826
           - *ref_827
           - *ref_828
           - *ref_829
           - *ref_830
           - *ref_831
           - *ref_832
+          - *ref_833
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -20812,49 +21414,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_833
+                    schema: *ref_834
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_834
+                    schema: *ref_835
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_835
+                    schema: *ref_836
                     header: x-ms-lease-time
                     language:
                       default:
                         name: LeaseTime
                         description: 'Approximate time remaining in the lease period, in seconds.'
                   - !<!HttpHeader> 
-                    schema: *ref_836
+                    schema: *ref_837
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_837
+                    schema: *ref_838
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_838
+                    schema: *ref_839
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_839
+                    schema: *ref_840
                     header: Date
                     language:
                       default:
@@ -20864,7 +21466,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -20873,7 +21475,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_840
+                    schema: *ref_841
                     header: x-ms-error-code
                     language:
                       default:
@@ -20894,9 +21496,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_841
+            schema: *ref_842
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20907,7 +21509,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_842
+          - !<!Parameter> &ref_843
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -20920,8 +21522,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_843
-            schema: *ref_207
+          - !<!Parameter> &ref_844
+            schema: *ref_208
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -20936,11 +21538,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_844
-            schema: *ref_513
+          - !<!Parameter> &ref_845
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_580
+              x-ms-parameter-grouping: *ref_581
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -20951,11 +21553,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_845
-            schema: *ref_513
+          - !<!Parameter> &ref_846
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_581
+              x-ms-parameter-grouping: *ref_582
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -20965,10 +21567,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_514
+            schema: *ref_515
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_582
+              x-ms-parameter-grouping: *ref_583
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -20977,11 +21579,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_846
-            schema: *ref_232
+          - !<!Parameter> &ref_847
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -20990,11 +21592,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_847
-            schema: *ref_232
+          - !<!Parameter> &ref_848
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -21003,11 +21605,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_848
-            schema: *ref_388
+          - !<!Parameter> &ref_849
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -21016,11 +21618,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_849
-            schema: *ref_388
+          - !<!Parameter> &ref_850
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -21029,11 +21631,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_850
-            schema: *ref_218
+          - !<!Parameter> &ref_851
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -21042,8 +21644,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_851
+          - *ref_148
+          - !<!Parameter> &ref_852
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -21056,6 +21658,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -21066,7 +21683,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_842
           - *ref_843
           - *ref_844
           - *ref_845
@@ -21076,6 +21692,7 @@ operationGroups:
           - *ref_849
           - *ref_850
           - *ref_851
+          - *ref_852
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -21086,56 +21703,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_852
+                    schema: *ref_853
                     header: x-ms-snapshot
                     language:
                       default:
                         name: Snapshot
                         description: Uniquely identifies the snapshot and indicates the snapshot version. It may be used in subsequent requests to access the snapshot
                   - !<!HttpHeader> 
-                    schema: *ref_853
+                    schema: *ref_854
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_854
+                    schema: *ref_855
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_855
+                    schema: *ref_856
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_856
+                    schema: *ref_857
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_857
+                    schema: *ref_858
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_858
+                    schema: *ref_859
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_859
+                    schema: *ref_860
                     header: x-ms-request-server-encrypted
                     language:
                       default:
@@ -21147,7 +21764,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -21156,7 +21773,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_860
+                    schema: *ref_861
                     header: x-ms-error-code
                     language:
                       default:
@@ -21177,8 +21794,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
-          - !<!Parameter> &ref_863
+          - *ref_147
+          - !<!Parameter> &ref_864
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -21191,8 +21808,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_864
-            schema: *ref_207
+          - !<!Parameter> &ref_865
+            schema: *ref_208
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -21207,7 +21824,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_865
+          - !<!Parameter> &ref_866
             schema: *ref_126
             implementation: Method
             language: !<!Languages> 
@@ -21218,8 +21835,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_866
-            schema: *ref_861
+          - !<!Parameter> &ref_867
+            schema: *ref_862
             implementation: Method
             language: !<!Languages> 
               default:
@@ -21229,11 +21846,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_867
-            schema: *ref_422
+          - !<!Parameter> &ref_868
+            schema: *ref_423
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: sourceIfModifiedSince
@@ -21242,11 +21859,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_868
-            schema: *ref_422
+          - !<!Parameter> &ref_869
+            schema: *ref_423
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_681
+              x-ms-parameter-grouping: *ref_682
             language: !<!Languages> 
               default:
                 name: sourceIfUnmodifiedSince
@@ -21255,11 +21872,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_869
-            schema: *ref_413
+          - !<!Parameter> &ref_870
+            schema: *ref_414
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_682
+              x-ms-parameter-grouping: *ref_683
             language: !<!Languages> 
               default:
                 name: sourceIfMatch
@@ -21268,11 +21885,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_870
-            schema: *ref_413
+          - !<!Parameter> &ref_871
+            schema: *ref_414
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_683
+              x-ms-parameter-grouping: *ref_684
             language: !<!Languages> 
               default:
                 name: sourceIfNoneMatch
@@ -21281,11 +21898,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_871
-            schema: *ref_232
+          - !<!Parameter> &ref_872
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -21294,11 +21911,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_872
-            schema: *ref_232
+          - !<!Parameter> &ref_873
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -21307,11 +21924,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_873
-            schema: *ref_388
+          - !<!Parameter> &ref_874
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -21320,11 +21937,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_874
-            schema: *ref_388
+          - !<!Parameter> &ref_875
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -21333,8 +21950,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_875
-            schema: *ref_862
+          - !<!Parameter> &ref_876
+            schema: *ref_863
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -21347,11 +21964,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_876
-            schema: *ref_218
+          - !<!Parameter> &ref_877
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -21360,8 +21977,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_877
+          - *ref_148
+          - !<!Parameter> &ref_878
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -21374,6 +21991,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -21384,7 +22016,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_863
           - *ref_864
           - *ref_865
           - *ref_866
@@ -21399,6 +22030,7 @@ operationGroups:
           - *ref_875
           - *ref_876
           - *ref_877
+          - *ref_878
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -21409,49 +22041,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_878
+                    schema: *ref_879
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_879
+                    schema: *ref_880
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_880
+                    schema: *ref_881
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_881
+                    schema: *ref_882
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_882
+                    schema: *ref_883
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_883
+                    schema: *ref_884
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_884
+                    schema: *ref_885
                     header: x-ms-copy-id
                     language:
                       default:
@@ -21468,7 +22100,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -21477,7 +22109,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_885
+                    schema: *ref_886
                     header: x-ms-error-code
                     language:
                       default:
@@ -21498,9 +22130,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_886
+            schema: *ref_887
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -21511,7 +22143,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_888
+          - !<!Parameter> &ref_889
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -21524,8 +22156,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_889
-            schema: *ref_207
+          - !<!Parameter> &ref_890
+            schema: *ref_208
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -21540,7 +22172,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_890
+          - !<!Parameter> &ref_891
             schema: *ref_126
             implementation: Method
             language: !<!Languages> 
@@ -21551,11 +22183,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_891
-            schema: *ref_422
+          - !<!Parameter> &ref_892
+            schema: *ref_423
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: sourceIfModifiedSince
@@ -21564,11 +22196,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_892
-            schema: *ref_422
+          - !<!Parameter> &ref_893
+            schema: *ref_423
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_681
+              x-ms-parameter-grouping: *ref_682
             language: !<!Languages> 
               default:
                 name: sourceIfUnmodifiedSince
@@ -21577,11 +22209,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_893
-            schema: *ref_413
+          - !<!Parameter> &ref_894
+            schema: *ref_414
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_682
+              x-ms-parameter-grouping: *ref_683
             language: !<!Languages> 
               default:
                 name: sourceIfMatch
@@ -21590,11 +22222,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_894
-            schema: *ref_413
+          - !<!Parameter> &ref_895
+            schema: *ref_414
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_683
+              x-ms-parameter-grouping: *ref_684
             language: !<!Languages> 
               default:
                 name: sourceIfNoneMatch
@@ -21603,11 +22235,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_895
-            schema: *ref_232
+          - !<!Parameter> &ref_896
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -21616,11 +22248,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_896
-            schema: *ref_232
+          - !<!Parameter> &ref_897
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -21629,11 +22261,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_897
-            schema: *ref_388
+          - !<!Parameter> &ref_898
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -21642,11 +22274,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_898
-            schema: *ref_388
+          - !<!Parameter> &ref_899
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -21655,8 +22287,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_899
-            schema: *ref_862
+          - !<!Parameter> &ref_900
+            schema: *ref_863
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -21669,11 +22301,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_900
-            schema: *ref_218
+          - !<!Parameter> &ref_901
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -21682,8 +22314,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_901
+          - *ref_148
+          - !<!Parameter> &ref_902
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -21694,8 +22326,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_902
-            schema: *ref_887
+          - !<!Parameter> &ref_903
+            schema: *ref_888
             implementation: Method
             language: !<!Languages> 
               default:
@@ -21707,6 +22339,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -21717,7 +22364,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_888
           - *ref_889
           - *ref_890
           - *ref_891
@@ -21732,6 +22378,7 @@ operationGroups:
           - *ref_900
           - *ref_901
           - *ref_902
+          - *ref_903
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -21742,70 +22389,70 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_903
+                    schema: *ref_904
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_904
+                    schema: *ref_905
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_905
+                    schema: *ref_906
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_906
+                    schema: *ref_907
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_907
+                    schema: *ref_908
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_908
+                    schema: *ref_909
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_909
+                    schema: *ref_910
                     header: x-ms-copy-id
                     language:
                       default:
                         name: CopyId
                         description: String identifier for this copy operation.
                   - !<!HttpHeader> 
-                    schema: *ref_910
+                    schema: *ref_911
                     header: x-ms-copy-status
                     language:
                       default:
                         name: CopyStatus
                         description: State of the copy operation identified by x-ms-copy-id.
                   - !<!HttpHeader> 
-                    schema: *ref_911
+                    schema: *ref_912
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: This response header is returned so that the client can check for the integrity of the copied content. This header is only returned if the source content MD5 was specified.
                   - !<!HttpHeader> 
-                    schema: *ref_912
+                    schema: *ref_913
                     header: x-ms-content-crc64
                     language:
                       default:
@@ -21815,7 +22462,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -21824,7 +22471,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_913
+                    schema: *ref_914
                     header: x-ms-error-code
                     language:
                       default:
@@ -21845,9 +22492,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_914
+            schema: *ref_915
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -21859,7 +22506,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_915
+            schema: *ref_916
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -21870,8 +22517,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_917
-            schema: *ref_916
+          - !<!Parameter> &ref_918
+            schema: *ref_917
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -21882,7 +22529,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_918
+          - !<!Parameter> &ref_919
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -21895,11 +22542,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_919
-            schema: *ref_218
+          - !<!Parameter> &ref_920
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -21908,8 +22555,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_920
+          - *ref_148
+          - !<!Parameter> &ref_921
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -21922,6 +22569,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -21932,10 +22594,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_917
           - *ref_918
           - *ref_919
           - *ref_920
+          - *ref_921
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -21946,28 +22608,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_916
+                    schema: *ref_917
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_921
+                    schema: *ref_922
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_922
+                    schema: *ref_923
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_923
+                    schema: *ref_924
                     header: Date
                     language:
                       default:
@@ -21977,7 +22639,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -21986,7 +22648,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_924
+                    schema: *ref_925
                     header: x-ms-error-code
                     language:
                       default:
@@ -22007,9 +22669,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_925
+            schema: *ref_926
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22020,7 +22682,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_926
+          - !<!Parameter> &ref_927
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -22033,7 +22695,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_927
+          - !<!Parameter> &ref_928
             schema: *ref_126
             implementation: Method
             required: true
@@ -22045,8 +22707,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_928
-            schema: *ref_861
+          - !<!Parameter> &ref_929
+            schema: *ref_862
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22056,8 +22718,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_929
+          - *ref_148
+          - !<!Parameter> &ref_930
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -22068,11 +22730,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_930
-            schema: *ref_218
+          - !<!Parameter> &ref_931
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -22083,6 +22745,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -22093,11 +22770,11 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_926
           - *ref_927
           - *ref_928
           - *ref_929
           - *ref_930
+          - *ref_931
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -22108,21 +22785,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_931
+                    schema: *ref_932
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_932
+                    schema: *ref_933
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_933
+                    schema: *ref_934
                     header: x-ms-version
                     language:
                       default:
@@ -22139,21 +22816,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_934
+                    schema: *ref_935
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_935
+                    schema: *ref_936
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_936
+                    schema: *ref_937
                     header: x-ms-version
                     language:
                       default:
@@ -22163,7 +22840,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -22172,7 +22849,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_937
+                    schema: *ref_938
                     header: x-ms-error-code
                     language:
                       default:
@@ -22195,9 +22872,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_186
+            schema: *ref_187
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22220,9 +22897,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_147
+          - *ref_148
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -22243,42 +22935,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_938
+                    schema: *ref_939
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_939
+                    schema: *ref_940
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_940
+                    schema: *ref_941
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_941
+                    schema: *ref_942
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_191
+                    schema: *ref_192
                     header: x-ms-sku-name
                     language:
                       default:
                         name: SkuName
                         description: Identifies the sku name of the account
                   - !<!HttpHeader> 
-                    schema: *ref_192
+                    schema: *ref_193
                     header: x-ms-account-kind
                     language:
                       default:
@@ -22288,7 +22980,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -22297,7 +22989,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_942
+                    schema: *ref_943
                     header: x-ms-error-code
                     language:
                       default:
@@ -22326,9 +23018,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_943
+            schema: *ref_944
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22339,7 +23031,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_952
+          - !<!Parameter> &ref_953
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -22352,8 +23044,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_953
-            schema: *ref_195
+          - !<!Parameter> &ref_954
+            schema: *ref_196
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22364,8 +23056,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_954
-            schema: *ref_944
+          - !<!Parameter> &ref_955
+            schema: *ref_945
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22375,11 +23067,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_955
-            schema: *ref_723
+          - !<!Parameter> &ref_956
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_945
+              x-ms-parameter-grouping: *ref_946
             language: !<!Languages> 
               default:
                 name: blobContentType
@@ -22388,29 +23080,16 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_956
-            schema: *ref_723
-            implementation: Method
-            extensions:
-              x-ms-parameter-grouping: *ref_946
-            language: !<!Languages> 
-              default:
-                name: blobContentEncoding
-                description: 'Optional. Sets the blob''s content encoding. If specified, this property is stored with the blob and returned with a read request.'
-                serializedName: x-ms-blob-content-encoding
-            protocol: !<!Protocols> 
-              http: !<!HttpParameter> 
-                in: header
           - !<!Parameter> &ref_957
-            schema: *ref_723
+            schema: *ref_724
             implementation: Method
             extensions:
               x-ms-parameter-grouping: *ref_947
             language: !<!Languages> 
               default:
-                name: blobContentLanguage
-                description: 'Optional. Set the blob''s content language. If specified, this property is stored with the blob and returned with a read request.'
-                serializedName: x-ms-blob-content-language
+                name: blobContentEncoding
+                description: 'Optional. Sets the blob''s content encoding. If specified, this property is stored with the blob and returned with a read request.'
+                serializedName: x-ms-blob-content-encoding
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
@@ -22421,17 +23100,30 @@ operationGroups:
               x-ms-parameter-grouping: *ref_948
             language: !<!Languages> 
               default:
+                name: blobContentLanguage
+                description: 'Optional. Set the blob''s content language. If specified, this property is stored with the blob and returned with a read request.'
+                serializedName: x-ms-blob-content-language
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: header
+          - !<!Parameter> &ref_959
+            schema: *ref_725
+            implementation: Method
+            extensions:
+              x-ms-parameter-grouping: *ref_949
+            language: !<!Languages> 
+              default:
                 name: blobContentMD5
                 description: 'Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks were validated when each was uploaded.'
                 serializedName: x-ms-blob-content-md5
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_959
-            schema: *ref_723
+          - !<!Parameter> &ref_960
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_949
+              x-ms-parameter-grouping: *ref_950
             language: !<!Languages> 
               default:
                 name: blobCacheControl
@@ -22440,8 +23132,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_960
-            schema: *ref_207
+          - !<!Parameter> &ref_961
+            schema: *ref_208
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -22456,11 +23148,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_961
-            schema: *ref_218
+          - !<!Parameter> &ref_962
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -22469,11 +23161,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_962
-            schema: *ref_723
+          - !<!Parameter> &ref_963
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_950
+              x-ms-parameter-grouping: *ref_951
             language: !<!Languages> 
               default:
                 name: blobContentDisposition
@@ -22482,11 +23174,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_963
-            schema: *ref_513
+          - !<!Parameter> &ref_964
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_580
+              x-ms-parameter-grouping: *ref_581
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -22497,11 +23189,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_964
-            schema: *ref_513
+          - !<!Parameter> &ref_965
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_581
+              x-ms-parameter-grouping: *ref_582
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -22511,10 +23203,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_514
+            schema: *ref_515
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_582
+              x-ms-parameter-grouping: *ref_583
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -22523,11 +23215,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_965
-            schema: *ref_232
+          - !<!Parameter> &ref_966
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -22536,11 +23228,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_966
-            schema: *ref_232
+          - !<!Parameter> &ref_967
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -22549,11 +23241,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_967
-            schema: *ref_388
+          - !<!Parameter> &ref_968
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -22562,11 +23254,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_968
-            schema: *ref_388
+          - !<!Parameter> &ref_969
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -22575,8 +23267,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_969
-            schema: *ref_740
+          - !<!Parameter> &ref_970
+            schema: *ref_741
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22587,8 +23279,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_970
-            schema: *ref_951
+          - !<!Parameter> &ref_971
+            schema: *ref_952
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22598,8 +23290,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_971
+          - *ref_148
+          - !<!Parameter> &ref_972
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -22612,6 +23304,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -22622,7 +23329,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_952
           - *ref_953
           - *ref_954
           - *ref_955
@@ -22642,6 +23348,7 @@ operationGroups:
           - *ref_969
           - *ref_970
           - *ref_971
+          - *ref_972
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -22652,63 +23359,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_723
+                    schema: *ref_724
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_972
+                    schema: *ref_973
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_973
+                    schema: *ref_974
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_974
+                    schema: *ref_975
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_975
+                    schema: *ref_976
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_976
+                    schema: *ref_977
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_977
+                    schema: *ref_978
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_978
+                    schema: *ref_979
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_979
+                    schema: *ref_980
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -22718,7 +23425,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -22727,7 +23434,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_980
+                    schema: *ref_981
                     header: x-ms-error-code
                     language:
                       default:
@@ -22748,9 +23455,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_981
+            schema: *ref_982
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22762,7 +23469,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_982
+            schema: *ref_983
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22776,8 +23483,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_986
-            schema: *ref_195
+          - !<!Parameter> &ref_987
+            schema: *ref_196
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22788,8 +23495,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_987
-            schema: *ref_983
+          - !<!Parameter> &ref_988
+            schema: *ref_984
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22799,8 +23506,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_988
-            schema: *ref_984
+          - !<!Parameter> &ref_989
+            schema: *ref_985
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22810,7 +23517,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_989
+          - !<!Parameter> &ref_990
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -22823,8 +23530,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_990
-            schema: *ref_513
+          - !<!Parameter> &ref_991
+            schema: *ref_514
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22834,11 +23541,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_991
-            schema: *ref_218
+          - !<!Parameter> &ref_992
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -22847,11 +23554,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_992
-            schema: *ref_513
+          - !<!Parameter> &ref_993
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_580
+              x-ms-parameter-grouping: *ref_581
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -22862,11 +23569,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_993
-            schema: *ref_513
+          - !<!Parameter> &ref_994
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_581
+              x-ms-parameter-grouping: *ref_582
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -22876,10 +23583,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_514
+            schema: *ref_515
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_582
+              x-ms-parameter-grouping: *ref_583
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -22888,11 +23595,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_994
-            schema: *ref_985
+          - !<!Parameter> &ref_995
+            schema: *ref_986
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_1016
+              x-ms-parameter-grouping: &ref_1017
                 name: sequence-number-access-conditions
             language: !<!Languages> 
               default:
@@ -22902,11 +23609,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_995
-            schema: *ref_985
+          - !<!Parameter> &ref_996
+            schema: *ref_986
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_1017
+              x-ms-parameter-grouping: &ref_1018
                 name: sequence-number-access-conditions
             language: !<!Languages> 
               default:
@@ -22916,11 +23623,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_996
-            schema: *ref_985
+          - !<!Parameter> &ref_997
+            schema: *ref_986
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_1018
+              x-ms-parameter-grouping: &ref_1019
                 name: sequence-number-access-conditions
             language: !<!Languages> 
               default:
@@ -22930,11 +23637,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_997
-            schema: *ref_232
+          - !<!Parameter> &ref_998
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -22943,11 +23650,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_998
-            schema: *ref_232
+          - !<!Parameter> &ref_999
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -22956,11 +23663,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_999
-            schema: *ref_388
+          - !<!Parameter> &ref_1000
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -22969,11 +23676,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1000
-            schema: *ref_388
+          - !<!Parameter> &ref_1001
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -22982,8 +23689,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_1001
+          - *ref_148
+          - !<!Parameter> &ref_1002
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -22997,8 +23704,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1003
-                schema: *ref_1002
+              - !<!Parameter> &ref_1004
+                schema: *ref_1003
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -23009,8 +23716,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_1003
+              - *ref_1004
             language: !<!Languages> 
               default:
                 name: ''
@@ -23025,7 +23745,6 @@ operationGroups:
                   - application/octet-stream
                 uri: '{url}'
         signatureParameters:
-          - *ref_986
           - *ref_987
           - *ref_988
           - *ref_989
@@ -23041,6 +23760,7 @@ operationGroups:
           - *ref_999
           - *ref_1000
           - *ref_1001
+          - *ref_1002
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -23051,77 +23771,77 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1004
+                    schema: *ref_1005
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1005
+                    schema: *ref_1006
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1006
+                    schema: *ref_1007
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1007
+                    schema: *ref_1008
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_985
+                    schema: *ref_986
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for the page blob.
                   - !<!HttpHeader> 
-                    schema: *ref_1008
+                    schema: *ref_1009
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1009
+                    schema: *ref_1010
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1010
+                    schema: *ref_1011
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1011
+                    schema: *ref_1012
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1012
+                    schema: *ref_1013
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1013
+                    schema: *ref_1014
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -23131,7 +23851,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -23140,7 +23860,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1014
+                    schema: *ref_1015
                     header: x-ms-error-code
                     language:
                       default:
@@ -23161,9 +23881,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_981
+            schema: *ref_982
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23175,7 +23895,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_1015
+            schema: *ref_1016
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23189,8 +23909,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1019
-            schema: *ref_195
+          - !<!Parameter> &ref_1020
+            schema: *ref_196
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23201,7 +23921,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1020
+          - !<!Parameter> &ref_1021
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -23214,8 +23934,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1021
-            schema: *ref_513
+          - !<!Parameter> &ref_1022
+            schema: *ref_514
             implementation: Method
             language: !<!Languages> 
               default:
@@ -23225,11 +23945,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1022
-            schema: *ref_218
+          - !<!Parameter> &ref_1023
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -23238,11 +23958,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1023
-            schema: *ref_513
+          - !<!Parameter> &ref_1024
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_580
+              x-ms-parameter-grouping: *ref_581
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -23253,11 +23973,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1024
-            schema: *ref_513
+          - !<!Parameter> &ref_1025
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_581
+              x-ms-parameter-grouping: *ref_582
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -23267,10 +23987,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_514
+            schema: *ref_515
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_582
+              x-ms-parameter-grouping: *ref_583
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -23279,11 +23999,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1025
-            schema: *ref_985
+          - !<!Parameter> &ref_1026
+            schema: *ref_986
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_1016
+              x-ms-parameter-grouping: *ref_1017
             language: !<!Languages> 
               default:
                 name: ifSequenceNumberLessThanOrEqualTo
@@ -23292,11 +24012,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1026
-            schema: *ref_985
+          - !<!Parameter> &ref_1027
+            schema: *ref_986
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_1017
+              x-ms-parameter-grouping: *ref_1018
             language: !<!Languages> 
               default:
                 name: ifSequenceNumberLessThan
@@ -23305,11 +24025,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1027
-            schema: *ref_985
+          - !<!Parameter> &ref_1028
+            schema: *ref_986
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_1018
+              x-ms-parameter-grouping: *ref_1019
             language: !<!Languages> 
               default:
                 name: ifSequenceNumberEqualTo
@@ -23318,11 +24038,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1028
-            schema: *ref_232
+          - !<!Parameter> &ref_1029
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -23331,11 +24051,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1029
-            schema: *ref_232
+          - !<!Parameter> &ref_1030
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -23344,11 +24064,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1030
-            schema: *ref_388
+          - !<!Parameter> &ref_1031
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -23357,11 +24077,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1031
-            schema: *ref_388
+          - !<!Parameter> &ref_1032
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -23370,8 +24090,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_1032
+          - *ref_148
+          - !<!Parameter> &ref_1033
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -23384,6 +24104,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -23394,7 +24129,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1019
           - *ref_1020
           - *ref_1021
           - *ref_1022
@@ -23408,6 +24142,7 @@ operationGroups:
           - *ref_1030
           - *ref_1031
           - *ref_1032
+          - *ref_1033
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -23418,63 +24153,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1033
+                    schema: *ref_1034
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1034
+                    schema: *ref_1035
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1035
+                    schema: *ref_1036
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1036
+                    schema: *ref_1037
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1037
+                    schema: *ref_1038
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for the page blob.
                   - !<!HttpHeader> 
-                    schema: *ref_1038
+                    schema: *ref_1039
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1039
+                    schema: *ref_1040
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1040
+                    schema: *ref_1041
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1041
+                    schema: *ref_1042
                     header: Date
                     language:
                       default:
@@ -23484,7 +24219,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -23493,7 +24228,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1042
+                    schema: *ref_1043
                     header: x-ms-error-code
                     language:
                       default:
@@ -23514,9 +24249,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_981
+            schema: *ref_982
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23528,7 +24263,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_982
+            schema: *ref_983
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23542,8 +24277,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1045
-            schema: *ref_862
+          - !<!Parameter> &ref_1046
+            schema: *ref_863
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23554,8 +24289,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1046
-            schema: *ref_1043
+          - !<!Parameter> &ref_1047
+            schema: *ref_1044
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23566,8 +24301,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1047
-            schema: *ref_887
+          - !<!Parameter> &ref_1048
+            schema: *ref_888
             implementation: Method
             language: !<!Languages> 
               default:
@@ -23577,8 +24312,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1048
-            schema: *ref_1044
+          - !<!Parameter> &ref_1049
+            schema: *ref_1045
             implementation: Method
             language: !<!Languages> 
               default:
@@ -23588,8 +24323,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1049
-            schema: *ref_195
+          - !<!Parameter> &ref_1050
+            schema: *ref_196
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23600,7 +24335,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1050
+          - !<!Parameter> &ref_1051
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -23613,8 +24348,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1051
-            schema: *ref_1043
+          - !<!Parameter> &ref_1052
+            schema: *ref_1044
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23625,11 +24360,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1052
-            schema: *ref_513
+          - !<!Parameter> &ref_1053
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_580
+              x-ms-parameter-grouping: *ref_581
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -23640,11 +24375,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1053
-            schema: *ref_513
+          - !<!Parameter> &ref_1054
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_581
+              x-ms-parameter-grouping: *ref_582
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -23654,10 +24389,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_514
+            schema: *ref_515
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_582
+              x-ms-parameter-grouping: *ref_583
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -23666,11 +24401,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1054
-            schema: *ref_218
+          - !<!Parameter> &ref_1055
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -23679,11 +24414,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1055
-            schema: *ref_985
+          - !<!Parameter> &ref_1056
+            schema: *ref_986
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_1016
+              x-ms-parameter-grouping: *ref_1017
             language: !<!Languages> 
               default:
                 name: ifSequenceNumberLessThanOrEqualTo
@@ -23692,11 +24427,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1056
-            schema: *ref_985
+          - !<!Parameter> &ref_1057
+            schema: *ref_986
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_1017
+              x-ms-parameter-grouping: *ref_1018
             language: !<!Languages> 
               default:
                 name: ifSequenceNumberLessThan
@@ -23705,11 +24440,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1057
-            schema: *ref_985
+          - !<!Parameter> &ref_1058
+            schema: *ref_986
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_1018
+              x-ms-parameter-grouping: *ref_1019
             language: !<!Languages> 
               default:
                 name: ifSequenceNumberEqualTo
@@ -23718,11 +24453,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1058
-            schema: *ref_232
+          - !<!Parameter> &ref_1059
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -23731,11 +24466,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1059
-            schema: *ref_232
+          - !<!Parameter> &ref_1060
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -23744,11 +24479,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1060
-            schema: *ref_388
+          - !<!Parameter> &ref_1061
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -23757,11 +24492,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1061
-            schema: *ref_388
+          - !<!Parameter> &ref_1062
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -23770,11 +24505,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1062
-            schema: *ref_422
+          - !<!Parameter> &ref_1063
+            schema: *ref_423
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: sourceIfModifiedSince
@@ -23783,11 +24518,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1063
-            schema: *ref_422
+          - !<!Parameter> &ref_1064
+            schema: *ref_423
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_681
+              x-ms-parameter-grouping: *ref_682
             language: !<!Languages> 
               default:
                 name: sourceIfUnmodifiedSince
@@ -23796,11 +24531,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1064
-            schema: *ref_413
+          - !<!Parameter> &ref_1065
+            schema: *ref_414
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_682
+              x-ms-parameter-grouping: *ref_683
             language: !<!Languages> 
               default:
                 name: sourceIfMatch
@@ -23809,11 +24544,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1065
-            schema: *ref_413
+          - !<!Parameter> &ref_1066
+            schema: *ref_414
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_683
+              x-ms-parameter-grouping: *ref_684
             language: !<!Languages> 
               default:
                 name: sourceIfNoneMatch
@@ -23822,8 +24557,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_1066
+          - *ref_148
+          - !<!Parameter> &ref_1067
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -23836,6 +24571,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -23846,7 +24596,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1045
           - *ref_1046
           - *ref_1047
           - *ref_1048
@@ -23868,6 +24617,7 @@ operationGroups:
           - *ref_1064
           - *ref_1065
           - *ref_1066
+          - *ref_1067
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -23878,70 +24628,70 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1043
+                    schema: *ref_1044
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1067
+                    schema: *ref_1068
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1068
+                    schema: *ref_1069
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1069
+                    schema: *ref_1070
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1070
+                    schema: *ref_1071
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for the page blob.
                   - !<!HttpHeader> 
-                    schema: *ref_1071
+                    schema: *ref_1072
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1072
+                    schema: *ref_1073
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1073
+                    schema: *ref_1074
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1074
+                    schema: *ref_1075
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1075
+                    schema: *ref_1076
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -23951,7 +24701,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -23960,7 +24710,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1076
+                    schema: *ref_1077
                     header: x-ms-error-code
                     language:
                       default:
@@ -23981,9 +24731,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_1077
+            schema: *ref_1078
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23994,8 +24744,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1078
-            schema: *ref_513
+          - !<!Parameter> &ref_1079
+            schema: *ref_514
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24007,7 +24757,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1079
+          - !<!Parameter> &ref_1080
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -24020,8 +24770,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1080
-            schema: *ref_513
+          - !<!Parameter> &ref_1081
+            schema: *ref_514
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24031,11 +24781,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1081
-            schema: *ref_218
+          - !<!Parameter> &ref_1082
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -24044,11 +24794,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1082
-            schema: *ref_232
+          - !<!Parameter> &ref_1083
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -24057,11 +24807,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1083
-            schema: *ref_232
+          - !<!Parameter> &ref_1084
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -24070,11 +24820,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1084
-            schema: *ref_388
+          - !<!Parameter> &ref_1085
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -24083,11 +24833,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1085
-            schema: *ref_388
+          - !<!Parameter> &ref_1086
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -24096,8 +24846,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_1086
+          - *ref_148
+          - !<!Parameter> &ref_1087
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -24110,6 +24860,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -24120,7 +24885,6 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_1078
           - *ref_1079
           - *ref_1080
           - *ref_1081
@@ -24129,9 +24893,10 @@ operationGroups:
           - *ref_1084
           - *ref_1085
           - *ref_1086
+          - *ref_1087
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1094
+            schema: *ref_1095
             language: !<!Languages> 
               default:
                 name: ''
@@ -24140,49 +24905,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1087
+                    schema: *ref_1088
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1088
+                    schema: *ref_1089
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1089
+                    schema: *ref_1090
                     header: x-ms-blob-content-length
                     language:
                       default:
                         name: BlobContentLength
                         description: The size of the blob in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_1090
+                    schema: *ref_1091
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1091
+                    schema: *ref_1092
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1092
+                    schema: *ref_1093
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1093
+                    schema: *ref_1094
                     header: Date
                     language:
                       default:
@@ -24195,7 +24960,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -24204,7 +24969,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1095
+                    schema: *ref_1096
                     header: x-ms-error-code
                     language:
                       default:
@@ -24225,9 +24990,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_1077
+            schema: *ref_1078
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24238,8 +25003,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1097
-            schema: *ref_513
+          - !<!Parameter> &ref_1098
+            schema: *ref_514
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24251,7 +25016,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1098
+          - !<!Parameter> &ref_1099
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -24264,8 +25029,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1099
-            schema: *ref_1096
+          - !<!Parameter> &ref_1100
+            schema: *ref_1097
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24278,8 +25043,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1100
-            schema: *ref_513
+          - !<!Parameter> &ref_1101
+            schema: *ref_514
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24289,11 +25054,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1101
-            schema: *ref_218
+          - !<!Parameter> &ref_1102
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -24302,11 +25067,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1102
-            schema: *ref_232
+          - !<!Parameter> &ref_1103
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -24315,11 +25080,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1103
-            schema: *ref_232
+          - !<!Parameter> &ref_1104
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -24328,11 +25093,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1104
-            schema: *ref_388
+          - !<!Parameter> &ref_1105
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -24341,11 +25106,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1105
-            schema: *ref_388
+          - !<!Parameter> &ref_1106
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -24354,8 +25119,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_1106
+          - *ref_148
+          - !<!Parameter> &ref_1107
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -24368,6 +25133,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -24378,7 +25158,6 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_1097
           - *ref_1098
           - *ref_1099
           - *ref_1100
@@ -24388,9 +25167,10 @@ operationGroups:
           - *ref_1104
           - *ref_1105
           - *ref_1106
+          - *ref_1107
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1094
+            schema: *ref_1095
             language: !<!Languages> 
               default:
                 name: ''
@@ -24399,49 +25179,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1107
+                    schema: *ref_1108
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1096
+                    schema: *ref_1097
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1108
+                    schema: *ref_1109
                     header: x-ms-blob-content-length
                     language:
                       default:
                         name: BlobContentLength
                         description: The size of the blob in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_1109
+                    schema: *ref_1110
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1110
+                    schema: *ref_1111
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1111
+                    schema: *ref_1112
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1112
+                    schema: *ref_1113
                     header: Date
                     language:
                       default:
@@ -24454,7 +25234,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -24463,7 +25243,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1113
+                    schema: *ref_1114
                     header: x-ms-error-code
                     language:
                       default:
@@ -24484,7 +25264,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
             schema: *ref_134
             implementation: Method
@@ -24497,7 +25277,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1114
+          - !<!Parameter> &ref_1115
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -24510,11 +25290,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1115
-            schema: *ref_218
+          - !<!Parameter> &ref_1116
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -24523,11 +25303,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1116
-            schema: *ref_513
+          - !<!Parameter> &ref_1117
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_580
+              x-ms-parameter-grouping: *ref_581
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -24538,11 +25318,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1117
-            schema: *ref_513
+          - !<!Parameter> &ref_1118
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_581
+              x-ms-parameter-grouping: *ref_582
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -24552,10 +25332,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_514
+            schema: *ref_515
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_582
+              x-ms-parameter-grouping: *ref_583
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -24564,11 +25344,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1118
-            schema: *ref_232
+          - !<!Parameter> &ref_1119
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -24577,11 +25357,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1119
-            schema: *ref_232
+          - !<!Parameter> &ref_1120
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -24590,11 +25370,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1120
-            schema: *ref_388
+          - !<!Parameter> &ref_1121
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -24603,11 +25383,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1121
-            schema: *ref_388
+          - !<!Parameter> &ref_1122
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -24616,8 +25396,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1122
-            schema: *ref_740
+          - !<!Parameter> &ref_1123
+            schema: *ref_741
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24628,8 +25408,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_1123
+          - *ref_148
+          - !<!Parameter> &ref_1124
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -24642,6 +25422,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -24652,7 +25447,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1114
           - *ref_1115
           - *ref_1116
           - *ref_1117
@@ -24662,6 +25456,7 @@ operationGroups:
           - *ref_1121
           - *ref_1122
           - *ref_1123
+          - *ref_1124
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -24672,49 +25467,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1124
+                    schema: *ref_1125
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1125
+                    schema: *ref_1126
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1126
+                    schema: *ref_1127
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for a page blob. This header is not returned for block blobs or append blobs
                   - !<!HttpHeader> 
-                    schema: *ref_1127
+                    schema: *ref_1128
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1128
+                    schema: *ref_1129
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1129
+                    schema: *ref_1130
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1130
+                    schema: *ref_1131
                     header: Date
                     language:
                       default:
@@ -24724,7 +25519,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -24733,7 +25528,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1131
+                    schema: *ref_1132
                     header: x-ms-error-code
                     language:
                       default:
@@ -24754,7 +25549,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
             schema: *ref_134
             implementation: Method
@@ -24767,7 +25562,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1133
+          - !<!Parameter> &ref_1134
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -24780,11 +25575,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1134
-            schema: *ref_218
+          - !<!Parameter> &ref_1135
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -24793,11 +25588,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1135
-            schema: *ref_232
+          - !<!Parameter> &ref_1136
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -24806,11 +25601,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1136
-            schema: *ref_232
+          - !<!Parameter> &ref_1137
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -24819,11 +25614,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1137
-            schema: *ref_388
+          - !<!Parameter> &ref_1138
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -24832,11 +25627,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1138
-            schema: *ref_388
+          - !<!Parameter> &ref_1139
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -24845,8 +25640,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1139
-            schema: *ref_1132
+          - !<!Parameter> &ref_1140
+            schema: *ref_1133
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24857,8 +25652,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1140
-            schema: *ref_951
+          - !<!Parameter> &ref_1141
+            schema: *ref_952
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24868,8 +25663,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_1141
+          - *ref_148
+          - !<!Parameter> &ref_1142
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -24882,6 +25677,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -24892,7 +25702,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1133
           - *ref_1134
           - *ref_1135
           - *ref_1136
@@ -24901,6 +25710,7 @@ operationGroups:
           - *ref_1139
           - *ref_1140
           - *ref_1141
+          - *ref_1142
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -24911,49 +25721,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1142
+                    schema: *ref_1143
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1143
+                    schema: *ref_1144
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1144
+                    schema: *ref_1145
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for a page blob. This header is not returned for block blobs or append blobs
                   - !<!HttpHeader> 
-                    schema: *ref_1145
+                    schema: *ref_1146
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1146
+                    schema: *ref_1147
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1147
+                    schema: *ref_1148
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1148
+                    schema: *ref_1149
                     header: Date
                     language:
                       default:
@@ -24963,7 +25773,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -24972,7 +25782,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1149
+                    schema: *ref_1150
                     header: x-ms-error-code
                     language:
                       default:
@@ -24993,9 +25803,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_1150
+            schema: *ref_1151
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25006,7 +25816,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1151
+          - !<!Parameter> &ref_1152
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -25019,11 +25829,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1152
-            schema: *ref_232
+          - !<!Parameter> &ref_1153
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -25032,11 +25842,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1153
-            schema: *ref_232
+          - !<!Parameter> &ref_1154
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -25045,11 +25855,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1154
-            schema: *ref_388
+          - !<!Parameter> &ref_1155
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -25058,11 +25868,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1155
-            schema: *ref_388
+          - !<!Parameter> &ref_1156
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -25071,8 +25881,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1156
-            schema: *ref_862
+          - !<!Parameter> &ref_1157
+            schema: *ref_863
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25085,8 +25895,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_1157
+          - *ref_148
+          - !<!Parameter> &ref_1158
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -25099,6 +25909,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -25109,13 +25934,13 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1151
           - *ref_1152
           - *ref_1153
           - *ref_1154
           - *ref_1155
           - *ref_1156
           - *ref_1157
+          - *ref_1158
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -25126,49 +25951,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1158
+                    schema: *ref_1159
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1159
+                    schema: *ref_1160
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1160
+                    schema: *ref_1161
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1161
+                    schema: *ref_1162
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1162
+                    schema: *ref_1163
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1163
+                    schema: *ref_1164
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1164
+                    schema: *ref_1165
                     header: x-ms-copy-id
                     language:
                       default:
@@ -25185,7 +26010,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -25194,7 +26019,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1165
+                    schema: *ref_1166
                     header: x-ms-error-code
                     language:
                       default:
@@ -25225,9 +26050,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_1166
+            schema: *ref_1167
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25238,7 +26063,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1167
+          - !<!Parameter> &ref_1168
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -25251,8 +26076,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1168
-            schema: *ref_195
+          - !<!Parameter> &ref_1169
+            schema: *ref_196
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25263,11 +26088,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1169
-            schema: *ref_723
+          - !<!Parameter> &ref_1170
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_945
+              x-ms-parameter-grouping: *ref_946
             language: !<!Languages> 
               default:
                 name: blobContentType
@@ -25276,29 +26101,16 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1170
-            schema: *ref_723
-            implementation: Method
-            extensions:
-              x-ms-parameter-grouping: *ref_946
-            language: !<!Languages> 
-              default:
-                name: blobContentEncoding
-                description: 'Optional. Sets the blob''s content encoding. If specified, this property is stored with the blob and returned with a read request.'
-                serializedName: x-ms-blob-content-encoding
-            protocol: !<!Protocols> 
-              http: !<!HttpParameter> 
-                in: header
           - !<!Parameter> &ref_1171
-            schema: *ref_723
+            schema: *ref_724
             implementation: Method
             extensions:
               x-ms-parameter-grouping: *ref_947
             language: !<!Languages> 
               default:
-                name: blobContentLanguage
-                description: 'Optional. Set the blob''s content language. If specified, this property is stored with the blob and returned with a read request.'
-                serializedName: x-ms-blob-content-language
+                name: blobContentEncoding
+                description: 'Optional. Sets the blob''s content encoding. If specified, this property is stored with the blob and returned with a read request.'
+                serializedName: x-ms-blob-content-encoding
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
@@ -25309,17 +26121,30 @@ operationGroups:
               x-ms-parameter-grouping: *ref_948
             language: !<!Languages> 
               default:
+                name: blobContentLanguage
+                description: 'Optional. Set the blob''s content language. If specified, this property is stored with the blob and returned with a read request.'
+                serializedName: x-ms-blob-content-language
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: header
+          - !<!Parameter> &ref_1173
+            schema: *ref_725
+            implementation: Method
+            extensions:
+              x-ms-parameter-grouping: *ref_949
+            language: !<!Languages> 
+              default:
                 name: blobContentMD5
                 description: 'Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks were validated when each was uploaded.'
                 serializedName: x-ms-blob-content-md5
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1173
-            schema: *ref_723
+          - !<!Parameter> &ref_1174
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_949
+              x-ms-parameter-grouping: *ref_950
             language: !<!Languages> 
               default:
                 name: blobCacheControl
@@ -25328,8 +26153,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1174
-            schema: *ref_207
+          - !<!Parameter> &ref_1175
+            schema: *ref_208
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -25344,11 +26169,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1175
-            schema: *ref_218
+          - !<!Parameter> &ref_1176
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -25357,11 +26182,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1176
-            schema: *ref_723
+          - !<!Parameter> &ref_1177
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_950
+              x-ms-parameter-grouping: *ref_951
             language: !<!Languages> 
               default:
                 name: blobContentDisposition
@@ -25370,11 +26195,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1177
-            schema: *ref_513
+          - !<!Parameter> &ref_1178
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_580
+              x-ms-parameter-grouping: *ref_581
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -25385,11 +26210,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1178
-            schema: *ref_513
+          - !<!Parameter> &ref_1179
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_581
+              x-ms-parameter-grouping: *ref_582
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -25399,10 +26224,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_514
+            schema: *ref_515
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_582
+              x-ms-parameter-grouping: *ref_583
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -25411,11 +26236,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1179
-            schema: *ref_232
+          - !<!Parameter> &ref_1180
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -25424,11 +26249,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1180
-            schema: *ref_232
+          - !<!Parameter> &ref_1181
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -25437,11 +26262,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1181
-            schema: *ref_388
+          - !<!Parameter> &ref_1182
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -25450,11 +26275,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1182
-            schema: *ref_388
+          - !<!Parameter> &ref_1183
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -25463,8 +26288,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_1183
+          - *ref_148
+          - !<!Parameter> &ref_1184
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -25477,6 +26302,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -25487,7 +26327,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1167
           - *ref_1168
           - *ref_1169
           - *ref_1170
@@ -25504,6 +26343,7 @@ operationGroups:
           - *ref_1181
           - *ref_1182
           - *ref_1183
+          - *ref_1184
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -25514,63 +26354,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1184
+                    schema: *ref_1185
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1185
+                    schema: *ref_1186
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1186
+                    schema: *ref_1187
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1187
+                    schema: *ref_1188
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1188
+                    schema: *ref_1189
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1189
+                    schema: *ref_1190
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1190
+                    schema: *ref_1191
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1191
+                    schema: *ref_1192
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1192
+                    schema: *ref_1193
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -25580,7 +26420,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -25589,7 +26429,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1193
+                    schema: *ref_1194
                     header: x-ms-error-code
                     language:
                       default:
@@ -25610,9 +26450,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_1194
+            schema: *ref_1195
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25623,7 +26463,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1196
+          - !<!Parameter> &ref_1197
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -25636,8 +26476,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1197
-            schema: *ref_195
+          - !<!Parameter> &ref_1198
+            schema: *ref_196
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25648,8 +26488,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1198
-            schema: *ref_983
+          - !<!Parameter> &ref_1199
+            schema: *ref_984
             implementation: Method
             language: !<!Languages> 
               default:
@@ -25659,8 +26499,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1199
-            schema: *ref_984
+          - !<!Parameter> &ref_1200
+            schema: *ref_985
             implementation: Method
             language: !<!Languages> 
               default:
@@ -25670,11 +26510,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1200
-            schema: *ref_218
+          - !<!Parameter> &ref_1201
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -25683,11 +26523,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1201
-            schema: *ref_1195
+          - !<!Parameter> &ref_1202
+            schema: *ref_1196
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_1226
+              x-ms-parameter-grouping: &ref_1227
                 name: append-position-access-conditions
             language: !<!Languages> 
               default:
@@ -25699,11 +26539,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1202
-            schema: *ref_1195
+          - !<!Parameter> &ref_1203
+            schema: *ref_1196
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_1227
+              x-ms-parameter-grouping: &ref_1228
                 name: append-position-access-conditions
             language: !<!Languages> 
               default:
@@ -25715,11 +26555,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1203
-            schema: *ref_513
+          - !<!Parameter> &ref_1204
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_580
+              x-ms-parameter-grouping: *ref_581
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -25730,11 +26570,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1204
-            schema: *ref_513
+          - !<!Parameter> &ref_1205
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_581
+              x-ms-parameter-grouping: *ref_582
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -25744,10 +26584,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_514
+            schema: *ref_515
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_582
+              x-ms-parameter-grouping: *ref_583
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -25756,11 +26596,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1205
-            schema: *ref_232
+          - !<!Parameter> &ref_1206
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -25769,11 +26609,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1206
-            schema: *ref_232
+          - !<!Parameter> &ref_1207
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -25782,11 +26622,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1207
-            schema: *ref_388
+          - !<!Parameter> &ref_1208
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -25795,11 +26635,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1208
-            schema: *ref_388
+          - !<!Parameter> &ref_1209
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -25808,8 +26648,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_1209
+          - *ref_148
+          - !<!Parameter> &ref_1210
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -25823,8 +26663,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1211
-                schema: *ref_1210
+              - !<!Parameter> &ref_1212
+                schema: *ref_1211
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -25835,8 +26675,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_1211
+              - *ref_1212
             language: !<!Languages> 
               default:
                 name: ''
@@ -25851,7 +26704,6 @@ operationGroups:
                   - application/octet-stream
                 uri: '{url}'
         signatureParameters:
-          - *ref_1196
           - *ref_1197
           - *ref_1198
           - *ref_1199
@@ -25865,6 +26717,7 @@ operationGroups:
           - *ref_1207
           - *ref_1208
           - *ref_1209
+          - *ref_1210
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -25875,84 +26728,84 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1212
+                    schema: *ref_1213
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1213
+                    schema: *ref_1214
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1214
+                    schema: *ref_1215
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1215
+                    schema: *ref_1216
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1216
+                    schema: *ref_1217
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1217
+                    schema: *ref_1218
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1218
+                    schema: *ref_1219
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1219
+                    schema: *ref_1220
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1220
+                    schema: *ref_1221
                     header: x-ms-blob-append-offset
                     language:
                       default:
                         name: BlobAppendOffset
                         description: 'This response header is returned only for append operations. It returns the offset at which the block was committed, in bytes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1221
+                    schema: *ref_1222
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_1222
+                    schema: *ref_1223
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1223
+                    schema: *ref_1224
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -25962,7 +26815,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -25971,7 +26824,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1224
+                    schema: *ref_1225
                     header: x-ms-error-code
                     language:
                       default:
@@ -25994,9 +26847,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_1194
+            schema: *ref_1195
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26007,8 +26860,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1228
-            schema: *ref_862
+          - !<!Parameter> &ref_1229
+            schema: *ref_863
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26019,8 +26872,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1229
-            schema: *ref_1225
+          - !<!Parameter> &ref_1230
+            schema: *ref_1226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26030,8 +26883,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1230
-            schema: *ref_887
+          - !<!Parameter> &ref_1231
+            schema: *ref_888
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26041,8 +26894,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1231
-            schema: *ref_1044
+          - !<!Parameter> &ref_1232
+            schema: *ref_1045
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26052,7 +26905,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1232
+          - !<!Parameter> &ref_1233
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -26065,8 +26918,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1233
-            schema: *ref_195
+          - !<!Parameter> &ref_1234
+            schema: *ref_196
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26077,8 +26930,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1234
-            schema: *ref_983
+          - !<!Parameter> &ref_1235
+            schema: *ref_984
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26088,11 +26941,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1235
-            schema: *ref_513
+          - !<!Parameter> &ref_1236
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_580
+              x-ms-parameter-grouping: *ref_581
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -26103,11 +26956,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1236
-            schema: *ref_513
+          - !<!Parameter> &ref_1237
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_581
+              x-ms-parameter-grouping: *ref_582
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -26117,10 +26970,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_514
+            schema: *ref_515
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_582
+              x-ms-parameter-grouping: *ref_583
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -26129,11 +26982,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1237
-            schema: *ref_218
+          - !<!Parameter> &ref_1238
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -26142,11 +26995,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1238
-            schema: *ref_1195
+          - !<!Parameter> &ref_1239
+            schema: *ref_1196
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_1226
+              x-ms-parameter-grouping: *ref_1227
             language: !<!Languages> 
               default:
                 name: maxSize
@@ -26157,11 +27010,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1239
-            schema: *ref_1195
+          - !<!Parameter> &ref_1240
+            schema: *ref_1196
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_1227
+              x-ms-parameter-grouping: *ref_1228
             language: !<!Languages> 
               default:
                 name: appendPosition
@@ -26172,11 +27025,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1240
-            schema: *ref_232
+          - !<!Parameter> &ref_1241
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -26185,11 +27038,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1241
-            schema: *ref_232
+          - !<!Parameter> &ref_1242
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -26198,11 +27051,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1242
-            schema: *ref_388
+          - !<!Parameter> &ref_1243
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -26211,11 +27064,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1243
-            schema: *ref_388
+          - !<!Parameter> &ref_1244
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -26224,11 +27077,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1244
-            schema: *ref_422
+          - !<!Parameter> &ref_1245
+            schema: *ref_423
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: sourceIfModifiedSince
@@ -26237,11 +27090,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1245
-            schema: *ref_422
+          - !<!Parameter> &ref_1246
+            schema: *ref_423
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_681
+              x-ms-parameter-grouping: *ref_682
             language: !<!Languages> 
               default:
                 name: sourceIfUnmodifiedSince
@@ -26250,11 +27103,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1246
-            schema: *ref_413
+          - !<!Parameter> &ref_1247
+            schema: *ref_414
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_682
+              x-ms-parameter-grouping: *ref_683
             language: !<!Languages> 
               default:
                 name: sourceIfMatch
@@ -26263,11 +27116,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1247
-            schema: *ref_413
+          - !<!Parameter> &ref_1248
+            schema: *ref_414
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_683
+              x-ms-parameter-grouping: *ref_684
             language: !<!Languages> 
               default:
                 name: sourceIfNoneMatch
@@ -26276,8 +27129,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_1248
+          - *ref_148
+          - !<!Parameter> &ref_1249
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -26290,6 +27143,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -26300,7 +27168,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1228
           - *ref_1229
           - *ref_1230
           - *ref_1231
@@ -26321,6 +27188,7 @@ operationGroups:
           - *ref_1246
           - *ref_1247
           - *ref_1248
+          - *ref_1249
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -26331,77 +27199,77 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1249
+                    schema: *ref_1250
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1250
+                    schema: *ref_1251
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1251
+                    schema: *ref_1252
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1252
+                    schema: *ref_1253
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1253
+                    schema: *ref_1254
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1254
+                    schema: *ref_1255
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1255
+                    schema: *ref_1256
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1256
+                    schema: *ref_1257
                     header: x-ms-blob-append-offset
                     language:
                       default:
                         name: BlobAppendOffset
                         description: 'This response header is returned only for append operations. It returns the offset at which the block was committed, in bytes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1257
+                    schema: *ref_1258
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_1258
+                    schema: *ref_1259
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
                         name: EncryptionKeySha256
                         description: The SHA-256 hash of the encryption key used to encrypt the block. This header is only returned when the block was encrypted with a customer-provided key.
                   - !<!HttpHeader> 
-                    schema: *ref_1259
+                    schema: *ref_1260
                     header: x-ms-request-server-encrypted
                     language:
                       default:
@@ -26411,7 +27279,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -26420,7 +27288,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1260
+                    schema: *ref_1261
                     header: x-ms-error-code
                     language:
                       default:
@@ -26451,9 +27319,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_1261
+            schema: *ref_1262
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26464,7 +27332,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1262
+          - !<!Parameter> &ref_1263
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -26477,8 +27345,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1263
-            schema: *ref_983
+          - !<!Parameter> &ref_1264
+            schema: *ref_984
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26488,8 +27356,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1264
-            schema: *ref_195
+          - !<!Parameter> &ref_1265
+            schema: *ref_196
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26500,11 +27368,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1265
-            schema: *ref_723
+          - !<!Parameter> &ref_1266
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_945
+              x-ms-parameter-grouping: *ref_946
             language: !<!Languages> 
               default:
                 name: blobContentType
@@ -26513,29 +27381,16 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1266
-            schema: *ref_723
-            implementation: Method
-            extensions:
-              x-ms-parameter-grouping: *ref_946
-            language: !<!Languages> 
-              default:
-                name: blobContentEncoding
-                description: 'Optional. Sets the blob''s content encoding. If specified, this property is stored with the blob and returned with a read request.'
-                serializedName: x-ms-blob-content-encoding
-            protocol: !<!Protocols> 
-              http: !<!HttpParameter> 
-                in: header
           - !<!Parameter> &ref_1267
-            schema: *ref_723
+            schema: *ref_724
             implementation: Method
             extensions:
               x-ms-parameter-grouping: *ref_947
             language: !<!Languages> 
               default:
-                name: blobContentLanguage
-                description: 'Optional. Set the blob''s content language. If specified, this property is stored with the blob and returned with a read request.'
-                serializedName: x-ms-blob-content-language
+                name: blobContentEncoding
+                description: 'Optional. Sets the blob''s content encoding. If specified, this property is stored with the blob and returned with a read request.'
+                serializedName: x-ms-blob-content-encoding
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
@@ -26546,17 +27401,30 @@ operationGroups:
               x-ms-parameter-grouping: *ref_948
             language: !<!Languages> 
               default:
+                name: blobContentLanguage
+                description: 'Optional. Set the blob''s content language. If specified, this property is stored with the blob and returned with a read request.'
+                serializedName: x-ms-blob-content-language
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: header
+          - !<!Parameter> &ref_1269
+            schema: *ref_725
+            implementation: Method
+            extensions:
+              x-ms-parameter-grouping: *ref_949
+            language: !<!Languages> 
+              default:
                 name: blobContentMD5
                 description: 'Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks were validated when each was uploaded.'
                 serializedName: x-ms-blob-content-md5
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1269
-            schema: *ref_723
+          - !<!Parameter> &ref_1270
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_949
+              x-ms-parameter-grouping: *ref_950
             language: !<!Languages> 
               default:
                 name: blobCacheControl
@@ -26565,8 +27433,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1270
-            schema: *ref_207
+          - !<!Parameter> &ref_1271
+            schema: *ref_208
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -26581,11 +27449,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1271
-            schema: *ref_218
+          - !<!Parameter> &ref_1272
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -26594,11 +27462,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1272
-            schema: *ref_723
+          - !<!Parameter> &ref_1273
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_950
+              x-ms-parameter-grouping: *ref_951
             language: !<!Languages> 
               default:
                 name: blobContentDisposition
@@ -26607,11 +27475,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1273
-            schema: *ref_513
+          - !<!Parameter> &ref_1274
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_580
+              x-ms-parameter-grouping: *ref_581
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -26622,11 +27490,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1274
-            schema: *ref_513
+          - !<!Parameter> &ref_1275
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_581
+              x-ms-parameter-grouping: *ref_582
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -26636,10 +27504,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_514
+            schema: *ref_515
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_582
+              x-ms-parameter-grouping: *ref_583
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -26648,7 +27516,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1275
+          - !<!Parameter> &ref_1276
             schema: *ref_126
             implementation: Method
             language: !<!Languages> 
@@ -26659,11 +27527,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1276
-            schema: *ref_232
+          - !<!Parameter> &ref_1277
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -26672,11 +27540,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1277
-            schema: *ref_232
+          - !<!Parameter> &ref_1278
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -26685,11 +27553,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1278
-            schema: *ref_388
+          - !<!Parameter> &ref_1279
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -26698,11 +27566,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1279
-            schema: *ref_388
+          - !<!Parameter> &ref_1280
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -26711,8 +27579,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_1280
+          - *ref_148
+          - !<!Parameter> &ref_1281
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -26726,8 +27594,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1282
-                schema: *ref_1281
+              - !<!Parameter> &ref_1283
+                schema: *ref_1282
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -26738,8 +27606,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_1282
+              - *ref_1283
             language: !<!Languages> 
               default:
                 name: ''
@@ -26754,7 +27635,6 @@ operationGroups:
                   - application/octet-stream
                 uri: '{url}'
         signatureParameters:
-          - *ref_1262
           - *ref_1263
           - *ref_1264
           - *ref_1265
@@ -26773,6 +27653,7 @@ operationGroups:
           - *ref_1278
           - *ref_1279
           - *ref_1280
+          - *ref_1281
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -26783,63 +27664,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1283
+                    schema: *ref_1284
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1284
+                    schema: *ref_1285
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1285
+                    schema: *ref_1286
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1286
+                    schema: *ref_1287
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1287
+                    schema: *ref_1288
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1288
+                    schema: *ref_1289
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1289
+                    schema: *ref_1290
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1290
+                    schema: *ref_1291
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1291
+                    schema: *ref_1292
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -26849,7 +27730,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -26858,7 +27739,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1292
+                    schema: *ref_1293
                     header: x-ms-error-code
                     language:
                       default:
@@ -26881,9 +27762,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_1293
+            schema: *ref_1294
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26894,8 +27775,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1295
-            schema: *ref_1294
+          - !<!Parameter> &ref_1296
+            schema: *ref_1295
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26908,8 +27789,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1296
-            schema: *ref_195
+          - !<!Parameter> &ref_1297
+            schema: *ref_196
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26920,8 +27801,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1297
-            schema: *ref_983
+          - !<!Parameter> &ref_1298
+            schema: *ref_984
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26931,8 +27812,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1298
-            schema: *ref_984
+          - !<!Parameter> &ref_1299
+            schema: *ref_985
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26942,7 +27823,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1299
+          - !<!Parameter> &ref_1300
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -26955,11 +27836,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1300
-            schema: *ref_218
+          - !<!Parameter> &ref_1301
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -26968,11 +27849,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1301
-            schema: *ref_513
+          - !<!Parameter> &ref_1302
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_580
+              x-ms-parameter-grouping: *ref_581
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -26983,11 +27864,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1302
-            schema: *ref_513
+          - !<!Parameter> &ref_1303
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_581
+              x-ms-parameter-grouping: *ref_582
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -26997,10 +27878,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_514
+            schema: *ref_515
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_582
+              x-ms-parameter-grouping: *ref_583
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -27009,8 +27890,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_1303
+          - *ref_148
+          - !<!Parameter> &ref_1304
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -27024,8 +27905,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1305
-                schema: *ref_1304
+              - !<!Parameter> &ref_1306
+                schema: *ref_1305
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -27036,8 +27917,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_1305
+              - *ref_1306
             language: !<!Languages> 
               default:
                 name: ''
@@ -27052,7 +27946,6 @@ operationGroups:
                   - application/octet-stream
                 uri: '{url}'
         signatureParameters:
-          - *ref_1295
           - *ref_1296
           - *ref_1297
           - *ref_1298
@@ -27061,6 +27954,7 @@ operationGroups:
           - *ref_1301
           - *ref_1302
           - *ref_1303
+          - *ref_1304
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -27071,56 +27965,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1306
+                    schema: *ref_1307
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1294
+                    schema: *ref_1295
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1307
+                    schema: *ref_1308
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1308
+                    schema: *ref_1309
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1309
+                    schema: *ref_1310
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1310
+                    schema: *ref_1311
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1311
+                    schema: *ref_1312
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1312
+                    schema: *ref_1313
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -27130,7 +28024,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -27139,7 +28033,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1313
+                    schema: *ref_1314
                     header: x-ms-error-code
                     language:
                       default:
@@ -27160,9 +28054,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_1293
+            schema: *ref_1294
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27173,8 +28067,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1314
-            schema: *ref_1294
+          - !<!Parameter> &ref_1315
+            schema: *ref_1295
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27187,8 +28081,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1315
-            schema: *ref_195
+          - !<!Parameter> &ref_1316
+            schema: *ref_196
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27199,8 +28093,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1316
-            schema: *ref_862
+          - !<!Parameter> &ref_1317
+            schema: *ref_863
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27211,8 +28105,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1317
-            schema: *ref_1225
+          - !<!Parameter> &ref_1318
+            schema: *ref_1226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27222,8 +28116,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1318
-            schema: *ref_887
+          - !<!Parameter> &ref_1319
+            schema: *ref_888
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27233,8 +28127,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1319
-            schema: *ref_1044
+          - !<!Parameter> &ref_1320
+            schema: *ref_1045
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27244,7 +28138,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1320
+          - !<!Parameter> &ref_1321
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -27257,11 +28151,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1321
-            schema: *ref_513
+          - !<!Parameter> &ref_1322
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_580
+              x-ms-parameter-grouping: *ref_581
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -27272,11 +28166,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1322
-            schema: *ref_513
+          - !<!Parameter> &ref_1323
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_581
+              x-ms-parameter-grouping: *ref_582
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -27286,10 +28180,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_514
+            schema: *ref_515
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_582
+              x-ms-parameter-grouping: *ref_583
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -27298,11 +28192,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1323
-            schema: *ref_218
+          - !<!Parameter> &ref_1324
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -27311,11 +28205,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1324
-            schema: *ref_422
+          - !<!Parameter> &ref_1325
+            schema: *ref_423
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: sourceIfModifiedSince
@@ -27324,11 +28218,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1325
-            schema: *ref_422
+          - !<!Parameter> &ref_1326
+            schema: *ref_423
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_681
+              x-ms-parameter-grouping: *ref_682
             language: !<!Languages> 
               default:
                 name: sourceIfUnmodifiedSince
@@ -27337,11 +28231,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1326
-            schema: *ref_413
+          - !<!Parameter> &ref_1327
+            schema: *ref_414
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_682
+              x-ms-parameter-grouping: *ref_683
             language: !<!Languages> 
               default:
                 name: sourceIfMatch
@@ -27350,11 +28244,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1327
-            schema: *ref_413
+          - !<!Parameter> &ref_1328
+            schema: *ref_414
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_683
+              x-ms-parameter-grouping: *ref_684
             language: !<!Languages> 
               default:
                 name: sourceIfNoneMatch
@@ -27363,8 +28257,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_1328
+          - *ref_148
+          - !<!Parameter> &ref_1329
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -27377,6 +28271,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -27387,7 +28296,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1314
           - *ref_1315
           - *ref_1316
           - *ref_1317
@@ -27402,6 +28310,7 @@ operationGroups:
           - *ref_1326
           - *ref_1327
           - *ref_1328
+          - *ref_1329
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -27412,56 +28321,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1329
+                    schema: *ref_1330
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1330
+                    schema: *ref_1331
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: x-ms-content-crc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1225
+                    schema: *ref_1226
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1331
+                    schema: *ref_1332
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1332
+                    schema: *ref_1333
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1333
+                    schema: *ref_1334
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1334
+                    schema: *ref_1335
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1335
+                    schema: *ref_1336
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -27471,7 +28380,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -27480,7 +28389,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1336
+                    schema: *ref_1337
                     header: x-ms-error-code
                     language:
                       default:
@@ -27501,9 +28410,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_1337
+            schema: *ref_1338
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27514,7 +28423,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1338
+          - !<!Parameter> &ref_1339
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -27527,11 +28436,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1339
-            schema: *ref_723
+          - !<!Parameter> &ref_1340
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_949
+              x-ms-parameter-grouping: *ref_950
             language: !<!Languages> 
               default:
                 name: blobCacheControl
@@ -27540,11 +28449,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1340
-            schema: *ref_723
+          - !<!Parameter> &ref_1341
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_945
+              x-ms-parameter-grouping: *ref_946
             language: !<!Languages> 
               default:
                 name: blobContentType
@@ -27553,29 +28462,16 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1341
-            schema: *ref_723
-            implementation: Method
-            extensions:
-              x-ms-parameter-grouping: *ref_946
-            language: !<!Languages> 
-              default:
-                name: blobContentEncoding
-                description: 'Optional. Sets the blob''s content encoding. If specified, this property is stored with the blob and returned with a read request.'
-                serializedName: x-ms-blob-content-encoding
-            protocol: !<!Protocols> 
-              http: !<!HttpParameter> 
-                in: header
           - !<!Parameter> &ref_1342
-            schema: *ref_723
+            schema: *ref_724
             implementation: Method
             extensions:
               x-ms-parameter-grouping: *ref_947
             language: !<!Languages> 
               default:
-                name: blobContentLanguage
-                description: 'Optional. Set the blob''s content language. If specified, this property is stored with the blob and returned with a read request.'
-                serializedName: x-ms-blob-content-language
+                name: blobContentEncoding
+                description: 'Optional. Sets the blob''s content encoding. If specified, this property is stored with the blob and returned with a read request.'
+                serializedName: x-ms-blob-content-encoding
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
@@ -27586,14 +28482,27 @@ operationGroups:
               x-ms-parameter-grouping: *ref_948
             language: !<!Languages> 
               default:
+                name: blobContentLanguage
+                description: 'Optional. Set the blob''s content language. If specified, this property is stored with the blob and returned with a read request.'
+                serializedName: x-ms-blob-content-language
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: header
+          - !<!Parameter> &ref_1344
+            schema: *ref_725
+            implementation: Method
+            extensions:
+              x-ms-parameter-grouping: *ref_949
+            language: !<!Languages> 
+              default:
                 name: blobContentMD5
                 description: 'Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks were validated when each was uploaded.'
                 serializedName: x-ms-blob-content-md5
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1344
-            schema: *ref_983
+          - !<!Parameter> &ref_1345
+            schema: *ref_984
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27603,8 +28512,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1345
-            schema: *ref_984
+          - !<!Parameter> &ref_1346
+            schema: *ref_985
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27614,8 +28523,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1346
-            schema: *ref_207
+          - !<!Parameter> &ref_1347
+            schema: *ref_208
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -27630,11 +28539,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1347
-            schema: *ref_218
+          - !<!Parameter> &ref_1348
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -27643,11 +28552,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1348
-            schema: *ref_723
+          - !<!Parameter> &ref_1349
+            schema: *ref_724
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_950
+              x-ms-parameter-grouping: *ref_951
             language: !<!Languages> 
               default:
                 name: blobContentDisposition
@@ -27656,11 +28565,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1349
-            schema: *ref_513
+          - !<!Parameter> &ref_1350
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_580
+              x-ms-parameter-grouping: *ref_581
             language: !<!Languages> 
               default:
                 name: encryptionKey
@@ -27671,11 +28580,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1350
-            schema: *ref_513
+          - !<!Parameter> &ref_1351
+            schema: *ref_514
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_581
+              x-ms-parameter-grouping: *ref_582
             language: !<!Languages> 
               default:
                 name: encryptionKeySha256
@@ -27685,10 +28594,10 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - !<!Parameter> 
-            schema: *ref_514
+            schema: *ref_515
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_582
+              x-ms-parameter-grouping: *ref_583
             language: !<!Languages> 
               default:
                 name: encryptionAlgorithm
@@ -27697,7 +28606,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1351
+          - !<!Parameter> &ref_1352
             schema: *ref_126
             implementation: Method
             language: !<!Languages> 
@@ -27708,11 +28617,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1352
-            schema: *ref_232
+          - !<!Parameter> &ref_1353
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_243
+              x-ms-parameter-grouping: *ref_244
             language: !<!Languages> 
               default:
                 name: ifModifiedSince
@@ -27721,11 +28630,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1353
-            schema: *ref_232
+          - !<!Parameter> &ref_1354
+            schema: *ref_233
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_268
+              x-ms-parameter-grouping: *ref_269
             language: !<!Languages> 
               default:
                 name: ifUnmodifiedSince
@@ -27734,11 +28643,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1354
-            schema: *ref_388
+          - !<!Parameter> &ref_1355
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_420
+              x-ms-parameter-grouping: *ref_421
             language: !<!Languages> 
               default:
                 name: ifMatch
@@ -27747,11 +28656,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1355
-            schema: *ref_388
+          - !<!Parameter> &ref_1356
+            schema: *ref_389
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_421
+              x-ms-parameter-grouping: *ref_422
             language: !<!Languages> 
               default:
                 name: ifNoneMatch
@@ -27760,8 +28669,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_1356
+          - *ref_148
+          - !<!Parameter> &ref_1357
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -27775,8 +28684,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1358
-                schema: *ref_1357
+              - !<!Parameter> &ref_1359
+                schema: *ref_1358
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -27787,8 +28696,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_1358
+              - *ref_1359
             language: !<!Languages> 
               default:
                 name: ''
@@ -27802,7 +28724,6 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_1338
           - *ref_1339
           - *ref_1340
           - *ref_1341
@@ -27821,6 +28742,7 @@ operationGroups:
           - *ref_1354
           - *ref_1355
           - *ref_1356
+          - *ref_1357
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -27831,21 +28753,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1359
+                    schema: *ref_1360
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1360
+                    schema: *ref_1361
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1361
+                    schema: *ref_1362
                     header: Content-MD5
                     language:
                       default:
@@ -27854,7 +28776,7 @@ operationGroups:
                           This header is returned so that the client can check for message content integrity. This header refers to the content of the request, meaning, in this case, the list of blocks, and not the content of the blob
                           itself.
                   - !<!HttpHeader> 
-                    schema: *ref_1362
+                    schema: *ref_1363
                     header: x-ms-content-crc64
                     language:
                       default:
@@ -27863,42 +28785,42 @@ operationGroups:
                           This header is returned so that the client can check for message content integrity. This header refers to the content of the request, meaning, in this case, the list of blocks, and not the content of the blob
                           itself.
                   - !<!HttpHeader> 
-                    schema: *ref_1363
+                    schema: *ref_1364
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1364
+                    schema: *ref_1365
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1365
+                    schema: *ref_1366
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1366
+                    schema: *ref_1367
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1367
+                    schema: *ref_1368
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1368
+                    schema: *ref_1369
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -27908,7 +28830,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -27917,7 +28839,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1369
+                    schema: *ref_1370
                     header: x-ms-error-code
                     language:
                       default:
@@ -27941,9 +28863,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-02-02'
         parameters:
-          - *ref_146
+          - *ref_147
           - !<!Parameter> 
-            schema: *ref_1337
+            schema: *ref_1338
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27954,8 +28876,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1371
-            schema: *ref_513
+          - !<!Parameter> &ref_1372
+            schema: *ref_514
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27967,8 +28889,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1372
-            schema: *ref_1370
+          - !<!Parameter> &ref_1373
+            schema: *ref_1371
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27979,7 +28901,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1373
+          - !<!Parameter> &ref_1374
             schema: *ref_135
             implementation: Method
             language: !<!Languages> 
@@ -27992,11 +28914,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1374
-            schema: *ref_218
+          - !<!Parameter> &ref_1375
+            schema: *ref_219
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_231
+              x-ms-parameter-grouping: *ref_232
             language: !<!Languages> 
               default:
                 name: leaseId
@@ -28005,8 +28927,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_147
-          - !<!Parameter> &ref_1375
+          - *ref_148
+          - !<!Parameter> &ref_1376
             schema: *ref_137
             implementation: Method
             language: !<!Languages> 
@@ -28019,6 +28941,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_141
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -28029,14 +28966,14 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_1371
           - *ref_1372
           - *ref_1373
           - *ref_1374
           - *ref_1375
+          - *ref_1376
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1384
+            schema: *ref_1385
             language: !<!Languages> 
               default:
                 name: ''
@@ -28045,56 +28982,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1376
+                    schema: *ref_1377
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1377
+                    schema: *ref_1378
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1378
+                    schema: *ref_1379
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: The media type of the body of the response. For Get Block List this is 'application/xml'
                   - !<!HttpHeader> 
-                    schema: *ref_1379
+                    schema: *ref_1380
                     header: x-ms-blob-content-length
                     language:
                       default:
                         name: BlobContentLength
                         description: The size of the blob in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_1380
+                    schema: *ref_1381
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1381
+                    schema: *ref_1382
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1382
+                    schema: *ref_1383
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1383
+                    schema: *ref_1384
                     header: Date
                     language:
                       default:
@@ -28107,7 +29044,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -28116,7 +29053,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1385
+                    schema: *ref_1386
                     header: x-ms-error-code
                     language:
                       default:

--- a/modelerfour/test/scenarios/blob-storage/namer.yaml
+++ b/modelerfour/test/scenarios/blob-storage/namer.yaml
@@ -59,7 +59,7 @@ schemas: !<!Schemas>
           name: Boolean
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_329
+    - !<!BooleanSchema> &ref_330
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -70,7 +70,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-has-immutability-policy
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_330
+    - !<!BooleanSchema> &ref_331
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -81,7 +81,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-has-legal-hold
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_548
+    - !<!BooleanSchema> &ref_549
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -92,7 +92,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_673
+    - !<!BooleanSchema> &ref_674
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -103,7 +103,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_697
+    - !<!BooleanSchema> &ref_698
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -114,7 +114,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-incremental-copy
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_714
+    - !<!BooleanSchema> &ref_715
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -125,7 +125,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_717
+    - !<!BooleanSchema> &ref_718
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -136,7 +136,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-access-tier-inferred
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1073
+    - !<!BooleanSchema> &ref_1074
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -147,7 +147,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1290
+    - !<!BooleanSchema> &ref_1291
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -158,7 +158,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1389
+    - !<!BooleanSchema> &ref_1390
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -169,7 +169,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_857
+    - !<!BooleanSchema> &ref_858
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -180,7 +180,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_955
+    - !<!BooleanSchema> &ref_956
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -191,7 +191,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1411
+    - !<!BooleanSchema> &ref_1412
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -202,7 +202,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1435
+    - !<!BooleanSchema> &ref_1436
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -213,7 +213,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1469
+    - !<!BooleanSchema> &ref_1470
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -224,7 +224,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1107
+    - !<!BooleanSchema> &ref_1108
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -235,7 +235,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1168
+    - !<!BooleanSchema> &ref_1169
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -246,7 +246,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1321
+    - !<!BooleanSchema> &ref_1322
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -257,7 +257,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-server-encrypted
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_1357
+    - !<!BooleanSchema> &ref_1358
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -299,7 +299,7 @@ schemas: !<!Schemas>
           name: Integer
           description: The maximum amount time that a browser should cache the preflight OPTIONS request.
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_262
+    - !<!NumberSchema> &ref_263
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -319,7 +319,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_296
+    - !<!NumberSchema> &ref_297
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -331,7 +331,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_387
+    - !<!NumberSchema> &ref_388
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -359,7 +359,7 @@ schemas: !<!Schemas>
           name: BlobSequenceNumber
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_543
+    - !<!NumberSchema> &ref_544
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -371,7 +371,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_626
+    - !<!NumberSchema> &ref_627
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -383,7 +383,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_635
+    - !<!NumberSchema> &ref_636
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -395,7 +395,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_646
+    - !<!NumberSchema> &ref_647
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -407,7 +407,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-committed-block-count
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_651
+    - !<!NumberSchema> &ref_652
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -419,7 +419,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_660
+    - !<!NumberSchema> &ref_661
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -431,7 +431,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_672
+    - !<!NumberSchema> &ref_673
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -443,7 +443,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-committed-block-count
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_699
+    - !<!NumberSchema> &ref_700
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -455,7 +455,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_707
+    - !<!NumberSchema> &ref_708
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -467,7 +467,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_713
+    - !<!NumberSchema> &ref_714
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -479,7 +479,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-committed-block-count
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_805
+    - !<!NumberSchema> &ref_806
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -491,7 +491,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_834
+    - !<!NumberSchema> &ref_835
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -503,7 +503,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1058
+    - !<!NumberSchema> &ref_1059
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -515,7 +515,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_930
+    - !<!NumberSchema> &ref_931
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -527,7 +527,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-lease-time
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1483
+    - !<!NumberSchema> &ref_1484
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -559,7 +559,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1130
+    - !<!NumberSchema> &ref_1131
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -571,7 +571,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1164
+    - !<!NumberSchema> &ref_1165
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -583,7 +583,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1185
+    - !<!NumberSchema> &ref_1186
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -623,7 +623,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1204
+    - !<!NumberSchema> &ref_1205
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -635,7 +635,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-content-length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1223
+    - !<!NumberSchema> &ref_1224
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -647,7 +647,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-sequence-number
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1242
+    - !<!NumberSchema> &ref_1243
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -670,7 +670,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1320
+    - !<!NumberSchema> &ref_1321
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -682,7 +682,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-committed-block-count
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1355
+    - !<!NumberSchema> &ref_1356
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -805,7 +805,7 @@ schemas: !<!Schemas>
           name: StaticWebsiteErrorDocument404Path
           description: The absolute path of the custom 404 page
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_241
+    - !<!StringSchema> &ref_242
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -816,7 +816,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_242
+    - !<!StringSchema> &ref_243
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -827,7 +827,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_244
+    - !<!StringSchema> &ref_245
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -848,17 +848,6 @@ schemas: !<!Schemas>
           name: StorageErrorMessage
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_247
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_248
       type: string
       apiVersions:
@@ -868,7 +857,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_249
       type: string
@@ -879,7 +868,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_250
       type: string
@@ -890,9 +879,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_255
+    - !<!StringSchema> &ref_251
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -901,7 +890,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_256
       type: string
@@ -912,7 +901,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_257
       type: string
@@ -923,9 +912,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_258
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_259
+    - !<!StringSchema> &ref_260
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -936,7 +936,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_261
+    - !<!StringSchema> &ref_262
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -947,7 +947,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_270
+    - !<!StringSchema> &ref_271
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -958,7 +958,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_271
+    - !<!StringSchema> &ref_272
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1065,7 +1065,7 @@ schemas: !<!Schemas>
           name: KeyInfoExpiry
           description: The date-time the key expires in ISO 8601 UTC time
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_282
+    - !<!StringSchema> &ref_283
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1076,7 +1076,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_283
+    - !<!StringSchema> &ref_284
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1087,7 +1087,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_284
+    - !<!StringSchema> &ref_285
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1148,7 +1148,7 @@ schemas: !<!Schemas>
           name: UserDelegationKeyValue
           description: The key as a base64 string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_286
+    - !<!StringSchema> &ref_287
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1158,17 +1158,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_288
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_289
       type: string
@@ -1179,7 +1168,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_290
       type: string
@@ -1190,9 +1179,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_291
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_294
+    - !<!StringSchema> &ref_295
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1203,7 +1203,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_297
+    - !<!StringSchema> &ref_298
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1214,17 +1214,6 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_304
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_305
       type: string
       apiVersions:
@@ -1234,7 +1223,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_306
       type: string
@@ -1245,9 +1234,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_307
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_308
+    - !<!StringSchema> &ref_309
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1258,7 +1258,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_314
+    - !<!StringSchema> &ref_315
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1269,7 +1269,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_315
+    - !<!StringSchema> &ref_316
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1280,7 +1280,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_316
+    - !<!StringSchema> &ref_317
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1291,7 +1291,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_318
+    - !<!StringSchema> &ref_319
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1313,7 +1313,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-meta
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_323
+    - !<!StringSchema> &ref_324
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1323,17 +1323,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_325
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_326
       type: string
@@ -1344,7 +1333,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_327
       type: string
@@ -1355,9 +1344,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_328
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_331
+    - !<!StringSchema> &ref_332
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1367,17 +1367,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_338
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_339
       type: string
@@ -1388,7 +1377,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_340
       type: string
@@ -1399,7 +1388,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_341
       type: string
@@ -1410,9 +1399,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_342
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_350
+    - !<!StringSchema> &ref_351
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1422,17 +1422,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_352
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_353
       type: string
@@ -1443,7 +1432,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_354
       type: string
@@ -1454,9 +1443,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_355
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_356
+    - !<!StringSchema> &ref_357
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1467,7 +1467,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_363
+    - !<!StringSchema> &ref_364
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1478,7 +1478,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_365
+    - !<!StringSchema> &ref_366
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1489,7 +1489,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_366
+    - !<!StringSchema> &ref_367
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1500,7 +1500,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_367
+    - !<!StringSchema> &ref_368
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1531,7 +1531,7 @@ schemas: !<!Schemas>
           name: AccessPolicyPermission
           description: the permissions for the acl policy
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_369
+    - !<!StringSchema> &ref_370
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1542,7 +1542,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_378
+    - !<!StringSchema> &ref_379
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1552,17 +1552,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_380
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_381
       type: string
@@ -1573,7 +1562,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_382
       type: string
@@ -1584,9 +1573,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_383
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_384
+    - !<!StringSchema> &ref_385
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1597,7 +1597,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_388
+    - !<!StringSchema> &ref_389
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1607,17 +1607,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_396
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_397
       type: string
@@ -1628,7 +1617,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_398
       type: string
@@ -1639,7 +1628,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_399
       type: string
@@ -1650,9 +1639,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_400
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_401
+    - !<!StringSchema> &ref_402
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1663,7 +1663,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_403
+    - !<!StringSchema> &ref_404
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1673,17 +1673,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_410
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_411
       type: string
@@ -1694,7 +1683,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_412
       type: string
@@ -1705,9 +1694,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_413
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_414
+    - !<!StringSchema> &ref_415
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1718,7 +1718,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_421
+    - !<!StringSchema> &ref_422
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1728,17 +1728,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_423
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_424
       type: string
@@ -1749,7 +1738,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_425
       type: string
@@ -1760,7 +1749,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_426
       type: string
@@ -1771,9 +1760,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_427
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_428
+    - !<!StringSchema> &ref_429
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1784,7 +1784,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_435
+    - !<!StringSchema> &ref_436
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1794,17 +1794,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_437
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_438
       type: string
@@ -1815,7 +1804,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_439
       type: string
@@ -1826,9 +1815,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_440
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_441
+    - !<!StringSchema> &ref_442
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1839,7 +1839,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_443
+    - !<!StringSchema> &ref_444
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1850,7 +1850,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_451
+    - !<!StringSchema> &ref_452
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1861,17 +1861,6 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-lease-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_452
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_453
       type: string
       apiVersions:
@@ -1881,7 +1870,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_454
       type: string
@@ -1892,9 +1881,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_455
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_456
+    - !<!StringSchema> &ref_457
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1905,7 +1905,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_465
+    - !<!StringSchema> &ref_466
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1916,7 +1916,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_466
+    - !<!StringSchema> &ref_467
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1927,7 +1927,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_467
+    - !<!StringSchema> &ref_468
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1938,7 +1938,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_468
+    - !<!StringSchema> &ref_469
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2175,7 +2175,7 @@ schemas: !<!Schemas>
           name: ListBlobsFlatSegmentResponseNextMarker
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_470
+    - !<!StringSchema> &ref_471
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2186,7 +2186,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_479
+    - !<!StringSchema> &ref_480
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2197,7 +2197,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_480
+    - !<!StringSchema> &ref_481
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2208,7 +2208,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_481
+    - !<!StringSchema> &ref_482
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2299,7 +2299,7 @@ schemas: !<!Schemas>
           name: ListBlobsHierarchySegmentResponseNextMarker
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_483
+    - !<!StringSchema> &ref_484
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2310,7 +2310,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_484
+    - !<!StringSchema> &ref_485
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2321,7 +2321,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_485
+    - !<!StringSchema> &ref_486
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2332,7 +2332,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_486
+    - !<!StringSchema> &ref_487
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2343,7 +2343,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_488
+    - !<!StringSchema> &ref_489
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2365,17 +2365,6 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_507
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_508
       type: string
       apiVersions:
@@ -2385,7 +2374,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_509
       type: string
@@ -2396,9 +2385,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_512
+    - !<!StringSchema> &ref_510
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2407,7 +2396,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_513
       type: string
@@ -2418,9 +2407,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_514
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_515
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2462,17 +2462,6 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-continuation
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_539
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: ETag
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_540
       type: string
       apiVersions:
@@ -2482,7 +2471,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_541
       type: string
@@ -2493,7 +2482,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_542
       type: string
@@ -2504,9 +2493,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_545
+    - !<!StringSchema> &ref_543
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2515,7 +2504,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_546
       type: string
@@ -2526,7 +2515,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_547
       type: string
@@ -2537,9 +2526,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_559
+    - !<!StringSchema> &ref_548
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2548,7 +2537,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-continuation
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_560
       type: string
@@ -2559,7 +2548,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-continuation
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_561
       type: string
@@ -2570,7 +2559,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_562
       type: string
@@ -2581,9 +2570,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_564
+    - !<!StringSchema> &ref_563
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2592,7 +2581,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_565
       type: string
@@ -2603,7 +2592,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_566
       type: string
@@ -2614,9 +2603,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_567
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_569
+    - !<!StringSchema> &ref_570
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2626,17 +2626,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_583
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_584
       type: string
@@ -2647,7 +2636,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_585
       type: string
@@ -2658,7 +2647,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_586
       type: string
@@ -2669,7 +2658,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_587
       type: string
@@ -2680,9 +2669,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_588
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_599
+    - !<!StringSchema> &ref_600
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2693,7 +2693,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_601
+    - !<!StringSchema> &ref_602
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2704,7 +2704,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-owner
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_602
+    - !<!StringSchema> &ref_603
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2715,7 +2715,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-group
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_603
+    - !<!StringSchema> &ref_604
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2726,7 +2726,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-permissions
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_604
+    - !<!StringSchema> &ref_605
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2737,17 +2737,6 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-acl
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_605
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_606
       type: string
       apiVersions:
@@ -2757,7 +2746,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_607
       type: string
@@ -2768,7 +2757,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_608
       type: string
@@ -2779,9 +2768,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_609
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_610
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2803,17 +2803,6 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-meta
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_627
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Content-Type
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_628
       type: string
       apiVersions:
@@ -2823,7 +2812,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Range
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_629
       type: string
@@ -2834,9 +2823,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: ETag
+          header: Content-Range
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_631
+    - !<!StringSchema> &ref_630
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2845,7 +2834,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Encoding
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_632
       type: string
@@ -2856,7 +2845,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Cache-Control
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_633
       type: string
@@ -2867,7 +2856,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Disposition
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_634
       type: string
@@ -2878,9 +2867,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Language
+          header: Content-Disposition
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_637
+    - !<!StringSchema> &ref_635
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2889,7 +2878,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-copy-status-description
+          header: Content-Language
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_638
       type: string
@@ -2900,7 +2889,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-copy-id
+          header: x-ms-copy-status-description
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_639
       type: string
@@ -2911,7 +2900,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-copy-progress
+          header: x-ms-copy-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_640
       type: string
@@ -2922,7 +2911,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-copy-source
+          header: x-ms-copy-progress
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_641
       type: string
@@ -2933,7 +2922,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-copy-source
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_642
       type: string
@@ -2944,7 +2933,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_643
       type: string
@@ -2955,7 +2944,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_644
       type: string
@@ -2966,9 +2955,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_645
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: Accept-Ranges
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_647
+    - !<!StringSchema> &ref_648
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2979,7 +2979,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_650
+    - !<!StringSchema> &ref_651
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -2989,17 +2989,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: x-ms-meta
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_652
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_653
       type: string
@@ -3010,7 +2999,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Range
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_654
       type: string
@@ -3021,9 +3010,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: ETag
+          header: Content-Range
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_656
+    - !<!StringSchema> &ref_655
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3032,7 +3021,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Encoding
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_657
       type: string
@@ -3043,7 +3032,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Cache-Control
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_658
       type: string
@@ -3054,7 +3043,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Disposition
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_659
       type: string
@@ -3065,9 +3054,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Language
+          header: Content-Disposition
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_663
+    - !<!StringSchema> &ref_660
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3076,7 +3065,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-copy-status-description
+          header: Content-Language
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_664
       type: string
@@ -3087,7 +3076,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-copy-id
+          header: x-ms-copy-status-description
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_665
       type: string
@@ -3098,7 +3087,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-copy-progress
+          header: x-ms-copy-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_666
       type: string
@@ -3109,7 +3098,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-copy-source
+          header: x-ms-copy-progress
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_667
       type: string
@@ -3120,7 +3109,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-copy-source
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_668
       type: string
@@ -3131,7 +3120,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_669
       type: string
@@ -3142,7 +3131,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_670
       type: string
@@ -3153,9 +3142,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_671
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: Accept-Ranges
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_674
+    - !<!StringSchema> &ref_675
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3166,7 +3166,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_676
+    - !<!StringSchema> &ref_677
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3177,7 +3177,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_691
+    - !<!StringSchema> &ref_692
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3188,7 +3188,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-meta
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_693
+    - !<!StringSchema> &ref_694
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3199,7 +3199,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-status-description
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_694
+    - !<!StringSchema> &ref_695
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3210,7 +3210,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_695
+    - !<!StringSchema> &ref_696
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3221,7 +3221,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-progress
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_696
+    - !<!StringSchema> &ref_697
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3232,7 +3232,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-source
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_698
+    - !<!StringSchema> &ref_699
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3243,7 +3243,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-destination-snapshot
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_700
+    - !<!StringSchema> &ref_701
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3254,7 +3254,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_701
+    - !<!StringSchema> &ref_702
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3264,17 +3264,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_703
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_704
       type: string
@@ -3285,7 +3274,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Disposition
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_705
       type: string
@@ -3296,7 +3285,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Language
+          header: Content-Disposition
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_706
       type: string
@@ -3307,9 +3296,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Cache-Control
+          header: Content-Language
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_708
+    - !<!StringSchema> &ref_707
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3318,7 +3307,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_709
       type: string
@@ -3329,7 +3318,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_710
       type: string
@@ -3340,9 +3329,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_711
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_712
+    - !<!StringSchema> &ref_713
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3353,7 +3353,7 @@ schemas: !<!Schemas>
           description: ''
           header: Accept-Ranges
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_715
+    - !<!StringSchema> &ref_716
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3364,7 +3364,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_716
+    - !<!StringSchema> &ref_717
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3375,7 +3375,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-access-tier
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_718
+    - !<!StringSchema> &ref_719
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3386,7 +3386,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-archive-status
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_720
+    - !<!StringSchema> &ref_721
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3396,17 +3396,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_732
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_733
       type: string
@@ -3417,7 +3406,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_734
       type: string
@@ -3428,9 +3417,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_735
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_736
+    - !<!StringSchema> &ref_737
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3441,7 +3441,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_750
+    - !<!StringSchema> &ref_751
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3451,17 +3451,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_752
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_753
       type: string
@@ -3472,7 +3461,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_754
       type: string
@@ -3483,7 +3472,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_755
       type: string
@@ -3494,7 +3483,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_756
       type: string
@@ -3505,9 +3494,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_757
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_767
+    - !<!StringSchema> &ref_768
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3517,17 +3517,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_769
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-owner
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_770
       type: string
@@ -3538,7 +3527,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-group
+          header: x-ms-owner
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_771
       type: string
@@ -3549,7 +3538,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-permissions
+          header: x-ms-group
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_772
       type: string
@@ -3560,7 +3549,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-acl
+          header: x-ms-permissions
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_773
       type: string
@@ -3571,7 +3560,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-acl
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_774
       type: string
@@ -3582,7 +3571,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_775
       type: string
@@ -3593,7 +3582,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_776
       type: string
@@ -3604,7 +3593,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_777
       type: string
@@ -3615,9 +3604,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_778
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_800
+    - !<!StringSchema> &ref_801
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3628,17 +3628,6 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_802
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_803
       type: string
       apiVersions:
@@ -3648,7 +3637,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_804
       type: string
@@ -3659,9 +3648,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_807
+    - !<!StringSchema> &ref_805
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3670,7 +3659,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_808
       type: string
@@ -3681,9 +3670,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_809
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_810
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3705,17 +3705,6 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1069
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1070
       type: string
       apiVersions:
@@ -3725,7 +3714,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1071
       type: string
@@ -3736,9 +3725,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1074
+    - !<!StringSchema> &ref_1072
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3747,7 +3736,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1075
       type: string
@@ -3758,9 +3747,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1076
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1283
+    - !<!StringSchema> &ref_1284
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3770,17 +3770,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1286
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1287
       type: string
@@ -3791,7 +3780,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1288
       type: string
@@ -3802,9 +3791,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1291
+    - !<!StringSchema> &ref_1289
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3813,7 +3802,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1292
       type: string
@@ -3824,9 +3813,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1293
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1382
+    - !<!StringSchema> &ref_1383
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3836,17 +3836,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1385
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1386
       type: string
@@ -3857,7 +3846,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1387
       type: string
@@ -3868,9 +3857,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1390
+    - !<!StringSchema> &ref_1388
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3879,7 +3868,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1391
       type: string
@@ -3890,9 +3879,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-error-code
+          header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_813
+    - !<!StringSchema> &ref_1392
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3901,7 +3890,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_814
       type: string
@@ -3912,7 +3901,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_815
       type: string
@@ -3923,9 +3912,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_816
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_817
+    - !<!StringSchema> &ref_818
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3936,7 +3936,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_832
+    - !<!StringSchema> &ref_833
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3946,17 +3946,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_835
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_836
       type: string
@@ -3967,7 +3956,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_837
       type: string
@@ -3978,9 +3967,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_838
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_839
+    - !<!StringSchema> &ref_840
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -3991,7 +3991,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_851
+    - !<!StringSchema> &ref_852
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4001,17 +4001,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_853
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_854
       type: string
@@ -4022,7 +4011,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_855
       type: string
@@ -4033,9 +4022,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_858
+    - !<!StringSchema> &ref_856
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4044,7 +4033,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_859
       type: string
@@ -4055,9 +4044,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_860
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_868
+    - !<!StringSchema> &ref_869
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4067,17 +4067,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_870
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_871
       type: string
@@ -4088,7 +4077,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_872
       type: string
@@ -4099,7 +4088,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_873
       type: string
@@ -4110,9 +4099,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_874
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_875
+    - !<!StringSchema> &ref_876
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4123,7 +4123,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_883
+    - !<!StringSchema> &ref_884
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4133,17 +4133,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_885
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_886
       type: string
@@ -4154,7 +4143,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_887
       type: string
@@ -4165,9 +4154,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_888
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_889
+    - !<!StringSchema> &ref_890
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4178,7 +4178,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_897
+    - !<!StringSchema> &ref_898
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4188,17 +4188,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_899
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_900
       type: string
@@ -4209,7 +4198,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-lease-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_901
       type: string
@@ -4220,7 +4209,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_902
       type: string
@@ -4231,9 +4220,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_903
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_904
+    - !<!StringSchema> &ref_905
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4244,7 +4244,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_913
+    - !<!StringSchema> &ref_914
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4254,17 +4254,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_915
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_916
       type: string
@@ -4275,7 +4264,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_917
       type: string
@@ -4286,7 +4275,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-lease-id
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_918
       type: string
@@ -4297,9 +4286,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-lease-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_919
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_920
+    - !<!StringSchema> &ref_921
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4310,7 +4310,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_928
+    - !<!StringSchema> &ref_929
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4320,17 +4320,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_931
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_932
       type: string
@@ -4341,7 +4330,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_933
       type: string
@@ -4352,9 +4341,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_934
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_935
+    - !<!StringSchema> &ref_936
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4364,17 +4364,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_948
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-snapshot
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_949
       type: string
@@ -4385,9 +4374,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: ETag
+          header: x-ms-snapshot
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_951
+    - !<!StringSchema> &ref_950
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4396,7 +4385,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_952
       type: string
@@ -4407,7 +4396,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_953
       type: string
@@ -4418,9 +4407,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_954
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_956
+    - !<!StringSchema> &ref_957
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4431,7 +4431,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_975
+    - !<!StringSchema> &ref_976
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4441,17 +4441,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_977
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_978
       type: string
@@ -4462,7 +4451,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_979
       type: string
@@ -4473,9 +4462,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_981
+    - !<!StringSchema> &ref_980
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4484,7 +4473,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-copy-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_982
       type: string
@@ -4495,9 +4484,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-copy-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_983
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1001
+    - !<!StringSchema> &ref_1002
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4508,17 +4508,6 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1003
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1004
       type: string
       apiVersions:
@@ -4528,7 +4517,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1005
       type: string
@@ -4539,9 +4528,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1006
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1007
+    - !<!StringSchema> &ref_1008
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4552,7 +4552,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1011
+    - !<!StringSchema> &ref_1012
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4563,7 +4563,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1014
+    - !<!StringSchema> &ref_1015
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4573,17 +4573,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1020
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1021
       type: string
@@ -4594,9 +4583,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1022
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1023
+    - !<!StringSchema> &ref_1024
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4606,17 +4606,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: x-ms-error-code
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1031
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1032
       type: string
@@ -4627,7 +4616,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1033
       type: string
@@ -4638,7 +4627,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1034
       type: string
@@ -4649,7 +4638,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1035
       type: string
@@ -4660,7 +4649,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1036
       type: string
@@ -4671,7 +4660,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1037
       type: string
@@ -4682,7 +4671,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1038
       type: string
@@ -4693,7 +4682,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1039
       type: string
@@ -4704,7 +4693,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1040
       type: string
@@ -4715,9 +4704,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1041
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1042
+    - !<!StringSchema> &ref_1043
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4728,7 +4728,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1393
+    - !<!StringSchema> &ref_1394
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4738,17 +4738,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: x-ms-client-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1407
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1408
       type: string
@@ -4759,9 +4748,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1412
+    - !<!StringSchema> &ref_1409
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4770,7 +4759,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1413
       type: string
@@ -4781,9 +4770,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1414
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1324
+    - !<!StringSchema> &ref_1325
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4794,7 +4794,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-client-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1432
+    - !<!StringSchema> &ref_1433
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4805,7 +4805,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1433
+    - !<!StringSchema> &ref_1434
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4816,7 +4816,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1436
+    - !<!StringSchema> &ref_1437
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4827,7 +4827,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1437
+    - !<!StringSchema> &ref_1438
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4886,7 +4886,7 @@ schemas: !<!Schemas>
           name: BlockLookupListLatestItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1461
+    - !<!StringSchema> &ref_1462
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4896,17 +4896,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1465
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1466
       type: string
@@ -4917,7 +4906,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1467
       type: string
@@ -4928,9 +4917,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1470
+    - !<!StringSchema> &ref_1468
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4939,7 +4928,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1471
       type: string
@@ -4950,9 +4939,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-error-code
+          header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1481
+    - !<!StringSchema> &ref_1472
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4961,7 +4950,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: ETag
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1482
       type: string
@@ -4972,9 +4961,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Type
+          header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1484
+    - !<!StringSchema> &ref_1483
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -4983,7 +4972,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1485
       type: string
@@ -4994,9 +4983,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1486
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1487
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5017,7 +5017,7 @@ schemas: !<!Schemas>
           name: BlockName
           description: The base64 encoded block ID.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1488
+    - !<!StringSchema> &ref_1489
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5028,7 +5028,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1099
+    - !<!StringSchema> &ref_1100
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5038,17 +5038,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1103
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1104
       type: string
@@ -5059,7 +5048,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1105
       type: string
@@ -5070,9 +5059,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1108
+    - !<!StringSchema> &ref_1106
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5081,7 +5070,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1109
       type: string
@@ -5092,9 +5081,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1110
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1126
+    - !<!StringSchema> &ref_1127
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5104,17 +5104,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1131
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1132
       type: string
@@ -5125,7 +5114,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1133
       type: string
@@ -5136,9 +5125,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1135
+    - !<!StringSchema> &ref_1134
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5147,7 +5136,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1136
       type: string
@@ -5158,9 +5147,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: ETag
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1165
+    - !<!StringSchema> &ref_1137
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5169,7 +5158,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1166
       type: string
@@ -5180,9 +5169,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1169
+    - !<!StringSchema> &ref_1167
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5191,7 +5180,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-encryption-key-sha256
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1170
       type: string
@@ -5202,9 +5191,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1171
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1184
+    - !<!StringSchema> &ref_1185
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5214,17 +5214,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1186
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1187
       type: string
@@ -5235,7 +5224,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1188
       type: string
@@ -5246,9 +5235,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1190
+    - !<!StringSchema> &ref_1189
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5257,7 +5246,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-error-code
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1191
       type: string
@@ -5268,9 +5257,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: ETag
+          header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1205
+    - !<!StringSchema> &ref_1192
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5279,7 +5268,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-client-request-id
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1206
       type: string
@@ -5290,7 +5279,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1207
       type: string
@@ -5301,9 +5290,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1208
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1209
+    - !<!StringSchema> &ref_1210
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5314,7 +5314,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1221
+    - !<!StringSchema> &ref_1222
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5324,17 +5324,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1224
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1225
       type: string
@@ -5345,7 +5334,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1226
       type: string
@@ -5356,9 +5345,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1227
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1228
+    - !<!StringSchema> &ref_1229
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5369,7 +5369,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1240
+    - !<!StringSchema> &ref_1241
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5379,17 +5379,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1243
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1244
       type: string
@@ -5400,7 +5389,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1245
       type: string
@@ -5411,9 +5400,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1246
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1247
+    - !<!StringSchema> &ref_1248
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5424,7 +5424,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1256
+    - !<!StringSchema> &ref_1257
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5434,17 +5434,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1258
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1259
       type: string
@@ -5455,7 +5444,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1260
       type: string
@@ -5466,9 +5455,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1262
+    - !<!StringSchema> &ref_1261
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5477,7 +5466,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-copy-id
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1263
       type: string
@@ -5488,9 +5477,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-copy-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1264
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1311
+    - !<!StringSchema> &ref_1312
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5500,17 +5500,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1315
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1316
       type: string
@@ -5521,7 +5510,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-request-id
+          header: x-ms-client-request-id
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1317
       type: string
@@ -5532,9 +5521,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1318
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1319
+    - !<!StringSchema> &ref_1320
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5544,17 +5544,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: x-ms-blob-append-offset
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1322
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_1323
       type: string
@@ -5565,9 +5554,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-encryption-key-sha256
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1324
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-error-code
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1347
+    - !<!StringSchema> &ref_1348
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5578,7 +5578,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1351
+    - !<!StringSchema> &ref_1352
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5589,7 +5589,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1352
+    - !<!StringSchema> &ref_1353
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5600,7 +5600,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1354
+    - !<!StringSchema> &ref_1355
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5611,7 +5611,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-append-offset
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1356
+    - !<!StringSchema> &ref_1357
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5622,7 +5622,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-encryption-key-sha256
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1358
+    - !<!StringSchema> &ref_1359
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -5832,7 +5832,7 @@ schemas: !<!Schemas>
           name: ArchiveStatus
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_1044
+    - !<!ChoiceSchema> &ref_1045
       choices:
         - !<!ChoiceValue> 
           value: P4
@@ -5910,7 +5910,7 @@ schemas: !<!Schemas>
           name: PremiumPageBlobAccessTier
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ChoiceSchema> &ref_957
+    - !<!ChoiceSchema> &ref_958
       choices:
         - !<!ChoiceValue> 
           value: High
@@ -6700,7 +6700,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-lease-duration
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_292
+    - !<!SealedChoiceSchema> &ref_293
       choices:
         - !<!ChoiceValue> 
           value: Standard_LRS
@@ -6743,7 +6743,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-sku-name
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_293
+    - !<!SealedChoiceSchema> &ref_294
       choices:
         - !<!ChoiceValue> 
           value: Storage
@@ -6908,7 +6908,7 @@ schemas: !<!Schemas>
           name: PathRenameMode
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_722
+    - !<!SealedChoiceSchema> &ref_723
       choices:
         - !<!ChoiceValue> 
           value: include
@@ -6932,7 +6932,7 @@ schemas: !<!Schemas>
           name: DeleteSnapshotsOptionType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_1472
+    - !<!SealedChoiceSchema> &ref_1473
       choices:
         - !<!ChoiceValue> 
           value: committed
@@ -6963,7 +6963,7 @@ schemas: !<!Schemas>
           name: BlockListType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_1234
+    - !<!SealedChoiceSchema> &ref_1235
       choices:
         - !<!ChoiceValue> 
           value: max
@@ -7024,27 +7024,37 @@ schemas: !<!Schemas>
           name: Constant21
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_251
+    - !<!ConstantSchema> &ref_238
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/xml
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/xml'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_252
       type: constant
       value: !<!ConstantValue> 
         value: stats
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant22
+          name: Constant23
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_260
+    - !<!ConstantSchema> &ref_261
       type: constant
       value: !<!ConstantValue> 
         value: list
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant23
+          name: Constant24
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_263
+    - !<!ConstantSchema> &ref_264
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -7057,70 +7067,60 @@ schemas: !<!Schemas>
           name: ListContainersIncludeType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_272
+    - !<!ConstantSchema> &ref_273
       type: constant
       value: !<!ConstantValue> 
         value: userdelegationkey
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant25
+          name: Constant26
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_287
+    - !<!ConstantSchema> &ref_288
       type: constant
       value: !<!ConstantValue> 
         value: account
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant26
+          name: Constant27
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_295
+    - !<!ConstantSchema> &ref_296
       type: constant
       value: !<!ConstantValue> 
         value: batch
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant27
+          name: Constant28
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_307
+    - !<!ConstantSchema> &ref_308
       type: constant
       value: !<!ConstantValue> 
         value: container
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant28
+          name: Constant29
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_342
+    - !<!ConstantSchema> &ref_343
       type: constant
       value: !<!ConstantValue> 
         value: metadata
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant29
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_357
-      type: constant
-      value: !<!ConstantValue> 
-        value: acl
-      valueType: *ref_0
-      language: !<!Languages> 
-        default:
           name: Constant30
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_385
+    - !<!ConstantSchema> &ref_358
       type: constant
       value: !<!ConstantValue> 
-        value: lease
+        value: acl
       valueType: *ref_0
       language: !<!Languages> 
         default:
@@ -7130,6 +7130,16 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_386
       type: constant
       value: !<!ConstantValue> 
+        value: lease
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Constant32
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_387
+      type: constant
+      value: !<!ConstantValue> 
         value: acquire
       valueType: *ref_0
       language: !<!Languages> 
@@ -7137,7 +7147,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_402
+    - !<!ConstantSchema> &ref_403
       type: constant
       value: !<!ConstantValue> 
         value: release
@@ -7147,7 +7157,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_415
+    - !<!ConstantSchema> &ref_416
       type: constant
       value: !<!ConstantValue> 
         value: renew
@@ -7157,7 +7167,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_429
+    - !<!ConstantSchema> &ref_430
       type: constant
       value: !<!ConstantValue> 
         value: break
@@ -7167,7 +7177,7 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_442
+    - !<!ConstantSchema> &ref_443
       type: constant
       value: !<!ConstantValue> 
         value: change
@@ -7177,37 +7187,37 @@ schemas: !<!Schemas>
           name: LeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_489
+    - !<!ConstantSchema> &ref_490
       type: constant
       value: !<!ConstantValue> 
         value: directory
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant37
+          name: Constant38
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_567
+    - !<!ConstantSchema> &ref_568
       type: constant
       value: !<!ConstantValue> 
         value: setAccessControl
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant38
+          name: Constant39
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_588
+    - !<!ConstantSchema> &ref_589
       type: constant
       value: !<!ConstantValue> 
         value: getAccessControl
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant39
+          name: Constant40
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_613
+    - !<!ConstantSchema> &ref_614
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -7220,7 +7230,7 @@ schemas: !<!Schemas>
           name: EncryptionAlgorithmType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1043
+    - !<!ConstantSchema> &ref_1044
       type: constant
       value: !<!ConstantValue> 
         value: PageBlob
@@ -7230,7 +7240,7 @@ schemas: !<!Schemas>
           name: BlobType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1264
+    - !<!ConstantSchema> &ref_1265
       type: constant
       value: !<!ConstantValue> 
         value: AppendBlob
@@ -7240,7 +7250,7 @@ schemas: !<!Schemas>
           name: BlobType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1359
+    - !<!ConstantSchema> &ref_1360
       type: constant
       value: !<!ConstantValue> 
         value: BlockBlob
@@ -7250,37 +7260,37 @@ schemas: !<!Schemas>
           name: BlobType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_810
+    - !<!ConstantSchema> &ref_811
       type: constant
       value: !<!ConstantValue> 
         value: undelete
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant44
+          name: Constant45
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_936
+    - !<!ConstantSchema> &ref_937
       type: constant
       value: !<!ConstantValue> 
         value: snapshot
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant45
+          name: Constant46
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_983
+    - !<!ConstantSchema> &ref_984
       type: constant
       value: !<!ConstantValue> 
         value: 'true'
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant46
+          name: Constant47
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1008
+    - !<!ConstantSchema> &ref_1009
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -7294,60 +7304,50 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-status
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1012
+    - !<!ConstantSchema> &ref_1013
       type: constant
       value: !<!ConstantValue> 
         value: copy
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant48
+          name: Constant49
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1013
+    - !<!ConstantSchema> &ref_1014
       type: constant
       value: !<!ConstantValue> 
         value: abort
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant49
+          name: Constant50
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1024
+    - !<!ConstantSchema> &ref_1025
       type: constant
       value: !<!ConstantValue> 
         value: tier
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant50
+          name: Constant51
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1392
+    - !<!ConstantSchema> &ref_1393
       type: constant
       value: !<!ConstantValue> 
         value: block
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant51
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1438
-      type: constant
-      value: !<!ConstantValue> 
-        value: blocklist
-      valueType: *ref_0
-      language: !<!Languages> 
-        default:
           name: Constant52
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1076
+    - !<!ConstantSchema> &ref_1439
       type: constant
       value: !<!ConstantValue> 
-        value: page
+        value: blocklist
       valueType: *ref_0
       language: !<!Languages> 
         default:
@@ -7357,6 +7357,16 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_1077
       type: constant
       value: !<!ConstantValue> 
+        value: page
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Constant54
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_1078
+      type: constant
+      value: !<!ConstantValue> 
         value: update
       valueType: *ref_0
       language: !<!Languages> 
@@ -7364,7 +7374,7 @@ schemas: !<!Schemas>
           name: PageWriteType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1110
+    - !<!ConstantSchema> &ref_1111
       type: constant
       value: !<!ConstantValue> 
         value: clear
@@ -7374,34 +7384,34 @@ schemas: !<!Schemas>
           name: PageWriteType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1171
+    - !<!ConstantSchema> &ref_1172
       type: constant
       value: !<!ConstantValue> 
         value: pagelist
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant56
+          name: Constant57
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1248
+    - !<!ConstantSchema> &ref_1249
       type: constant
       value: !<!ConstantValue> 
         value: incrementalcopy
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant57
+          name: Constant58
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_1293
+    - !<!ConstantSchema> &ref_1294
       type: constant
       value: !<!ConstantValue> 
         value: appendblock
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant58
+          name: Constant59
           description: ''
       protocol: !<!Protocols> {}
   dictionaries:
@@ -7422,7 +7432,7 @@ schemas: !<!Schemas>
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
   binaries:
-    - !<!BinarySchema> &ref_298
+    - !<!BinarySchema> &ref_299
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7432,7 +7442,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_1373
+    - !<!BinarySchema> &ref_1374
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7442,7 +7452,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_1397
+    - !<!BinarySchema> &ref_1398
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7452,7 +7462,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_1090
+    - !<!BinarySchema> &ref_1091
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7462,7 +7472,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_1303
+    - !<!BinarySchema> &ref_1304
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -7484,7 +7494,7 @@ schemas: !<!Schemas>
           name: BlobPropertiesContentMD5
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_630
+    - !<!ByteArraySchema> &ref_631
       type: byte-array
       format: byte
       apiVersions:
@@ -7496,7 +7506,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_648
+    - !<!ByteArraySchema> &ref_649
       type: byte-array
       format: byte
       apiVersions:
@@ -7508,7 +7518,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-content-md5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_655
+    - !<!ByteArraySchema> &ref_656
       type: byte-array
       format: byte
       apiVersions:
@@ -7520,7 +7530,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_661
+    - !<!ByteArraySchema> &ref_662
       type: byte-array
       format: byte
       apiVersions:
@@ -7532,7 +7542,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_675
+    - !<!ByteArraySchema> &ref_676
       type: byte-array
       format: byte
       apiVersions:
@@ -7544,7 +7554,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-blob-content-md5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_702
+    - !<!ByteArraySchema> &ref_703
       type: byte-array
       format: byte
       apiVersions:
@@ -7567,7 +7577,7 @@ schemas: !<!Schemas>
           name: ByteArray
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1068
+    - !<!ByteArraySchema> &ref_1069
       type: byte-array
       format: byte
       apiVersions:
@@ -7579,7 +7589,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1285
+    - !<!ByteArraySchema> &ref_1286
       type: byte-array
       format: byte
       apiVersions:
@@ -7590,64 +7600,6 @@ schemas: !<!Schemas>
           name: ByteArray
           description: ''
           header: Content-MD5
-      protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1078
-      type: byte-array
-      format: byte
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: ByteArray
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1384
-      type: byte-array
-      format: byte
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: ByteArray
-          description: ''
-          header: Content-MD5
-      protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_993
-      type: byte-array
-      format: byte
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: ByteArray
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1009
-      type: byte-array
-      format: byte
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: ByteArray
-          description: ''
-          header: Content-MD5
-      protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1010
-      type: byte-array
-      format: byte
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: ByteArray
-          description: ''
-          header: x-ms-content-crc64
       protocol: !<!Protocols> {}
     - !<!ByteArraySchema> &ref_1079
       type: byte-array
@@ -7660,7 +7612,7 @@ schemas: !<!Schemas>
           name: ByteArray
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1406
+    - !<!ByteArraySchema> &ref_1385
       type: byte-array
       format: byte
       apiVersions:
@@ -7672,7 +7624,30 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1410
+    - !<!ByteArraySchema> &ref_994
+      type: byte-array
+      format: byte
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: ByteArray
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ByteArraySchema> &ref_1010
+      type: byte-array
+      format: byte
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: ByteArray
+          description: ''
+          header: Content-MD5
+      protocol: !<!Protocols> {}
+    - !<!ByteArraySchema> &ref_1011
       type: byte-array
       format: byte
       apiVersions:
@@ -7684,7 +7659,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1137
+    - !<!ByteArraySchema> &ref_1080
       type: byte-array
       format: byte
       apiVersions:
@@ -7695,7 +7670,7 @@ schemas: !<!Schemas>
           name: ByteArray
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1430
+    - !<!ByteArraySchema> &ref_1407
       type: byte-array
       format: byte
       apiVersions:
@@ -7706,6 +7681,29 @@ schemas: !<!Schemas>
           name: ByteArray
           description: ''
           header: Content-MD5
+      protocol: !<!Protocols> {}
+    - !<!ByteArraySchema> &ref_1411
+      type: byte-array
+      format: byte
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: ByteArray
+          description: ''
+          header: x-ms-content-crc64
+      protocol: !<!Protocols> {}
+    - !<!ByteArraySchema> &ref_1138
+      type: byte-array
+      format: byte
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: ByteArray
+          description: ''
       protocol: !<!Protocols> {}
     - !<!ByteArraySchema> &ref_1431
       type: byte-array
@@ -7717,9 +7715,9 @@ schemas: !<!Schemas>
         default:
           name: ByteArray
           description: ''
-          header: x-ms-content-crc64
+          header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1463
+    - !<!ByteArraySchema> &ref_1432
       type: byte-array
       format: byte
       apiVersions:
@@ -7729,7 +7727,7 @@ schemas: !<!Schemas>
         default:
           name: ByteArray
           description: ''
-          header: Content-MD5
+          header: x-ms-content-crc64
       protocol: !<!Protocols> {}
     - !<!ByteArraySchema> &ref_1464
       type: byte-array
@@ -7741,9 +7739,9 @@ schemas: !<!Schemas>
         default:
           name: ByteArray
           description: ''
-          header: x-ms-content-crc64
+          header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1101
+    - !<!ByteArraySchema> &ref_1465
       type: byte-array
       format: byte
       apiVersions:
@@ -7753,7 +7751,7 @@ schemas: !<!Schemas>
         default:
           name: ByteArray
           description: ''
-          header: Content-MD5
+          header: x-ms-content-crc64
       protocol: !<!Protocols> {}
     - !<!ByteArraySchema> &ref_1102
       type: byte-array
@@ -7765,9 +7763,9 @@ schemas: !<!Schemas>
         default:
           name: ByteArray
           description: ''
-          header: x-ms-content-crc64
+          header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1128
+    - !<!ByteArraySchema> &ref_1103
       type: byte-array
       format: byte
       apiVersions:
@@ -7777,7 +7775,7 @@ schemas: !<!Schemas>
         default:
           name: ByteArray
           description: ''
-          header: Content-MD5
+          header: x-ms-content-crc64
       protocol: !<!Protocols> {}
     - !<!ByteArraySchema> &ref_1129
       type: byte-array
@@ -7789,9 +7787,9 @@ schemas: !<!Schemas>
         default:
           name: ByteArray
           description: ''
-          header: x-ms-content-crc64
+          header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1162
+    - !<!ByteArraySchema> &ref_1130
       type: byte-array
       format: byte
       apiVersions:
@@ -7801,7 +7799,7 @@ schemas: !<!Schemas>
         default:
           name: ByteArray
           description: ''
-          header: Content-MD5
+          header: x-ms-content-crc64
       protocol: !<!Protocols> {}
     - !<!ByteArraySchema> &ref_1163
       type: byte-array
@@ -7813,9 +7811,9 @@ schemas: !<!Schemas>
         default:
           name: ByteArray
           description: ''
-          header: x-ms-content-crc64
+          header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1313
+    - !<!ByteArraySchema> &ref_1164
       type: byte-array
       format: byte
       apiVersions:
@@ -7825,7 +7823,7 @@ schemas: !<!Schemas>
         default:
           name: ByteArray
           description: ''
-          header: Content-MD5
+          header: x-ms-content-crc64
       protocol: !<!Protocols> {}
     - !<!ByteArraySchema> &ref_1314
       type: byte-array
@@ -7837,9 +7835,21 @@ schemas: !<!Schemas>
         default:
           name: ByteArray
           description: ''
+          header: Content-MD5
+      protocol: !<!Protocols> {}
+    - !<!ByteArraySchema> &ref_1315
+      type: byte-array
+      format: byte
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: ByteArray
+          description: ''
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1349
+    - !<!ByteArraySchema> &ref_1350
       type: byte-array
       format: byte
       apiVersions:
@@ -7851,7 +7861,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!ByteArraySchema> &ref_1350
+    - !<!ByteArraySchema> &ref_1351
       type: byte-array
       format: byte
       apiVersions:
@@ -7864,7 +7874,7 @@ schemas: !<!Schemas>
           header: x-ms-content-crc64
       protocol: !<!Protocols> {}
   dateTimes:
-    - !<!DateTimeSchema> &ref_258
+    - !<!DateTimeSchema> &ref_259
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7898,7 +7908,7 @@ schemas: !<!Schemas>
           name: ContainerPropertiesLastModified
           description: ''
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_285
+    - !<!DateTimeSchema> &ref_286
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7932,7 +7942,7 @@ schemas: !<!Schemas>
           name: UserDelegationKeySignedExpiry
           description: The date-time the key expires
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_291
+    - !<!DateTimeSchema> &ref_292
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7944,7 +7954,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_313
+    - !<!DateTimeSchema> &ref_314
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7956,7 +7966,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_317
+    - !<!DateTimeSchema> &ref_318
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7968,7 +7978,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_324
+    - !<!DateTimeSchema> &ref_325
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -7980,7 +7990,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_328
+    - !<!DateTimeSchema> &ref_329
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8004,7 +8014,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_351
+    - !<!DateTimeSchema> &ref_352
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8016,7 +8026,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_355
+    - !<!DateTimeSchema> &ref_356
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8028,7 +8038,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_364
+    - !<!DateTimeSchema> &ref_365
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8040,7 +8050,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_368
+    - !<!DateTimeSchema> &ref_369
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8074,7 +8084,7 @@ schemas: !<!Schemas>
           name: AccessPolicyExpiry
           description: the date-time the policy expires
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_379
+    - !<!DateTimeSchema> &ref_380
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8086,7 +8096,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_383
+    - !<!DateTimeSchema> &ref_384
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8098,7 +8108,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_395
+    - !<!DateTimeSchema> &ref_396
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8110,7 +8120,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_400
+    - !<!DateTimeSchema> &ref_401
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8122,7 +8132,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_409
+    - !<!DateTimeSchema> &ref_410
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8134,7 +8144,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_413
+    - !<!DateTimeSchema> &ref_414
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8146,7 +8156,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_422
+    - !<!DateTimeSchema> &ref_423
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8158,7 +8168,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_427
+    - !<!DateTimeSchema> &ref_428
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8170,7 +8180,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_436
+    - !<!DateTimeSchema> &ref_437
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8182,7 +8192,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_440
+    - !<!DateTimeSchema> &ref_441
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8194,7 +8204,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_450
+    - !<!DateTimeSchema> &ref_451
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8206,7 +8216,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_455
+    - !<!DateTimeSchema> &ref_456
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8218,7 +8228,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_469
+    - !<!DateTimeSchema> &ref_470
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8285,7 +8295,7 @@ schemas: !<!Schemas>
           name: BlobPropertiesAccessTierChangeTime
           description: ''
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_482
+    - !<!DateTimeSchema> &ref_483
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8297,7 +8307,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_487
+    - !<!DateTimeSchema> &ref_488
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8309,7 +8319,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_506
+    - !<!DateTimeSchema> &ref_507
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8321,7 +8331,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_510
+    - !<!DateTimeSchema> &ref_511
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8345,7 +8355,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_544
+    - !<!DateTimeSchema> &ref_545
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8357,19 +8367,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_563
-      type: date-time
-      format: date-time-rfc1123
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: DateTime
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_581
+    - !<!DateTimeSchema> &ref_564
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8391,9 +8389,21 @@ schemas: !<!Schemas>
         default:
           name: DateTime
           description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!DateTimeSchema> &ref_583
+      type: date-time
+      format: date-time-rfc1123
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: DateTime
+          description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_598
+    - !<!DateTimeSchema> &ref_599
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8405,7 +8415,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_600
+    - !<!DateTimeSchema> &ref_601
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8417,7 +8427,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_625
+    - !<!DateTimeSchema> &ref_626
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8429,7 +8439,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_636
+    - !<!DateTimeSchema> &ref_637
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8441,7 +8451,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-completion-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_645
+    - !<!DateTimeSchema> &ref_646
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8453,7 +8463,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_649
+    - !<!DateTimeSchema> &ref_650
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8465,7 +8475,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_662
+    - !<!DateTimeSchema> &ref_663
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8477,7 +8487,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-completion-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_671
+    - !<!DateTimeSchema> &ref_672
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8488,18 +8498,6 @@ schemas: !<!Schemas>
           name: DateTime
           description: ''
           header: Date
-      protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_689
-      type: date-time
-      format: date-time-rfc1123
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-02-02'
-      language: !<!Languages> 
-        default:
-          name: DateTime
-          description: ''
-          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!DateTimeSchema> &ref_690
       type: date-time
@@ -8511,9 +8509,21 @@ schemas: !<!Schemas>
         default:
           name: DateTime
           description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!DateTimeSchema> &ref_691
+      type: date-time
+      format: date-time-rfc1123
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-02-02'
+      language: !<!Languages> 
+        default:
+          name: DateTime
+          description: ''
           header: x-ms-creation-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_692
+    - !<!DateTimeSchema> &ref_693
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8525,7 +8535,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-copy-completion-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_711
+    - !<!DateTimeSchema> &ref_712
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8537,7 +8547,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_719
+    - !<!DateTimeSchema> &ref_720
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8549,7 +8559,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-access-tier-change-time
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_735
+    - !<!DateTimeSchema> &ref_736
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8561,7 +8571,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_749
+    - !<!DateTimeSchema> &ref_750
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8573,7 +8583,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_751
+    - !<!DateTimeSchema> &ref_752
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8585,7 +8595,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_766
+    - !<!DateTimeSchema> &ref_767
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8597,7 +8607,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_768
+    - !<!DateTimeSchema> &ref_769
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8609,7 +8619,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_801
+    - !<!DateTimeSchema> &ref_802
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8621,7 +8631,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_806
+    - !<!DateTimeSchema> &ref_807
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8633,7 +8643,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1067
+    - !<!DateTimeSchema> &ref_1068
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8645,7 +8655,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1072
+    - !<!DateTimeSchema> &ref_1073
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8657,7 +8667,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1284
+    - !<!DateTimeSchema> &ref_1285
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8669,7 +8679,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1289
+    - !<!DateTimeSchema> &ref_1290
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8681,7 +8691,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1383
+    - !<!DateTimeSchema> &ref_1384
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8693,7 +8703,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1388
+    - !<!DateTimeSchema> &ref_1389
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8705,7 +8715,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_816
+    - !<!DateTimeSchema> &ref_817
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8717,7 +8727,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_833
+    - !<!DateTimeSchema> &ref_834
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8729,7 +8739,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_838
+    - !<!DateTimeSchema> &ref_839
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8741,7 +8751,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_852
+    - !<!DateTimeSchema> &ref_853
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8753,7 +8763,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_856
+    - !<!DateTimeSchema> &ref_857
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8765,7 +8775,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_869
+    - !<!DateTimeSchema> &ref_870
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8777,7 +8787,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_874
+    - !<!DateTimeSchema> &ref_875
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8789,7 +8799,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_884
+    - !<!DateTimeSchema> &ref_885
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8801,7 +8811,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_888
+    - !<!DateTimeSchema> &ref_889
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8813,7 +8823,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_898
+    - !<!DateTimeSchema> &ref_899
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8825,7 +8835,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_903
+    - !<!DateTimeSchema> &ref_904
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8837,7 +8847,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_914
+    - !<!DateTimeSchema> &ref_915
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8849,7 +8859,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_919
+    - !<!DateTimeSchema> &ref_920
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8861,7 +8871,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_929
+    - !<!DateTimeSchema> &ref_930
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8873,7 +8883,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_934
+    - !<!DateTimeSchema> &ref_935
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8885,7 +8895,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_950
+    - !<!DateTimeSchema> &ref_951
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8897,7 +8907,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_954
+    - !<!DateTimeSchema> &ref_955
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8909,7 +8919,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_976
+    - !<!DateTimeSchema> &ref_977
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8921,7 +8931,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_980
+    - !<!DateTimeSchema> &ref_981
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8933,7 +8943,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1002
+    - !<!DateTimeSchema> &ref_1003
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8945,7 +8955,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1006
+    - !<!DateTimeSchema> &ref_1007
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8957,7 +8967,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1022
+    - !<!DateTimeSchema> &ref_1023
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8969,7 +8979,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1041
+    - !<!DateTimeSchema> &ref_1042
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8981,7 +8991,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1409
+    - !<!DateTimeSchema> &ref_1410
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -8993,7 +9003,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1434
+    - !<!DateTimeSchema> &ref_1435
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9005,7 +9015,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1462
+    - !<!DateTimeSchema> &ref_1463
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9017,7 +9027,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1468
+    - !<!DateTimeSchema> &ref_1469
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9029,7 +9039,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1480
+    - !<!DateTimeSchema> &ref_1481
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9041,7 +9051,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1487
+    - !<!DateTimeSchema> &ref_1488
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9053,7 +9063,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1100
+    - !<!DateTimeSchema> &ref_1101
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9065,7 +9075,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1106
+    - !<!DateTimeSchema> &ref_1107
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9077,7 +9087,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1127
+    - !<!DateTimeSchema> &ref_1128
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9089,7 +9099,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1134
+    - !<!DateTimeSchema> &ref_1135
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9101,7 +9111,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1161
+    - !<!DateTimeSchema> &ref_1162
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9113,7 +9123,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1167
+    - !<!DateTimeSchema> &ref_1168
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9125,7 +9135,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1183
+    - !<!DateTimeSchema> &ref_1184
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9137,7 +9147,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1189
+    - !<!DateTimeSchema> &ref_1190
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9149,7 +9159,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1203
+    - !<!DateTimeSchema> &ref_1204
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9161,7 +9171,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1208
+    - !<!DateTimeSchema> &ref_1209
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9173,7 +9183,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1222
+    - !<!DateTimeSchema> &ref_1223
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9185,7 +9195,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1227
+    - !<!DateTimeSchema> &ref_1228
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9197,7 +9207,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1241
+    - !<!DateTimeSchema> &ref_1242
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9209,7 +9219,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1246
+    - !<!DateTimeSchema> &ref_1247
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9221,7 +9231,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1257
+    - !<!DateTimeSchema> &ref_1258
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9233,7 +9243,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1261
+    - !<!DateTimeSchema> &ref_1262
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9245,7 +9255,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1312
+    - !<!DateTimeSchema> &ref_1313
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9257,7 +9267,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1318
+    - !<!DateTimeSchema> &ref_1319
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9269,7 +9279,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1348
+    - !<!DateTimeSchema> &ref_1349
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9281,7 +9291,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_1353
+    - !<!DateTimeSchema> &ref_1354
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -9300,9 +9310,9 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_3
           originalParameter:
-            - !<!Parameter> &ref_319
+            - !<!Parameter> &ref_320
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_320
+              groupedBy: !<!Parameter> &ref_321
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9319,9 +9329,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_332
+            - !<!Parameter> &ref_333
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_335
+              groupedBy: !<!Parameter> &ref_336
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9338,9 +9348,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_343
+            - !<!Parameter> &ref_344
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_345
+              groupedBy: !<!Parameter> &ref_346
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9357,9 +9367,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_358
+            - !<!Parameter> &ref_359
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_359
+              groupedBy: !<!Parameter> &ref_360
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9376,9 +9386,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_370
+            - !<!Parameter> &ref_371
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_373
+              groupedBy: !<!Parameter> &ref_374
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9395,9 +9405,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_495
+            - !<!Parameter> &ref_496
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_500
+              groupedBy: !<!Parameter> &ref_501
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9414,9 +9424,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_521
+            - !<!Parameter> &ref_522
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_530
+              groupedBy: !<!Parameter> &ref_531
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9433,9 +9443,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_549
+            - !<!Parameter> &ref_550
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_554
+              groupedBy: !<!Parameter> &ref_555
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9452,9 +9462,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_568
+            - !<!Parameter> &ref_569
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_574
+              groupedBy: !<!Parameter> &ref_575
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9471,9 +9481,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_589
+            - !<!Parameter> &ref_590
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_594
+              groupedBy: !<!Parameter> &ref_595
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9490,9 +9500,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_610
+            - !<!Parameter> &ref_611
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_618
+              groupedBy: !<!Parameter> &ref_619
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9509,9 +9519,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_677
+            - !<!Parameter> &ref_678
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_685
+              groupedBy: !<!Parameter> &ref_686
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9528,9 +9538,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_721
+            - !<!Parameter> &ref_722
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_727
+              groupedBy: !<!Parameter> &ref_728
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9547,9 +9557,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_737
+            - !<!Parameter> &ref_738
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_742
+              groupedBy: !<!Parameter> &ref_743
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9566,9 +9576,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_757
+            - !<!Parameter> &ref_758
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_762
+              groupedBy: !<!Parameter> &ref_763
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9585,9 +9595,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_783
+            - !<!Parameter> &ref_784
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_792
+              groupedBy: !<!Parameter> &ref_793
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9604,9 +9614,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_823
+            - !<!Parameter> &ref_824
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_829
+              groupedBy: !<!Parameter> &ref_830
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9623,9 +9633,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_840
+            - !<!Parameter> &ref_841
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_847
+              groupedBy: !<!Parameter> &ref_848
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9642,9 +9652,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_943
+            - !<!Parameter> &ref_944
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_944
+              groupedBy: !<!Parameter> &ref_945
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9661,9 +9671,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_967
+            - !<!Parameter> &ref_968
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_968
+              groupedBy: !<!Parameter> &ref_969
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9680,9 +9690,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_992
+            - !<!Parameter> &ref_993
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_994
+              groupedBy: !<!Parameter> &ref_995
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9699,9 +9709,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1015
+            - !<!Parameter> &ref_1016
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1016
+              groupedBy: !<!Parameter> &ref_1017
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9718,9 +9728,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1025
+            - !<!Parameter> &ref_1026
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1026
+              groupedBy: !<!Parameter> &ref_1027
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9737,9 +9747,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1050
+            - !<!Parameter> &ref_1051
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1059
+              groupedBy: !<!Parameter> &ref_1060
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9756,9 +9766,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1080
+            - !<!Parameter> &ref_1081
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1091
+              groupedBy: !<!Parameter> &ref_1092
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9775,9 +9785,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1111
+            - !<!Parameter> &ref_1112
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1121
+              groupedBy: !<!Parameter> &ref_1122
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9794,9 +9804,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1140
+            - !<!Parameter> &ref_1141
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1152
+              groupedBy: !<!Parameter> &ref_1153
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9813,9 +9823,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1172
+            - !<!Parameter> &ref_1173
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1177
+              groupedBy: !<!Parameter> &ref_1178
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9832,9 +9842,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1192
+            - !<!Parameter> &ref_1193
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1197
+              groupedBy: !<!Parameter> &ref_1198
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9851,9 +9861,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1210
+            - !<!Parameter> &ref_1211
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1217
+              groupedBy: !<!Parameter> &ref_1218
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9870,9 +9880,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1229
+            - !<!Parameter> &ref_1230
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1235
+              groupedBy: !<!Parameter> &ref_1236
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9889,9 +9899,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1270
+            - !<!Parameter> &ref_1271
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1278
+              groupedBy: !<!Parameter> &ref_1279
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9908,9 +9918,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1294
+            - !<!Parameter> &ref_1295
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1304
+              groupedBy: !<!Parameter> &ref_1305
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9927,9 +9937,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1327
+            - !<!Parameter> &ref_1328
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1338
+              groupedBy: !<!Parameter> &ref_1339
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9946,9 +9956,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1365
+            - !<!Parameter> &ref_1366
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1374
+              groupedBy: !<!Parameter> &ref_1375
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9965,9 +9975,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1394
+            - !<!Parameter> &ref_1395
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1398
+              groupedBy: !<!Parameter> &ref_1399
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -9984,9 +9994,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1416
+            - !<!Parameter> &ref_1417
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1421
+              groupedBy: !<!Parameter> &ref_1422
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -10003,9 +10013,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1444
+            - !<!Parameter> &ref_1445
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1453
+              groupedBy: !<!Parameter> &ref_1454
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -10022,9 +10032,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1473
+            - !<!Parameter> &ref_1474
               schema: *ref_3
-              groupedBy: !<!Parameter> &ref_1474
+              groupedBy: !<!Parameter> &ref_1475
                 schema: *ref_4
                 implementation: Method
                 language: !<!Languages> 
@@ -10060,7 +10070,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_5
           originalParameter:
-            - !<!Parameter> &ref_333
+            - !<!Parameter> &ref_334
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_7
                 schema: *ref_6
@@ -10079,9 +10089,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_344
+            - !<!Parameter> &ref_345
               schema: *ref_5
-              groupedBy: !<!Parameter> &ref_346
+              groupedBy: !<!Parameter> &ref_347
                 schema: *ref_6
                 implementation: Method
                 language: !<!Languages> 
@@ -10098,7 +10108,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_371
+            - !<!Parameter> &ref_372
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_8
                 schema: *ref_6
@@ -10117,7 +10127,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_389
+            - !<!Parameter> &ref_390
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_9
                 schema: *ref_6
@@ -10136,7 +10146,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_404
+            - !<!Parameter> &ref_405
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_10
                 schema: *ref_6
@@ -10155,7 +10165,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_416
+            - !<!Parameter> &ref_417
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_11
                 schema: *ref_6
@@ -10174,7 +10184,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_430
+            - !<!Parameter> &ref_431
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_12
                 schema: *ref_6
@@ -10193,7 +10203,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_444
+            - !<!Parameter> &ref_445
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_13
                 schema: *ref_6
@@ -10212,7 +10222,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_496
+            - !<!Parameter> &ref_497
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_14
                 schema: *ref_6
@@ -10231,7 +10241,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_522
+            - !<!Parameter> &ref_523
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_15
                 schema: *ref_6
@@ -10250,7 +10260,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_550
+            - !<!Parameter> &ref_551
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_16
                 schema: *ref_6
@@ -10269,7 +10279,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_572
+            - !<!Parameter> &ref_573
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_17
                 schema: *ref_6
@@ -10288,7 +10298,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_592
+            - !<!Parameter> &ref_593
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_18
                 schema: *ref_6
@@ -10307,7 +10317,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_614
+            - !<!Parameter> &ref_615
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_19
                 schema: *ref_6
@@ -10326,7 +10336,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_681
+            - !<!Parameter> &ref_682
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_20
                 schema: *ref_6
@@ -10345,7 +10355,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_723
+            - !<!Parameter> &ref_724
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_21
                 schema: *ref_6
@@ -10364,7 +10374,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_740
+            - !<!Parameter> &ref_741
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_22
                 schema: *ref_6
@@ -10383,7 +10393,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_760
+            - !<!Parameter> &ref_761
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_23
                 schema: *ref_6
@@ -10402,7 +10412,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_784
+            - !<!Parameter> &ref_785
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_24
                 schema: *ref_6
@@ -10421,7 +10431,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_824
+            - !<!Parameter> &ref_825
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_25
                 schema: *ref_6
@@ -10440,7 +10450,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_843
+            - !<!Parameter> &ref_844
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_26
                 schema: *ref_6
@@ -10459,7 +10469,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_860
+            - !<!Parameter> &ref_861
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_27
                 schema: *ref_6
@@ -10478,7 +10488,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_876
+            - !<!Parameter> &ref_877
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_28
                 schema: *ref_6
@@ -10497,7 +10507,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_890
+            - !<!Parameter> &ref_891
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_29
                 schema: *ref_6
@@ -10516,7 +10526,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_905
+            - !<!Parameter> &ref_906
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_30
                 schema: *ref_6
@@ -10535,7 +10545,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_921
+            - !<!Parameter> &ref_922
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_31
                 schema: *ref_6
@@ -10554,7 +10564,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_939
+            - !<!Parameter> &ref_940
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_32
                 schema: *ref_6
@@ -10573,7 +10583,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_962
+            - !<!Parameter> &ref_963
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_33
                 schema: *ref_6
@@ -10592,7 +10602,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_988
+            - !<!Parameter> &ref_989
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_34
                 schema: *ref_6
@@ -10611,7 +10621,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1054
+            - !<!Parameter> &ref_1055
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_35
                 schema: *ref_6
@@ -10630,7 +10640,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1086
+            - !<!Parameter> &ref_1087
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_36
                 schema: *ref_6
@@ -10649,7 +10659,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1117
+            - !<!Parameter> &ref_1118
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_37
                 schema: *ref_6
@@ -10668,7 +10678,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1144
+            - !<!Parameter> &ref_1145
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_38
                 schema: *ref_6
@@ -10687,7 +10697,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1173
+            - !<!Parameter> &ref_1174
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_39
                 schema: *ref_6
@@ -10706,7 +10716,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1193
+            - !<!Parameter> &ref_1194
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_40
                 schema: *ref_6
@@ -10725,7 +10735,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1213
+            - !<!Parameter> &ref_1214
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_41
                 schema: *ref_6
@@ -10744,7 +10754,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1230
+            - !<!Parameter> &ref_1231
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_42
                 schema: *ref_6
@@ -10763,7 +10773,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1249
+            - !<!Parameter> &ref_1250
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_43
                 schema: *ref_6
@@ -10782,7 +10792,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1274
+            - !<!Parameter> &ref_1275
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_44
                 schema: *ref_6
@@ -10801,7 +10811,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1299
+            - !<!Parameter> &ref_1300
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_45
                 schema: *ref_6
@@ -10820,7 +10830,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1330
+            - !<!Parameter> &ref_1331
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_46
                 schema: *ref_6
@@ -10839,7 +10849,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1369
+            - !<!Parameter> &ref_1370
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_47
                 schema: *ref_6
@@ -10858,7 +10868,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1448
+            - !<!Parameter> &ref_1449
               schema: *ref_5
               groupedBy: !<!Parameter> &ref_48
                 schema: *ref_6
@@ -10886,7 +10896,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_5
           originalParameter:
-            - !<!Parameter> &ref_334
+            - !<!Parameter> &ref_335
               schema: *ref_5
               groupedBy: *ref_7
               implementation: Method
@@ -10898,7 +10908,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_372
+            - !<!Parameter> &ref_373
               schema: *ref_5
               groupedBy: *ref_8
               implementation: Method
@@ -10910,7 +10920,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_390
+            - !<!Parameter> &ref_391
               schema: *ref_5
               groupedBy: *ref_9
               implementation: Method
@@ -10922,7 +10932,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_405
+            - !<!Parameter> &ref_406
               schema: *ref_5
               groupedBy: *ref_10
               implementation: Method
@@ -10934,7 +10944,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_417
+            - !<!Parameter> &ref_418
               schema: *ref_5
               groupedBy: *ref_11
               implementation: Method
@@ -10946,7 +10956,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_431
+            - !<!Parameter> &ref_432
               schema: *ref_5
               groupedBy: *ref_12
               implementation: Method
@@ -10958,7 +10968,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_445
+            - !<!Parameter> &ref_446
               schema: *ref_5
               groupedBy: *ref_13
               implementation: Method
@@ -10970,7 +10980,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_497
+            - !<!Parameter> &ref_498
               schema: *ref_5
               groupedBy: *ref_14
               implementation: Method
@@ -10982,7 +10992,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_523
+            - !<!Parameter> &ref_524
               schema: *ref_5
               groupedBy: *ref_15
               implementation: Method
@@ -10994,7 +11004,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_551
+            - !<!Parameter> &ref_552
               schema: *ref_5
               groupedBy: *ref_16
               implementation: Method
@@ -11006,7 +11016,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_573
+            - !<!Parameter> &ref_574
               schema: *ref_5
               groupedBy: *ref_17
               implementation: Method
@@ -11018,7 +11028,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_593
+            - !<!Parameter> &ref_594
               schema: *ref_5
               groupedBy: *ref_18
               implementation: Method
@@ -11030,7 +11040,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_615
+            - !<!Parameter> &ref_616
               schema: *ref_5
               groupedBy: *ref_19
               implementation: Method
@@ -11042,7 +11052,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_682
+            - !<!Parameter> &ref_683
               schema: *ref_5
               groupedBy: *ref_20
               implementation: Method
@@ -11054,7 +11064,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_724
+            - !<!Parameter> &ref_725
               schema: *ref_5
               groupedBy: *ref_21
               implementation: Method
@@ -11066,7 +11076,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_741
+            - !<!Parameter> &ref_742
               schema: *ref_5
               groupedBy: *ref_22
               implementation: Method
@@ -11078,7 +11088,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_761
+            - !<!Parameter> &ref_762
               schema: *ref_5
               groupedBy: *ref_23
               implementation: Method
@@ -11090,7 +11100,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_785
+            - !<!Parameter> &ref_786
               schema: *ref_5
               groupedBy: *ref_24
               implementation: Method
@@ -11102,7 +11112,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_825
+            - !<!Parameter> &ref_826
               schema: *ref_5
               groupedBy: *ref_25
               implementation: Method
@@ -11114,7 +11124,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_844
+            - !<!Parameter> &ref_845
               schema: *ref_5
               groupedBy: *ref_26
               implementation: Method
@@ -11126,7 +11136,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_861
+            - !<!Parameter> &ref_862
               schema: *ref_5
               groupedBy: *ref_27
               implementation: Method
@@ -11138,7 +11148,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_877
+            - !<!Parameter> &ref_878
               schema: *ref_5
               groupedBy: *ref_28
               implementation: Method
@@ -11150,7 +11160,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_891
+            - !<!Parameter> &ref_892
               schema: *ref_5
               groupedBy: *ref_29
               implementation: Method
@@ -11162,7 +11172,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_906
+            - !<!Parameter> &ref_907
               schema: *ref_5
               groupedBy: *ref_30
               implementation: Method
@@ -11174,7 +11184,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_922
+            - !<!Parameter> &ref_923
               schema: *ref_5
               groupedBy: *ref_31
               implementation: Method
@@ -11186,7 +11196,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_940
+            - !<!Parameter> &ref_941
               schema: *ref_5
               groupedBy: *ref_32
               implementation: Method
@@ -11198,7 +11208,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_963
+            - !<!Parameter> &ref_964
               schema: *ref_5
               groupedBy: *ref_33
               implementation: Method
@@ -11210,7 +11220,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_989
+            - !<!Parameter> &ref_990
               schema: *ref_5
               groupedBy: *ref_34
               implementation: Method
@@ -11222,7 +11232,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1055
+            - !<!Parameter> &ref_1056
               schema: *ref_5
               groupedBy: *ref_35
               implementation: Method
@@ -11234,7 +11244,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1087
+            - !<!Parameter> &ref_1088
               schema: *ref_5
               groupedBy: *ref_36
               implementation: Method
@@ -11246,7 +11256,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1118
+            - !<!Parameter> &ref_1119
               schema: *ref_5
               groupedBy: *ref_37
               implementation: Method
@@ -11258,7 +11268,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1145
+            - !<!Parameter> &ref_1146
               schema: *ref_5
               groupedBy: *ref_38
               implementation: Method
@@ -11270,7 +11280,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1174
+            - !<!Parameter> &ref_1175
               schema: *ref_5
               groupedBy: *ref_39
               implementation: Method
@@ -11282,7 +11292,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1194
+            - !<!Parameter> &ref_1195
               schema: *ref_5
               groupedBy: *ref_40
               implementation: Method
@@ -11294,7 +11304,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1214
+            - !<!Parameter> &ref_1215
               schema: *ref_5
               groupedBy: *ref_41
               implementation: Method
@@ -11306,7 +11316,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1231
+            - !<!Parameter> &ref_1232
               schema: *ref_5
               groupedBy: *ref_42
               implementation: Method
@@ -11318,7 +11328,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1250
+            - !<!Parameter> &ref_1251
               schema: *ref_5
               groupedBy: *ref_43
               implementation: Method
@@ -11330,7 +11340,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1275
+            - !<!Parameter> &ref_1276
               schema: *ref_5
               groupedBy: *ref_44
               implementation: Method
@@ -11342,7 +11352,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1300
+            - !<!Parameter> &ref_1301
               schema: *ref_5
               groupedBy: *ref_45
               implementation: Method
@@ -11354,7 +11364,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1331
+            - !<!Parameter> &ref_1332
               schema: *ref_5
               groupedBy: *ref_46
               implementation: Method
@@ -11366,7 +11376,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1370
+            - !<!Parameter> &ref_1371
               schema: *ref_5
               groupedBy: *ref_47
               implementation: Method
@@ -11378,7 +11388,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1449
+            - !<!Parameter> &ref_1450
               schema: *ref_5
               groupedBy: *ref_48
               implementation: Method
@@ -11399,7 +11409,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_49
           originalParameter:
-            - !<!Parameter> &ref_498
+            - !<!Parameter> &ref_499
               schema: *ref_49
               groupedBy: *ref_14
               implementation: Method
@@ -11411,7 +11421,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_524
+            - !<!Parameter> &ref_525
               schema: *ref_49
               groupedBy: *ref_15
               implementation: Method
@@ -11423,7 +11433,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_552
+            - !<!Parameter> &ref_553
               schema: *ref_49
               groupedBy: *ref_16
               implementation: Method
@@ -11435,7 +11445,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_570
+            - !<!Parameter> &ref_571
               schema: *ref_49
               groupedBy: *ref_17
               implementation: Method
@@ -11447,7 +11457,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_590
+            - !<!Parameter> &ref_591
               schema: *ref_49
               groupedBy: *ref_18
               implementation: Method
@@ -11459,7 +11469,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_616
+            - !<!Parameter> &ref_617
               schema: *ref_49
               groupedBy: *ref_19
               implementation: Method
@@ -11471,7 +11481,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_683
+            - !<!Parameter> &ref_684
               schema: *ref_49
               groupedBy: *ref_20
               implementation: Method
@@ -11483,7 +11493,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_725
+            - !<!Parameter> &ref_726
               schema: *ref_49
               groupedBy: *ref_21
               implementation: Method
@@ -11495,7 +11505,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_738
+            - !<!Parameter> &ref_739
               schema: *ref_49
               groupedBy: *ref_22
               implementation: Method
@@ -11507,7 +11517,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_758
+            - !<!Parameter> &ref_759
               schema: *ref_49
               groupedBy: *ref_23
               implementation: Method
@@ -11519,7 +11529,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_786
+            - !<!Parameter> &ref_787
               schema: *ref_49
               groupedBy: *ref_24
               implementation: Method
@@ -11531,7 +11541,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_826
+            - !<!Parameter> &ref_827
               schema: *ref_49
               groupedBy: *ref_25
               implementation: Method
@@ -11543,7 +11553,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_845
+            - !<!Parameter> &ref_846
               schema: *ref_49
               groupedBy: *ref_26
               implementation: Method
@@ -11555,7 +11565,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_862
+            - !<!Parameter> &ref_863
               schema: *ref_49
               groupedBy: *ref_27
               implementation: Method
@@ -11567,7 +11577,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_878
+            - !<!Parameter> &ref_879
               schema: *ref_49
               groupedBy: *ref_28
               implementation: Method
@@ -11579,7 +11589,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_892
+            - !<!Parameter> &ref_893
               schema: *ref_49
               groupedBy: *ref_29
               implementation: Method
@@ -11591,7 +11601,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_907
+            - !<!Parameter> &ref_908
               schema: *ref_49
               groupedBy: *ref_30
               implementation: Method
@@ -11603,7 +11613,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_923
+            - !<!Parameter> &ref_924
               schema: *ref_49
               groupedBy: *ref_31
               implementation: Method
@@ -11615,7 +11625,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_941
+            - !<!Parameter> &ref_942
               schema: *ref_49
               groupedBy: *ref_32
               implementation: Method
@@ -11627,7 +11637,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_964
+            - !<!Parameter> &ref_965
               schema: *ref_49
               groupedBy: *ref_33
               implementation: Method
@@ -11639,7 +11649,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_990
+            - !<!Parameter> &ref_991
               schema: *ref_49
               groupedBy: *ref_34
               implementation: Method
@@ -11651,7 +11661,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1056
+            - !<!Parameter> &ref_1057
               schema: *ref_49
               groupedBy: *ref_35
               implementation: Method
@@ -11663,7 +11673,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1088
+            - !<!Parameter> &ref_1089
               schema: *ref_49
               groupedBy: *ref_36
               implementation: Method
@@ -11675,7 +11685,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1119
+            - !<!Parameter> &ref_1120
               schema: *ref_49
               groupedBy: *ref_37
               implementation: Method
@@ -11687,7 +11697,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1146
+            - !<!Parameter> &ref_1147
               schema: *ref_49
               groupedBy: *ref_38
               implementation: Method
@@ -11699,7 +11709,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1175
+            - !<!Parameter> &ref_1176
               schema: *ref_49
               groupedBy: *ref_39
               implementation: Method
@@ -11711,7 +11721,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1195
+            - !<!Parameter> &ref_1196
               schema: *ref_49
               groupedBy: *ref_40
               implementation: Method
@@ -11723,7 +11733,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1215
+            - !<!Parameter> &ref_1216
               schema: *ref_49
               groupedBy: *ref_41
               implementation: Method
@@ -11735,7 +11745,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1232
+            - !<!Parameter> &ref_1233
               schema: *ref_49
               groupedBy: *ref_42
               implementation: Method
@@ -11747,7 +11757,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1251
+            - !<!Parameter> &ref_1252
               schema: *ref_49
               groupedBy: *ref_43
               implementation: Method
@@ -11759,7 +11769,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1276
+            - !<!Parameter> &ref_1277
               schema: *ref_49
               groupedBy: *ref_44
               implementation: Method
@@ -11771,7 +11781,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1301
+            - !<!Parameter> &ref_1302
               schema: *ref_49
               groupedBy: *ref_45
               implementation: Method
@@ -11783,7 +11793,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1332
+            - !<!Parameter> &ref_1333
               schema: *ref_49
               groupedBy: *ref_46
               implementation: Method
@@ -11795,7 +11805,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1371
+            - !<!Parameter> &ref_1372
               schema: *ref_49
               groupedBy: *ref_47
               implementation: Method
@@ -11807,7 +11817,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1450
+            - !<!Parameter> &ref_1451
               schema: *ref_49
               groupedBy: *ref_48
               implementation: Method
@@ -11828,7 +11838,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_49
           originalParameter:
-            - !<!Parameter> &ref_499
+            - !<!Parameter> &ref_500
               schema: *ref_49
               groupedBy: *ref_14
               implementation: Method
@@ -11840,7 +11850,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_525
+            - !<!Parameter> &ref_526
               schema: *ref_49
               groupedBy: *ref_15
               implementation: Method
@@ -11852,7 +11862,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_553
+            - !<!Parameter> &ref_554
               schema: *ref_49
               groupedBy: *ref_16
               implementation: Method
@@ -11864,7 +11874,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_571
+            - !<!Parameter> &ref_572
               schema: *ref_49
               groupedBy: *ref_17
               implementation: Method
@@ -11876,7 +11886,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_591
+            - !<!Parameter> &ref_592
               schema: *ref_49
               groupedBy: *ref_18
               implementation: Method
@@ -11888,7 +11898,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_617
+            - !<!Parameter> &ref_618
               schema: *ref_49
               groupedBy: *ref_19
               implementation: Method
@@ -11900,7 +11910,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_684
+            - !<!Parameter> &ref_685
               schema: *ref_49
               groupedBy: *ref_20
               implementation: Method
@@ -11912,7 +11922,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_726
+            - !<!Parameter> &ref_727
               schema: *ref_49
               groupedBy: *ref_21
               implementation: Method
@@ -11924,7 +11934,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_739
+            - !<!Parameter> &ref_740
               schema: *ref_49
               groupedBy: *ref_22
               implementation: Method
@@ -11936,7 +11946,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_759
+            - !<!Parameter> &ref_760
               schema: *ref_49
               groupedBy: *ref_23
               implementation: Method
@@ -11948,7 +11958,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_787
+            - !<!Parameter> &ref_788
               schema: *ref_49
               groupedBy: *ref_24
               implementation: Method
@@ -11960,7 +11970,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_827
+            - !<!Parameter> &ref_828
               schema: *ref_49
               groupedBy: *ref_25
               implementation: Method
@@ -11972,7 +11982,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_846
+            - !<!Parameter> &ref_847
               schema: *ref_49
               groupedBy: *ref_26
               implementation: Method
@@ -11984,7 +11994,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_863
+            - !<!Parameter> &ref_864
               schema: *ref_49
               groupedBy: *ref_27
               implementation: Method
@@ -11996,7 +12006,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_879
+            - !<!Parameter> &ref_880
               schema: *ref_49
               groupedBy: *ref_28
               implementation: Method
@@ -12008,7 +12018,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_893
+            - !<!Parameter> &ref_894
               schema: *ref_49
               groupedBy: *ref_29
               implementation: Method
@@ -12020,7 +12030,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_908
+            - !<!Parameter> &ref_909
               schema: *ref_49
               groupedBy: *ref_30
               implementation: Method
@@ -12032,7 +12042,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_924
+            - !<!Parameter> &ref_925
               schema: *ref_49
               groupedBy: *ref_31
               implementation: Method
@@ -12044,7 +12054,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_942
+            - !<!Parameter> &ref_943
               schema: *ref_49
               groupedBy: *ref_32
               implementation: Method
@@ -12056,7 +12066,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_965
+            - !<!Parameter> &ref_966
               schema: *ref_49
               groupedBy: *ref_33
               implementation: Method
@@ -12068,7 +12078,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_991
+            - !<!Parameter> &ref_992
               schema: *ref_49
               groupedBy: *ref_34
               implementation: Method
@@ -12080,7 +12090,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1057
+            - !<!Parameter> &ref_1058
               schema: *ref_49
               groupedBy: *ref_35
               implementation: Method
@@ -12092,7 +12102,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1089
+            - !<!Parameter> &ref_1090
               schema: *ref_49
               groupedBy: *ref_36
               implementation: Method
@@ -12104,7 +12114,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1120
+            - !<!Parameter> &ref_1121
               schema: *ref_49
               groupedBy: *ref_37
               implementation: Method
@@ -12116,7 +12126,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1147
+            - !<!Parameter> &ref_1148
               schema: *ref_49
               groupedBy: *ref_38
               implementation: Method
@@ -12128,7 +12138,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1176
+            - !<!Parameter> &ref_1177
               schema: *ref_49
               groupedBy: *ref_39
               implementation: Method
@@ -12140,7 +12150,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1196
+            - !<!Parameter> &ref_1197
               schema: *ref_49
               groupedBy: *ref_40
               implementation: Method
@@ -12152,7 +12162,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1216
+            - !<!Parameter> &ref_1217
               schema: *ref_49
               groupedBy: *ref_41
               implementation: Method
@@ -12164,7 +12174,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1233
+            - !<!Parameter> &ref_1234
               schema: *ref_49
               groupedBy: *ref_42
               implementation: Method
@@ -12176,7 +12186,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1252
+            - !<!Parameter> &ref_1253
               schema: *ref_49
               groupedBy: *ref_43
               implementation: Method
@@ -12188,7 +12198,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1277
+            - !<!Parameter> &ref_1278
               schema: *ref_49
               groupedBy: *ref_44
               implementation: Method
@@ -12200,7 +12210,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1302
+            - !<!Parameter> &ref_1303
               schema: *ref_49
               groupedBy: *ref_45
               implementation: Method
@@ -12212,7 +12222,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1333
+            - !<!Parameter> &ref_1334
               schema: *ref_49
               groupedBy: *ref_46
               implementation: Method
@@ -12224,7 +12234,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1372
+            - !<!Parameter> &ref_1373
               schema: *ref_49
               groupedBy: *ref_47
               implementation: Method
@@ -12236,7 +12246,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1451
+            - !<!Parameter> &ref_1452
               schema: *ref_49
               groupedBy: *ref_48
               implementation: Method
@@ -12267,7 +12277,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_49
           originalParameter:
-            - !<!Parameter> &ref_490
+            - !<!Parameter> &ref_491
               schema: *ref_49
               groupedBy: !<!Parameter> &ref_51
                 schema: *ref_50
@@ -12286,7 +12296,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_516
+            - !<!Parameter> &ref_517
               schema: *ref_49
               groupedBy: !<!Parameter> &ref_52
                 schema: *ref_50
@@ -12305,7 +12315,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_778
+            - !<!Parameter> &ref_779
               schema: *ref_49
               groupedBy: !<!Parameter> &ref_53
                 schema: *ref_50
@@ -12333,7 +12343,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_49
           originalParameter:
-            - !<!Parameter> &ref_491
+            - !<!Parameter> &ref_492
               schema: *ref_49
               groupedBy: *ref_51
               implementation: Method
@@ -12345,7 +12355,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_517
+            - !<!Parameter> &ref_518
               schema: *ref_49
               groupedBy: *ref_52
               implementation: Method
@@ -12357,7 +12367,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_779
+            - !<!Parameter> &ref_780
               schema: *ref_49
               groupedBy: *ref_53
               implementation: Method
@@ -12378,7 +12388,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_49
           originalParameter:
-            - !<!Parameter> &ref_492
+            - !<!Parameter> &ref_493
               schema: *ref_49
               groupedBy: *ref_51
               implementation: Method
@@ -12390,7 +12400,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_518
+            - !<!Parameter> &ref_519
               schema: *ref_49
               groupedBy: *ref_52
               implementation: Method
@@ -12402,7 +12412,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_780
+            - !<!Parameter> &ref_781
               schema: *ref_49
               groupedBy: *ref_53
               implementation: Method
@@ -12423,7 +12433,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_49
           originalParameter:
-            - !<!Parameter> &ref_493
+            - !<!Parameter> &ref_494
               schema: *ref_49
               groupedBy: *ref_51
               implementation: Method
@@ -12435,7 +12445,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_519
+            - !<!Parameter> &ref_520
               schema: *ref_49
               groupedBy: *ref_52
               implementation: Method
@@ -12447,7 +12457,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_781
+            - !<!Parameter> &ref_782
               schema: *ref_49
               groupedBy: *ref_53
               implementation: Method
@@ -12468,7 +12478,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_49
           originalParameter:
-            - !<!Parameter> &ref_494
+            - !<!Parameter> &ref_495
               schema: *ref_49
               groupedBy: *ref_51
               implementation: Method
@@ -12480,7 +12490,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_520
+            - !<!Parameter> &ref_521
               schema: *ref_49
               groupedBy: *ref_52
               implementation: Method
@@ -12492,7 +12502,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_782
+            - !<!Parameter> &ref_783
               schema: *ref_49
               groupedBy: *ref_53
               implementation: Method
@@ -12523,7 +12533,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_54
           originalParameter:
-            - !<!Parameter> &ref_526
+            - !<!Parameter> &ref_527
               schema: *ref_54
               groupedBy: !<!Parameter> &ref_56
                 schema: *ref_55
@@ -12542,7 +12552,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_788
+            - !<!Parameter> &ref_789
               schema: *ref_54
               groupedBy: !<!Parameter> &ref_57
                 schema: *ref_55
@@ -12561,7 +12571,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_958
+            - !<!Parameter> &ref_959
               schema: *ref_54
               groupedBy: !<!Parameter> &ref_58
                 schema: *ref_55
@@ -12580,7 +12590,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_984
+            - !<!Parameter> &ref_985
               schema: *ref_54
               groupedBy: !<!Parameter> &ref_59
                 schema: *ref_55
@@ -12599,7 +12609,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1148
+            - !<!Parameter> &ref_1149
               schema: *ref_54
               groupedBy: !<!Parameter> &ref_60
                 schema: *ref_55
@@ -12618,7 +12628,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1334
+            - !<!Parameter> &ref_1335
               schema: *ref_54
               groupedBy: !<!Parameter> &ref_61
                 schema: *ref_55
@@ -12637,7 +12647,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1417
+            - !<!Parameter> &ref_1418
               schema: *ref_54
               groupedBy: !<!Parameter> &ref_62
                 schema: *ref_55
@@ -12665,7 +12675,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_54
           originalParameter:
-            - !<!Parameter> &ref_527
+            - !<!Parameter> &ref_528
               schema: *ref_54
               groupedBy: *ref_56
               implementation: Method
@@ -12677,7 +12687,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_789
+            - !<!Parameter> &ref_790
               schema: *ref_54
               groupedBy: *ref_57
               implementation: Method
@@ -12689,7 +12699,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_959
+            - !<!Parameter> &ref_960
               schema: *ref_54
               groupedBy: *ref_58
               implementation: Method
@@ -12701,7 +12711,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_985
+            - !<!Parameter> &ref_986
               schema: *ref_54
               groupedBy: *ref_59
               implementation: Method
@@ -12713,7 +12723,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1149
+            - !<!Parameter> &ref_1150
               schema: *ref_54
               groupedBy: *ref_60
               implementation: Method
@@ -12725,7 +12735,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1335
+            - !<!Parameter> &ref_1336
               schema: *ref_54
               groupedBy: *ref_61
               implementation: Method
@@ -12737,7 +12747,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1418
+            - !<!Parameter> &ref_1419
               schema: *ref_54
               groupedBy: *ref_62
               implementation: Method
@@ -12758,7 +12768,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_63
           originalParameter:
-            - !<!Parameter> &ref_528
+            - !<!Parameter> &ref_529
               schema: *ref_63
               groupedBy: *ref_56
               implementation: Method
@@ -12770,7 +12780,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_790
+            - !<!Parameter> &ref_791
               schema: *ref_63
               groupedBy: *ref_57
               implementation: Method
@@ -12782,7 +12792,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_960
+            - !<!Parameter> &ref_961
               schema: *ref_63
               groupedBy: *ref_58
               implementation: Method
@@ -12794,7 +12804,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_986
+            - !<!Parameter> &ref_987
               schema: *ref_63
               groupedBy: *ref_59
               implementation: Method
@@ -12806,7 +12816,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1150
+            - !<!Parameter> &ref_1151
               schema: *ref_63
               groupedBy: *ref_60
               implementation: Method
@@ -12818,7 +12828,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1336
+            - !<!Parameter> &ref_1337
               schema: *ref_63
               groupedBy: *ref_61
               implementation: Method
@@ -12830,7 +12840,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1419
+            - !<!Parameter> &ref_1420
               schema: *ref_63
               groupedBy: *ref_62
               implementation: Method
@@ -12851,7 +12861,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_63
           originalParameter:
-            - !<!Parameter> &ref_529
+            - !<!Parameter> &ref_530
               schema: *ref_63
               groupedBy: *ref_56
               implementation: Method
@@ -12863,7 +12873,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_791
+            - !<!Parameter> &ref_792
               schema: *ref_63
               groupedBy: *ref_57
               implementation: Method
@@ -12875,7 +12885,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_961
+            - !<!Parameter> &ref_962
               schema: *ref_63
               groupedBy: *ref_58
               implementation: Method
@@ -12887,7 +12897,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_987
+            - !<!Parameter> &ref_988
               schema: *ref_63
               groupedBy: *ref_59
               implementation: Method
@@ -12899,7 +12909,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1151
+            - !<!Parameter> &ref_1152
               schema: *ref_63
               groupedBy: *ref_60
               implementation: Method
@@ -12911,7 +12921,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1337
+            - !<!Parameter> &ref_1338
               schema: *ref_63
               groupedBy: *ref_61
               implementation: Method
@@ -12923,7 +12933,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1420
+            - !<!Parameter> &ref_1421
               schema: *ref_63
               groupedBy: *ref_62
               implementation: Method
@@ -12954,7 +12964,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_64
           originalParameter:
-            - !<!Parameter> &ref_611
+            - !<!Parameter> &ref_612
               schema: *ref_64
               groupedBy: !<!Parameter> &ref_66
                 schema: *ref_65
@@ -12975,7 +12985,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_678
+            - !<!Parameter> &ref_679
               schema: *ref_64
               groupedBy: !<!Parameter> &ref_67
                 schema: *ref_65
@@ -12996,7 +13006,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_841
+            - !<!Parameter> &ref_842
               schema: *ref_64
               groupedBy: !<!Parameter> &ref_68
                 schema: *ref_65
@@ -13017,7 +13027,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_937
+            - !<!Parameter> &ref_938
               schema: *ref_64
               groupedBy: !<!Parameter> &ref_69
                 schema: *ref_65
@@ -13038,7 +13048,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1052
+            - !<!Parameter> &ref_1053
               schema: *ref_64
               groupedBy: !<!Parameter> &ref_70
                 schema: *ref_65
@@ -13059,7 +13069,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1081
+            - !<!Parameter> &ref_1082
               schema: *ref_64
               groupedBy: !<!Parameter> &ref_71
                 schema: *ref_65
@@ -13080,7 +13090,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1112
+            - !<!Parameter> &ref_1113
               schema: *ref_64
               groupedBy: !<!Parameter> &ref_72
                 schema: *ref_65
@@ -13101,7 +13111,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1138
+            - !<!Parameter> &ref_1139
               schema: *ref_64
               groupedBy: !<!Parameter> &ref_73
                 schema: *ref_65
@@ -13122,7 +13132,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1211
+            - !<!Parameter> &ref_1212
               schema: *ref_64
               groupedBy: !<!Parameter> &ref_74
                 schema: *ref_65
@@ -13143,7 +13153,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1272
+            - !<!Parameter> &ref_1273
               schema: *ref_64
               groupedBy: !<!Parameter> &ref_75
                 schema: *ref_65
@@ -13164,7 +13174,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1297
+            - !<!Parameter> &ref_1298
               schema: *ref_64
               groupedBy: !<!Parameter> &ref_76
                 schema: *ref_65
@@ -13185,7 +13195,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1325
+            - !<!Parameter> &ref_1326
               schema: *ref_64
               groupedBy: !<!Parameter> &ref_77
                 schema: *ref_65
@@ -13206,7 +13216,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1367
+            - !<!Parameter> &ref_1368
               schema: *ref_64
               groupedBy: !<!Parameter> &ref_78
                 schema: *ref_65
@@ -13227,7 +13237,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1395
+            - !<!Parameter> &ref_1396
               schema: *ref_64
               groupedBy: !<!Parameter> &ref_79
                 schema: *ref_65
@@ -13248,7 +13258,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1414
+            - !<!Parameter> &ref_1415
               schema: *ref_64
               groupedBy: !<!Parameter> &ref_80
                 schema: *ref_65
@@ -13269,7 +13279,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1446
+            - !<!Parameter> &ref_1447
               schema: *ref_64
               groupedBy: !<!Parameter> &ref_81
                 schema: *ref_65
@@ -13301,7 +13311,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_64
           originalParameter:
-            - !<!Parameter> &ref_612
+            - !<!Parameter> &ref_613
               schema: *ref_64
               groupedBy: *ref_66
               implementation: Method
@@ -13313,7 +13323,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_679
+            - !<!Parameter> &ref_680
               schema: *ref_64
               groupedBy: *ref_67
               implementation: Method
@@ -13325,7 +13335,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_842
+            - !<!Parameter> &ref_843
               schema: *ref_64
               groupedBy: *ref_68
               implementation: Method
@@ -13337,7 +13347,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_938
+            - !<!Parameter> &ref_939
               schema: *ref_64
               groupedBy: *ref_69
               implementation: Method
@@ -13349,7 +13359,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1053
+            - !<!Parameter> &ref_1054
               schema: *ref_64
               groupedBy: *ref_70
               implementation: Method
@@ -13361,7 +13371,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1082
+            - !<!Parameter> &ref_1083
               schema: *ref_64
               groupedBy: *ref_71
               implementation: Method
@@ -13373,7 +13383,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1113
+            - !<!Parameter> &ref_1114
               schema: *ref_64
               groupedBy: *ref_72
               implementation: Method
@@ -13385,7 +13395,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1139
+            - !<!Parameter> &ref_1140
               schema: *ref_64
               groupedBy: *ref_73
               implementation: Method
@@ -13397,7 +13407,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1212
+            - !<!Parameter> &ref_1213
               schema: *ref_64
               groupedBy: *ref_74
               implementation: Method
@@ -13409,7 +13419,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1273
+            - !<!Parameter> &ref_1274
               schema: *ref_64
               groupedBy: *ref_75
               implementation: Method
@@ -13421,7 +13431,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1298
+            - !<!Parameter> &ref_1299
               schema: *ref_64
               groupedBy: *ref_76
               implementation: Method
@@ -13433,7 +13443,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1326
+            - !<!Parameter> &ref_1327
               schema: *ref_64
               groupedBy: *ref_77
               implementation: Method
@@ -13445,7 +13455,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1368
+            - !<!Parameter> &ref_1369
               schema: *ref_64
               groupedBy: *ref_78
               implementation: Method
@@ -13457,7 +13467,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1396
+            - !<!Parameter> &ref_1397
               schema: *ref_64
               groupedBy: *ref_79
               implementation: Method
@@ -13469,7 +13479,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1415
+            - !<!Parameter> &ref_1416
               schema: *ref_64
               groupedBy: *ref_80
               implementation: Method
@@ -13481,7 +13491,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1447
+            - !<!Parameter> &ref_1448
               schema: *ref_64
               groupedBy: *ref_81
               implementation: Method
@@ -13512,7 +13522,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_82
           originalParameter:
-            - !<!Parameter> &ref_818
+            - !<!Parameter> &ref_819
               schema: *ref_82
               groupedBy: !<!Parameter> &ref_84
                 schema: *ref_83
@@ -13531,7 +13541,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1049
+            - !<!Parameter> &ref_1050
               schema: *ref_82
               groupedBy: !<!Parameter> &ref_85
                 schema: *ref_83
@@ -13550,7 +13560,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1269
+            - !<!Parameter> &ref_1270
               schema: *ref_82
               groupedBy: !<!Parameter> &ref_86
                 schema: *ref_83
@@ -13569,7 +13579,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1364
+            - !<!Parameter> &ref_1365
               schema: *ref_82
               groupedBy: !<!Parameter> &ref_87
                 schema: *ref_83
@@ -13588,7 +13598,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1439
+            - !<!Parameter> &ref_1440
               schema: *ref_82
               groupedBy: !<!Parameter> &ref_88
                 schema: *ref_83
@@ -13616,7 +13626,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_82
           originalParameter:
-            - !<!Parameter> &ref_819
+            - !<!Parameter> &ref_820
               schema: *ref_82
               groupedBy: *ref_84
               implementation: Method
@@ -13628,7 +13638,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1045
+            - !<!Parameter> &ref_1046
               schema: *ref_82
               groupedBy: *ref_85
               implementation: Method
@@ -13640,7 +13650,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1265
+            - !<!Parameter> &ref_1266
               schema: *ref_82
               groupedBy: *ref_86
               implementation: Method
@@ -13652,7 +13662,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1360
+            - !<!Parameter> &ref_1361
               schema: *ref_82
               groupedBy: *ref_87
               implementation: Method
@@ -13664,7 +13674,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1440
+            - !<!Parameter> &ref_1441
               schema: *ref_82
               groupedBy: *ref_88
               implementation: Method
@@ -13685,7 +13695,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_89
           originalParameter:
-            - !<!Parameter> &ref_820
+            - !<!Parameter> &ref_821
               schema: *ref_89
               groupedBy: *ref_84
               implementation: Method
@@ -13697,7 +13707,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1048
+            - !<!Parameter> &ref_1049
               schema: *ref_89
               groupedBy: *ref_85
               implementation: Method
@@ -13709,7 +13719,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1268
+            - !<!Parameter> &ref_1269
               schema: *ref_89
               groupedBy: *ref_86
               implementation: Method
@@ -13721,7 +13731,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1363
+            - !<!Parameter> &ref_1364
               schema: *ref_89
               groupedBy: *ref_87
               implementation: Method
@@ -13733,7 +13743,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1443
+            - !<!Parameter> &ref_1444
               schema: *ref_89
               groupedBy: *ref_88
               implementation: Method
@@ -13754,7 +13764,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_82
           originalParameter:
-            - !<!Parameter> &ref_821
+            - !<!Parameter> &ref_822
               schema: *ref_82
               groupedBy: *ref_84
               implementation: Method
@@ -13766,7 +13776,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1046
+            - !<!Parameter> &ref_1047
               schema: *ref_82
               groupedBy: *ref_85
               implementation: Method
@@ -13778,7 +13788,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1266
+            - !<!Parameter> &ref_1267
               schema: *ref_82
               groupedBy: *ref_86
               implementation: Method
@@ -13790,7 +13800,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1361
+            - !<!Parameter> &ref_1362
               schema: *ref_82
               groupedBy: *ref_87
               implementation: Method
@@ -13802,7 +13812,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1441
+            - !<!Parameter> &ref_1442
               schema: *ref_82
               groupedBy: *ref_88
               implementation: Method
@@ -13823,7 +13833,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_82
           originalParameter:
-            - !<!Parameter> &ref_822
+            - !<!Parameter> &ref_823
               schema: *ref_82
               groupedBy: *ref_84
               implementation: Method
@@ -13835,7 +13845,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1047
+            - !<!Parameter> &ref_1048
               schema: *ref_82
               groupedBy: *ref_85
               implementation: Method
@@ -13847,7 +13857,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1267
+            - !<!Parameter> &ref_1268
               schema: *ref_82
               groupedBy: *ref_86
               implementation: Method
@@ -13859,7 +13869,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1362
+            - !<!Parameter> &ref_1363
               schema: *ref_82
               groupedBy: *ref_87
               implementation: Method
@@ -13871,7 +13881,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1442
+            - !<!Parameter> &ref_1443
               schema: *ref_82
               groupedBy: *ref_88
               implementation: Method
@@ -13892,7 +13902,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_82
           originalParameter:
-            - !<!Parameter> &ref_828
+            - !<!Parameter> &ref_829
               schema: *ref_82
               groupedBy: *ref_84
               implementation: Method
@@ -13904,7 +13914,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1051
+            - !<!Parameter> &ref_1052
               schema: *ref_82
               groupedBy: *ref_85
               implementation: Method
@@ -13916,7 +13926,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1271
+            - !<!Parameter> &ref_1272
               schema: *ref_82
               groupedBy: *ref_86
               implementation: Method
@@ -13928,7 +13938,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1366
+            - !<!Parameter> &ref_1367
               schema: *ref_82
               groupedBy: *ref_87
               implementation: Method
@@ -13940,7 +13950,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1445
+            - !<!Parameter> &ref_1446
               schema: *ref_82
               groupedBy: *ref_88
               implementation: Method
@@ -13971,7 +13981,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_90
           originalParameter:
-            - !<!Parameter> &ref_1083
+            - !<!Parameter> &ref_1084
               schema: *ref_90
               groupedBy: !<!Parameter> &ref_92
                 schema: *ref_91
@@ -13990,7 +14000,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1114
+            - !<!Parameter> &ref_1115
               schema: *ref_90
               groupedBy: !<!Parameter> &ref_93
                 schema: *ref_91
@@ -14009,7 +14019,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1141
+            - !<!Parameter> &ref_1142
               schema: *ref_90
               groupedBy: !<!Parameter> &ref_94
                 schema: *ref_91
@@ -14037,7 +14047,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_90
           originalParameter:
-            - !<!Parameter> &ref_1084
+            - !<!Parameter> &ref_1085
               schema: *ref_90
               groupedBy: *ref_92
               implementation: Method
@@ -14049,7 +14059,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1115
+            - !<!Parameter> &ref_1116
               schema: *ref_90
               groupedBy: *ref_93
               implementation: Method
@@ -14061,7 +14071,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1142
+            - !<!Parameter> &ref_1143
               schema: *ref_90
               groupedBy: *ref_94
               implementation: Method
@@ -14082,7 +14092,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_90
           originalParameter:
-            - !<!Parameter> &ref_1085
+            - !<!Parameter> &ref_1086
               schema: *ref_90
               groupedBy: *ref_92
               implementation: Method
@@ -14094,7 +14104,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1116
+            - !<!Parameter> &ref_1117
               schema: *ref_90
               groupedBy: *ref_93
               implementation: Method
@@ -14106,7 +14116,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1143
+            - !<!Parameter> &ref_1144
               schema: *ref_90
               groupedBy: *ref_94
               implementation: Method
@@ -14137,7 +14147,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_95
           originalParameter:
-            - !<!Parameter> &ref_1295
+            - !<!Parameter> &ref_1296
               schema: *ref_95
               groupedBy: !<!Parameter> &ref_97
                 schema: *ref_96
@@ -14158,7 +14168,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1328
+            - !<!Parameter> &ref_1329
               schema: *ref_95
               groupedBy: !<!Parameter> &ref_98
                 schema: *ref_96
@@ -14190,7 +14200,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_95
           originalParameter:
-            - !<!Parameter> &ref_1296
+            - !<!Parameter> &ref_1297
               schema: *ref_95
               groupedBy: *ref_97
               implementation: Method
@@ -14204,7 +14214,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_1329
+            - !<!Parameter> &ref_1330
               schema: *ref_95
               groupedBy: *ref_98
               implementation: Method
@@ -14234,7 +14244,7 @@ schemas: !<!Schemas>
           description: Parameter group
       protocol: !<!Protocols> {}
   uris:
-    - !<!UriSchema> &ref_966
+    - !<!UriSchema> &ref_967
       type: uri
       apiVersions:
         - !<!ApiVersion> 
@@ -14593,7 +14603,7 @@ schemas: !<!Schemas>
     - *ref_109
     - *ref_120
     - *ref_121
-    - !<!ObjectSchema> &ref_243
+    - !<!ObjectSchema> &ref_244
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -14617,7 +14627,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_254
+    - !<!ObjectSchema> &ref_255
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -14677,7 +14687,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_125
-    - !<!ObjectSchema> &ref_269
+    - !<!ObjectSchema> &ref_270
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -14906,13 +14916,13 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_140
     - *ref_141
-    - !<!ObjectSchema> &ref_273
+    - !<!ObjectSchema> &ref_274
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2019-02-02'
       properties:
-        - !<!Property> &ref_275
+        - !<!Property> &ref_276
           schema: *ref_142
           required: true
           serializedName: Start
@@ -14921,7 +14931,7 @@ schemas: !<!Schemas>
               name: start
               description: The date-time the key is active in ISO 8601 UTC time
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_276
+        - !<!Property> &ref_277
           schema: *ref_143
           required: true
           serializedName: Expiry
@@ -14940,7 +14950,7 @@ schemas: !<!Schemas>
           description: Key information
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_281
+    - !<!ObjectSchema> &ref_282
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -15104,7 +15114,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_155
-    - !<!ObjectSchema> &ref_464
+    - !<!ObjectSchema> &ref_465
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -15633,7 +15643,7 @@ schemas: !<!Schemas>
     - *ref_190
     - *ref_191
     - *ref_192
-    - !<!ObjectSchema> &ref_478
+    - !<!ObjectSchema> &ref_479
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -15812,7 +15822,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_200
     - *ref_201
-    - !<!ObjectSchema> &ref_511
+    - !<!ObjectSchema> &ref_512
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -15868,7 +15878,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_204
-    - !<!ObjectSchema> &ref_1452
+    - !<!ObjectSchema> &ref_1453
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -15944,7 +15954,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_1479
+    - !<!ObjectSchema> &ref_1480
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -16040,7 +16050,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_210
-    - !<!ObjectSchema> &ref_1182
+    - !<!ObjectSchema> &ref_1183
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -16175,7 +16185,7 @@ schemas: !<!Schemas>
   arrays:
     - *ref_215
     - *ref_216
-    - !<!ArraySchema> &ref_362
+    - !<!ArraySchema> &ref_363
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -16192,7 +16202,7 @@ schemas: !<!Schemas>
           name: SignedIdentifiers
           description: a collection of signed identifiers
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_457
+    - !<!ArraySchema> &ref_458
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -16247,7 +16257,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: header
-  - !<!Parameter> &ref_515
+  - !<!Parameter> &ref_516
     schema: *ref_230
     implementation: Client
     extensions:
@@ -16294,7 +16304,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_239
+          - !<!Parameter> &ref_240
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -16308,7 +16318,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_240
+          - !<!Parameter> &ref_241
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -16322,7 +16332,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_238
+              - !<!Parameter> &ref_239
                 schema: *ref_237
                 implementation: Method
                 required: true
@@ -16334,8 +16344,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_238
+              - *ref_239
             language: !<!Languages> 
               default:
                 name: ''
@@ -16349,8 +16372,8 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_239
           - *ref_240
+          - *ref_241
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -16368,14 +16391,14 @@ operationGroups:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_241
+                    schema: *ref_242
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_242
+                    schema: *ref_243
                     header: x-ms-version
                     language:
                       default:
@@ -16385,7 +16408,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -16394,7 +16417,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_244
+                    schema: *ref_245
                     header: x-ms-error-code
                     language:
                       default:
@@ -16440,7 +16463,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_245
+          - !<!Parameter> &ref_246
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -16454,7 +16477,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_246
+          - !<!Parameter> &ref_247
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -16467,6 +16490,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16477,8 +16515,8 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_245
           - *ref_246
+          - *ref_247
         responses:
           - !<!SchemaResponse> 
             schema: *ref_237
@@ -16490,21 +16528,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_247
+                    schema: *ref_248
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_248
+                    schema: *ref_249
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_249
+                    schema: *ref_250
                     header: x-ms-version
                     language:
                       default:
@@ -16517,7 +16555,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -16526,7 +16564,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_250
+                    schema: *ref_251
                     header: x-ms-error-code
                     language:
                       default:
@@ -16561,7 +16599,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_251
+            schema: *ref_252
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16572,7 +16610,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_252
+          - !<!Parameter> &ref_253
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -16586,7 +16624,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_253
+          - !<!Parameter> &ref_254
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -16599,6 +16637,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16609,11 +16662,11 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_252
           - *ref_253
+          - *ref_254
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_254
+            schema: *ref_255
             language: !<!Languages> 
               default:
                 name: ''
@@ -16622,28 +16675,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_255
+                    schema: *ref_256
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_256
+                    schema: *ref_257
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_257
+                    schema: *ref_258
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_258
+                    schema: *ref_259
                     header: Date
                     language:
                       default:
@@ -16656,7 +16709,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -16665,7 +16718,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_259
+                    schema: *ref_260
                     header: x-ms-error-code
                     language:
                       default:
@@ -16688,7 +16741,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_260
+            schema: *ref_261
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16699,8 +16752,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_264
-            schema: *ref_261
+          - !<!Parameter> &ref_265
+            schema: *ref_262
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16710,8 +16763,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_265
-            schema: *ref_261
+          - !<!Parameter> &ref_266
+            schema: *ref_262
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16724,8 +16777,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_266
-            schema: *ref_262
+          - !<!Parameter> &ref_267
+            schema: *ref_263
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16739,7 +16792,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_263
+            schema: *ref_264
             implementation: Method
             language: !<!Languages> 
               default:
@@ -16749,7 +16802,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_267
+          - !<!Parameter> &ref_268
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -16763,7 +16816,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_268
+          - !<!Parameter> &ref_269
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -16776,6 +16829,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16786,14 +16854,14 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_264
           - *ref_265
           - *ref_266
           - *ref_267
           - *ref_268
+          - *ref_269
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_269
+            schema: *ref_270
             language: !<!Languages> 
               default:
                 name: ''
@@ -16802,21 +16870,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_261
+                    schema: *ref_262
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_270
+                    schema: *ref_271
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_271
+                    schema: *ref_272
                     header: x-ms-version
                     language:
                       default:
@@ -16829,7 +16897,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -16878,7 +16946,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_272
+            schema: *ref_273
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16889,7 +16957,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_279
+          - !<!Parameter> &ref_280
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -16903,7 +16971,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_280
+          - !<!Parameter> &ref_281
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -16917,8 +16985,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_274
-                schema: *ref_273
+              - !<!Parameter> &ref_275
+                schema: *ref_274
                 flattened: true
                 implementation: Method
                 required: true
@@ -16930,33 +16998,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - !<!VirtualParameter> &ref_277
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_278
                 schema: *ref_142
                 implementation: Method
-                originalParameter: *ref_274
+                originalParameter: *ref_275
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_275
+                targetProperty: *ref_276
                 language: !<!Languages> 
                   default:
                     name: start
                     description: The date-time the key is active in ISO 8601 UTC time
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_278
+              - !<!VirtualParameter> &ref_279
                 schema: *ref_143
                 implementation: Method
-                originalParameter: *ref_274
+                originalParameter: *ref_275
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_276
+                targetProperty: *ref_277
                 language: !<!Languages> 
                   default:
                     name: expiry
                     description: The date-time the key expires in ISO 8601 UTC time
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_277
               - *ref_278
+              - *ref_279
             language: !<!Languages> 
               default:
                 name: ''
@@ -16970,11 +17051,11 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_279
           - *ref_280
+          - *ref_281
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_281
+            schema: *ref_282
             language: !<!Languages> 
               default:
                 name: ''
@@ -16983,28 +17064,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_282
+                    schema: *ref_283
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_283
+                    schema: *ref_284
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_284
+                    schema: *ref_285
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_285
+                    schema: *ref_286
                     header: Date
                     language:
                       default:
@@ -17017,7 +17098,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -17026,7 +17107,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_286
+                    schema: *ref_287
                     header: x-ms-error-code
                     language:
                       default:
@@ -17049,7 +17130,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_287
+            schema: *ref_288
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17075,6 +17156,21 @@ operationGroups:
           - *ref_235
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -17095,42 +17191,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_288
+                    schema: *ref_289
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_289
+                    schema: *ref_290
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_290
+                    schema: *ref_291
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_291
+                    schema: *ref_292
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_292
+                    schema: *ref_293
                     header: x-ms-sku-name
                     language:
                       default:
                         name: SkuName
                         description: Identifies the sku name of the account
                   - !<!HttpHeader> 
-                    schema: *ref_293
+                    schema: *ref_294
                     header: x-ms-account-kind
                     language:
                       default:
@@ -17140,7 +17236,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -17149,7 +17245,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_294
+                    schema: *ref_295
                     header: x-ms-error-code
                     language:
                       default:
@@ -17172,7 +17268,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_295
+            schema: *ref_296
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17183,8 +17279,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_300
-            schema: *ref_296
+          - !<!Parameter> &ref_301
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17195,8 +17291,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_301
-            schema: *ref_297
+          - !<!Parameter> &ref_302
+            schema: *ref_298
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17207,7 +17303,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_302
+          - !<!Parameter> &ref_303
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -17221,7 +17317,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_303
+          - !<!Parameter> &ref_304
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -17235,8 +17331,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_299
-                schema: *ref_298
+              - !<!Parameter> &ref_300
+                schema: *ref_299
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -17247,8 +17343,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_299
+              - *ref_300
             language: !<!Languages> 
               default:
                 name: ''
@@ -17262,10 +17371,10 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_300
           - *ref_301
           - *ref_302
           - *ref_303
+          - *ref_304
         responses:
           - !<!BinaryResponse> 
             binary: true
@@ -17277,21 +17386,21 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_297
+                    schema: *ref_298
                     header: Content-Type
                     language:
                       default:
                         name: ContentType
                         description: 'The media type of the body of the response. For batch requests, this is multipart/mixed; boundary=batchresponse_GUID'
                   - !<!HttpHeader> 
-                    schema: *ref_304
+                    schema: *ref_305
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_305
+                    schema: *ref_306
                     header: x-ms-version
                     language:
                       default:
@@ -17304,7 +17413,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -17313,7 +17422,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_306
+                    schema: *ref_307
                     header: x-ms-error-code
                     language:
                       default:
@@ -17344,7 +17453,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17355,7 +17464,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_309
+          - !<!Parameter> &ref_310
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -17368,8 +17477,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_310
-            schema: *ref_308
+          - !<!Parameter> &ref_311
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -17384,7 +17493,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_311
+          - !<!Parameter> &ref_312
             schema: *ref_136
             implementation: Method
             language: !<!Languages> 
@@ -17396,7 +17505,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_235
-          - !<!Parameter> &ref_312
+          - !<!Parameter> &ref_313
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -17409,6 +17518,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -17419,10 +17543,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_309
           - *ref_310
           - *ref_311
           - *ref_312
+          - *ref_313
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -17433,42 +17557,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_308
+                    schema: *ref_309
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_313
+                    schema: *ref_314
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_314
+                    schema: *ref_315
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_315
+                    schema: *ref_316
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_316
+                    schema: *ref_317
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_317
+                    schema: *ref_318
                     header: Date
                     language:
                       default:
@@ -17478,7 +17602,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -17487,7 +17611,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_318
+                    schema: *ref_319
                     header: x-ms-error-code
                     language:
                       default:
@@ -17510,7 +17634,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17521,7 +17645,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_321
+          - !<!Parameter> &ref_322
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -17534,9 +17658,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_319
+          - *ref_320
           - *ref_235
-          - !<!Parameter> &ref_322
+          - !<!Parameter> &ref_323
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -17550,9 +17674,22 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_320
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_321
             signatureParameters:
-              - *ref_320
+              - *ref_321
             language: !<!Languages> 
               default:
                 name: ''
@@ -17563,8 +17700,8 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_321
           - *ref_322
+          - *ref_323
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -17582,14 +17719,14 @@ operationGroups:
                         name: Metadata
                         description: ''
                   - !<!HttpHeader> 
-                    schema: *ref_323
+                    schema: *ref_324
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_324
+                    schema: *ref_325
                     header: Last-Modified
                     language:
                       default:
@@ -17617,28 +17754,28 @@ operationGroups:
                         name: LeaseStatus
                         description: The current lease status of the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_325
+                    schema: *ref_326
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_326
+                    schema: *ref_327
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_327
+                    schema: *ref_328
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_328
+                    schema: *ref_329
                     header: Date
                     language:
                       default:
@@ -17652,14 +17789,14 @@ operationGroups:
                         name: BlobPublicAccess
                         description: Indicated whether data in the container may be accessed publicly and the level of access
                   - !<!HttpHeader> 
-                    schema: *ref_329
+                    schema: *ref_330
                     header: x-ms-has-immutability-policy
                     language:
                       default:
                         name: HasImmutabilityPolicy
                         description: Indicates whether the container has an immutability policy set on it.
                   - !<!HttpHeader> 
-                    schema: *ref_330
+                    schema: *ref_331
                     header: x-ms-has-legal-hold
                     language:
                       default:
@@ -17669,7 +17806,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -17678,7 +17815,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_331
+                    schema: *ref_332
                     header: x-ms-error-code
                     language:
                       default:
@@ -17701,7 +17838,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17712,7 +17849,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_336
+          - !<!Parameter> &ref_337
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -17725,11 +17862,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_332
           - *ref_333
           - *ref_334
+          - *ref_335
           - *ref_235
-          - !<!Parameter> &ref_337
+          - !<!Parameter> &ref_338
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -17743,10 +17880,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_335
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_336
               - *ref_7
             signatureParameters:
-              - *ref_335
+              - *ref_336
               - *ref_7
             language: !<!Languages> 
               default:
@@ -17758,8 +17908,8 @@ operationGroups:
                 method: delete
                 uri: '{url}'
         signatureParameters:
-          - *ref_336
           - *ref_337
+          - *ref_338
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -17770,21 +17920,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_338
+                    schema: *ref_339
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_339
+                    schema: *ref_340
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_340
+                    schema: *ref_341
                     header: x-ms-version
                     language:
                       default:
@@ -17801,7 +17951,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -17810,7 +17960,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_341
+                    schema: *ref_342
                     header: x-ms-error-code
                     language:
                       default:
@@ -17833,7 +17983,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17845,7 +17995,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_342
+            schema: *ref_343
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -17856,7 +18006,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_347
+          - !<!Parameter> &ref_348
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -17869,9 +18019,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_343
-          - !<!Parameter> &ref_348
-            schema: *ref_308
+          - *ref_344
+          - !<!Parameter> &ref_349
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -17886,9 +18036,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_344
+          - *ref_345
           - *ref_235
-          - !<!Parameter> &ref_349
+          - !<!Parameter> &ref_350
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -17902,11 +18052,24 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_345
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_346
+              - *ref_347
             signatureParameters:
-              - *ref_345
               - *ref_346
+              - *ref_347
             language: !<!Languages> 
               default:
                 name: ''
@@ -17917,9 +18080,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_347
           - *ref_348
           - *ref_349
+          - *ref_350
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -17930,42 +18093,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_350
+                    schema: *ref_351
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_351
+                    schema: *ref_352
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_352
+                    schema: *ref_353
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_353
+                    schema: *ref_354
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_354
+                    schema: *ref_355
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_355
+                    schema: *ref_356
                     header: Date
                     language:
                       default:
@@ -17975,7 +18138,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -17984,7 +18147,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_356
+                    schema: *ref_357
                     header: x-ms-error-code
                     language:
                       default:
@@ -18007,7 +18170,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18019,7 +18182,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_357
+            schema: *ref_358
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18030,7 +18193,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_360
+          - !<!Parameter> &ref_361
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -18043,9 +18206,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_358
+          - *ref_359
           - *ref_235
-          - !<!Parameter> &ref_361
+          - !<!Parameter> &ref_362
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -18059,9 +18222,22 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_359
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_360
             signatureParameters:
-              - *ref_359
+              - *ref_360
             language: !<!Languages> 
               default:
                 name: ''
@@ -18072,11 +18248,11 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_360
           - *ref_361
+          - *ref_362
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_362
+            schema: *ref_363
             language: !<!Languages> 
               default:
                 name: ''
@@ -18092,42 +18268,42 @@ operationGroups:
                         name: BlobPublicAccess
                         description: Indicated whether data in the container may be accessed publicly and the level of access
                   - !<!HttpHeader> 
-                    schema: *ref_363
+                    schema: *ref_364
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_364
+                    schema: *ref_365
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_365
+                    schema: *ref_366
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_366
+                    schema: *ref_367
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_367
+                    schema: *ref_368
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_368
+                    schema: *ref_369
                     header: Date
                     language:
                       default:
@@ -18140,7 +18316,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -18149,7 +18325,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_369
+                    schema: *ref_370
                     header: x-ms-error-code
                     language:
                       default:
@@ -18172,7 +18348,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18184,7 +18360,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_357
+            schema: *ref_358
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18195,7 +18371,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_375
+          - !<!Parameter> &ref_376
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -18208,8 +18384,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_370
-          - !<!Parameter> &ref_376
+          - *ref_371
+          - !<!Parameter> &ref_377
             schema: *ref_136
             implementation: Method
             language: !<!Languages> 
@@ -18220,10 +18396,10 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_371
           - *ref_372
+          - *ref_373
           - *ref_235
-          - !<!Parameter> &ref_377
+          - !<!Parameter> &ref_378
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -18237,8 +18413,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_374
-                schema: *ref_362
+              - !<!Parameter> &ref_375
+                schema: *ref_363
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -18249,11 +18425,24 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - *ref_373
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_374
               - *ref_8
             signatureParameters:
+              - *ref_375
               - *ref_374
-              - *ref_373
               - *ref_8
             language: !<!Languages> 
               default:
@@ -18268,9 +18457,9 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_375
           - *ref_376
           - *ref_377
+          - *ref_378
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -18281,42 +18470,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_378
+                    schema: *ref_379
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_379
+                    schema: *ref_380
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_380
+                    schema: *ref_381
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_381
+                    schema: *ref_382
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_382
+                    schema: *ref_383
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_383
+                    schema: *ref_384
                     header: Date
                     language:
                       default:
@@ -18326,7 +18515,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -18335,7 +18524,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_384
+                    schema: *ref_385
                     header: x-ms-error-code
                     language:
                       default:
@@ -18358,7 +18547,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18370,7 +18559,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18382,7 +18571,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_386
+            schema: *ref_387
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18393,7 +18582,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_391
+          - !<!Parameter> &ref_392
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -18406,8 +18595,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_392
-            schema: *ref_387
+          - !<!Parameter> &ref_393
+            schema: *ref_388
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18417,8 +18606,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_393
-            schema: *ref_388
+          - !<!Parameter> &ref_394
+            schema: *ref_389
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18428,10 +18617,10 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_389
           - *ref_390
+          - *ref_391
           - *ref_235
-          - !<!Parameter> &ref_394
+          - !<!Parameter> &ref_395
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -18445,6 +18634,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_9
             signatureParameters:
               - *ref_9
@@ -18458,10 +18660,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_391
           - *ref_392
           - *ref_393
           - *ref_394
+          - *ref_395
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -18472,49 +18674,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_388
+                    schema: *ref_389
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_395
+                    schema: *ref_396
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_396
+                    schema: *ref_397
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a container's lease
                   - !<!HttpHeader> 
-                    schema: *ref_397
+                    schema: *ref_398
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_398
+                    schema: *ref_399
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_399
+                    schema: *ref_400
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_400
+                    schema: *ref_401
                     header: Date
                     language:
                       default:
@@ -18524,7 +18726,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -18533,7 +18735,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_401
+                    schema: *ref_402
                     header: x-ms-error-code
                     language:
                       default:
@@ -18556,7 +18758,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18568,7 +18770,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18580,7 +18782,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_402
+            schema: *ref_403
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18591,7 +18793,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_406
+          - !<!Parameter> &ref_407
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -18604,8 +18806,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_407
-            schema: *ref_403
+          - !<!Parameter> &ref_408
+            schema: *ref_404
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18616,10 +18818,10 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_404
           - *ref_405
+          - *ref_406
           - *ref_235
-          - !<!Parameter> &ref_408
+          - !<!Parameter> &ref_409
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -18633,6 +18835,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_10
             signatureParameters:
               - *ref_10
@@ -18646,9 +18861,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_406
           - *ref_407
           - *ref_408
+          - *ref_409
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -18659,42 +18874,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_403
+                    schema: *ref_404
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_409
+                    schema: *ref_410
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_410
+                    schema: *ref_411
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_411
+                    schema: *ref_412
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_412
+                    schema: *ref_413
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_413
+                    schema: *ref_414
                     header: Date
                     language:
                       default:
@@ -18704,7 +18919,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -18713,7 +18928,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_414
+                    schema: *ref_415
                     header: x-ms-error-code
                     language:
                       default:
@@ -18736,7 +18951,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18748,7 +18963,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18760,7 +18975,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_415
+            schema: *ref_416
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18771,7 +18986,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_418
+          - !<!Parameter> &ref_419
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -18784,8 +18999,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_419
-            schema: *ref_403
+          - !<!Parameter> &ref_420
+            schema: *ref_404
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18796,10 +19011,10 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_416
           - *ref_417
+          - *ref_418
           - *ref_235
-          - !<!Parameter> &ref_420
+          - !<!Parameter> &ref_421
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -18813,6 +19028,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_11
             signatureParameters:
               - *ref_11
@@ -18826,9 +19054,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_418
           - *ref_419
           - *ref_420
+          - *ref_421
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -18839,49 +19067,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_421
+                    schema: *ref_422
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_422
+                    schema: *ref_423
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_423
+                    schema: *ref_424
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a container's lease
                   - !<!HttpHeader> 
-                    schema: *ref_424
+                    schema: *ref_425
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_425
+                    schema: *ref_426
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_426
+                    schema: *ref_427
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_427
+                    schema: *ref_428
                     header: Date
                     language:
                       default:
@@ -18891,7 +19119,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -18900,7 +19128,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_428
+                    schema: *ref_429
                     header: x-ms-error-code
                     language:
                       default:
@@ -18923,7 +19151,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18935,7 +19163,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18947,7 +19175,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_429
+            schema: *ref_430
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -18958,7 +19186,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_432
+          - !<!Parameter> &ref_433
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -18971,8 +19199,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_433
-            schema: *ref_387
+          - !<!Parameter> &ref_434
+            schema: *ref_388
             implementation: Method
             language: !<!Languages> 
               default:
@@ -18985,10 +19213,10 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_430
           - *ref_431
+          - *ref_432
           - *ref_235
-          - !<!Parameter> &ref_434
+          - !<!Parameter> &ref_435
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -19002,6 +19230,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_12
             signatureParameters:
               - *ref_12
@@ -19015,9 +19256,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_432
           - *ref_433
           - *ref_434
+          - *ref_435
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -19028,49 +19269,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_435
+                    schema: *ref_436
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_436
+                    schema: *ref_437
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_387
+                    schema: *ref_388
                     header: x-ms-lease-time
                     language:
                       default:
                         name: LeaseTime
                         description: 'Approximate time remaining in the lease period, in seconds.'
                   - !<!HttpHeader> 
-                    schema: *ref_437
+                    schema: *ref_438
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_438
+                    schema: *ref_439
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_439
+                    schema: *ref_440
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_440
+                    schema: *ref_441
                     header: Date
                     language:
                       default:
@@ -19080,7 +19321,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -19089,7 +19330,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_441
+                    schema: *ref_442
                     header: x-ms-error-code
                     language:
                       default:
@@ -19112,7 +19353,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19124,7 +19365,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19136,7 +19377,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_442
+            schema: *ref_443
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19147,7 +19388,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_446
+          - !<!Parameter> &ref_447
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -19160,8 +19401,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_447
-            schema: *ref_403
+          - !<!Parameter> &ref_448
+            schema: *ref_404
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19172,8 +19413,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_448
-            schema: *ref_443
+          - !<!Parameter> &ref_449
+            schema: *ref_444
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19184,10 +19425,10 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_444
           - *ref_445
+          - *ref_446
           - *ref_235
-          - !<!Parameter> &ref_449
+          - !<!Parameter> &ref_450
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -19201,6 +19442,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_13
             signatureParameters:
               - *ref_13
@@ -19214,10 +19468,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_446
           - *ref_447
           - *ref_448
           - *ref_449
+          - *ref_450
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -19228,49 +19482,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_443
+                    schema: *ref_444
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_450
+                    schema: *ref_451
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_451
+                    schema: *ref_452
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a container's lease
                   - !<!HttpHeader> 
-                    schema: *ref_452
+                    schema: *ref_453
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_453
+                    schema: *ref_454
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_454
+                    schema: *ref_455
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_455
+                    schema: *ref_456
                     header: Date
                     language:
                       default:
@@ -19280,7 +19534,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -19289,7 +19543,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_456
+                    schema: *ref_457
                     header: x-ms-error-code
                     language:
                       default:
@@ -19312,7 +19566,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19324,7 +19578,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_260
+            schema: *ref_261
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19335,8 +19589,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_458
-            schema: *ref_261
+          - !<!Parameter> &ref_459
+            schema: *ref_262
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19346,8 +19600,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_459
-            schema: *ref_261
+          - !<!Parameter> &ref_460
+            schema: *ref_262
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19360,8 +19614,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_460
-            schema: *ref_262
+          - !<!Parameter> &ref_461
+            schema: *ref_263
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19374,8 +19628,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_461
-            schema: *ref_457
+          - !<!Parameter> &ref_462
+            schema: *ref_458
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19386,7 +19640,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
                 style: form
-          - !<!Parameter> &ref_462
+          - !<!Parameter> &ref_463
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -19400,7 +19654,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_463
+          - !<!Parameter> &ref_464
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -19413,6 +19667,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -19423,15 +19692,15 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_458
           - *ref_459
           - *ref_460
           - *ref_461
           - *ref_462
           - *ref_463
+          - *ref_464
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_464
+            schema: *ref_465
             language: !<!Languages> 
               default:
                 name: ''
@@ -19440,35 +19709,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_465
+                    schema: *ref_466
                     header: Content-Type
                     language:
                       default:
                         name: ContentType
                         description: The media type of the body of the response. For List Blobs this is 'application/xml'
                   - !<!HttpHeader> 
-                    schema: *ref_466
+                    schema: *ref_467
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_467
+                    schema: *ref_468
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_468
+                    schema: *ref_469
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_469
+                    schema: *ref_470
                     header: Date
                     language:
                       default:
@@ -19481,7 +19750,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -19518,7 +19787,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_307
+            schema: *ref_308
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19530,7 +19799,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_260
+            schema: *ref_261
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19541,8 +19810,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_471
-            schema: *ref_261
+          - !<!Parameter> &ref_472
+            schema: *ref_262
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19552,8 +19821,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_472
-            schema: *ref_470
+          - !<!Parameter> &ref_473
+            schema: *ref_471
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19566,8 +19835,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_473
-            schema: *ref_261
+          - !<!Parameter> &ref_474
+            schema: *ref_262
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19580,8 +19849,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_474
-            schema: *ref_262
+          - !<!Parameter> &ref_475
+            schema: *ref_263
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19594,8 +19863,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_475
-            schema: *ref_457
+          - !<!Parameter> &ref_476
+            schema: *ref_458
             implementation: Method
             language: !<!Languages> 
               default:
@@ -19606,7 +19875,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
                 style: form
-          - !<!Parameter> &ref_476
+          - !<!Parameter> &ref_477
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -19620,7 +19889,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_477
+          - !<!Parameter> &ref_478
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -19633,6 +19902,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -19643,16 +19927,16 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_471
           - *ref_472
           - *ref_473
           - *ref_474
           - *ref_475
           - *ref_476
           - *ref_477
+          - *ref_478
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_478
+            schema: *ref_479
             language: !<!Languages> 
               default:
                 name: ''
@@ -19661,35 +19945,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_470
+                    schema: *ref_471
                     header: Content-Type
                     language:
                       default:
                         name: ContentType
                         description: The media type of the body of the response. For List Blobs this is 'application/xml'
                   - !<!HttpHeader> 
-                    schema: *ref_479
+                    schema: *ref_480
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_480
+                    schema: *ref_481
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_481
+                    schema: *ref_482
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_482
+                    schema: *ref_483
                     header: Date
                     language:
                       default:
@@ -19702,7 +19986,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -19711,7 +19995,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_483
+                    schema: *ref_484
                     header: x-ms-error-code
                     language:
                       default:
@@ -19739,7 +20023,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_287
+            schema: *ref_288
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19765,6 +20049,21 @@ operationGroups:
           - *ref_235
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -19785,42 +20084,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_484
+                    schema: *ref_485
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_485
+                    schema: *ref_486
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_486
+                    schema: *ref_487
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_487
+                    schema: *ref_488
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_292
+                    schema: *ref_293
                     header: x-ms-sku-name
                     language:
                       default:
                         name: SkuName
                         description: Identifies the sku name of the account
                   - !<!HttpHeader> 
-                    schema: *ref_293
+                    schema: *ref_294
                     header: x-ms-account-kind
                     language:
                       default:
@@ -19830,7 +20129,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -19839,7 +20138,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_488
+                    schema: *ref_489
                     header: x-ms-error-code
                     language:
                       default:
@@ -19870,7 +20169,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_489
+            schema: *ref_490
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -19881,7 +20180,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_501
+          - !<!Parameter> &ref_502
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -19894,7 +20193,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_502
+          - !<!Parameter> &ref_503
             schema: *ref_49
             implementation: Method
             language: !<!Languages> 
@@ -19905,7 +20204,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_503
+          - !<!Parameter> &ref_504
             schema: *ref_49
             implementation: Method
             language: !<!Languages> 
@@ -19918,7 +20217,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_504
+          - !<!Parameter> &ref_505
             schema: *ref_49
             implementation: Method
             language: !<!Languages> 
@@ -19932,7 +20231,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_490
           - *ref_491
           - *ref_492
           - *ref_493
@@ -19942,8 +20240,9 @@ operationGroups:
           - *ref_497
           - *ref_498
           - *ref_499
+          - *ref_500
           - *ref_235
-          - !<!Parameter> &ref_505
+          - !<!Parameter> &ref_506
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -19957,12 +20256,25 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_51
-              - *ref_500
+              - *ref_501
               - *ref_14
             signatureParameters:
               - *ref_51
-              - *ref_500
+              - *ref_501
               - *ref_14
             language: !<!Languages> 
               default:
@@ -19974,11 +20286,11 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_501
           - *ref_502
           - *ref_503
           - *ref_504
           - *ref_505
+          - *ref_506
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -19996,42 +20308,42 @@ operationGroups:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_506
+                    schema: *ref_507
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_507
+                    schema: *ref_508
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_508
+                    schema: *ref_509
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_509
+                    schema: *ref_510
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_296
+                    schema: *ref_297
                     header: Content-Length
                     language:
                       default:
                         name: ContentLength
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_510
+                    schema: *ref_511
                     header: Date
                     language:
                       default:
@@ -20041,7 +20353,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_511
+            schema: *ref_512
             language: !<!Languages> 
               default:
                 name: ''
@@ -20050,21 +20362,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_512
+                    schema: *ref_513
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_513
+                    schema: *ref_514
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_514
+                    schema: *ref_515
                     header: x-ms-version
                     language:
                       default:
@@ -20089,7 +20401,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_231
-          - !<!Parameter> &ref_531
+          - !<!Parameter> &ref_532
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -20102,7 +20414,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_532
+          - !<!Parameter> &ref_533
             schema: *ref_63
             implementation: Method
             language: !<!Languages> 
@@ -20115,8 +20427,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_515
-          - !<!Parameter> &ref_533
+          - *ref_516
+          - !<!Parameter> &ref_534
             schema: *ref_63
             implementation: Method
             required: true
@@ -20130,7 +20442,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_534
+          - !<!Parameter> &ref_535
             schema: *ref_49
             implementation: Method
             language: !<!Languages> 
@@ -20141,7 +20453,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_535
+          - !<!Parameter> &ref_536
             schema: *ref_49
             implementation: Method
             language: !<!Languages> 
@@ -20154,7 +20466,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_536
+          - !<!Parameter> &ref_537
             schema: *ref_49
             implementation: Method
             language: !<!Languages> 
@@ -20168,13 +20480,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_516
           - *ref_517
           - *ref_518
           - *ref_519
           - *ref_520
           - *ref_521
-          - !<!Parameter> &ref_537
+          - *ref_522
+          - !<!Parameter> &ref_538
             schema: *ref_63
             implementation: Method
             language: !<!Languages> 
@@ -20185,7 +20497,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_522
           - *ref_523
           - *ref_524
           - *ref_525
@@ -20193,8 +20504,9 @@ operationGroups:
           - *ref_527
           - *ref_528
           - *ref_529
+          - *ref_530
           - *ref_235
-          - !<!Parameter> &ref_538
+          - !<!Parameter> &ref_539
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -20208,13 +20520,26 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_52
-              - *ref_530
+              - *ref_531
               - *ref_15
               - *ref_56
             signatureParameters:
               - *ref_52
-              - *ref_530
+              - *ref_531
               - *ref_15
               - *ref_56
             language: !<!Languages> 
@@ -20227,7 +20552,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_531
           - *ref_532
           - *ref_533
           - *ref_534
@@ -20235,6 +20559,7 @@ operationGroups:
           - *ref_536
           - *ref_537
           - *ref_538
+          - *ref_539
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -20254,7 +20579,7 @@ operationGroups:
                           When renaming a directory, the number of paths that are renamed with each invocation is limited. If the number of paths to be renamed exceeds this limit, a continuation token is returned in this response header.
                           When a continuation token is returned in the response, it must be specified in a subsequent invocation of the rename operation to continue renaming the directory.
                   - !<!HttpHeader> 
-                    schema: *ref_539
+                    schema: *ref_540
                     header: ETag
                     language:
                       default:
@@ -20268,35 +20593,35 @@ operationGroups:
                         name: LastModified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_540
+                    schema: *ref_541
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_541
+                    schema: *ref_542
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_542
+                    schema: *ref_543
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_543
+                    schema: *ref_544
                     header: Content-Length
                     language:
                       default:
                         name: ContentLength
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_544
+                    schema: *ref_545
                     header: Date
                     language:
                       default:
@@ -20306,7 +20631,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_511
+            schema: *ref_512
             language: !<!Languages> 
               default:
                 name: ''
@@ -20315,21 +20640,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_545
+                    schema: *ref_546
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_546
+                    schema: *ref_547
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_547
+                    schema: *ref_548
                     header: x-ms-version
                     language:
                       default:
@@ -20354,7 +20679,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_231
-          - !<!Parameter> &ref_555
+          - !<!Parameter> &ref_556
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -20367,8 +20692,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_556
-            schema: *ref_548
+          - !<!Parameter> &ref_557
+            schema: *ref_549
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20379,7 +20704,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_557
+          - !<!Parameter> &ref_558
             schema: *ref_63
             implementation: Method
             language: !<!Languages> 
@@ -20392,13 +20717,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_549
           - *ref_550
           - *ref_551
           - *ref_552
           - *ref_553
+          - *ref_554
           - *ref_235
-          - !<!Parameter> &ref_558
+          - !<!Parameter> &ref_559
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -20412,10 +20737,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_554
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_555
               - *ref_16
             signatureParameters:
-              - *ref_554
+              - *ref_555
               - *ref_16
             language: !<!Languages> 
               default:
@@ -20427,10 +20765,10 @@ operationGroups:
                 method: delete
                 uri: '{url}'
         signatureParameters:
-          - *ref_555
           - *ref_556
           - *ref_557
           - *ref_558
+          - *ref_559
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -20441,7 +20779,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_559
+                    schema: *ref_560
                     header: x-ms-continuation
                     language:
                       default:
@@ -20450,28 +20788,28 @@ operationGroups:
                           When renaming a directory, the number of paths that are renamed with each invocation is limited. If the number of paths to be renamed exceeds this limit, a continuation token is returned in this response header.
                           When a continuation token is returned in the response, it must be specified in a subsequent invocation of the rename operation to continue renaming the directory.
                   - !<!HttpHeader> 
-                    schema: *ref_560
+                    schema: *ref_561
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_561
+                    schema: *ref_562
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_562
+                    schema: *ref_563
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_563
+                    schema: *ref_564
                     header: Date
                     language:
                       default:
@@ -20481,7 +20819,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_511
+            schema: *ref_512
             language: !<!Languages> 
               default:
                 name: ''
@@ -20490,21 +20828,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_564
+                    schema: *ref_565
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_565
+                    schema: *ref_566
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_566
+                    schema: *ref_567
                     header: x-ms-version
                     language:
                       default:
@@ -20527,7 +20865,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_567
+            schema: *ref_568
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20538,7 +20876,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_575
+          - !<!Parameter> &ref_576
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -20551,9 +20889,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_568
-          - !<!Parameter> &ref_576
-            schema: *ref_569
+          - *ref_569
+          - !<!Parameter> &ref_577
+            schema: *ref_570
             implementation: Method
             language: !<!Languages> 
               default:
@@ -20563,8 +20901,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_577
-            schema: *ref_569
+          - !<!Parameter> &ref_578
+            schema: *ref_570
             implementation: Method
             language: !<!Languages> 
               default:
@@ -20574,7 +20912,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_578
+          - !<!Parameter> &ref_579
             schema: *ref_49
             implementation: Method
             language: !<!Languages> 
@@ -20587,8 +20925,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_579
-            schema: *ref_569
+          - !<!Parameter> &ref_580
+            schema: *ref_570
             implementation: Method
             language: !<!Languages> 
               default:
@@ -20600,11 +20938,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_570
           - *ref_571
           - *ref_572
           - *ref_573
-          - !<!Parameter> &ref_580
+          - *ref_574
+          - !<!Parameter> &ref_581
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -20619,10 +20957,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_574
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_575
               - *ref_17
             signatureParameters:
-              - *ref_574
+              - *ref_575
               - *ref_17
             language: !<!Languages> 
               default:
@@ -20634,12 +20985,12 @@ operationGroups:
                 method: patch
                 uri: '{url}'
         signatureParameters:
-          - *ref_575
           - *ref_576
           - *ref_577
           - *ref_578
           - *ref_579
           - *ref_580
+          - *ref_581
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -20650,35 +21001,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_581
+                    schema: *ref_582
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_569
+                    schema: *ref_570
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_582
+                    schema: *ref_583
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_583
+                    schema: *ref_584
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_584
+                    schema: *ref_585
                     header: x-ms-version
                     language:
                       default:
@@ -20688,7 +21039,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_511
+            schema: *ref_512
             language: !<!Languages> 
               default:
                 name: ''
@@ -20697,21 +21048,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_585
+                    schema: *ref_586
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_586
+                    schema: *ref_587
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_587
+                    schema: *ref_588
                     header: x-ms-version
                     language:
                       default:
@@ -20734,7 +21085,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_588
+            schema: *ref_589
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -20745,7 +21096,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_595
+          - !<!Parameter> &ref_596
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -20758,8 +21109,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_596
-            schema: *ref_548
+          - !<!Parameter> &ref_597
+            schema: *ref_549
             implementation: Method
             language: !<!Languages> 
               default:
@@ -20771,12 +21122,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_589
           - *ref_590
           - *ref_591
           - *ref_592
           - *ref_593
-          - !<!Parameter> &ref_597
+          - *ref_594
+          - !<!Parameter> &ref_598
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -20791,10 +21142,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_594
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_595
               - *ref_18
             signatureParameters:
-              - *ref_594
+              - *ref_595
               - *ref_18
             language: !<!Languages> 
               default:
@@ -20806,9 +21170,9 @@ operationGroups:
                 method: head
                 uri: '{url}'
         signatureParameters:
-          - *ref_595
           - *ref_596
           - *ref_597
+          - *ref_598
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -20819,63 +21183,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_598
+                    schema: *ref_599
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_599
+                    schema: *ref_600
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_600
+                    schema: *ref_601
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_601
+                    schema: *ref_602
                     header: x-ms-owner
                     language:
                       default:
                         name: XMsOwner
                         description: The owner of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_602
+                    schema: *ref_603
                     header: x-ms-group
                     language:
                       default:
                         name: XMsGroup
                         description: The owning group of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_603
+                    schema: *ref_604
                     header: x-ms-permissions
                     language:
                       default:
                         name: XMsPermissions
                         description: 'The POSIX access permissions for the file owner, the file owning group, and others. Included in the response if Hierarchical Namespace is enabled for the account.'
                   - !<!HttpHeader> 
-                    schema: *ref_604
+                    schema: *ref_605
                     header: x-ms-acl
                     language:
                       default:
                         name: XMsAcl
                         description: The POSIX access control list for the file or directory.  Included in the response only if the action is "getAccessControl" and Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_605
+                    schema: *ref_606
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_606
+                    schema: *ref_607
                     header: x-ms-version
                     language:
                       default:
@@ -20885,7 +21249,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_511
+            schema: *ref_512
             language: !<!Languages> 
               default:
                 name: ''
@@ -20894,21 +21258,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_607
+                    schema: *ref_608
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_608
+                    schema: *ref_609
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_609
+                    schema: *ref_610
                     header: x-ms-version
                     language:
                       default:
@@ -20938,7 +21302,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_231
-          - !<!Parameter> &ref_619
+          - !<!Parameter> &ref_620
             schema: *ref_64
             implementation: Method
             language: !<!Languages> 
@@ -20951,7 +21315,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_620
+          - !<!Parameter> &ref_621
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -20964,7 +21328,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_621
+          - !<!Parameter> &ref_622
             schema: *ref_64
             implementation: Method
             language: !<!Languages> 
@@ -20975,9 +21339,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_610
-          - !<!Parameter> &ref_622
-            schema: *ref_548
+          - *ref_611
+          - !<!Parameter> &ref_623
+            schema: *ref_549
             implementation: Method
             language: !<!Languages> 
               default:
@@ -20987,8 +21351,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_623
-            schema: *ref_548
+          - !<!Parameter> &ref_624
+            schema: *ref_549
             implementation: Method
             language: !<!Languages> 
               default:
@@ -20998,13 +21362,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_611
           - *ref_612
+          - *ref_613
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: &ref_680
+              x-ms-parameter-grouping: &ref_681
                 name: cpk-info
             language: !<!Languages> 
               default:
@@ -21014,12 +21378,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_614
           - *ref_615
           - *ref_616
           - *ref_617
+          - *ref_618
           - *ref_235
-          - !<!Parameter> &ref_624
+          - !<!Parameter> &ref_625
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -21033,11 +21397,24 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_618
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_619
               - *ref_66
               - *ref_19
             signatureParameters:
-              - *ref_618
+              - *ref_619
               - *ref_66
               - *ref_19
             language: !<!Languages> 
@@ -21050,12 +21427,12 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_619
           - *ref_620
           - *ref_621
           - *ref_622
           - *ref_623
           - *ref_624
+          - *ref_625
         responses:
           - !<!BinaryResponse> 
             binary: true
@@ -21067,7 +21444,7 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_625
+                    schema: *ref_626
                     header: Last-Modified
                     language:
                       default:
@@ -21081,56 +21458,56 @@ operationGroups:
                         name: Metadata
                         description: ''
                   - !<!HttpHeader> 
-                    schema: *ref_626
+                    schema: *ref_627
                     header: Content-Length
                     language:
                       default:
                         name: ContentLength
                         description: The number of bytes present in the response body.
                   - !<!HttpHeader> 
-                    schema: *ref_627
+                    schema: *ref_628
                     header: Content-Type
                     language:
                       default:
                         name: ContentType
                         description: The media type of the body of the response. For Download Blob this is 'application/octet-stream'
                   - !<!HttpHeader> 
-                    schema: *ref_628
+                    schema: *ref_629
                     header: Content-Range
                     language:
                       default:
                         name: ContentRange
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the blob by setting the 'Range' request header.
                   - !<!HttpHeader> 
-                    schema: *ref_629
+                    schema: *ref_630
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_630
+                    schema: *ref_631
                     header: Content-MD5
                     language:
                       default:
                         name: ContentMD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_631
+                    schema: *ref_632
                     header: Content-Encoding
                     language:
                       default:
                         name: ContentEncoding
                         description: This header returns the value that was specified for the Content-Encoding request header
                   - !<!HttpHeader> 
-                    schema: *ref_632
+                    schema: *ref_633
                     header: Cache-Control
                     language:
                       default:
                         name: CacheControl
                         description: This header is returned if it was previously specified for the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_633
+                    schema: *ref_634
                     header: Content-Disposition
                     language:
                       default:
@@ -21140,14 +21517,14 @@ operationGroups:
                           payload, and also can be used to attach additional metadata. For example, if set to attachment, it indicates that the user-agent should not display the response, but instead show a Save As dialog with a filename
                           other than the blob name specified.
                   - !<!HttpHeader> 
-                    schema: *ref_634
+                    schema: *ref_635
                     header: Content-Language
                     language:
                       default:
                         name: ContentLanguage
                         description: This header returns the value that was specified for the Content-Language request header.
                   - !<!HttpHeader> 
-                    schema: *ref_635
+                    schema: *ref_636
                     header: x-ms-blob-sequence-number
                     language:
                       default:
@@ -21161,7 +21538,7 @@ operationGroups:
                         name: BlobType
                         description: The blob's type.
                   - !<!HttpHeader> 
-                    schema: *ref_636
+                    schema: *ref_637
                     header: x-ms-copy-completion-time
                     language:
                       default:
@@ -21170,7 +21547,7 @@ operationGroups:
                           Conclusion time of the last attempted Copy Blob operation where this blob was the destination blob. This value can specify the time of a completed, aborted, or failed copy attempt. This header does not appear if a
                           copy is pending, if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List.
                   - !<!HttpHeader> 
-                    schema: *ref_637
+                    schema: *ref_638
                     header: x-ms-copy-status-description
                     language:
                       default:
@@ -21179,14 +21556,14 @@ operationGroups:
                           Only appears when x-ms-copy-status is failed or pending. Describes the cause of the last fatal or non-fatal copy operation failure. This header does not appear if this blob has never been the destination in a Copy
                           Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List
                   - !<!HttpHeader> 
-                    schema: *ref_638
+                    schema: *ref_639
                     header: x-ms-copy-id
                     language:
                       default:
                         name: CopyId
                         description: 'String identifier for this copy operation. Use with Get Blob Properties to check the status of this copy operation, or pass to Abort Copy Blob to abort a pending copy.'
                   - !<!HttpHeader> 
-                    schema: *ref_639
+                    schema: *ref_640
                     header: x-ms-copy-progress
                     language:
                       default:
@@ -21196,7 +21573,7 @@ operationGroups:
                           header does not appear if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block
                           List
                   - !<!HttpHeader> 
-                    schema: *ref_640
+                    schema: *ref_641
                     header: x-ms-copy-source
                     language:
                       default:
@@ -21233,49 +21610,49 @@ operationGroups:
                         name: LeaseStatus
                         description: The current lease status of the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_641
+                    schema: *ref_642
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_642
+                    schema: *ref_643
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_643
+                    schema: *ref_644
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_644
+                    schema: *ref_645
                     header: Accept-Ranges
                     language:
                       default:
                         name: AcceptRanges
                         description: Indicates that the service supports requests for partial blob content.
                   - !<!HttpHeader> 
-                    schema: *ref_645
+                    schema: *ref_646
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_646
+                    schema: *ref_647
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_548
+                    schema: *ref_549
                     header: x-ms-server-encrypted
                     language:
                       default:
@@ -21284,14 +21661,14 @@ operationGroups:
                           The value of this header is set to true if the blob data and application metadata are completely encrypted using the specified algorithm. Otherwise, the value is set to false (when the blob is unencrypted, or if
                           only parts of the blob/application metadata are encrypted).
                   - !<!HttpHeader> 
-                    schema: *ref_647
+                    schema: *ref_648
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
                         name: EncryptionKeySha256
                         description: The SHA-256 hash of the encryption key used to encrypt the blob. This header is only returned when the blob was encrypted with a customer-provided key.
                   - !<!HttpHeader> 
-                    schema: *ref_648
+                    schema: *ref_649
                     header: x-ms-blob-content-md5
                     language:
                       default:
@@ -21314,70 +21691,70 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_649
+                    schema: *ref_650
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_650
+                    schema: *ref_651
                     header: x-ms-meta
                     language:
                       default:
                         name: Metadata
                         description: ''
                   - !<!HttpHeader> 
-                    schema: *ref_651
+                    schema: *ref_652
                     header: Content-Length
                     language:
                       default:
                         name: ContentLength
                         description: The number of bytes present in the response body.
                   - !<!HttpHeader> 
-                    schema: *ref_652
+                    schema: *ref_653
                     header: Content-Type
                     language:
                       default:
                         name: ContentType
                         description: The media type of the body of the response. For Download Blob this is 'application/octet-stream'
                   - !<!HttpHeader> 
-                    schema: *ref_653
+                    schema: *ref_654
                     header: Content-Range
                     language:
                       default:
                         name: ContentRange
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the blob by setting the 'Range' request header.
                   - !<!HttpHeader> 
-                    schema: *ref_654
+                    schema: *ref_655
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_655
+                    schema: *ref_656
                     header: Content-MD5
                     language:
                       default:
                         name: ContentMD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_656
+                    schema: *ref_657
                     header: Content-Encoding
                     language:
                       default:
                         name: ContentEncoding
                         description: This header returns the value that was specified for the Content-Encoding request header
                   - !<!HttpHeader> 
-                    schema: *ref_657
+                    schema: *ref_658
                     header: Cache-Control
                     language:
                       default:
                         name: CacheControl
                         description: This header is returned if it was previously specified for the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_658
+                    schema: *ref_659
                     header: Content-Disposition
                     language:
                       default:
@@ -21387,14 +21764,14 @@ operationGroups:
                           payload, and also can be used to attach additional metadata. For example, if set to attachment, it indicates that the user-agent should not display the response, but instead show a Save As dialog with a filename
                           other than the blob name specified.
                   - !<!HttpHeader> 
-                    schema: *ref_659
+                    schema: *ref_660
                     header: Content-Language
                     language:
                       default:
                         name: ContentLanguage
                         description: This header returns the value that was specified for the Content-Language request header.
                   - !<!HttpHeader> 
-                    schema: *ref_660
+                    schema: *ref_661
                     header: x-ms-blob-sequence-number
                     language:
                       default:
@@ -21408,7 +21785,7 @@ operationGroups:
                         name: BlobType
                         description: The blob's type.
                   - !<!HttpHeader> 
-                    schema: *ref_661
+                    schema: *ref_662
                     header: x-ms-content-crc64
                     language:
                       default:
@@ -21417,7 +21794,7 @@ operationGroups:
                           If the request is to read a specified range and the x-ms-range-get-content-crc64 is set to true, then the request returns a crc64 for the range, as long as the range size is less than or equal to 4 MB. If both
                           x-ms-range-get-content-crc64 & x-ms-range-get-content-md5 is specified in the same request, it will fail with 400(Bad Request)
                   - !<!HttpHeader> 
-                    schema: *ref_662
+                    schema: *ref_663
                     header: x-ms-copy-completion-time
                     language:
                       default:
@@ -21426,7 +21803,7 @@ operationGroups:
                           Conclusion time of the last attempted Copy Blob operation where this blob was the destination blob. This value can specify the time of a completed, aborted, or failed copy attempt. This header does not appear if a
                           copy is pending, if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List.
                   - !<!HttpHeader> 
-                    schema: *ref_663
+                    schema: *ref_664
                     header: x-ms-copy-status-description
                     language:
                       default:
@@ -21435,14 +21812,14 @@ operationGroups:
                           Only appears when x-ms-copy-status is failed or pending. Describes the cause of the last fatal or non-fatal copy operation failure. This header does not appear if this blob has never been the destination in a Copy
                           Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List
                   - !<!HttpHeader> 
-                    schema: *ref_664
+                    schema: *ref_665
                     header: x-ms-copy-id
                     language:
                       default:
                         name: CopyId
                         description: 'String identifier for this copy operation. Use with Get Blob Properties to check the status of this copy operation, or pass to Abort Copy Blob to abort a pending copy.'
                   - !<!HttpHeader> 
-                    schema: *ref_665
+                    schema: *ref_666
                     header: x-ms-copy-progress
                     language:
                       default:
@@ -21452,7 +21829,7 @@ operationGroups:
                           header does not appear if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block
                           List
                   - !<!HttpHeader> 
-                    schema: *ref_666
+                    schema: *ref_667
                     header: x-ms-copy-source
                     language:
                       default:
@@ -21489,49 +21866,49 @@ operationGroups:
                         name: LeaseStatus
                         description: The current lease status of the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_667
+                    schema: *ref_668
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_668
+                    schema: *ref_669
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_669
+                    schema: *ref_670
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_670
+                    schema: *ref_671
                     header: Accept-Ranges
                     language:
                       default:
                         name: AcceptRanges
                         description: Indicates that the service supports requests for partial blob content.
                   - !<!HttpHeader> 
-                    schema: *ref_671
+                    schema: *ref_672
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_672
+                    schema: *ref_673
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_673
+                    schema: *ref_674
                     header: x-ms-server-encrypted
                     language:
                       default:
@@ -21540,14 +21917,14 @@ operationGroups:
                           The value of this header is set to true if the blob data and application metadata are completely encrypted using the specified algorithm. Otherwise, the value is set to false (when the blob is unencrypted, or if
                           only parts of the blob/application metadata are encrypted).
                   - !<!HttpHeader> 
-                    schema: *ref_674
+                    schema: *ref_675
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
                         name: EncryptionKeySha256
                         description: The SHA-256 hash of the encryption key used to encrypt the blob. This header is only returned when the blob was encrypted with a customer-provided key.
                   - !<!HttpHeader> 
-                    schema: *ref_675
+                    schema: *ref_676
                     header: x-ms-blob-content-md5
                     language:
                       default:
@@ -21562,7 +21939,7 @@ operationGroups:
                   - '206'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -21571,7 +21948,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_676
+                    schema: *ref_677
                     header: x-ms-error-code
                     language:
                       default:
@@ -21593,7 +21970,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_231
-          - !<!Parameter> &ref_686
+          - !<!Parameter> &ref_687
             schema: *ref_64
             implementation: Method
             language: !<!Languages> 
@@ -21606,7 +21983,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_687
+          - !<!Parameter> &ref_688
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -21619,14 +21996,14 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_677
           - *ref_678
           - *ref_679
+          - *ref_680
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: EncryptionAlgorithm
@@ -21635,12 +22012,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_681
           - *ref_682
           - *ref_683
           - *ref_684
+          - *ref_685
           - *ref_235
-          - !<!Parameter> &ref_688
+          - !<!Parameter> &ref_689
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -21654,11 +22031,24 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_685
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_686
               - *ref_67
               - *ref_20
             signatureParameters:
-              - *ref_685
+              - *ref_686
               - *ref_67
               - *ref_20
             language: !<!Languages> 
@@ -21671,9 +22061,9 @@ operationGroups:
                 method: head
                 uri: '{url}'
         signatureParameters:
-          - *ref_686
           - *ref_687
           - *ref_688
+          - *ref_689
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -21684,21 +22074,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_689
+                    schema: *ref_690
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_690
+                    schema: *ref_691
                     header: x-ms-creation-time
                     language:
                       default:
                         name: CreationTime
                         description: Returns the date and time the blob was created.
                   - !<!HttpHeader> 
-                    schema: *ref_691
+                    schema: *ref_692
                     header: x-ms-meta
                     language:
                       default:
@@ -21712,7 +22102,7 @@ operationGroups:
                         name: BlobType
                         description: The blob's type.
                   - !<!HttpHeader> 
-                    schema: *ref_692
+                    schema: *ref_693
                     header: x-ms-copy-completion-time
                     language:
                       default:
@@ -21721,7 +22111,7 @@ operationGroups:
                           Conclusion time of the last attempted Copy Blob operation where this blob was the destination blob. This value can specify the time of a completed, aborted, or failed copy attempt. This header does not appear if a
                           copy is pending, if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List.
                   - !<!HttpHeader> 
-                    schema: *ref_693
+                    schema: *ref_694
                     header: x-ms-copy-status-description
                     language:
                       default:
@@ -21730,14 +22120,14 @@ operationGroups:
                           Only appears when x-ms-copy-status is failed or pending. Describes the cause of the last fatal or non-fatal copy operation failure. This header does not appear if this blob has never been the destination in a Copy
                           Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List
                   - !<!HttpHeader> 
-                    schema: *ref_694
+                    schema: *ref_695
                     header: x-ms-copy-id
                     language:
                       default:
                         name: CopyId
                         description: 'String identifier for this copy operation. Use with Get Blob Properties to check the status of this copy operation, or pass to Abort Copy Blob to abort a pending copy.'
                   - !<!HttpHeader> 
-                    schema: *ref_695
+                    schema: *ref_696
                     header: x-ms-copy-progress
                     language:
                       default:
@@ -21747,7 +22137,7 @@ operationGroups:
                           header does not appear if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block
                           List
                   - !<!HttpHeader> 
-                    schema: *ref_696
+                    schema: *ref_697
                     header: x-ms-copy-source
                     language:
                       default:
@@ -21763,14 +22153,14 @@ operationGroups:
                         name: CopyStatus
                         description: State of the copy operation identified by x-ms-copy-id.
                   - !<!HttpHeader> 
-                    schema: *ref_697
+                    schema: *ref_698
                     header: x-ms-incremental-copy
                     language:
                       default:
                         name: IsIncrementalCopy
                         description: Included if the blob is incremental copy blob.
                   - !<!HttpHeader> 
-                    schema: *ref_698
+                    schema: *ref_699
                     header: x-ms-copy-destination-snapshot
                     language:
                       default:
@@ -21798,42 +22188,42 @@ operationGroups:
                         name: LeaseStatus
                         description: The current lease status of the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_699
+                    schema: *ref_700
                     header: Content-Length
                     language:
                       default:
                         name: ContentLength
                         description: The number of bytes present in the response body.
                   - !<!HttpHeader> 
-                    schema: *ref_700
+                    schema: *ref_701
                     header: Content-Type
                     language:
                       default:
                         name: ContentType
                         description: The content type specified for the blob. The default content type is 'application/octet-stream'
                   - !<!HttpHeader> 
-                    schema: *ref_701
+                    schema: *ref_702
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_702
+                    schema: *ref_703
                     header: Content-MD5
                     language:
                       default:
                         name: ContentMD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_703
+                    schema: *ref_704
                     header: Content-Encoding
                     language:
                       default:
                         name: ContentEncoding
                         description: This header returns the value that was specified for the Content-Encoding request header
                   - !<!HttpHeader> 
-                    schema: *ref_704
+                    schema: *ref_705
                     header: Content-Disposition
                     language:
                       default:
@@ -21843,70 +22233,70 @@ operationGroups:
                           payload, and also can be used to attach additional metadata. For example, if set to attachment, it indicates that the user-agent should not display the response, but instead show a Save As dialog with a filename
                           other than the blob name specified.
                   - !<!HttpHeader> 
-                    schema: *ref_705
+                    schema: *ref_706
                     header: Content-Language
                     language:
                       default:
                         name: ContentLanguage
                         description: This header returns the value that was specified for the Content-Language request header.
                   - !<!HttpHeader> 
-                    schema: *ref_706
+                    schema: *ref_707
                     header: Cache-Control
                     language:
                       default:
                         name: CacheControl
                         description: This header is returned if it was previously specified for the blob.
                   - !<!HttpHeader> 
-                    schema: *ref_707
+                    schema: *ref_708
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for a page blob. This header is not returned for block blobs or append blobs
                   - !<!HttpHeader> 
-                    schema: *ref_708
+                    schema: *ref_709
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_709
+                    schema: *ref_710
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_710
+                    schema: *ref_711
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_711
+                    schema: *ref_712
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_712
+                    schema: *ref_713
                     header: Accept-Ranges
                     language:
                       default:
                         name: AcceptRanges
                         description: Indicates that the service supports requests for partial blob content.
                   - !<!HttpHeader> 
-                    schema: *ref_713
+                    schema: *ref_714
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_714
+                    schema: *ref_715
                     header: x-ms-server-encrypted
                     language:
                       default:
@@ -21915,14 +22305,14 @@ operationGroups:
                           The value of this header is set to true if the blob data and application metadata are completely encrypted using the specified algorithm. Otherwise, the value is set to false (when the blob is unencrypted, or if
                           only parts of the blob/application metadata are encrypted).
                   - !<!HttpHeader> 
-                    schema: *ref_715
+                    schema: *ref_716
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
                         name: EncryptionKeySha256
                         description: The SHA-256 hash of the encryption key used to encrypt the metadata. This header is only returned when the metadata was encrypted with a customer-provided key.
                   - !<!HttpHeader> 
-                    schema: *ref_716
+                    schema: *ref_717
                     header: x-ms-access-tier
                     language:
                       default:
@@ -21931,14 +22321,14 @@ operationGroups:
                           The tier of page blob on a premium storage account or tier of block blob on blob storage LRS accounts. For a list of allowed premium page blob tiers, see
                           https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage#features. For blob storage LRS accounts, valid values are Hot/Cool/Archive.
                   - !<!HttpHeader> 
-                    schema: *ref_717
+                    schema: *ref_718
                     header: x-ms-access-tier-inferred
                     language:
                       default:
                         name: AccessTierInferred
                         description: 'For page blobs on a premium storage account only. If the access tier is not explicitly set on the blob, the tier is inferred based on its content length and this header will be returned with true value.'
                   - !<!HttpHeader> 
-                    schema: *ref_718
+                    schema: *ref_719
                     header: x-ms-archive-status
                     language:
                       default:
@@ -21947,7 +22337,7 @@ operationGroups:
                           For blob storage LRS accounts, valid values are rehydrate-pending-to-hot/rehydrate-pending-to-cool. If the blob is being rehydrated and is not complete then this header is returned indicating that rehydrate is
                           pending and also tells the destination tier.
                   - !<!HttpHeader> 
-                    schema: *ref_719
+                    schema: *ref_720
                     header: x-ms-access-tier-change-time
                     language:
                       default:
@@ -21957,7 +22347,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -21966,7 +22356,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_720
+                    schema: *ref_721
                     header: x-ms-error-code
                     language:
                       default:
@@ -21988,7 +22378,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_231
-          - !<!Parameter> &ref_728
+          - !<!Parameter> &ref_729
             schema: *ref_64
             implementation: Method
             language: !<!Languages> 
@@ -22001,7 +22391,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_729
+          - !<!Parameter> &ref_730
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -22014,9 +22404,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_721
-          - !<!Parameter> &ref_730
-            schema: *ref_722
+          - *ref_722
+          - !<!Parameter> &ref_731
+            schema: *ref_723
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22026,12 +22416,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_723
           - *ref_724
           - *ref_725
           - *ref_726
+          - *ref_727
           - *ref_235
-          - !<!Parameter> &ref_731
+          - !<!Parameter> &ref_732
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -22045,10 +22435,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_727
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_728
               - *ref_21
             signatureParameters:
-              - *ref_727
+              - *ref_728
               - *ref_21
             language: !<!Languages> 
               default:
@@ -22060,10 +22463,10 @@ operationGroups:
                 method: delete
                 uri: '{url}'
         signatureParameters:
-          - *ref_728
           - *ref_729
           - *ref_730
           - *ref_731
+          - *ref_732
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -22074,28 +22477,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_732
+                    schema: *ref_733
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_733
+                    schema: *ref_734
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_734
+                    schema: *ref_735
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_735
+                    schema: *ref_736
                     header: Date
                     language:
                       default:
@@ -22105,7 +22508,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -22114,7 +22517,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_736
+                    schema: *ref_737
                     header: x-ms-error-code
                     language:
                       default:
@@ -22142,7 +22545,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_567
+            schema: *ref_568
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22153,7 +22556,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_743
+          - !<!Parameter> &ref_744
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -22166,9 +22569,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_737
-          - !<!Parameter> &ref_744
-            schema: *ref_569
+          - *ref_738
+          - !<!Parameter> &ref_745
+            schema: *ref_570
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22178,8 +22581,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_745
-            schema: *ref_569
+          - !<!Parameter> &ref_746
+            schema: *ref_570
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22189,7 +22592,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_746
+          - !<!Parameter> &ref_747
             schema: *ref_49
             implementation: Method
             language: !<!Languages> 
@@ -22202,8 +22605,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_747
-            schema: *ref_569
+          - !<!Parameter> &ref_748
+            schema: *ref_570
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22215,11 +22618,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_738
           - *ref_739
           - *ref_740
           - *ref_741
-          - !<!Parameter> &ref_748
+          - *ref_742
+          - !<!Parameter> &ref_749
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -22234,10 +22637,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_742
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_743
               - *ref_22
             signatureParameters:
-              - *ref_742
+              - *ref_743
               - *ref_22
             language: !<!Languages> 
               default:
@@ -22249,12 +22665,12 @@ operationGroups:
                 method: patch
                 uri: '{url}'
         signatureParameters:
-          - *ref_743
           - *ref_744
           - *ref_745
           - *ref_746
           - *ref_747
           - *ref_748
+          - *ref_749
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -22265,35 +22681,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_749
+                    schema: *ref_750
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_750
+                    schema: *ref_751
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_751
+                    schema: *ref_752
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_752
+                    schema: *ref_753
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_753
+                    schema: *ref_754
                     header: x-ms-version
                     language:
                       default:
@@ -22303,7 +22719,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_511
+            schema: *ref_512
             language: !<!Languages> 
               default:
                 name: ''
@@ -22312,21 +22728,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_754
+                    schema: *ref_755
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_755
+                    schema: *ref_756
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_756
+                    schema: *ref_757
                     header: x-ms-version
                     language:
                       default:
@@ -22349,7 +22765,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_588
+            schema: *ref_589
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22360,7 +22776,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_763
+          - !<!Parameter> &ref_764
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -22373,8 +22789,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_764
-            schema: *ref_548
+          - !<!Parameter> &ref_765
+            schema: *ref_549
             implementation: Method
             language: !<!Languages> 
               default:
@@ -22386,12 +22802,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_757
           - *ref_758
           - *ref_759
           - *ref_760
           - *ref_761
-          - !<!Parameter> &ref_765
+          - *ref_762
+          - !<!Parameter> &ref_766
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -22406,10 +22822,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_762
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_763
               - *ref_23
             signatureParameters:
-              - *ref_762
+              - *ref_763
               - *ref_23
             language: !<!Languages> 
               default:
@@ -22421,9 +22850,9 @@ operationGroups:
                 method: head
                 uri: '{url}'
         signatureParameters:
-          - *ref_763
           - *ref_764
           - *ref_765
+          - *ref_766
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -22434,63 +22863,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_766
+                    schema: *ref_767
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_767
+                    schema: *ref_768
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_768
+                    schema: *ref_769
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the file or directory was last modified. Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_769
+                    schema: *ref_770
                     header: x-ms-owner
                     language:
                       default:
                         name: XMsOwner
                         description: The owner of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_770
+                    schema: *ref_771
                     header: x-ms-group
                     language:
                       default:
                         name: XMsGroup
                         description: The owning group of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_771
+                    schema: *ref_772
                     header: x-ms-permissions
                     language:
                       default:
                         name: XMsPermissions
                         description: 'The POSIX access permissions for the file owner, the file owning group, and others. Included in the response if Hierarchical Namespace is enabled for the account.'
                   - !<!HttpHeader> 
-                    schema: *ref_772
+                    schema: *ref_773
                     header: x-ms-acl
                     language:
                       default:
                         name: XMsAcl
                         description: The POSIX access control list for the file or directory.  Included in the response only if the action is "getAccessControl" and Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_773
+                    schema: *ref_774
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_774
+                    schema: *ref_775
                     header: x-ms-version
                     language:
                       default:
@@ -22500,7 +22929,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_511
+            schema: *ref_512
             language: !<!Languages> 
               default:
                 name: ''
@@ -22509,21 +22938,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_775
+                    schema: *ref_776
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_776
+                    schema: *ref_777
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_777
+                    schema: *ref_778
                     header: x-ms-version
                     language:
                       default:
@@ -22545,7 +22974,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_231
-          - !<!Parameter> &ref_793
+          - !<!Parameter> &ref_794
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -22558,8 +22987,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_515
-          - !<!Parameter> &ref_794
+          - *ref_516
+          - !<!Parameter> &ref_795
             schema: *ref_63
             implementation: Method
             required: true
@@ -22573,7 +23002,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_795
+          - !<!Parameter> &ref_796
             schema: *ref_49
             implementation: Method
             language: !<!Languages> 
@@ -22584,7 +23013,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_796
+          - !<!Parameter> &ref_797
             schema: *ref_49
             implementation: Method
             language: !<!Languages> 
@@ -22597,7 +23026,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_797
+          - !<!Parameter> &ref_798
             schema: *ref_49
             implementation: Method
             language: !<!Languages> 
@@ -22611,13 +23040,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_778
           - *ref_779
           - *ref_780
           - *ref_781
           - *ref_782
           - *ref_783
-          - !<!Parameter> &ref_798
+          - *ref_784
+          - !<!Parameter> &ref_799
             schema: *ref_63
             implementation: Method
             language: !<!Languages> 
@@ -22628,7 +23057,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_784
           - *ref_785
           - *ref_786
           - *ref_787
@@ -22636,8 +23064,9 @@ operationGroups:
           - *ref_789
           - *ref_790
           - *ref_791
+          - *ref_792
           - *ref_235
-          - !<!Parameter> &ref_799
+          - !<!Parameter> &ref_800
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -22651,13 +23080,26 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_53
-              - *ref_792
+              - *ref_793
               - *ref_24
               - *ref_57
             signatureParameters:
               - *ref_53
-              - *ref_792
+              - *ref_793
               - *ref_24
               - *ref_57
             language: !<!Languages> 
@@ -22670,13 +23112,13 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_793
           - *ref_794
           - *ref_795
           - *ref_796
           - *ref_797
           - *ref_798
           - *ref_799
+          - *ref_800
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -22687,49 +23129,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_800
+                    schema: *ref_801
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_801
+                    schema: *ref_802
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_802
+                    schema: *ref_803
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_803
+                    schema: *ref_804
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_804
+                    schema: *ref_805
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_805
+                    schema: *ref_806
                     header: Content-Length
                     language:
                       default:
                         name: ContentLength
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_806
+                    schema: *ref_807
                     header: Date
                     language:
                       default:
@@ -22739,7 +23181,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_511
+            schema: *ref_512
             language: !<!Languages> 
               default:
                 name: ''
@@ -22748,21 +23190,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_807
+                    schema: *ref_808
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_808
+                    schema: *ref_809
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_809
+                    schema: *ref_810
                     header: x-ms-version
                     language:
                       default:
@@ -22788,7 +23230,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_810
+            schema: *ref_811
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -22799,7 +23241,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_811
+          - !<!Parameter> &ref_812
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -22813,7 +23255,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_235
-          - !<!Parameter> &ref_812
+          - !<!Parameter> &ref_813
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -22826,6 +23268,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -22836,8 +23293,8 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_811
           - *ref_812
+          - *ref_813
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -22848,28 +23305,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_813
+                    schema: *ref_814
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_814
+                    schema: *ref_815
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_815
+                    schema: *ref_816
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_816
+                    schema: *ref_817
                     header: Date
                     language:
                       default:
@@ -22879,7 +23336,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -22888,7 +23345,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_817
+                    schema: *ref_818
                     header: x-ms-error-code
                     language:
                       default:
@@ -22922,7 +23379,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_830
+          - !<!Parameter> &ref_831
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -22935,7 +23392,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_818
           - *ref_819
           - *ref_820
           - *ref_821
@@ -22946,8 +23402,9 @@ operationGroups:
           - *ref_826
           - *ref_827
           - *ref_828
+          - *ref_829
           - *ref_235
-          - !<!Parameter> &ref_831
+          - !<!Parameter> &ref_832
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -22961,12 +23418,25 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_84
-              - *ref_829
+              - *ref_830
               - *ref_25
             signatureParameters:
               - *ref_84
-              - *ref_829
+              - *ref_830
               - *ref_25
             language: !<!Languages> 
               default:
@@ -22978,8 +23448,8 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_830
           - *ref_831
+          - *ref_832
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -22990,49 +23460,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_832
+                    schema: *ref_833
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_833
+                    schema: *ref_834
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_834
+                    schema: *ref_835
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for a page blob. This header is not returned for block blobs or append blobs
                   - !<!HttpHeader> 
-                    schema: *ref_835
+                    schema: *ref_836
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_836
+                    schema: *ref_837
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_837
+                    schema: *ref_838
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_838
+                    schema: *ref_839
                     header: Date
                     language:
                       default:
@@ -23042,7 +23512,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -23051,7 +23521,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_839
+                    schema: *ref_840
                     header: x-ms-error-code
                     language:
                       default:
@@ -23074,7 +23544,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_342
+            schema: *ref_343
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23085,7 +23555,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_848
+          - !<!Parameter> &ref_849
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -23098,8 +23568,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_849
-            schema: *ref_308
+          - !<!Parameter> &ref_850
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -23114,14 +23584,14 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_840
           - *ref_841
           - *ref_842
+          - *ref_843
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: EncryptionAlgorithm
@@ -23130,12 +23600,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_843
           - *ref_844
           - *ref_845
           - *ref_846
+          - *ref_847
           - *ref_235
-          - !<!Parameter> &ref_850
+          - !<!Parameter> &ref_851
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -23149,11 +23619,24 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_847
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_848
               - *ref_68
               - *ref_26
             signatureParameters:
-              - *ref_847
+              - *ref_848
               - *ref_68
               - *ref_26
             language: !<!Languages> 
@@ -23166,9 +23649,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_848
           - *ref_849
           - *ref_850
+          - *ref_851
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -23179,56 +23662,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_851
+                    schema: *ref_852
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_852
+                    schema: *ref_853
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_853
+                    schema: *ref_854
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_854
+                    schema: *ref_855
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_855
+                    schema: *ref_856
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_856
+                    schema: *ref_857
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_857
+                    schema: *ref_858
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_858
+                    schema: *ref_859
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -23238,7 +23721,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -23247,7 +23730,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_859
+                    schema: *ref_860
                     header: x-ms-error-code
                     language:
                       default:
@@ -23270,7 +23753,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23282,7 +23765,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_386
+            schema: *ref_387
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23293,7 +23776,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_864
+          - !<!Parameter> &ref_865
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -23306,8 +23789,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_865
-            schema: *ref_387
+          - !<!Parameter> &ref_866
+            schema: *ref_388
             implementation: Method
             language: !<!Languages> 
               default:
@@ -23317,8 +23800,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_866
-            schema: *ref_388
+          - !<!Parameter> &ref_867
+            schema: *ref_389
             implementation: Method
             language: !<!Languages> 
               default:
@@ -23328,12 +23811,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_860
           - *ref_861
           - *ref_862
           - *ref_863
+          - *ref_864
           - *ref_235
-          - !<!Parameter> &ref_867
+          - !<!Parameter> &ref_868
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -23347,6 +23830,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_27
             signatureParameters:
               - *ref_27
@@ -23360,10 +23856,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_864
           - *ref_865
           - *ref_866
           - *ref_867
+          - *ref_868
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -23374,49 +23870,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_868
+                    schema: *ref_869
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_869
+                    schema: *ref_870
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_870
+                    schema: *ref_871
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a blobs's lease
                   - !<!HttpHeader> 
-                    schema: *ref_871
+                    schema: *ref_872
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_872
+                    schema: *ref_873
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_873
+                    schema: *ref_874
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_874
+                    schema: *ref_875
                     header: Date
                     language:
                       default:
@@ -23426,7 +23922,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -23435,7 +23931,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_875
+                    schema: *ref_876
                     header: x-ms-error-code
                     language:
                       default:
@@ -23458,7 +23954,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23470,7 +23966,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_402
+            schema: *ref_403
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23481,7 +23977,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_880
+          - !<!Parameter> &ref_881
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -23494,8 +23990,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_881
-            schema: *ref_403
+          - !<!Parameter> &ref_882
+            schema: *ref_404
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23506,12 +24002,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_876
           - *ref_877
           - *ref_878
           - *ref_879
+          - *ref_880
           - *ref_235
-          - !<!Parameter> &ref_882
+          - !<!Parameter> &ref_883
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -23525,6 +24021,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_28
             signatureParameters:
               - *ref_28
@@ -23538,9 +24047,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_880
           - *ref_881
           - *ref_882
+          - *ref_883
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -23551,42 +24060,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_883
+                    schema: *ref_884
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_884
+                    schema: *ref_885
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_885
+                    schema: *ref_886
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_886
+                    schema: *ref_887
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_887
+                    schema: *ref_888
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_888
+                    schema: *ref_889
                     header: Date
                     language:
                       default:
@@ -23596,7 +24105,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -23605,7 +24114,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_889
+                    schema: *ref_890
                     header: x-ms-error-code
                     language:
                       default:
@@ -23628,7 +24137,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23640,7 +24149,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_415
+            schema: *ref_416
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23651,7 +24160,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_894
+          - !<!Parameter> &ref_895
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -23664,8 +24173,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_895
-            schema: *ref_403
+          - !<!Parameter> &ref_896
+            schema: *ref_404
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23676,12 +24185,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_890
           - *ref_891
           - *ref_892
           - *ref_893
+          - *ref_894
           - *ref_235
-          - !<!Parameter> &ref_896
+          - !<!Parameter> &ref_897
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -23695,6 +24204,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_29
             signatureParameters:
               - *ref_29
@@ -23708,9 +24230,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_894
           - *ref_895
           - *ref_896
+          - *ref_897
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -23721,49 +24243,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_897
+                    schema: *ref_898
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_898
+                    schema: *ref_899
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_899
+                    schema: *ref_900
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a blobs's lease
                   - !<!HttpHeader> 
-                    schema: *ref_900
+                    schema: *ref_901
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_901
+                    schema: *ref_902
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_902
+                    schema: *ref_903
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_903
+                    schema: *ref_904
                     header: Date
                     language:
                       default:
@@ -23773,7 +24295,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -23782,7 +24304,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_904
+                    schema: *ref_905
                     header: x-ms-error-code
                     language:
                       default:
@@ -23805,7 +24327,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23817,7 +24339,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_442
+            schema: *ref_443
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23828,7 +24350,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_909
+          - !<!Parameter> &ref_910
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -23841,8 +24363,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_910
-            schema: *ref_403
+          - !<!Parameter> &ref_911
+            schema: *ref_404
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23853,8 +24375,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_911
-            schema: *ref_443
+          - !<!Parameter> &ref_912
+            schema: *ref_444
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -23865,12 +24387,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_905
           - *ref_906
           - *ref_907
           - *ref_908
+          - *ref_909
           - *ref_235
-          - !<!Parameter> &ref_912
+          - !<!Parameter> &ref_913
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -23884,6 +24406,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_30
             signatureParameters:
               - *ref_30
@@ -23897,10 +24432,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_909
           - *ref_910
           - *ref_911
           - *ref_912
+          - *ref_913
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -23911,49 +24446,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_913
+                    schema: *ref_914
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_914
+                    schema: *ref_915
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_915
+                    schema: *ref_916
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_916
+                    schema: *ref_917
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_917
+                    schema: *ref_918
                     header: x-ms-lease-id
                     language:
                       default:
                         name: LeaseId
                         description: Uniquely identifies a blobs's lease
                   - !<!HttpHeader> 
-                    schema: *ref_918
+                    schema: *ref_919
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_919
+                    schema: *ref_920
                     header: Date
                     language:
                       default:
@@ -23963,7 +24498,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -23972,7 +24507,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_920
+                    schema: *ref_921
                     header: x-ms-error-code
                     language:
                       default:
@@ -23995,7 +24530,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_385
+            schema: *ref_386
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24007,7 +24542,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_429
+            schema: *ref_430
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24018,7 +24553,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_925
+          - !<!Parameter> &ref_926
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -24031,8 +24566,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_926
-            schema: *ref_387
+          - !<!Parameter> &ref_927
+            schema: *ref_388
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24045,12 +24580,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_921
           - *ref_922
           - *ref_923
           - *ref_924
+          - *ref_925
           - *ref_235
-          - !<!Parameter> &ref_927
+          - !<!Parameter> &ref_928
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -24064,6 +24599,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_31
             signatureParameters:
               - *ref_31
@@ -24077,9 +24625,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_925
           - *ref_926
           - *ref_927
+          - *ref_928
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -24090,49 +24638,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_928
+                    schema: *ref_929
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_929
+                    schema: *ref_930
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_930
+                    schema: *ref_931
                     header: x-ms-lease-time
                     language:
                       default:
                         name: LeaseTime
                         description: 'Approximate time remaining in the lease period, in seconds.'
                   - !<!HttpHeader> 
-                    schema: *ref_931
+                    schema: *ref_932
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_932
+                    schema: *ref_933
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_933
+                    schema: *ref_934
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_934
+                    schema: *ref_935
                     header: Date
                     language:
                       default:
@@ -24142,7 +24690,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -24151,7 +24699,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_935
+                    schema: *ref_936
                     header: x-ms-error-code
                     language:
                       default:
@@ -24174,7 +24722,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_936
+            schema: *ref_937
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24185,7 +24733,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_945
+          - !<!Parameter> &ref_946
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -24198,8 +24746,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_946
-            schema: *ref_308
+          - !<!Parameter> &ref_947
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -24214,13 +24762,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_937
           - *ref_938
+          - *ref_939
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: EncryptionAlgorithm
@@ -24229,13 +24777,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_939
           - *ref_940
           - *ref_941
           - *ref_942
           - *ref_943
+          - *ref_944
           - *ref_235
-          - !<!Parameter> &ref_947
+          - !<!Parameter> &ref_948
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -24249,13 +24797,26 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_69
               - *ref_32
-              - *ref_944
+              - *ref_945
             signatureParameters:
               - *ref_69
               - *ref_32
-              - *ref_944
+              - *ref_945
             language: !<!Languages> 
               default:
                 name: ''
@@ -24266,9 +24827,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_945
           - *ref_946
           - *ref_947
+          - *ref_948
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -24279,56 +24840,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_948
+                    schema: *ref_949
                     header: x-ms-snapshot
                     language:
                       default:
                         name: Snapshot
                         description: Uniquely identifies the snapshot and indicates the snapshot version. It may be used in subsequent requests to access the snapshot
                   - !<!HttpHeader> 
-                    schema: *ref_949
+                    schema: *ref_950
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_950
+                    schema: *ref_951
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_951
+                    schema: *ref_952
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_952
+                    schema: *ref_953
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_953
+                    schema: *ref_954
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_954
+                    schema: *ref_955
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_955
+                    schema: *ref_956
                     header: x-ms-request-server-encrypted
                     language:
                       default:
@@ -24340,7 +24901,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -24349,7 +24910,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_956
+                    schema: *ref_957
                     header: x-ms-error-code
                     language:
                       default:
@@ -24371,7 +24932,7 @@ operationGroups:
             version: '2019-02-02'
         parameters:
           - *ref_231
-          - !<!Parameter> &ref_969
+          - !<!Parameter> &ref_970
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -24384,8 +24945,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_970
-            schema: *ref_308
+          - !<!Parameter> &ref_971
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -24400,7 +24961,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_971
+          - !<!Parameter> &ref_972
             schema: *ref_182
             implementation: Method
             language: !<!Languages> 
@@ -24411,8 +24972,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_972
-            schema: *ref_957
+          - !<!Parameter> &ref_973
+            schema: *ref_958
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24422,7 +24983,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_958
           - *ref_959
           - *ref_960
           - *ref_961
@@ -24430,8 +24990,9 @@ operationGroups:
           - *ref_963
           - *ref_964
           - *ref_965
-          - !<!Parameter> &ref_973
-            schema: *ref_966
+          - *ref_966
+          - !<!Parameter> &ref_974
+            schema: *ref_967
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24444,9 +25005,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_967
+          - *ref_968
           - *ref_235
-          - !<!Parameter> &ref_974
+          - !<!Parameter> &ref_975
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -24460,13 +25021,26 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_58
               - *ref_33
-              - *ref_968
+              - *ref_969
             signatureParameters:
               - *ref_58
               - *ref_33
-              - *ref_968
+              - *ref_969
             language: !<!Languages> 
               default:
                 name: ''
@@ -24477,12 +25051,12 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_969
           - *ref_970
           - *ref_971
           - *ref_972
           - *ref_973
           - *ref_974
+          - *ref_975
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -24493,49 +25067,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_975
+                    schema: *ref_976
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_976
+                    schema: *ref_977
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_977
+                    schema: *ref_978
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_978
+                    schema: *ref_979
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_979
+                    schema: *ref_980
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_980
+                    schema: *ref_981
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_981
+                    schema: *ref_982
                     header: x-ms-copy-id
                     language:
                       default:
@@ -24552,7 +25126,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -24561,7 +25135,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_982
+                    schema: *ref_983
                     header: x-ms-error-code
                     language:
                       default:
@@ -24584,7 +25158,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_983
+            schema: *ref_984
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24595,7 +25169,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_995
+          - !<!Parameter> &ref_996
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -24608,8 +25182,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_996
-            schema: *ref_308
+          - !<!Parameter> &ref_997
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -24624,7 +25198,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_997
+          - !<!Parameter> &ref_998
             schema: *ref_182
             implementation: Method
             language: !<!Languages> 
@@ -24635,7 +25209,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_984
           - *ref_985
           - *ref_986
           - *ref_987
@@ -24643,8 +25216,9 @@ operationGroups:
           - *ref_989
           - *ref_990
           - *ref_991
-          - !<!Parameter> &ref_998
-            schema: *ref_966
+          - *ref_992
+          - !<!Parameter> &ref_999
+            schema: *ref_967
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24657,9 +25231,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_992
+          - *ref_993
           - *ref_235
-          - !<!Parameter> &ref_999
+          - !<!Parameter> &ref_1000
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -24670,8 +25244,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1000
-            schema: *ref_993
+          - !<!Parameter> &ref_1001
+            schema: *ref_994
             implementation: Method
             language: !<!Languages> 
               default:
@@ -24684,13 +25258,26 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_59
               - *ref_34
-              - *ref_994
+              - *ref_995
             signatureParameters:
               - *ref_59
               - *ref_34
-              - *ref_994
+              - *ref_995
             language: !<!Languages> 
               default:
                 name: ''
@@ -24701,12 +25288,12 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_995
           - *ref_996
           - *ref_997
           - *ref_998
           - *ref_999
           - *ref_1000
+          - *ref_1001
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -24717,70 +25304,70 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1001
+                    schema: *ref_1002
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1002
+                    schema: *ref_1003
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1003
+                    schema: *ref_1004
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1004
+                    schema: *ref_1005
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1005
+                    schema: *ref_1006
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1006
+                    schema: *ref_1007
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1007
+                    schema: *ref_1008
                     header: x-ms-copy-id
                     language:
                       default:
                         name: CopyId
                         description: String identifier for this copy operation.
                   - !<!HttpHeader> 
-                    schema: *ref_1008
+                    schema: *ref_1009
                     header: x-ms-copy-status
                     language:
                       default:
                         name: CopyStatus
                         description: State of the copy operation identified by x-ms-copy-id.
                   - !<!HttpHeader> 
-                    schema: *ref_1009
+                    schema: *ref_1010
                     header: Content-MD5
                     language:
                       default:
                         name: ContentMD5
                         description: This response header is returned so that the client can check for the integrity of the copied content. This header is only returned if the source content MD5 was specified.
                   - !<!HttpHeader> 
-                    schema: *ref_1010
+                    schema: *ref_1011
                     header: x-ms-content-crc64
                     language:
                       default:
@@ -24790,7 +25377,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -24799,7 +25386,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1011
+                    schema: *ref_1012
                     header: x-ms-error-code
                     language:
                       default:
@@ -24822,7 +25409,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1012
+            schema: *ref_1013
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24834,7 +25421,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_1013
+            schema: *ref_1014
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24845,8 +25432,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1017
-            schema: *ref_1014
+          - !<!Parameter> &ref_1018
+            schema: *ref_1015
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24857,7 +25444,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1018
+          - !<!Parameter> &ref_1019
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -24870,9 +25457,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_1015
+          - *ref_1016
           - *ref_235
-          - !<!Parameter> &ref_1019
+          - !<!Parameter> &ref_1020
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -24886,9 +25473,22 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_1016
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1017
             signatureParameters:
-              - *ref_1016
+              - *ref_1017
             language: !<!Languages> 
               default:
                 name: ''
@@ -24899,9 +25499,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1017
           - *ref_1018
           - *ref_1019
+          - *ref_1020
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -24912,28 +25512,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1014
+                    schema: *ref_1015
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1020
+                    schema: *ref_1021
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1021
+                    schema: *ref_1022
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1022
+                    schema: *ref_1023
                     header: Date
                     language:
                       default:
@@ -24943,7 +25543,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -24952,7 +25552,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1023
+                    schema: *ref_1024
                     header: x-ms-error-code
                     language:
                       default:
@@ -24975,7 +25575,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1024
+            schema: *ref_1025
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -24986,7 +25586,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1027
+          - !<!Parameter> &ref_1028
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -24999,7 +25599,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1028
+          - !<!Parameter> &ref_1029
             schema: *ref_182
             implementation: Method
             required: true
@@ -25011,8 +25611,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1029
-            schema: *ref_957
+          - !<!Parameter> &ref_1030
+            schema: *ref_958
             implementation: Method
             language: !<!Languages> 
               default:
@@ -25023,7 +25623,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_235
-          - !<!Parameter> &ref_1030
+          - !<!Parameter> &ref_1031
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -25034,13 +25634,26 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1025
+          - *ref_1026
         requests:
           - !<!Request> 
             parameters:
-              - *ref_1026
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1027
             signatureParameters:
-              - *ref_1026
+              - *ref_1027
             language: !<!Languages> 
               default:
                 name: ''
@@ -25051,10 +25664,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1027
           - *ref_1028
           - *ref_1029
           - *ref_1030
+          - *ref_1031
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -25065,21 +25678,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1031
+                    schema: *ref_1032
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1032
+                    schema: *ref_1033
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1033
+                    schema: *ref_1034
                     header: x-ms-version
                     language:
                       default:
@@ -25096,21 +25709,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1034
+                    schema: *ref_1035
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1035
+                    schema: *ref_1036
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1036
+                    schema: *ref_1037
                     header: x-ms-version
                     language:
                       default:
@@ -25120,7 +25733,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -25129,7 +25742,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1037
+                    schema: *ref_1038
                     header: x-ms-error-code
                     language:
                       default:
@@ -25154,7 +25767,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_287
+            schema: *ref_288
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25180,6 +25793,21 @@ operationGroups:
           - *ref_235
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -25200,42 +25828,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1038
+                    schema: *ref_1039
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1039
+                    schema: *ref_1040
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1040
+                    schema: *ref_1041
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1041
+                    schema: *ref_1042
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_292
+                    schema: *ref_293
                     header: x-ms-sku-name
                     language:
                       default:
                         name: SkuName
                         description: Identifies the sku name of the account
                   - !<!HttpHeader> 
-                    schema: *ref_293
+                    schema: *ref_294
                     header: x-ms-account-kind
                     language:
                       default:
@@ -25245,7 +25873,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -25254,7 +25882,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1042
+                    schema: *ref_1043
                     header: x-ms-error-code
                     language:
                       default:
@@ -25285,7 +25913,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1043
+            schema: *ref_1044
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25296,7 +25924,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1060
+          - !<!Parameter> &ref_1061
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -25309,8 +25937,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1061
-            schema: *ref_296
+          - !<!Parameter> &ref_1062
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25321,8 +25949,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1062
-            schema: *ref_1044
+          - !<!Parameter> &ref_1063
+            schema: *ref_1045
             implementation: Method
             language: !<!Languages> 
               default:
@@ -25332,13 +25960,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1045
           - *ref_1046
           - *ref_1047
           - *ref_1048
           - *ref_1049
-          - !<!Parameter> &ref_1063
-            schema: *ref_308
+          - *ref_1050
+          - !<!Parameter> &ref_1064
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -25353,15 +25981,15 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1050
           - *ref_1051
           - *ref_1052
           - *ref_1053
+          - *ref_1054
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: EncryptionAlgorithm
@@ -25370,12 +25998,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1054
           - *ref_1055
           - *ref_1056
           - *ref_1057
-          - !<!Parameter> &ref_1064
-            schema: *ref_834
+          - *ref_1058
+          - !<!Parameter> &ref_1065
+            schema: *ref_835
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25386,8 +26014,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1065
-            schema: *ref_1058
+          - !<!Parameter> &ref_1066
+            schema: *ref_1059
             implementation: Method
             language: !<!Languages> 
               default:
@@ -25398,7 +26026,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_235
-          - !<!Parameter> &ref_1066
+          - !<!Parameter> &ref_1067
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -25412,13 +26040,26 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_85
-              - *ref_1059
+              - *ref_1060
               - *ref_70
               - *ref_35
             signatureParameters:
               - *ref_85
-              - *ref_1059
+              - *ref_1060
               - *ref_70
               - *ref_35
             language: !<!Languages> 
@@ -25431,13 +26072,13 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1060
           - *ref_1061
           - *ref_1062
           - *ref_1063
           - *ref_1064
           - *ref_1065
           - *ref_1066
+          - *ref_1067
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -25455,56 +26096,56 @@ operationGroups:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1067
+                    schema: *ref_1068
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1068
+                    schema: *ref_1069
                     header: Content-MD5
                     language:
                       default:
                         name: ContentMD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1069
+                    schema: *ref_1070
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1070
+                    schema: *ref_1071
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1071
+                    schema: *ref_1072
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1072
+                    schema: *ref_1073
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1073
+                    schema: *ref_1074
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1074
+                    schema: *ref_1075
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -25514,7 +26155,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -25523,7 +26164,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1075
+                    schema: *ref_1076
                     header: x-ms-error-code
                     language:
                       default:
@@ -25546,7 +26187,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1076
+            schema: *ref_1077
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25558,7 +26199,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_1077
+            schema: *ref_1078
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25572,8 +26213,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1093
-            schema: *ref_296
+          - !<!Parameter> &ref_1094
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25584,8 +26225,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1094
-            schema: *ref_1078
+          - !<!Parameter> &ref_1095
+            schema: *ref_1079
             implementation: Method
             language: !<!Languages> 
               default:
@@ -25595,8 +26236,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1095
-            schema: *ref_1079
+          - !<!Parameter> &ref_1096
+            schema: *ref_1080
             implementation: Method
             language: !<!Languages> 
               default:
@@ -25606,7 +26247,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1096
+          - !<!Parameter> &ref_1097
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -25619,7 +26260,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1097
+          - !<!Parameter> &ref_1098
             schema: *ref_64
             implementation: Method
             language: !<!Languages> 
@@ -25630,14 +26271,14 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1080
           - *ref_1081
           - *ref_1082
+          - *ref_1083
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: EncryptionAlgorithm
@@ -25646,15 +26287,15 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1083
           - *ref_1084
           - *ref_1085
           - *ref_1086
           - *ref_1087
           - *ref_1088
           - *ref_1089
+          - *ref_1090
           - *ref_235
-          - !<!Parameter> &ref_1098
+          - !<!Parameter> &ref_1099
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -25668,8 +26309,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1092
-                schema: *ref_1090
+              - !<!Parameter> &ref_1093
+                schema: *ref_1091
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -25680,13 +26321,26 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
-              - *ref_1091
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1092
               - *ref_71
               - *ref_92
               - *ref_36
             signatureParameters:
+              - *ref_1093
               - *ref_1092
-              - *ref_1091
               - *ref_71
               - *ref_92
               - *ref_36
@@ -25704,12 +26358,12 @@ operationGroups:
                   - application/octet-stream
                 uri: '{url}'
         signatureParameters:
-          - *ref_1093
           - *ref_1094
           - *ref_1095
           - *ref_1096
           - *ref_1097
           - *ref_1098
+          - *ref_1099
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -25720,28 +26374,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1099
+                    schema: *ref_1100
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1100
+                    schema: *ref_1101
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1101
+                    schema: *ref_1102
                     header: Content-MD5
                     language:
                       default:
                         name: ContentMD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1102
+                    schema: *ref_1103
                     header: x-ms-content-crc64
                     language:
                       default:
@@ -25755,42 +26409,42 @@ operationGroups:
                         name: BlobSequenceNumber
                         description: The current sequence number for the page blob.
                   - !<!HttpHeader> 
-                    schema: *ref_1103
+                    schema: *ref_1104
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1104
+                    schema: *ref_1105
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1105
+                    schema: *ref_1106
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1106
+                    schema: *ref_1107
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1107
+                    schema: *ref_1108
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1108
+                    schema: *ref_1109
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -25800,7 +26454,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -25809,7 +26463,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1109
+                    schema: *ref_1110
                     header: x-ms-error-code
                     language:
                       default:
@@ -25832,7 +26486,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1076
+            schema: *ref_1077
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25844,7 +26498,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_1110
+            schema: *ref_1111
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25858,8 +26512,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1122
-            schema: *ref_296
+          - !<!Parameter> &ref_1123
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -25870,7 +26524,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1123
+          - !<!Parameter> &ref_1124
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -25883,7 +26537,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1124
+          - !<!Parameter> &ref_1125
             schema: *ref_64
             implementation: Method
             language: !<!Languages> 
@@ -25894,14 +26548,14 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1111
           - *ref_1112
           - *ref_1113
+          - *ref_1114
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: EncryptionAlgorithm
@@ -25910,15 +26564,15 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1114
           - *ref_1115
           - *ref_1116
           - *ref_1117
           - *ref_1118
           - *ref_1119
           - *ref_1120
+          - *ref_1121
           - *ref_235
-          - !<!Parameter> &ref_1125
+          - !<!Parameter> &ref_1126
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -25932,12 +26586,25 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_1121
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1122
               - *ref_72
               - *ref_93
               - *ref_37
             signatureParameters:
-              - *ref_1121
+              - *ref_1122
               - *ref_72
               - *ref_93
               - *ref_37
@@ -25951,10 +26618,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1122
           - *ref_1123
           - *ref_1124
           - *ref_1125
+          - *ref_1126
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -25965,63 +26632,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1126
+                    schema: *ref_1127
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1127
+                    schema: *ref_1128
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1128
+                    schema: *ref_1129
                     header: Content-MD5
                     language:
                       default:
                         name: ContentMD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1129
+                    schema: *ref_1130
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: XMsContentCrc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1130
+                    schema: *ref_1131
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for the page blob.
                   - !<!HttpHeader> 
-                    schema: *ref_1131
+                    schema: *ref_1132
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1132
+                    schema: *ref_1133
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1133
+                    schema: *ref_1134
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1134
+                    schema: *ref_1135
                     header: Date
                     language:
                       default:
@@ -26031,7 +26698,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -26040,7 +26707,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1135
+                    schema: *ref_1136
                     header: x-ms-error-code
                     language:
                       default:
@@ -26063,7 +26730,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1076
+            schema: *ref_1077
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26075,7 +26742,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_1077
+            schema: *ref_1078
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26089,8 +26756,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1153
-            schema: *ref_966
+          - !<!Parameter> &ref_1154
+            schema: *ref_967
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26101,8 +26768,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1154
-            schema: *ref_1136
+          - !<!Parameter> &ref_1155
+            schema: *ref_1137
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26113,8 +26780,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1155
-            schema: *ref_993
+          - !<!Parameter> &ref_1156
+            schema: *ref_994
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26124,8 +26791,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1156
-            schema: *ref_1137
+          - !<!Parameter> &ref_1157
+            schema: *ref_1138
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26135,8 +26802,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1157
-            schema: *ref_296
+          - !<!Parameter> &ref_1158
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26147,7 +26814,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1158
+          - !<!Parameter> &ref_1159
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -26160,8 +26827,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1159
-            schema: *ref_1136
+          - !<!Parameter> &ref_1160
+            schema: *ref_1137
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26172,13 +26839,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1138
           - *ref_1139
+          - *ref_1140
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: EncryptionAlgorithm
@@ -26187,7 +26854,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1140
           - *ref_1141
           - *ref_1142
           - *ref_1143
@@ -26199,8 +26865,9 @@ operationGroups:
           - *ref_1149
           - *ref_1150
           - *ref_1151
+          - *ref_1152
           - *ref_235
-          - !<!Parameter> &ref_1160
+          - !<!Parameter> &ref_1161
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -26214,14 +26881,27 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_73
-              - *ref_1152
+              - *ref_1153
               - *ref_94
               - *ref_38
               - *ref_60
             signatureParameters:
               - *ref_73
-              - *ref_1152
+              - *ref_1153
               - *ref_94
               - *ref_38
               - *ref_60
@@ -26235,7 +26915,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1153
           - *ref_1154
           - *ref_1155
           - *ref_1156
@@ -26243,6 +26922,7 @@ operationGroups:
           - *ref_1158
           - *ref_1159
           - *ref_1160
+          - *ref_1161
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -26253,70 +26933,70 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1136
+                    schema: *ref_1137
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1161
+                    schema: *ref_1162
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1162
+                    schema: *ref_1163
                     header: Content-MD5
                     language:
                       default:
                         name: ContentMD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1163
+                    schema: *ref_1164
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: XMsContentCrc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1164
+                    schema: *ref_1165
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for the page blob.
                   - !<!HttpHeader> 
-                    schema: *ref_1165
+                    schema: *ref_1166
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1166
+                    schema: *ref_1167
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1167
+                    schema: *ref_1168
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1168
+                    schema: *ref_1169
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1169
+                    schema: *ref_1170
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -26326,7 +27006,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -26335,7 +27015,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1170
+                    schema: *ref_1171
                     header: x-ms-error-code
                     language:
                       default:
@@ -26358,7 +27038,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1171
+            schema: *ref_1172
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26369,7 +27049,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1178
+          - !<!Parameter> &ref_1179
             schema: *ref_64
             implementation: Method
             language: !<!Languages> 
@@ -26382,7 +27062,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1179
+          - !<!Parameter> &ref_1180
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -26395,7 +27075,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1180
+          - !<!Parameter> &ref_1181
             schema: *ref_64
             implementation: Method
             language: !<!Languages> 
@@ -26406,13 +27086,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1172
           - *ref_1173
           - *ref_1174
           - *ref_1175
           - *ref_1176
+          - *ref_1177
           - *ref_235
-          - !<!Parameter> &ref_1181
+          - !<!Parameter> &ref_1182
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -26426,10 +27106,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_1177
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1178
               - *ref_39
             signatureParameters:
-              - *ref_1177
+              - *ref_1178
               - *ref_39
             language: !<!Languages> 
               default:
@@ -26441,13 +27134,13 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_1178
           - *ref_1179
           - *ref_1180
           - *ref_1181
+          - *ref_1182
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1182
+            schema: *ref_1183
             language: !<!Languages> 
               default:
                 name: ''
@@ -26456,49 +27149,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1183
+                    schema: *ref_1184
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1184
+                    schema: *ref_1185
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1185
+                    schema: *ref_1186
                     header: x-ms-blob-content-length
                     language:
                       default:
                         name: BlobContentLength
                         description: The size of the blob in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_1186
+                    schema: *ref_1187
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1187
+                    schema: *ref_1188
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1188
+                    schema: *ref_1189
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1189
+                    schema: *ref_1190
                     header: Date
                     language:
                       default:
@@ -26511,7 +27204,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -26520,7 +27213,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1190
+                    schema: *ref_1191
                     header: x-ms-error-code
                     language:
                       default:
@@ -26543,7 +27236,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1171
+            schema: *ref_1172
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26554,7 +27247,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1198
+          - !<!Parameter> &ref_1199
             schema: *ref_64
             implementation: Method
             language: !<!Languages> 
@@ -26567,7 +27260,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1199
+          - !<!Parameter> &ref_1200
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -26580,8 +27273,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1200
-            schema: *ref_1191
+          - !<!Parameter> &ref_1201
+            schema: *ref_1192
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26594,7 +27287,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1201
+          - !<!Parameter> &ref_1202
             schema: *ref_64
             implementation: Method
             language: !<!Languages> 
@@ -26605,13 +27298,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1192
           - *ref_1193
           - *ref_1194
           - *ref_1195
           - *ref_1196
+          - *ref_1197
           - *ref_235
-          - !<!Parameter> &ref_1202
+          - !<!Parameter> &ref_1203
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -26625,10 +27318,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_1197
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1198
               - *ref_40
             signatureParameters:
-              - *ref_1197
+              - *ref_1198
               - *ref_40
             language: !<!Languages> 
               default:
@@ -26640,14 +27346,14 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_1198
           - *ref_1199
           - *ref_1200
           - *ref_1201
           - *ref_1202
+          - *ref_1203
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1182
+            schema: *ref_1183
             language: !<!Languages> 
               default:
                 name: ''
@@ -26656,49 +27362,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1203
+                    schema: *ref_1204
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1191
+                    schema: *ref_1192
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1204
+                    schema: *ref_1205
                     header: x-ms-blob-content-length
                     language:
                       default:
                         name: BlobContentLength
                         description: The size of the blob in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_1205
+                    schema: *ref_1206
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1206
+                    schema: *ref_1207
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1207
+                    schema: *ref_1208
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1208
+                    schema: *ref_1209
                     header: Date
                     language:
                       default:
@@ -26711,7 +27417,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -26720,7 +27426,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1209
+                    schema: *ref_1210
                     header: x-ms-error-code
                     language:
                       default:
@@ -26754,7 +27460,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1218
+          - !<!Parameter> &ref_1219
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -26767,14 +27473,14 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_1210
           - *ref_1211
           - *ref_1212
+          - *ref_1213
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: EncryptionAlgorithm
@@ -26783,12 +27489,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1213
           - *ref_1214
           - *ref_1215
           - *ref_1216
-          - !<!Parameter> &ref_1219
-            schema: *ref_834
+          - *ref_1217
+          - !<!Parameter> &ref_1220
+            schema: *ref_835
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26800,7 +27506,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_235
-          - !<!Parameter> &ref_1220
+          - !<!Parameter> &ref_1221
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -26814,11 +27520,24 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_1217
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1218
               - *ref_74
               - *ref_41
             signatureParameters:
-              - *ref_1217
+              - *ref_1218
               - *ref_74
               - *ref_41
             language: !<!Languages> 
@@ -26831,9 +27550,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1218
           - *ref_1219
           - *ref_1220
+          - *ref_1221
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -26844,49 +27563,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1221
+                    schema: *ref_1222
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1222
+                    schema: *ref_1223
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1223
+                    schema: *ref_1224
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for a page blob. This header is not returned for block blobs or append blobs
                   - !<!HttpHeader> 
-                    schema: *ref_1224
+                    schema: *ref_1225
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1225
+                    schema: *ref_1226
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1226
+                    schema: *ref_1227
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1227
+                    schema: *ref_1228
                     header: Date
                     language:
                       default:
@@ -26896,7 +27615,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -26905,7 +27624,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1228
+                    schema: *ref_1229
                     header: x-ms-error-code
                     language:
                       default:
@@ -26939,7 +27658,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1236
+          - !<!Parameter> &ref_1237
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -26952,13 +27671,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_1229
           - *ref_1230
           - *ref_1231
           - *ref_1232
           - *ref_1233
-          - !<!Parameter> &ref_1237
-            schema: *ref_1234
+          - *ref_1234
+          - !<!Parameter> &ref_1238
+            schema: *ref_1235
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -26969,8 +27688,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1238
-            schema: *ref_1058
+          - !<!Parameter> &ref_1239
+            schema: *ref_1059
             implementation: Method
             language: !<!Languages> 
               default:
@@ -26981,7 +27700,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_235
-          - !<!Parameter> &ref_1239
+          - !<!Parameter> &ref_1240
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -26995,10 +27714,23 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_1235
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1236
               - *ref_42
             signatureParameters:
-              - *ref_1235
+              - *ref_1236
               - *ref_42
             language: !<!Languages> 
               default:
@@ -27010,10 +27742,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1236
           - *ref_1237
           - *ref_1238
           - *ref_1239
+          - *ref_1240
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -27024,49 +27756,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1240
+                    schema: *ref_1241
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1241
+                    schema: *ref_1242
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1242
+                    schema: *ref_1243
                     header: x-ms-blob-sequence-number
                     language:
                       default:
                         name: BlobSequenceNumber
                         description: The current sequence number for a page blob. This header is not returned for block blobs or append blobs
                   - !<!HttpHeader> 
-                    schema: *ref_1243
+                    schema: *ref_1244
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1244
+                    schema: *ref_1245
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1245
+                    schema: *ref_1246
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1246
+                    schema: *ref_1247
                     header: Date
                     language:
                       default:
@@ -27076,7 +27808,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -27085,7 +27817,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1247
+                    schema: *ref_1248
                     header: x-ms-error-code
                     language:
                       default:
@@ -27108,7 +27840,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1248
+            schema: *ref_1249
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27119,7 +27851,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1253
+          - !<!Parameter> &ref_1254
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -27132,12 +27864,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_1249
           - *ref_1250
           - *ref_1251
           - *ref_1252
-          - !<!Parameter> &ref_1254
-            schema: *ref_966
+          - *ref_1253
+          - !<!Parameter> &ref_1255
+            schema: *ref_967
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27151,7 +27883,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_235
-          - !<!Parameter> &ref_1255
+          - !<!Parameter> &ref_1256
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -27165,6 +27897,19 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_43
             signatureParameters:
               - *ref_43
@@ -27178,9 +27923,9 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1253
           - *ref_1254
           - *ref_1255
+          - *ref_1256
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -27191,49 +27936,49 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1256
+                    schema: *ref_1257
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1257
+                    schema: *ref_1258
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1258
+                    schema: *ref_1259
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1259
+                    schema: *ref_1260
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1260
+                    schema: *ref_1261
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1261
+                    schema: *ref_1262
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1262
+                    schema: *ref_1263
                     header: x-ms-copy-id
                     language:
                       default:
@@ -27250,7 +27995,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -27259,7 +28004,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1263
+                    schema: *ref_1264
                     header: x-ms-error-code
                     language:
                       default:
@@ -27292,7 +28037,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1264
+            schema: *ref_1265
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27303,7 +28048,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1279
+          - !<!Parameter> &ref_1280
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -27316,8 +28061,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1280
-            schema: *ref_296
+          - !<!Parameter> &ref_1281
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27328,13 +28073,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1265
           - *ref_1266
           - *ref_1267
           - *ref_1268
           - *ref_1269
-          - !<!Parameter> &ref_1281
-            schema: *ref_308
+          - *ref_1270
+          - !<!Parameter> &ref_1282
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -27349,15 +28094,15 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1270
           - *ref_1271
           - *ref_1272
           - *ref_1273
+          - *ref_1274
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: EncryptionAlgorithm
@@ -27366,12 +28111,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1274
           - *ref_1275
           - *ref_1276
           - *ref_1277
+          - *ref_1278
           - *ref_235
-          - !<!Parameter> &ref_1282
+          - !<!Parameter> &ref_1283
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -27385,13 +28130,26 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_86
-              - *ref_1278
+              - *ref_1279
               - *ref_75
               - *ref_44
             signatureParameters:
               - *ref_86
-              - *ref_1278
+              - *ref_1279
               - *ref_75
               - *ref_44
             language: !<!Languages> 
@@ -27404,10 +28162,10 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1279
           - *ref_1280
           - *ref_1281
           - *ref_1282
+          - *ref_1283
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -27418,63 +28176,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1283
+                    schema: *ref_1284
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1284
+                    schema: *ref_1285
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1285
+                    schema: *ref_1286
                     header: Content-MD5
                     language:
                       default:
                         name: ContentMD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1286
+                    schema: *ref_1287
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1287
+                    schema: *ref_1288
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1288
+                    schema: *ref_1289
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1289
+                    schema: *ref_1290
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1290
+                    schema: *ref_1291
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1291
+                    schema: *ref_1292
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -27484,7 +28242,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -27493,7 +28251,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1292
+                    schema: *ref_1293
                     header: x-ms-error-code
                     language:
                       default:
@@ -27516,7 +28274,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1293
+            schema: *ref_1294
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27527,7 +28285,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1306
+          - !<!Parameter> &ref_1307
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -27540,8 +28298,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1307
-            schema: *ref_296
+          - !<!Parameter> &ref_1308
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27552,8 +28310,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1308
-            schema: *ref_1078
+          - !<!Parameter> &ref_1309
+            schema: *ref_1079
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27563,8 +28321,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1309
-            schema: *ref_1079
+          - !<!Parameter> &ref_1310
+            schema: *ref_1080
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27574,16 +28332,16 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1294
           - *ref_1295
           - *ref_1296
           - *ref_1297
           - *ref_1298
+          - *ref_1299
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: EncryptionAlgorithm
@@ -27592,12 +28350,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1299
           - *ref_1300
           - *ref_1301
           - *ref_1302
+          - *ref_1303
           - *ref_235
-          - !<!Parameter> &ref_1310
+          - !<!Parameter> &ref_1311
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -27611,8 +28369,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1305
-                schema: *ref_1303
+              - !<!Parameter> &ref_1306
+                schema: *ref_1304
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -27623,13 +28381,26 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
-              - *ref_1304
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1305
               - *ref_97
               - *ref_76
               - *ref_45
             signatureParameters:
+              - *ref_1306
               - *ref_1305
-              - *ref_1304
               - *ref_97
               - *ref_76
               - *ref_45
@@ -27647,11 +28418,11 @@ operationGroups:
                   - application/octet-stream
                 uri: '{url}'
         signatureParameters:
-          - *ref_1306
           - *ref_1307
           - *ref_1308
           - *ref_1309
           - *ref_1310
+          - *ref_1311
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -27662,84 +28433,84 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1311
+                    schema: *ref_1312
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1312
+                    schema: *ref_1313
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1313
+                    schema: *ref_1314
                     header: Content-MD5
                     language:
                       default:
                         name: ContentMD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1314
+                    schema: *ref_1315
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: XMsContentCrc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1315
+                    schema: *ref_1316
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1316
+                    schema: *ref_1317
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1317
+                    schema: *ref_1318
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1318
+                    schema: *ref_1319
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1319
+                    schema: *ref_1320
                     header: x-ms-blob-append-offset
                     language:
                       default:
                         name: BlobAppendOffset
                         description: 'This response header is returned only for append operations. It returns the offset at which the block was committed, in bytes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1320
+                    schema: *ref_1321
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_1321
+                    schema: *ref_1322
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1322
+                    schema: *ref_1323
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -27749,7 +28520,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -27758,7 +28529,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1323
+                    schema: *ref_1324
                     header: x-ms-error-code
                     language:
                       default:
@@ -27783,7 +28554,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1293
+            schema: *ref_1294
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27794,8 +28565,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1339
-            schema: *ref_966
+          - !<!Parameter> &ref_1340
+            schema: *ref_967
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27806,8 +28577,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1340
-            schema: *ref_1324
+          - !<!Parameter> &ref_1341
+            schema: *ref_1325
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27817,8 +28588,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1341
-            schema: *ref_993
+          - !<!Parameter> &ref_1342
+            schema: *ref_994
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27828,8 +28599,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1342
-            schema: *ref_1137
+          - !<!Parameter> &ref_1343
+            schema: *ref_1138
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27839,7 +28610,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1343
+          - !<!Parameter> &ref_1344
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -27852,8 +28623,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1344
-            schema: *ref_296
+          - !<!Parameter> &ref_1345
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -27864,8 +28635,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1345
-            schema: *ref_1078
+          - !<!Parameter> &ref_1346
+            schema: *ref_1079
             implementation: Method
             language: !<!Languages> 
               default:
@@ -27875,13 +28646,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1325
           - *ref_1326
+          - *ref_1327
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: EncryptionAlgorithm
@@ -27890,7 +28661,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1327
           - *ref_1328
           - *ref_1329
           - *ref_1330
@@ -27901,8 +28671,9 @@ operationGroups:
           - *ref_1335
           - *ref_1336
           - *ref_1337
+          - *ref_1338
           - *ref_235
-          - !<!Parameter> &ref_1346
+          - !<!Parameter> &ref_1347
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -27916,14 +28687,27 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_77
-              - *ref_1338
+              - *ref_1339
               - *ref_98
               - *ref_46
               - *ref_61
             signatureParameters:
               - *ref_77
-              - *ref_1338
+              - *ref_1339
               - *ref_98
               - *ref_46
               - *ref_61
@@ -27937,7 +28721,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1339
           - *ref_1340
           - *ref_1341
           - *ref_1342
@@ -27945,6 +28728,7 @@ operationGroups:
           - *ref_1344
           - *ref_1345
           - *ref_1346
+          - *ref_1347
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -27955,77 +28739,77 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1347
+                    schema: *ref_1348
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1348
+                    schema: *ref_1349
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1349
+                    schema: *ref_1350
                     header: Content-MD5
                     language:
                       default:
                         name: ContentMD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1350
+                    schema: *ref_1351
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: XMsContentCrc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1351
+                    schema: *ref_1352
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1352
+                    schema: *ref_1353
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1353
+                    schema: *ref_1354
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1354
+                    schema: *ref_1355
                     header: x-ms-blob-append-offset
                     language:
                       default:
                         name: BlobAppendOffset
                         description: 'This response header is returned only for append operations. It returns the offset at which the block was committed, in bytes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1355
+                    schema: *ref_1356
                     header: x-ms-blob-committed-block-count
                     language:
                       default:
                         name: BlobCommittedBlockCount
                         description: The number of committed blocks present in the blob. This header is returned only for append blobs.
                   - !<!HttpHeader> 
-                    schema: *ref_1356
+                    schema: *ref_1357
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
                         name: EncryptionKeySha256
                         description: The SHA-256 hash of the encryption key used to encrypt the block. This header is only returned when the block was encrypted with a customer-provided key.
                   - !<!HttpHeader> 
-                    schema: *ref_1357
+                    schema: *ref_1358
                     header: x-ms-request-server-encrypted
                     language:
                       default:
@@ -28035,7 +28819,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -28044,7 +28828,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1358
+                    schema: *ref_1359
                     header: x-ms-error-code
                     language:
                       default:
@@ -28077,7 +28861,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1359
+            schema: *ref_1360
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28088,7 +28872,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1376
+          - !<!Parameter> &ref_1377
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -28101,8 +28885,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1377
-            schema: *ref_1078
+          - !<!Parameter> &ref_1378
+            schema: *ref_1079
             implementation: Method
             language: !<!Languages> 
               default:
@@ -28112,8 +28896,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1378
-            schema: *ref_296
+          - !<!Parameter> &ref_1379
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28124,13 +28908,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1360
           - *ref_1361
           - *ref_1362
           - *ref_1363
           - *ref_1364
-          - !<!Parameter> &ref_1379
-            schema: *ref_308
+          - *ref_1365
+          - !<!Parameter> &ref_1380
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -28145,15 +28929,15 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1365
           - *ref_1366
           - *ref_1367
           - *ref_1368
+          - *ref_1369
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: EncryptionAlgorithm
@@ -28162,7 +28946,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1380
+          - !<!Parameter> &ref_1381
             schema: *ref_182
             implementation: Method
             language: !<!Languages> 
@@ -28173,12 +28957,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1369
           - *ref_1370
           - *ref_1371
           - *ref_1372
+          - *ref_1373
           - *ref_235
-          - !<!Parameter> &ref_1381
+          - !<!Parameter> &ref_1382
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -28192,8 +28976,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1375
-                schema: *ref_1373
+              - !<!Parameter> &ref_1376
+                schema: *ref_1374
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -28204,14 +28988,27 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_87
-              - *ref_1374
+              - *ref_1375
               - *ref_78
               - *ref_47
             signatureParameters:
-              - *ref_1375
+              - *ref_1376
               - *ref_87
-              - *ref_1374
+              - *ref_1375
               - *ref_78
               - *ref_47
             language: !<!Languages> 
@@ -28228,12 +29025,12 @@ operationGroups:
                   - application/octet-stream
                 uri: '{url}'
         signatureParameters:
-          - *ref_1376
           - *ref_1377
           - *ref_1378
           - *ref_1379
           - *ref_1380
           - *ref_1381
+          - *ref_1382
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -28244,63 +29041,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1382
+                    schema: *ref_1383
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1383
+                    schema: *ref_1384
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1384
+                    schema: *ref_1385
                     header: Content-MD5
                     language:
                       default:
                         name: ContentMD5
                         description: 'If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_1385
+                    schema: *ref_1386
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1386
+                    schema: *ref_1387
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1387
+                    schema: *ref_1388
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1388
+                    schema: *ref_1389
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1389
+                    schema: *ref_1390
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1390
+                    schema: *ref_1391
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -28310,7 +29107,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -28319,7 +29116,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1391
+                    schema: *ref_1392
                     header: x-ms-error-code
                     language:
                       default:
@@ -28344,7 +29141,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1392
+            schema: *ref_1393
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28355,8 +29152,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1400
-            schema: *ref_1393
+          - !<!Parameter> &ref_1401
+            schema: *ref_1394
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28369,8 +29166,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1401
-            schema: *ref_296
+          - !<!Parameter> &ref_1402
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28381,8 +29178,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1402
-            schema: *ref_1078
+          - !<!Parameter> &ref_1403
+            schema: *ref_1079
             implementation: Method
             language: !<!Languages> 
               default:
@@ -28392,8 +29189,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1403
-            schema: *ref_1079
+          - !<!Parameter> &ref_1404
+            schema: *ref_1080
             implementation: Method
             language: !<!Languages> 
               default:
@@ -28403,7 +29200,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1404
+          - !<!Parameter> &ref_1405
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -28416,14 +29213,14 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_1394
           - *ref_1395
           - *ref_1396
+          - *ref_1397
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: EncryptionAlgorithm
@@ -28433,7 +29230,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_235
-          - !<!Parameter> &ref_1405
+          - !<!Parameter> &ref_1406
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -28447,8 +29244,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1399
-                schema: *ref_1397
+              - !<!Parameter> &ref_1400
+                schema: *ref_1398
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -28459,11 +29256,24 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
-              - *ref_1398
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1399
               - *ref_79
             signatureParameters:
+              - *ref_1400
               - *ref_1399
-              - *ref_1398
               - *ref_79
             language: !<!Languages> 
               default:
@@ -28479,12 +29289,12 @@ operationGroups:
                   - application/octet-stream
                 uri: '{url}'
         signatureParameters:
-          - *ref_1400
           - *ref_1401
           - *ref_1402
           - *ref_1403
           - *ref_1404
           - *ref_1405
+          - *ref_1406
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -28495,56 +29305,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1406
+                    schema: *ref_1407
                     header: Content-MD5
                     language:
                       default:
                         name: ContentMD5
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1393
+                    schema: *ref_1394
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1407
+                    schema: *ref_1408
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1408
+                    schema: *ref_1409
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1409
+                    schema: *ref_1410
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1410
+                    schema: *ref_1411
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: XMsContentCrc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1411
+                    schema: *ref_1412
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1412
+                    schema: *ref_1413
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -28554,7 +29364,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -28563,7 +29373,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1413
+                    schema: *ref_1414
                     header: x-ms-error-code
                     language:
                       default:
@@ -28586,7 +29396,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1392
+            schema: *ref_1393
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28597,8 +29407,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1422
-            schema: *ref_1393
+          - !<!Parameter> &ref_1423
+            schema: *ref_1394
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28611,8 +29421,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1423
-            schema: *ref_296
+          - !<!Parameter> &ref_1424
+            schema: *ref_297
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28623,8 +29433,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1424
-            schema: *ref_966
+          - !<!Parameter> &ref_1425
+            schema: *ref_967
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28635,8 +29445,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1425
-            schema: *ref_1324
+          - !<!Parameter> &ref_1426
+            schema: *ref_1325
             implementation: Method
             language: !<!Languages> 
               default:
@@ -28646,8 +29456,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1426
-            schema: *ref_993
+          - !<!Parameter> &ref_1427
+            schema: *ref_994
             implementation: Method
             language: !<!Languages> 
               default:
@@ -28657,8 +29467,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1427
-            schema: *ref_1137
+          - !<!Parameter> &ref_1428
+            schema: *ref_1138
             implementation: Method
             language: !<!Languages> 
               default:
@@ -28668,7 +29478,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1428
+          - !<!Parameter> &ref_1429
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -28681,13 +29491,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_1414
           - *ref_1415
+          - *ref_1416
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: EncryptionAlgorithm
@@ -28696,13 +29506,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1416
           - *ref_1417
           - *ref_1418
           - *ref_1419
           - *ref_1420
+          - *ref_1421
           - *ref_235
-          - !<!Parameter> &ref_1429
+          - !<!Parameter> &ref_1430
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -28716,12 +29526,25 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_80
-              - *ref_1421
+              - *ref_1422
               - *ref_62
             signatureParameters:
               - *ref_80
-              - *ref_1421
+              - *ref_1422
               - *ref_62
             language: !<!Languages> 
               default:
@@ -28733,7 +29556,6 @@ operationGroups:
                 method: put
                 uri: '{url}'
         signatureParameters:
-          - *ref_1422
           - *ref_1423
           - *ref_1424
           - *ref_1425
@@ -28741,6 +29563,7 @@ operationGroups:
           - *ref_1427
           - *ref_1428
           - *ref_1429
+          - *ref_1430
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -28751,56 +29574,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1430
+                    schema: *ref_1431
                     header: Content-MD5
                     language:
                       default:
                         name: ContentMD5
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1431
+                    schema: *ref_1432
                     header: x-ms-content-crc64
                     language:
                       default:
                         name: XMsContentCrc64
                         description: This header is returned so that the client can check for message content integrity. The value of this header is computed by the Blob service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_1324
+                    schema: *ref_1325
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1432
+                    schema: *ref_1433
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1433
+                    schema: *ref_1434
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1434
+                    schema: *ref_1435
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1435
+                    schema: *ref_1436
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1436
+                    schema: *ref_1437
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -28810,7 +29633,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -28819,7 +29642,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1437
+                    schema: *ref_1438
                     header: x-ms-error-code
                     language:
                       default:
@@ -28842,7 +29665,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1438
+            schema: *ref_1439
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -28853,7 +29676,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1455
+          - !<!Parameter> &ref_1456
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -28866,13 +29689,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_1439
           - *ref_1440
           - *ref_1441
           - *ref_1442
           - *ref_1443
-          - !<!Parameter> &ref_1456
-            schema: *ref_1078
+          - *ref_1444
+          - !<!Parameter> &ref_1457
+            schema: *ref_1079
             implementation: Method
             language: !<!Languages> 
               default:
@@ -28882,8 +29705,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1457
-            schema: *ref_1079
+          - !<!Parameter> &ref_1458
+            schema: *ref_1080
             implementation: Method
             language: !<!Languages> 
               default:
@@ -28893,8 +29716,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1458
-            schema: *ref_308
+          - !<!Parameter> &ref_1459
+            schema: *ref_309
             implementation: Method
             extensions:
               x-ms-header-collection-prefix: x-ms-meta-
@@ -28909,15 +29732,15 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1444
           - *ref_1445
           - *ref_1446
           - *ref_1447
+          - *ref_1448
           - !<!Parameter> 
-            schema: *ref_613
+            schema: *ref_614
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_680
+              x-ms-parameter-grouping: *ref_681
             language: !<!Languages> 
               default:
                 name: EncryptionAlgorithm
@@ -28926,7 +29749,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_1459
+          - !<!Parameter> &ref_1460
             schema: *ref_182
             implementation: Method
             language: !<!Languages> 
@@ -28937,12 +29760,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_1448
           - *ref_1449
           - *ref_1450
           - *ref_1451
+          - *ref_1452
           - *ref_235
-          - !<!Parameter> &ref_1460
+          - !<!Parameter> &ref_1461
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -28956,8 +29779,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_1454
-                schema: *ref_1452
+              - !<!Parameter> &ref_1455
+                schema: *ref_1453
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -28968,14 +29791,27 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_88
-              - *ref_1453
+              - *ref_1454
               - *ref_81
               - *ref_48
             signatureParameters:
-              - *ref_1454
+              - *ref_1455
               - *ref_88
-              - *ref_1453
+              - *ref_1454
               - *ref_81
               - *ref_48
             language: !<!Languages> 
@@ -28991,12 +29827,12 @@ operationGroups:
                   - application/xml
                 uri: '{url}'
         signatureParameters:
-          - *ref_1455
           - *ref_1456
           - *ref_1457
           - *ref_1458
           - *ref_1459
           - *ref_1460
+          - *ref_1461
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -29007,21 +29843,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1461
+                    schema: *ref_1462
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1462
+                    schema: *ref_1463
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1463
+                    schema: *ref_1464
                     header: Content-MD5
                     language:
                       default:
@@ -29030,7 +29866,7 @@ operationGroups:
                           This header is returned so that the client can check for message content integrity. This header refers to the content of the request, meaning, in this case, the list of blocks, and not the content of the blob
                           itself.
                   - !<!HttpHeader> 
-                    schema: *ref_1464
+                    schema: *ref_1465
                     header: x-ms-content-crc64
                     language:
                       default:
@@ -29039,42 +29875,42 @@ operationGroups:
                           This header is returned so that the client can check for message content integrity. This header refers to the content of the request, meaning, in this case, the list of blocks, and not the content of the blob
                           itself.
                   - !<!HttpHeader> 
-                    schema: *ref_1465
+                    schema: *ref_1466
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1466
+                    schema: *ref_1467
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1467
+                    schema: *ref_1468
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1468
+                    schema: *ref_1469
                     header: Date
                     language:
                       default:
                         name: Date
                         description: UTC date/time value generated by the service that indicates the time at which the response was initiated
                   - !<!HttpHeader> 
-                    schema: *ref_1469
+                    schema: *ref_1470
                     header: x-ms-request-server-encrypted
                     language:
                       default:
                         name: IsServerEncrypted
                         description: 'The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise.'
                   - !<!HttpHeader> 
-                    schema: *ref_1470
+                    schema: *ref_1471
                     header: x-ms-encryption-key-sha256
                     language:
                       default:
@@ -29084,7 +29920,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -29093,7 +29929,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1471
+                    schema: *ref_1472
                     header: x-ms-error-code
                     language:
                       default:
@@ -29119,7 +29955,7 @@ operationGroups:
         parameters:
           - *ref_231
           - !<!Parameter> 
-            schema: *ref_1438
+            schema: *ref_1439
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -29130,7 +29966,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1475
+          - !<!Parameter> &ref_1476
             schema: *ref_64
             implementation: Method
             language: !<!Languages> 
@@ -29143,8 +29979,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1476
-            schema: *ref_1472
+          - !<!Parameter> &ref_1477
+            schema: *ref_1473
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -29155,7 +29991,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_1477
+          - !<!Parameter> &ref_1478
             schema: *ref_234
             implementation: Method
             language: !<!Languages> 
@@ -29168,9 +30004,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_1473
+          - *ref_1474
           - *ref_235
-          - !<!Parameter> &ref_1478
+          - !<!Parameter> &ref_1479
             schema: *ref_236
             implementation: Method
             language: !<!Languages> 
@@ -29184,9 +30020,22 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_1474
+              - !<!Parameter> 
+                schema: *ref_238
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_1475
             signatureParameters:
-              - *ref_1474
+              - *ref_1475
             language: !<!Languages> 
               default:
                 name: ''
@@ -29197,13 +30046,13 @@ operationGroups:
                 method: get
                 uri: '{url}'
         signatureParameters:
-          - *ref_1475
           - *ref_1476
           - *ref_1477
           - *ref_1478
+          - *ref_1479
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1479
+            schema: *ref_1480
             language: !<!Languages> 
               default:
                 name: ''
@@ -29212,56 +30061,56 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1480
+                    schema: *ref_1481
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob''s metadata or properties, changes the last-modified time of the blob.'
                   - !<!HttpHeader> 
-                    schema: *ref_1481
+                    schema: *ref_1482
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'The ETag contains a value that you can use to perform operations conditionally. If the request version is 2011-08-18 or newer, the ETag value will be in quotes.'
                   - !<!HttpHeader> 
-                    schema: *ref_1482
+                    schema: *ref_1483
                     header: Content-Type
                     language:
                       default:
                         name: ContentType
                         description: The media type of the body of the response. For Get Block List this is 'application/xml'
                   - !<!HttpHeader> 
-                    schema: *ref_1483
+                    schema: *ref_1484
                     header: x-ms-blob-content-length
                     language:
                       default:
                         name: BlobContentLength
                         description: The size of the blob in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_1484
+                    schema: *ref_1485
                     header: x-ms-client-request-id
                     language:
                       default:
                         name: ClientRequestId
                         description: 'If a client request id header is sent in the request, this header will be present in the response with the same value.'
                   - !<!HttpHeader> 
-                    schema: *ref_1485
+                    schema: *ref_1486
                     header: x-ms-request-id
                     language:
                       default:
                         name: RequestId
                         description: This header uniquely identifies the request that was made and can be used for troubleshooting the request.
                   - !<!HttpHeader> 
-                    schema: *ref_1486
+                    schema: *ref_1487
                     header: x-ms-version
                     language:
                       default:
                         name: Version
                         description: Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above.
                   - !<!HttpHeader> 
-                    schema: *ref_1487
+                    schema: *ref_1488
                     header: Date
                     language:
                       default:
@@ -29274,7 +30123,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_243
+            schema: *ref_244
             language: !<!Languages> 
               default:
                 name: ''
@@ -29283,7 +30132,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_1488
+                    schema: *ref_1489
                     header: x-ms-error-code
                     language:
                       default:

--- a/modelerfour/test/scenarios/body-array/flattened.yaml
+++ b/modelerfour/test/scenarios/body-array/flattened.yaml
@@ -198,6 +198,17 @@ schemas: !<!Schemas>
           name: FooEnum
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_27
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_25
       type: dictionary
@@ -287,7 +298,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_28
+    - !<!ObjectSchema> &ref_29
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -353,7 +364,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_27
+    - !<!ArraySchema> &ref_28
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -364,7 +375,7 @@ schemas: !<!Schemas>
           name: paths·5372i4·array-null·get·responses·200·content·application-json·schema
           description: The null Array value
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_29
+    - !<!ArraySchema> &ref_30
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -375,7 +386,7 @@ schemas: !<!Schemas>
           name: paths·1uy1mnt·array-invalid·get·responses·200·content·application-json·schema
           description: 'The invalid Array [1, 2, 3'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_30
+    - !<!ArraySchema> &ref_31
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -386,7 +397,7 @@ schemas: !<!Schemas>
           name: paths·1ikiqbg·array-empty·put·requestbody·content·application-json·schema
           description: 'The empty array value []'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_32
+    - !<!ArraySchema> &ref_33
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -397,7 +408,7 @@ schemas: !<!Schemas>
           name: paths·4qcv8i·array-prim-boolean-tfft·get·responses·200·content·application-json·schema
           description: 'The array value [true, false, false, true]'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_35
+    - !<!ArraySchema> &ref_36
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -408,7 +419,7 @@ schemas: !<!Schemas>
           name: paths·19o55rh·array-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema
           description: 'The array value [1, -1, 3, 300]'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_37
+    - !<!ArraySchema> &ref_38
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -419,7 +430,7 @@ schemas: !<!Schemas>
           name: paths·1whly4n·array-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema
           description: 'The array value [0, -0.01, 1.2e20]'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_39
+    - !<!ArraySchema> &ref_40
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -441,7 +452,7 @@ schemas: !<!Schemas>
           name: paths·1tc2k9c·array-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema
           description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_42
+    - !<!ArraySchema> &ref_43
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -452,7 +463,7 @@ schemas: !<!Schemas>
           name: paths·oh6rci·array-prim-enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema
           description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_44
+    - !<!ArraySchema> &ref_45
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -463,7 +474,7 @@ schemas: !<!Schemas>
           name: paths·1q38byd·array-prim-string_enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema
           description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_46
+    - !<!ArraySchema> &ref_47
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -474,7 +485,7 @@ schemas: !<!Schemas>
           name: paths·mwrg2p·array-prim-uuid-valid·get·responses·200·content·application-json·schema
           description: 'The array value [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''d1399005-30f7-40d6-8da6-dd7c89ad34db'', ''f42f6aa1-a5bc-4ddf-907e-5f915de43205'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_48
+    - !<!ArraySchema> &ref_49
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -485,7 +496,7 @@ schemas: !<!Schemas>
           name: paths·1apmyez·array-prim-date-valid·get·responses·200·content·application-json·schema
           description: 'The array value [''2000-12-01'', ''1980-01-02'', ''1492-10-12'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_50
+    - !<!ArraySchema> &ref_51
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -496,7 +507,7 @@ schemas: !<!Schemas>
           name: paths·y50dvb·array-prim-date_time-valid·get·responses·200·content·application-json·schema
           description: 'The array value [''2000-12-01t00:00:01z'', ''1980-01-02T00:11:35+01:00'', ''1492-10-12T10:15:01-08:00'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_52
+    - !<!ArraySchema> &ref_53
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -507,7 +518,7 @@ schemas: !<!Schemas>
           name: paths·h0gugx·array-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema
           description: 'The array value [''Fri, 01 Dec 2000 00:00:01 GMT'', ''Wed, 02 Jan 1980 00:11:35 GMT'', ''Wed, 12 Oct 1492 10:15:01 GMT'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_54
+    - !<!ArraySchema> &ref_55
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -518,7 +529,7 @@ schemas: !<!Schemas>
           name: paths·ymuy4h·array-prim-duration-valid·get·responses·200·content·application-json·schema
           description: 'The array value [''P123DT22H14M12.011S'', ''P5DT1H0M0S'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_56
+    - !<!ArraySchema> &ref_57
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -529,7 +540,7 @@ schemas: !<!Schemas>
           name: paths·mxj79g·array-prim-byte-valid·get·responses·200·content·application-json·schema
           description: 'The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_58
+    - !<!ArraySchema> &ref_59
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -540,7 +551,7 @@ schemas: !<!Schemas>
           name: paths·be8wva·array-prim-base64url-valid·get·responses·200·content·application-json·schema
           description: 'Get array value [''a string that gets encoded with base64url'', ''test string'' ''Lorem ipsum''] with the items base64url encoded'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_59
+    - !<!ArraySchema> &ref_60
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -551,7 +562,7 @@ schemas: !<!Schemas>
           name: paths·bxca8q·array-complex-null·get·responses·200·content·application-json·schema
           description: array of complex type with null value
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_61
+    - !<!ArraySchema> &ref_62
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -573,7 +584,7 @@ schemas: !<!Schemas>
           name: paths·1u1qf6m·array-array-valid·put·requestbody·content·application-json·schema·items
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_62
+    - !<!ArraySchema> &ref_63
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -584,7 +595,7 @@ schemas: !<!Schemas>
           name: paths·1bio5vf·array-array-valid·put·requestbody·content·application-json·schema
           description: 'An array of array of strings [[''1'', ''2'', ''3''], [''4'', ''5'', ''6''], [''7'', ''8'', ''9'']]'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_64
+    - !<!ArraySchema> &ref_65
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -624,6 +635,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -636,7 +662,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -650,7 +676,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -675,6 +701,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -687,7 +728,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -701,7 +742,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -726,6 +767,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -738,7 +794,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -752,7 +808,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -778,8 +834,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
-                schema: *ref_30
+              - !<!Parameter> &ref_32
+                schema: *ref_31
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -790,8 +846,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_31
+              - *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -817,7 +886,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -842,6 +911,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -854,7 +938,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_32
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -868,7 +952,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -894,8 +978,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
-                schema: *ref_32
+              - !<!Parameter> &ref_34
+                schema: *ref_33
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -906,8 +990,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -933,7 +1030,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -958,6 +1055,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -970,7 +1082,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_32
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -984,7 +1096,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1009,6 +1121,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1021,7 +1148,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_32
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -1035,7 +1162,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1060,6 +1187,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1072,7 +1214,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1086,7 +1228,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1112,8 +1254,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
-                schema: *ref_29
+              - !<!Parameter> &ref_35
+                schema: *ref_30
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1124,8 +1266,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -1151,7 +1306,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1176,6 +1331,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1188,7 +1358,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1202,7 +1372,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1227,6 +1397,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1239,7 +1424,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1253,7 +1438,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1278,6 +1463,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1290,7 +1490,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1304,7 +1504,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1330,8 +1530,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_35
+              - !<!Parameter> &ref_37
+                schema: *ref_36
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1342,8 +1542,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -1369,7 +1582,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1394,6 +1607,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1406,7 +1634,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1420,7 +1648,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1445,6 +1673,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1457,7 +1700,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1471,7 +1714,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1496,6 +1739,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1508,7 +1766,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_37
+            schema: *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1522,7 +1780,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1548,8 +1806,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_38
-                schema: *ref_37
+              - !<!Parameter> &ref_39
+                schema: *ref_38
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1560,8 +1818,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_38
+              - *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -1587,7 +1858,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1612,6 +1883,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1624,7 +1910,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_37
+            schema: *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1638,7 +1924,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1663,6 +1949,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1675,7 +1976,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_37
+            schema: *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1689,7 +1990,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1714,6 +2015,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1726,7 +2042,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_39
+            schema: *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1740,7 +2056,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1766,8 +2082,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_40
-                schema: *ref_39
+              - !<!Parameter> &ref_41
+                schema: *ref_40
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1778,8 +2094,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_40
+              - *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -1805,7 +2134,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1830,6 +2159,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1842,7 +2186,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_39
+            schema: *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1856,7 +2200,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1881,6 +2225,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1893,7 +2252,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_39
+            schema: *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1907,7 +2266,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1932,6 +2291,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1958,7 +2332,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1984,7 +2358,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_41
+              - !<!Parameter> &ref_42
                 schema: *ref_22
                 implementation: Method
                 required: true
@@ -1996,8 +2370,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_41
+              - *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -2023,7 +2410,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2048,6 +2435,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2060,7 +2462,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_42
+            schema: *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -2074,7 +2476,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2100,8 +2502,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_43
-                schema: *ref_42
+              - !<!Parameter> &ref_44
+                schema: *ref_43
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2112,8 +2514,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_43
+              - *ref_44
             language: !<!Languages> 
               default:
                 name: ''
@@ -2139,7 +2554,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2164,6 +2579,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2176,7 +2606,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_44
+            schema: *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -2190,7 +2620,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2216,8 +2646,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_45
-                schema: *ref_44
+              - !<!Parameter> &ref_46
+                schema: *ref_45
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2228,8 +2658,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -2255,7 +2698,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2280,6 +2723,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2306,7 +2764,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2331,6 +2789,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2357,7 +2830,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2382,6 +2855,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2394,7 +2882,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2408,7 +2896,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2434,8 +2922,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_47
-                schema: *ref_46
+              - !<!Parameter> &ref_48
+                schema: *ref_47
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2446,8 +2934,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_47
+              - *ref_48
             language: !<!Languages> 
               default:
                 name: ''
@@ -2473,7 +2974,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2498,6 +2999,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2510,7 +3026,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2524,7 +3040,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2549,6 +3065,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2561,7 +3092,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -2575,7 +3106,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2601,8 +3132,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_49
-                schema: *ref_48
+              - !<!Parameter> &ref_50
+                schema: *ref_49
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2613,8 +3144,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_49
+              - *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -2640,7 +3184,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2665,6 +3209,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2677,7 +3236,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -2691,7 +3250,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2716,6 +3275,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2728,7 +3302,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -2742,7 +3316,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2767,6 +3341,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2779,7 +3368,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_50
+            schema: *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -2793,7 +3382,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2819,8 +3408,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_51
-                schema: *ref_50
+              - !<!Parameter> &ref_52
+                schema: *ref_51
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2831,8 +3420,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_51
+              - *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -2858,7 +3460,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2883,6 +3485,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2895,7 +3512,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_50
+            schema: *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -2909,7 +3526,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2934,6 +3551,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2946,7 +3578,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_50
+            schema: *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -2960,7 +3592,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2985,6 +3617,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2997,7 +3644,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3011,7 +3658,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3037,8 +3684,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_53
-                schema: *ref_52
+              - !<!Parameter> &ref_54
+                schema: *ref_53
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3049,8 +3696,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_53
+              - *ref_54
             language: !<!Languages> 
               default:
                 name: ''
@@ -3076,7 +3736,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3101,6 +3761,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3113,7 +3788,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_54
+            schema: *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -3127,7 +3802,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3153,8 +3828,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_55
-                schema: *ref_54
+              - !<!Parameter> &ref_56
+                schema: *ref_55
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3165,8 +3840,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_55
+              - *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3192,7 +3880,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3217,6 +3905,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3229,7 +3932,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_56
+            schema: *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3243,7 +3946,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3269,8 +3972,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_57
-                schema: *ref_56
+              - !<!Parameter> &ref_58
+                schema: *ref_57
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3281,8 +3984,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_57
+              - *ref_58
             language: !<!Languages> 
               default:
                 name: ''
@@ -3308,7 +4024,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3333,6 +4049,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3345,7 +4076,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_56
+            schema: *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3359,7 +4090,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3384,6 +4115,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3396,7 +4142,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_58
+            schema: *ref_59
             language: !<!Languages> 
               default:
                 name: ''
@@ -3410,7 +4156,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3435,6 +4181,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3447,7 +4208,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3461,7 +4222,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3486,6 +4247,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3498,7 +4274,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3512,7 +4288,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3537,6 +4313,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3549,7 +4340,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3563,7 +4354,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3588,6 +4379,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3600,7 +4406,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3614,7 +4420,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3639,6 +4445,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3651,7 +4472,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3665,7 +4486,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3691,8 +4512,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_60
-                schema: *ref_59
+              - !<!Parameter> &ref_61
+                schema: *ref_60
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3703,8 +4524,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_60
+              - *ref_61
             language: !<!Languages> 
               default:
                 name: ''
@@ -3730,7 +4564,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3755,6 +4589,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3767,7 +4616,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3781,7 +4630,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3806,6 +4655,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3818,7 +4682,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3832,7 +4696,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3857,6 +4721,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3869,7 +4748,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3883,7 +4762,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3908,6 +4787,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3920,7 +4814,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3934,7 +4828,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3959,6 +4853,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3971,7 +4880,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3985,7 +4894,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4011,8 +4920,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_63
-                schema: *ref_62
+              - !<!Parameter> &ref_64
+                schema: *ref_63
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -4023,8 +4932,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -4050,7 +4972,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4075,6 +4997,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4087,7 +5024,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4101,7 +5038,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4126,6 +5063,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4138,7 +5090,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4152,7 +5104,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4177,6 +5129,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4189,7 +5156,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4203,7 +5170,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4228,6 +5195,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4240,7 +5222,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4254,7 +5236,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4279,6 +5261,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4291,7 +5288,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4305,7 +5302,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4331,8 +5328,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_65
-                schema: *ref_64
+              - !<!Parameter> &ref_66
+                schema: *ref_65
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -4343,8 +5340,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_65
+              - *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -4370,7 +5380,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-array/grouped.yaml
+++ b/modelerfour/test/scenarios/body-array/grouped.yaml
@@ -198,6 +198,17 @@ schemas: !<!Schemas>
           name: FooEnum
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_27
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_25
       type: dictionary
@@ -287,7 +298,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_28
+    - !<!ObjectSchema> &ref_29
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -353,7 +364,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_27
+    - !<!ArraySchema> &ref_28
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -364,7 +375,7 @@ schemas: !<!Schemas>
           name: paths·5372i4·array-null·get·responses·200·content·application-json·schema
           description: The null Array value
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_29
+    - !<!ArraySchema> &ref_30
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -375,7 +386,7 @@ schemas: !<!Schemas>
           name: paths·1uy1mnt·array-invalid·get·responses·200·content·application-json·schema
           description: 'The invalid Array [1, 2, 3'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_30
+    - !<!ArraySchema> &ref_31
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -386,7 +397,7 @@ schemas: !<!Schemas>
           name: paths·1ikiqbg·array-empty·put·requestbody·content·application-json·schema
           description: 'The empty array value []'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_32
+    - !<!ArraySchema> &ref_33
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -397,7 +408,7 @@ schemas: !<!Schemas>
           name: paths·4qcv8i·array-prim-boolean-tfft·get·responses·200·content·application-json·schema
           description: 'The array value [true, false, false, true]'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_35
+    - !<!ArraySchema> &ref_36
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -408,7 +419,7 @@ schemas: !<!Schemas>
           name: paths·19o55rh·array-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema
           description: 'The array value [1, -1, 3, 300]'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_37
+    - !<!ArraySchema> &ref_38
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -419,7 +430,7 @@ schemas: !<!Schemas>
           name: paths·1whly4n·array-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema
           description: 'The array value [0, -0.01, 1.2e20]'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_39
+    - !<!ArraySchema> &ref_40
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -441,7 +452,7 @@ schemas: !<!Schemas>
           name: paths·1tc2k9c·array-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema
           description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_42
+    - !<!ArraySchema> &ref_43
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -452,7 +463,7 @@ schemas: !<!Schemas>
           name: paths·oh6rci·array-prim-enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema
           description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_44
+    - !<!ArraySchema> &ref_45
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -463,7 +474,7 @@ schemas: !<!Schemas>
           name: paths·1q38byd·array-prim-string_enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema
           description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_46
+    - !<!ArraySchema> &ref_47
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -474,7 +485,7 @@ schemas: !<!Schemas>
           name: paths·mwrg2p·array-prim-uuid-valid·get·responses·200·content·application-json·schema
           description: 'The array value [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''d1399005-30f7-40d6-8da6-dd7c89ad34db'', ''f42f6aa1-a5bc-4ddf-907e-5f915de43205'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_48
+    - !<!ArraySchema> &ref_49
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -485,7 +496,7 @@ schemas: !<!Schemas>
           name: paths·1apmyez·array-prim-date-valid·get·responses·200·content·application-json·schema
           description: 'The array value [''2000-12-01'', ''1980-01-02'', ''1492-10-12'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_50
+    - !<!ArraySchema> &ref_51
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -496,7 +507,7 @@ schemas: !<!Schemas>
           name: paths·y50dvb·array-prim-date_time-valid·get·responses·200·content·application-json·schema
           description: 'The array value [''2000-12-01t00:00:01z'', ''1980-01-02T00:11:35+01:00'', ''1492-10-12T10:15:01-08:00'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_52
+    - !<!ArraySchema> &ref_53
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -507,7 +518,7 @@ schemas: !<!Schemas>
           name: paths·h0gugx·array-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema
           description: 'The array value [''Fri, 01 Dec 2000 00:00:01 GMT'', ''Wed, 02 Jan 1980 00:11:35 GMT'', ''Wed, 12 Oct 1492 10:15:01 GMT'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_54
+    - !<!ArraySchema> &ref_55
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -518,7 +529,7 @@ schemas: !<!Schemas>
           name: paths·ymuy4h·array-prim-duration-valid·get·responses·200·content·application-json·schema
           description: 'The array value [''P123DT22H14M12.011S'', ''P5DT1H0M0S'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_56
+    - !<!ArraySchema> &ref_57
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -529,7 +540,7 @@ schemas: !<!Schemas>
           name: paths·mxj79g·array-prim-byte-valid·get·responses·200·content·application-json·schema
           description: 'The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_58
+    - !<!ArraySchema> &ref_59
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -540,7 +551,7 @@ schemas: !<!Schemas>
           name: paths·be8wva·array-prim-base64url-valid·get·responses·200·content·application-json·schema
           description: 'Get array value [''a string that gets encoded with base64url'', ''test string'' ''Lorem ipsum''] with the items base64url encoded'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_59
+    - !<!ArraySchema> &ref_60
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -551,7 +562,7 @@ schemas: !<!Schemas>
           name: paths·bxca8q·array-complex-null·get·responses·200·content·application-json·schema
           description: array of complex type with null value
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_61
+    - !<!ArraySchema> &ref_62
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -573,7 +584,7 @@ schemas: !<!Schemas>
           name: paths·1u1qf6m·array-array-valid·put·requestbody·content·application-json·schema·items
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_62
+    - !<!ArraySchema> &ref_63
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -584,7 +595,7 @@ schemas: !<!Schemas>
           name: paths·1bio5vf·array-array-valid·put·requestbody·content·application-json·schema
           description: 'An array of array of strings [[''1'', ''2'', ''3''], [''4'', ''5'', ''6''], [''7'', ''8'', ''9'']]'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_64
+    - !<!ArraySchema> &ref_65
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -624,6 +635,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -636,7 +662,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -650,7 +676,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -675,6 +701,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -687,7 +728,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -701,7 +742,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -726,6 +767,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -738,7 +794,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -752,7 +808,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -778,8 +834,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
-                schema: *ref_30
+              - !<!Parameter> &ref_32
+                schema: *ref_31
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -790,8 +846,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_31
+              - *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -817,7 +886,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -842,6 +911,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -854,7 +938,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_32
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -868,7 +952,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -894,8 +978,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
-                schema: *ref_32
+              - !<!Parameter> &ref_34
+                schema: *ref_33
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -906,8 +990,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -933,7 +1030,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -958,6 +1055,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -970,7 +1082,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_32
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -984,7 +1096,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1009,6 +1121,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1021,7 +1148,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_32
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -1035,7 +1162,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1060,6 +1187,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1072,7 +1214,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1086,7 +1228,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1112,8 +1254,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
-                schema: *ref_29
+              - !<!Parameter> &ref_35
+                schema: *ref_30
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1124,8 +1266,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -1151,7 +1306,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1176,6 +1331,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1188,7 +1358,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1202,7 +1372,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1227,6 +1397,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1239,7 +1424,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1253,7 +1438,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1278,6 +1463,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1290,7 +1490,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1304,7 +1504,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1330,8 +1530,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_35
+              - !<!Parameter> &ref_37
+                schema: *ref_36
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1342,8 +1542,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -1369,7 +1582,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1394,6 +1607,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1406,7 +1634,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1420,7 +1648,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1445,6 +1673,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1457,7 +1700,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1471,7 +1714,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1496,6 +1739,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1508,7 +1766,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_37
+            schema: *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1522,7 +1780,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1548,8 +1806,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_38
-                schema: *ref_37
+              - !<!Parameter> &ref_39
+                schema: *ref_38
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1560,8 +1818,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_38
+              - *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -1587,7 +1858,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1612,6 +1883,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1624,7 +1910,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_37
+            schema: *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1638,7 +1924,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1663,6 +1949,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1675,7 +1976,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_37
+            schema: *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1689,7 +1990,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1714,6 +2015,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1726,7 +2042,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_39
+            schema: *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1740,7 +2056,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1766,8 +2082,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_40
-                schema: *ref_39
+              - !<!Parameter> &ref_41
+                schema: *ref_40
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1778,8 +2094,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_40
+              - *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -1805,7 +2134,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1830,6 +2159,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1842,7 +2186,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_39
+            schema: *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1856,7 +2200,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1881,6 +2225,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1893,7 +2252,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_39
+            schema: *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1907,7 +2266,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1932,6 +2291,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1958,7 +2332,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1984,7 +2358,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_41
+              - !<!Parameter> &ref_42
                 schema: *ref_22
                 implementation: Method
                 required: true
@@ -1996,8 +2370,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_41
+              - *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -2023,7 +2410,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2048,6 +2435,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2060,7 +2462,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_42
+            schema: *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -2074,7 +2476,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2100,8 +2502,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_43
-                schema: *ref_42
+              - !<!Parameter> &ref_44
+                schema: *ref_43
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2112,8 +2514,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_43
+              - *ref_44
             language: !<!Languages> 
               default:
                 name: ''
@@ -2139,7 +2554,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2164,6 +2579,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2176,7 +2606,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_44
+            schema: *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -2190,7 +2620,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2216,8 +2646,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_45
-                schema: *ref_44
+              - !<!Parameter> &ref_46
+                schema: *ref_45
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2228,8 +2658,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -2255,7 +2698,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2280,6 +2723,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2306,7 +2764,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2331,6 +2789,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2357,7 +2830,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2382,6 +2855,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2394,7 +2882,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2408,7 +2896,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2434,8 +2922,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_47
-                schema: *ref_46
+              - !<!Parameter> &ref_48
+                schema: *ref_47
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2446,8 +2934,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_47
+              - *ref_48
             language: !<!Languages> 
               default:
                 name: ''
@@ -2473,7 +2974,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2498,6 +2999,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2510,7 +3026,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2524,7 +3040,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2549,6 +3065,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2561,7 +3092,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -2575,7 +3106,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2601,8 +3132,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_49
-                schema: *ref_48
+              - !<!Parameter> &ref_50
+                schema: *ref_49
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2613,8 +3144,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_49
+              - *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -2640,7 +3184,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2665,6 +3209,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2677,7 +3236,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -2691,7 +3250,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2716,6 +3275,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2728,7 +3302,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -2742,7 +3316,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2767,6 +3341,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2779,7 +3368,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_50
+            schema: *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -2793,7 +3382,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2819,8 +3408,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_51
-                schema: *ref_50
+              - !<!Parameter> &ref_52
+                schema: *ref_51
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2831,8 +3420,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_51
+              - *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -2858,7 +3460,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2883,6 +3485,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2895,7 +3512,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_50
+            schema: *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -2909,7 +3526,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2934,6 +3551,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2946,7 +3578,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_50
+            schema: *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -2960,7 +3592,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2985,6 +3617,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2997,7 +3644,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3011,7 +3658,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3037,8 +3684,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_53
-                schema: *ref_52
+              - !<!Parameter> &ref_54
+                schema: *ref_53
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3049,8 +3696,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_53
+              - *ref_54
             language: !<!Languages> 
               default:
                 name: ''
@@ -3076,7 +3736,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3101,6 +3761,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3113,7 +3788,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_54
+            schema: *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -3127,7 +3802,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3153,8 +3828,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_55
-                schema: *ref_54
+              - !<!Parameter> &ref_56
+                schema: *ref_55
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3165,8 +3840,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_55
+              - *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3192,7 +3880,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3217,6 +3905,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3229,7 +3932,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_56
+            schema: *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3243,7 +3946,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3269,8 +3972,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_57
-                schema: *ref_56
+              - !<!Parameter> &ref_58
+                schema: *ref_57
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3281,8 +3984,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_57
+              - *ref_58
             language: !<!Languages> 
               default:
                 name: ''
@@ -3308,7 +4024,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3333,6 +4049,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3345,7 +4076,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_56
+            schema: *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3359,7 +4090,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3384,6 +4115,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3396,7 +4142,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_58
+            schema: *ref_59
             language: !<!Languages> 
               default:
                 name: ''
@@ -3410,7 +4156,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3435,6 +4181,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3447,7 +4208,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3461,7 +4222,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3486,6 +4247,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3498,7 +4274,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3512,7 +4288,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3537,6 +4313,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3549,7 +4340,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3563,7 +4354,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3588,6 +4379,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3600,7 +4406,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3614,7 +4420,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3639,6 +4445,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3651,7 +4472,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3665,7 +4486,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3691,8 +4512,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_60
-                schema: *ref_59
+              - !<!Parameter> &ref_61
+                schema: *ref_60
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3703,8 +4524,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_60
+              - *ref_61
             language: !<!Languages> 
               default:
                 name: ''
@@ -3730,7 +4564,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3755,6 +4589,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3767,7 +4616,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3781,7 +4630,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3806,6 +4655,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3818,7 +4682,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3832,7 +4696,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3857,6 +4721,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3869,7 +4748,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3883,7 +4762,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3908,6 +4787,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3920,7 +4814,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3934,7 +4828,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3959,6 +4853,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3971,7 +4880,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3985,7 +4894,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4011,8 +4920,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_63
-                schema: *ref_62
+              - !<!Parameter> &ref_64
+                schema: *ref_63
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -4023,8 +4932,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -4050,7 +4972,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4075,6 +4997,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4087,7 +5024,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4101,7 +5038,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4126,6 +5063,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4138,7 +5090,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4152,7 +5104,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4177,6 +5129,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4189,7 +5156,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4203,7 +5170,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4228,6 +5195,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4240,7 +5222,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4254,7 +5236,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4279,6 +5261,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4291,7 +5288,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4305,7 +5302,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4331,8 +5328,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_65
-                schema: *ref_64
+              - !<!Parameter> &ref_66
+                schema: *ref_65
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -4343,8 +5340,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_65
+              - *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -4370,7 +5380,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-array/modeler.yaml
+++ b/modelerfour/test/scenarios/body-array/modeler.yaml
@@ -198,6 +198,17 @@ schemas: !<!Schemas>
           name: FooEnum
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_26
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_7
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_25
       type: dictionary
@@ -287,7 +298,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_27
+    - !<!ObjectSchema> &ref_28
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -353,7 +364,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_26
+    - !<!ArraySchema> &ref_27
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -364,7 +375,7 @@ schemas: !<!Schemas>
           name: paths·5372i4·array-null·get·responses·200·content·application-json·schema
           description: The null Array value
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_29
+    - !<!ArraySchema> &ref_30
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -375,7 +386,7 @@ schemas: !<!Schemas>
           name: paths·1uy1mnt·array-invalid·get·responses·200·content·application-json·schema
           description: 'The invalid Array [1, 2, 3'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_30
+    - !<!ArraySchema> &ref_31
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -386,7 +397,7 @@ schemas: !<!Schemas>
           name: paths·1ikiqbg·array-empty·put·requestbody·content·application-json·schema
           description: 'The empty array value []'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_32
+    - !<!ArraySchema> &ref_33
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -397,7 +408,7 @@ schemas: !<!Schemas>
           name: paths·4qcv8i·array-prim-boolean-tfft·get·responses·200·content·application-json·schema
           description: 'The array value [true, false, false, true]'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_35
+    - !<!ArraySchema> &ref_36
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -408,7 +419,7 @@ schemas: !<!Schemas>
           name: paths·19o55rh·array-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema
           description: 'The array value [1, -1, 3, 300]'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_37
+    - !<!ArraySchema> &ref_38
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -419,7 +430,7 @@ schemas: !<!Schemas>
           name: paths·1whly4n·array-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema
           description: 'The array value [0, -0.01, 1.2e20]'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_39
+    - !<!ArraySchema> &ref_40
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -441,7 +452,7 @@ schemas: !<!Schemas>
           name: paths·1tc2k9c·array-prim-string-foo1-foo2-foo3·get·responses·200·content·application-json·schema
           description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_42
+    - !<!ArraySchema> &ref_43
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -452,7 +463,7 @@ schemas: !<!Schemas>
           name: paths·oh6rci·array-prim-enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema
           description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_44
+    - !<!ArraySchema> &ref_45
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -463,7 +474,7 @@ schemas: !<!Schemas>
           name: paths·1q38byd·array-prim-string_enum-foo1-foo2-foo3·get·responses·200·content·application-json·schema
           description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_46
+    - !<!ArraySchema> &ref_47
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -474,7 +485,7 @@ schemas: !<!Schemas>
           name: paths·mwrg2p·array-prim-uuid-valid·get·responses·200·content·application-json·schema
           description: 'The array value [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''d1399005-30f7-40d6-8da6-dd7c89ad34db'', ''f42f6aa1-a5bc-4ddf-907e-5f915de43205'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_48
+    - !<!ArraySchema> &ref_49
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -485,7 +496,7 @@ schemas: !<!Schemas>
           name: paths·1apmyez·array-prim-date-valid·get·responses·200·content·application-json·schema
           description: 'The array value [''2000-12-01'', ''1980-01-02'', ''1492-10-12'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_50
+    - !<!ArraySchema> &ref_51
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -496,7 +507,7 @@ schemas: !<!Schemas>
           name: paths·y50dvb·array-prim-date_time-valid·get·responses·200·content·application-json·schema
           description: 'The array value [''2000-12-01t00:00:01z'', ''1980-01-02T00:11:35+01:00'', ''1492-10-12T10:15:01-08:00'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_52
+    - !<!ArraySchema> &ref_53
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -507,7 +518,7 @@ schemas: !<!Schemas>
           name: paths·h0gugx·array-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema
           description: 'The array value [''Fri, 01 Dec 2000 00:00:01 GMT'', ''Wed, 02 Jan 1980 00:11:35 GMT'', ''Wed, 12 Oct 1492 10:15:01 GMT'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_54
+    - !<!ArraySchema> &ref_55
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -518,7 +529,7 @@ schemas: !<!Schemas>
           name: paths·ymuy4h·array-prim-duration-valid·get·responses·200·content·application-json·schema
           description: 'The array value [''P123DT22H14M12.011S'', ''P5DT1H0M0S'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_56
+    - !<!ArraySchema> &ref_57
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -529,7 +540,7 @@ schemas: !<!Schemas>
           name: paths·mxj79g·array-prim-byte-valid·get·responses·200·content·application-json·schema
           description: 'The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_58
+    - !<!ArraySchema> &ref_59
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -540,7 +551,7 @@ schemas: !<!Schemas>
           name: paths·be8wva·array-prim-base64url-valid·get·responses·200·content·application-json·schema
           description: 'Get array value [''a string that gets encoded with base64url'', ''test string'' ''Lorem ipsum''] with the items base64url encoded'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_59
+    - !<!ArraySchema> &ref_60
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -551,7 +562,7 @@ schemas: !<!Schemas>
           name: paths·bxca8q·array-complex-null·get·responses·200·content·application-json·schema
           description: array of complex type with null value
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_61
+    - !<!ArraySchema> &ref_62
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -573,7 +584,7 @@ schemas: !<!Schemas>
           name: paths·1u1qf6m·array-array-valid·put·requestbody·content·application-json·schema·items
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_62
+    - !<!ArraySchema> &ref_63
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -584,7 +595,7 @@ schemas: !<!Schemas>
           name: paths·1bio5vf·array-array-valid·put·requestbody·content·application-json·schema
           description: 'An array of array of strings [[''1'', ''2'', ''3''], [''4'', ''5'', ''6''], [''7'', ''8'', ''9'']]'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_64
+    - !<!ArraySchema> &ref_65
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -596,7 +607,7 @@ schemas: !<!Schemas>
           description: An array of Dictionaries with value null
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_28
+  - !<!Parameter> &ref_29
     schema: *ref_7
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -621,9 +632,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -636,7 +662,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -650,7 +676,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -672,9 +698,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -687,7 +728,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -701,7 +742,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -723,9 +764,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -738,7 +794,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -752,7 +808,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -774,12 +830,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
-                schema: *ref_30
+              - !<!Parameter> &ref_32
+                schema: *ref_31
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -790,8 +846,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_31
+              - *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -817,7 +886,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -839,9 +908,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -854,7 +938,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_32
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -868,7 +952,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -890,12 +974,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
-                schema: *ref_32
+              - !<!Parameter> &ref_34
+                schema: *ref_33
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -906,8 +990,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -933,7 +1030,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -955,9 +1052,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -970,7 +1082,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_32
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -984,7 +1096,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1006,9 +1118,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1021,7 +1148,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_32
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -1035,7 +1162,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1057,9 +1184,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1072,7 +1214,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1086,7 +1228,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1108,12 +1250,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
-                schema: *ref_29
+              - !<!Parameter> &ref_35
+                schema: *ref_30
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1124,8 +1266,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -1151,7 +1306,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1173,9 +1328,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1188,7 +1358,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1202,7 +1372,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1224,9 +1394,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1239,7 +1424,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1253,7 +1438,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1275,9 +1460,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1290,7 +1490,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1304,7 +1504,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1326,12 +1526,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_35
+              - !<!Parameter> &ref_37
+                schema: *ref_36
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1342,8 +1542,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -1369,7 +1582,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1391,9 +1604,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1406,7 +1634,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1420,7 +1648,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1442,9 +1670,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1457,7 +1700,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1471,7 +1714,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1493,9 +1736,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1508,7 +1766,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_37
+            schema: *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1522,7 +1780,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1544,12 +1802,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_38
-                schema: *ref_37
+              - !<!Parameter> &ref_39
+                schema: *ref_38
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1560,8 +1818,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_38
+              - *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -1587,7 +1858,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1609,9 +1880,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1624,7 +1910,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_37
+            schema: *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1638,7 +1924,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1660,9 +1946,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1675,7 +1976,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_37
+            schema: *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1689,7 +1990,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1711,9 +2012,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1726,7 +2042,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_39
+            schema: *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1740,7 +2056,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1762,12 +2078,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_40
-                schema: *ref_39
+              - !<!Parameter> &ref_41
+                schema: *ref_40
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1778,8 +2094,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_40
+              - *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -1805,7 +2134,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1827,9 +2156,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1842,7 +2186,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_39
+            schema: *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1856,7 +2200,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1878,9 +2222,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1893,7 +2252,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_39
+            schema: *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1907,7 +2266,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1929,9 +2288,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1958,7 +2332,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1980,11 +2354,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_41
+              - !<!Parameter> &ref_42
                 schema: *ref_10
                 implementation: Method
                 required: true
@@ -1996,8 +2370,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_41
+              - *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -2023,7 +2410,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2045,9 +2432,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2060,7 +2462,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_42
+            schema: *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -2074,7 +2476,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2096,12 +2498,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_43
-                schema: *ref_42
+              - !<!Parameter> &ref_44
+                schema: *ref_43
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2112,8 +2514,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_43
+              - *ref_44
             language: !<!Languages> 
               default:
                 name: ''
@@ -2139,7 +2554,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2161,9 +2576,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2176,7 +2606,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_44
+            schema: *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -2190,7 +2620,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2212,12 +2642,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_45
-                schema: *ref_44
+              - !<!Parameter> &ref_46
+                schema: *ref_45
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2228,8 +2658,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -2255,7 +2698,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2277,9 +2720,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2306,7 +2764,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2328,9 +2786,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2357,7 +2830,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2379,9 +2852,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2394,7 +2882,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2408,7 +2896,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2430,12 +2918,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_47
-                schema: *ref_46
+              - !<!Parameter> &ref_48
+                schema: *ref_47
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2446,8 +2934,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_47
+              - *ref_48
             language: !<!Languages> 
               default:
                 name: ''
@@ -2473,7 +2974,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2495,9 +2996,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2510,7 +3026,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2524,7 +3040,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2546,9 +3062,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2561,7 +3092,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -2575,7 +3106,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2597,12 +3128,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_49
-                schema: *ref_48
+              - !<!Parameter> &ref_50
+                schema: *ref_49
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2613,8 +3144,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_49
+              - *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -2640,7 +3184,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2662,9 +3206,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2677,7 +3236,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -2691,7 +3250,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2713,9 +3272,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2728,7 +3302,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -2742,7 +3316,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2764,9 +3338,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2779,7 +3368,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_50
+            schema: *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -2793,7 +3382,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2815,12 +3404,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_51
-                schema: *ref_50
+              - !<!Parameter> &ref_52
+                schema: *ref_51
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2831,8 +3420,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_51
+              - *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -2858,7 +3460,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2880,9 +3482,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2895,7 +3512,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_50
+            schema: *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -2909,7 +3526,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2931,9 +3548,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2946,7 +3578,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_50
+            schema: *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -2960,7 +3592,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2982,9 +3614,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2997,7 +3644,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3011,7 +3658,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3033,12 +3680,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_53
-                schema: *ref_52
+              - !<!Parameter> &ref_54
+                schema: *ref_53
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3049,8 +3696,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_53
+              - *ref_54
             language: !<!Languages> 
               default:
                 name: ''
@@ -3076,7 +3736,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3098,9 +3758,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3113,7 +3788,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_54
+            schema: *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -3127,7 +3802,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3149,12 +3824,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_55
-                schema: *ref_54
+              - !<!Parameter> &ref_56
+                schema: *ref_55
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3165,8 +3840,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_55
+              - *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3192,7 +3880,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3214,9 +3902,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3229,7 +3932,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_56
+            schema: *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3243,7 +3946,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3265,12 +3968,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_57
-                schema: *ref_56
+              - !<!Parameter> &ref_58
+                schema: *ref_57
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3281,8 +3984,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_57
+              - *ref_58
             language: !<!Languages> 
               default:
                 name: ''
@@ -3308,7 +4024,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3330,9 +4046,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3345,7 +4076,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_56
+            schema: *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3359,7 +4090,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3381,9 +4112,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3396,7 +4142,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_58
+            schema: *ref_59
             language: !<!Languages> 
               default:
                 name: ''
@@ -3410,7 +4156,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3432,9 +4178,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3447,7 +4208,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3461,7 +4222,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3483,9 +4244,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3498,7 +4274,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3512,7 +4288,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3534,9 +4310,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3549,7 +4340,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3563,7 +4354,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3585,9 +4376,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3600,7 +4406,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3614,7 +4420,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3636,9 +4442,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3651,7 +4472,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3665,7 +4486,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3687,12 +4508,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_60
-                schema: *ref_59
+              - !<!Parameter> &ref_61
+                schema: *ref_60
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3703,8 +4524,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_60
+              - *ref_61
             language: !<!Languages> 
               default:
                 name: ''
@@ -3730,7 +4564,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3752,9 +4586,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3767,7 +4616,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3781,7 +4630,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3803,9 +4652,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3818,7 +4682,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3832,7 +4696,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3854,9 +4718,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3869,7 +4748,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3883,7 +4762,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3905,9 +4784,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3920,7 +4814,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3934,7 +4828,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3956,9 +4850,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3971,7 +4880,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3985,7 +4894,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4007,12 +4916,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_63
-                schema: *ref_62
+              - !<!Parameter> &ref_64
+                schema: *ref_63
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -4023,8 +4932,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -4050,7 +4972,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4072,9 +4994,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4087,7 +5024,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4101,7 +5038,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4123,9 +5060,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4138,7 +5090,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4152,7 +5104,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4174,9 +5126,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4189,7 +5156,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4203,7 +5170,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4225,9 +5192,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4240,7 +5222,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4254,7 +5236,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4276,9 +5258,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4291,7 +5288,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4305,7 +5302,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4327,12 +5324,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_65
-                schema: *ref_64
+              - !<!Parameter> &ref_66
+                schema: *ref_65
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -4343,8 +5340,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_65
+              - *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -4370,7 +5380,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-array/namer.yaml
+++ b/modelerfour/test/scenarios/body-array/namer.yaml
@@ -198,6 +198,17 @@ schemas: !<!Schemas>
           name: FooEnum
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_27
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_25
       type: dictionary
@@ -287,7 +298,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_28
+    - !<!ObjectSchema> &ref_29
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -353,7 +364,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_27
+    - !<!ArraySchema> &ref_28
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -364,7 +375,7 @@ schemas: !<!Schemas>
           name: ArrayOfGet200ApplicationJsonItemsItem
           description: The null Array value
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_29
+    - !<!ArraySchema> &ref_30
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -375,7 +386,7 @@ schemas: !<!Schemas>
           name: ArrayOfInteger
           description: 'The invalid Array [1, 2, 3'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_30
+    - !<!ArraySchema> &ref_31
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -386,7 +397,7 @@ schemas: !<!Schemas>
           name: ArrayOfPutContentSchemaItem
           description: 'The empty array value []'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_32
+    - !<!ArraySchema> &ref_33
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -397,7 +408,7 @@ schemas: !<!Schemas>
           name: ArrayOfBoolean
           description: 'The array value [true, false, false, true]'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_35
+    - !<!ArraySchema> &ref_36
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -408,7 +419,7 @@ schemas: !<!Schemas>
           name: ArrayOfInteger
           description: 'The array value [1, -1, 3, 300]'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_37
+    - !<!ArraySchema> &ref_38
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -419,7 +430,7 @@ schemas: !<!Schemas>
           name: ArrayOfNumber
           description: 'The array value [0, -0.01, 1.2e20]'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_39
+    - !<!ArraySchema> &ref_40
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -441,7 +452,7 @@ schemas: !<!Schemas>
           name: ArrayOfString
           description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_42
+    - !<!ArraySchema> &ref_43
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -452,7 +463,7 @@ schemas: !<!Schemas>
           name: ArrayOfFooEnum
           description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_44
+    - !<!ArraySchema> &ref_45
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -463,7 +474,7 @@ schemas: !<!Schemas>
           name: ArrayOfEnum0
           description: 'The array value [''foo1'', ''foo2'', ''foo3'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_46
+    - !<!ArraySchema> &ref_47
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -474,7 +485,7 @@ schemas: !<!Schemas>
           name: ArrayOfUuid
           description: 'The array value [''6dcc7237-45fe-45c4-8a6b-3a8a3f625652'', ''d1399005-30f7-40d6-8da6-dd7c89ad34db'', ''f42f6aa1-a5bc-4ddf-907e-5f915de43205'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_48
+    - !<!ArraySchema> &ref_49
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -485,7 +496,7 @@ schemas: !<!Schemas>
           name: ArrayOfDate
           description: 'The array value [''2000-12-01'', ''1980-01-02'', ''1492-10-12'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_50
+    - !<!ArraySchema> &ref_51
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -496,7 +507,7 @@ schemas: !<!Schemas>
           name: ArrayOfDateTime
           description: 'The array value [''2000-12-01t00:00:01z'', ''1980-01-02T00:11:35+01:00'', ''1492-10-12T10:15:01-08:00'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_52
+    - !<!ArraySchema> &ref_53
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -507,7 +518,7 @@ schemas: !<!Schemas>
           name: ArrayOfDateTime
           description: 'The array value [''Fri, 01 Dec 2000 00:00:01 GMT'', ''Wed, 02 Jan 1980 00:11:35 GMT'', ''Wed, 12 Oct 1492 10:15:01 GMT'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_54
+    - !<!ArraySchema> &ref_55
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -518,7 +529,7 @@ schemas: !<!Schemas>
           name: ArrayOfDuration
           description: 'The array value [''P123DT22H14M12.011S'', ''P5DT1H0M0S'']'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_56
+    - !<!ArraySchema> &ref_57
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -529,7 +540,7 @@ schemas: !<!Schemas>
           name: ArrayOfByteArray
           description: 'The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_58
+    - !<!ArraySchema> &ref_59
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -540,7 +551,7 @@ schemas: !<!Schemas>
           name: ArrayOfByteArray
           description: 'Get array value [''a string that gets encoded with base64url'', ''test string'' ''Lorem ipsum''] with the items base64url encoded'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_59
+    - !<!ArraySchema> &ref_60
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -551,7 +562,7 @@ schemas: !<!Schemas>
           name: ArrayOfProduct
           description: array of complex type with null value
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_61
+    - !<!ArraySchema> &ref_62
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -573,7 +584,7 @@ schemas: !<!Schemas>
           name: ArrayOfPutContentSchemaItemsItem
           description: Array of PutContentSchemaItemsItem
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_62
+    - !<!ArraySchema> &ref_63
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -584,7 +595,7 @@ schemas: !<!Schemas>
           name: ArrayOfPutContentSchemaItemsItem
           description: 'An array of array of strings [[''1'', ''2'', ''3''], [''4'', ''5'', ''6''], [''7'', ''8'', ''9'']]'
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_64
+    - !<!ArraySchema> &ref_65
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -624,6 +635,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -636,7 +662,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -650,7 +676,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -675,6 +701,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -687,7 +728,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -701,7 +742,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -726,6 +767,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -738,7 +794,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -752,7 +808,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -778,8 +834,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
-                schema: *ref_30
+              - !<!Parameter> &ref_32
+                schema: *ref_31
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -790,8 +846,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_31
+              - *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -817,7 +886,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -842,6 +911,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -854,7 +938,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_32
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -868,7 +952,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -894,8 +978,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
-                schema: *ref_32
+              - !<!Parameter> &ref_34
+                schema: *ref_33
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -906,8 +990,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -933,7 +1030,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -958,6 +1055,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -970,7 +1082,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_32
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -984,7 +1096,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1009,6 +1121,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1021,7 +1148,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_32
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -1035,7 +1162,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1060,6 +1187,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1072,7 +1214,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1086,7 +1228,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1112,8 +1254,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
-                schema: *ref_29
+              - !<!Parameter> &ref_35
+                schema: *ref_30
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1124,8 +1266,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -1151,7 +1306,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1176,6 +1331,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1188,7 +1358,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1202,7 +1372,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1227,6 +1397,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1239,7 +1424,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1253,7 +1438,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1278,6 +1463,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1290,7 +1490,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1304,7 +1504,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1330,8 +1530,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_35
+              - !<!Parameter> &ref_37
+                schema: *ref_36
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1342,8 +1542,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -1369,7 +1582,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1394,6 +1607,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1406,7 +1634,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1420,7 +1648,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1445,6 +1673,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1457,7 +1700,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1471,7 +1714,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1496,6 +1739,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1508,7 +1766,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_37
+            schema: *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1522,7 +1780,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1548,8 +1806,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_38
-                schema: *ref_37
+              - !<!Parameter> &ref_39
+                schema: *ref_38
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1560,8 +1818,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_38
+              - *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -1587,7 +1858,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1612,6 +1883,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1624,7 +1910,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_37
+            schema: *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1638,7 +1924,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1663,6 +1949,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1675,7 +1976,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_37
+            schema: *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1689,7 +1990,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1714,6 +2015,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1726,7 +2042,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_39
+            schema: *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1740,7 +2056,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1766,8 +2082,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_40
-                schema: *ref_39
+              - !<!Parameter> &ref_41
+                schema: *ref_40
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1778,8 +2094,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_40
+              - *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -1805,7 +2134,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1830,6 +2159,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1842,7 +2186,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_39
+            schema: *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1856,7 +2200,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1881,6 +2225,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1893,7 +2252,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_39
+            schema: *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1907,7 +2266,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1932,6 +2291,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1958,7 +2332,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1984,7 +2358,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_41
+              - !<!Parameter> &ref_42
                 schema: *ref_22
                 implementation: Method
                 required: true
@@ -1996,8 +2370,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_41
+              - *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -2023,7 +2410,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2048,6 +2435,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2060,7 +2462,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_42
+            schema: *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -2074,7 +2476,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2100,8 +2502,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_43
-                schema: *ref_42
+              - !<!Parameter> &ref_44
+                schema: *ref_43
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2112,8 +2514,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_43
+              - *ref_44
             language: !<!Languages> 
               default:
                 name: ''
@@ -2139,7 +2554,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2164,6 +2579,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2176,7 +2606,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_44
+            schema: *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -2190,7 +2620,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2216,8 +2646,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_45
-                schema: *ref_44
+              - !<!Parameter> &ref_46
+                schema: *ref_45
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2228,8 +2658,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -2255,7 +2698,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2280,6 +2723,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2306,7 +2764,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2331,6 +2789,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2357,7 +2830,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2382,6 +2855,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2394,7 +2882,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2408,7 +2896,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2434,8 +2922,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_47
-                schema: *ref_46
+              - !<!Parameter> &ref_48
+                schema: *ref_47
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2446,8 +2934,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_47
+              - *ref_48
             language: !<!Languages> 
               default:
                 name: ''
@@ -2473,7 +2974,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2498,6 +2999,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2510,7 +3026,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2524,7 +3040,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2549,6 +3065,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2561,7 +3092,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -2575,7 +3106,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2601,8 +3132,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_49
-                schema: *ref_48
+              - !<!Parameter> &ref_50
+                schema: *ref_49
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2613,8 +3144,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_49
+              - *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -2640,7 +3184,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2665,6 +3209,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2677,7 +3236,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -2691,7 +3250,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2716,6 +3275,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2728,7 +3302,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -2742,7 +3316,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2767,6 +3341,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2779,7 +3368,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_50
+            schema: *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -2793,7 +3382,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2819,8 +3408,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_51
-                schema: *ref_50
+              - !<!Parameter> &ref_52
+                schema: *ref_51
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2831,8 +3420,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_51
+              - *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -2858,7 +3460,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2883,6 +3485,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2895,7 +3512,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_50
+            schema: *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -2909,7 +3526,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2934,6 +3551,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2946,7 +3578,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_50
+            schema: *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -2960,7 +3592,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -2985,6 +3617,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2997,7 +3644,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3011,7 +3658,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3037,8 +3684,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_53
-                schema: *ref_52
+              - !<!Parameter> &ref_54
+                schema: *ref_53
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3049,8 +3696,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_53
+              - *ref_54
             language: !<!Languages> 
               default:
                 name: ''
@@ -3076,7 +3736,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3101,6 +3761,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3113,7 +3788,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_54
+            schema: *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -3127,7 +3802,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3153,8 +3828,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_55
-                schema: *ref_54
+              - !<!Parameter> &ref_56
+                schema: *ref_55
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3165,8 +3840,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_55
+              - *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3192,7 +3880,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3217,6 +3905,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3229,7 +3932,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_56
+            schema: *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3243,7 +3946,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3269,8 +3972,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_57
-                schema: *ref_56
+              - !<!Parameter> &ref_58
+                schema: *ref_57
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3281,8 +3984,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_57
+              - *ref_58
             language: !<!Languages> 
               default:
                 name: ''
@@ -3308,7 +4024,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3333,6 +4049,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3345,7 +4076,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_56
+            schema: *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3359,7 +4090,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3384,6 +4115,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3396,7 +4142,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_58
+            schema: *ref_59
             language: !<!Languages> 
               default:
                 name: ''
@@ -3410,7 +4156,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3435,6 +4181,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3447,7 +4208,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3461,7 +4222,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3486,6 +4247,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3498,7 +4274,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3512,7 +4288,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3537,6 +4313,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3549,7 +4340,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3563,7 +4354,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3588,6 +4379,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3600,7 +4406,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3614,7 +4420,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3639,6 +4445,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3651,7 +4472,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_59
+            schema: *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3665,7 +4486,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3691,8 +4512,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_60
-                schema: *ref_59
+              - !<!Parameter> &ref_61
+                schema: *ref_60
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3703,8 +4524,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_60
+              - *ref_61
             language: !<!Languages> 
               default:
                 name: ''
@@ -3730,7 +4564,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3755,6 +4589,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3767,7 +4616,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3781,7 +4630,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3806,6 +4655,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3818,7 +4682,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3832,7 +4696,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3857,6 +4721,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3869,7 +4748,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3883,7 +4762,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3908,6 +4787,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3920,7 +4814,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3934,7 +4828,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -3959,6 +4853,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3971,7 +4880,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_61
+            schema: *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3985,7 +4894,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4011,8 +4920,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_63
-                schema: *ref_62
+              - !<!Parameter> &ref_64
+                schema: *ref_63
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -4023,8 +4932,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -4050,7 +4972,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4075,6 +4997,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4087,7 +5024,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4101,7 +5038,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4126,6 +5063,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4138,7 +5090,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4152,7 +5104,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4177,6 +5129,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4189,7 +5156,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4203,7 +5170,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4228,6 +5195,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4240,7 +5222,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4254,7 +5236,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4279,6 +5261,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4291,7 +5288,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_64
+            schema: *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4305,7 +5302,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -4331,8 +5328,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_65
-                schema: *ref_64
+              - !<!Parameter> &ref_66
+                schema: *ref_65
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -4343,8 +5340,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_65
+              - *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -4370,7 +5380,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-boolean.quirks/flattened.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-boolean.quirks
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_4
+    - !<!BooleanSchema> &ref_5
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -24,14 +24,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -41,15 +41,26 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -57,7 +68,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -76,7 +87,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -103,6 +114,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -115,7 +141,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -129,7 +155,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -155,8 +181,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_4
+              - !<!Parameter> &ref_7
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -167,8 +193,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,7 +233,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,6 +258,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -231,7 +285,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -245,7 +299,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -271,8 +325,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_4
+              - !<!Parameter> &ref_8
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -283,8 +337,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -310,7 +377,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -335,6 +402,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -347,7 +429,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -361,7 +443,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -386,6 +468,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,7 +495,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -412,7 +509,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-boolean.quirks/grouped.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-boolean.quirks
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_4
+    - !<!BooleanSchema> &ref_5
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -24,14 +24,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -41,15 +41,26 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -57,7 +68,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -76,7 +87,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -103,6 +114,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -115,7 +141,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -129,7 +155,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -155,8 +181,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_4
+              - !<!Parameter> &ref_7
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -167,8 +193,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,7 +233,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,6 +258,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -231,7 +285,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -245,7 +299,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -271,8 +325,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_4
+              - !<!Parameter> &ref_8
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -283,8 +337,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -310,7 +377,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -335,6 +402,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -347,7 +429,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -361,7 +443,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -386,6 +468,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,7 +495,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -412,7 +509,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-boolean.quirks/modeler.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/modeler.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-boolean.quirks
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_3
+    - !<!BooleanSchema> &ref_4
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -41,8 +41,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_3
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_4
+    - !<!ObjectSchema> &ref_5
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -75,7 +86,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_5
+  - !<!Parameter> &ref_6
     schema: *ref_2
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -100,9 +111,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -115,7 +141,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -129,7 +155,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -151,12 +177,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_3
+              - !<!Parameter> &ref_7
+                schema: *ref_4
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -167,8 +193,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,7 +233,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -216,9 +255,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -231,7 +285,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -245,7 +299,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -267,12 +321,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_3
+              - !<!Parameter> &ref_8
+                schema: *ref_4
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -283,8 +337,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -310,7 +377,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -332,9 +399,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -347,7 +429,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -361,7 +443,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -383,9 +465,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,7 +495,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -412,7 +509,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-boolean.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-boolean.quirks/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-boolean.quirks
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_4
+    - !<!BooleanSchema> &ref_5
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -24,14 +24,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -41,15 +41,26 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -57,7 +68,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -76,7 +87,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -103,6 +114,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -115,7 +141,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -129,7 +155,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -155,8 +181,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_4
+              - !<!Parameter> &ref_7
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -167,8 +193,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,7 +233,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,6 +258,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -231,7 +285,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -245,7 +299,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -271,8 +325,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_4
+              - !<!Parameter> &ref_8
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -283,8 +337,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -310,7 +377,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -335,6 +402,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -347,7 +429,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -361,7 +443,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -386,6 +468,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,7 +495,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -412,7 +509,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-boolean/flattened.yaml
+++ b/modelerfour/test/scenarios/body-boolean/flattened.yaml
@@ -11,7 +11,7 @@ schemas: !<!Schemas>
           name: bool
           description: simple boolean
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_8
+    - !<!BooleanSchema> &ref_9
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -22,7 +22,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -31,14 +31,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_1
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -49,7 +49,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_6
+    - !<!ConstantSchema> &ref_7
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -62,7 +62,17 @@ schemas: !<!Schemas>
           name: paths·6qykq·bool-true·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_7
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_8
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -76,14 +86,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -91,7 +101,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -110,7 +120,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_1
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -137,6 +147,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -163,7 +188,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -190,7 +215,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_6
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -201,6 +226,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -227,7 +265,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -252,6 +290,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -278,7 +331,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -305,7 +358,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_7
+                schema: *ref_8
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -316,6 +369,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -342,7 +408,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -367,6 +433,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -379,7 +460,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -393,7 +474,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -418,6 +499,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -430,7 +526,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -444,7 +540,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-boolean/grouped.yaml
+++ b/modelerfour/test/scenarios/body-boolean/grouped.yaml
@@ -11,7 +11,7 @@ schemas: !<!Schemas>
           name: bool
           description: simple boolean
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_8
+    - !<!BooleanSchema> &ref_9
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -22,7 +22,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -31,14 +31,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_1
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -49,7 +49,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_6
+    - !<!ConstantSchema> &ref_7
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -62,7 +62,17 @@ schemas: !<!Schemas>
           name: paths·6qykq·bool-true·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_7
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_8
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -76,14 +86,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -91,7 +101,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -110,7 +120,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_1
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -137,6 +147,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -163,7 +188,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -190,7 +215,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_6
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -201,6 +226,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -227,7 +265,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -252,6 +290,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -278,7 +331,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -305,7 +358,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_7
+                schema: *ref_8
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -316,6 +369,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -342,7 +408,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -367,6 +433,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -379,7 +460,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -393,7 +474,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -418,6 +499,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -430,7 +526,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -444,7 +540,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-boolean/modeler.yaml
+++ b/modelerfour/test/scenarios/body-boolean/modeler.yaml
@@ -11,7 +11,7 @@ schemas: !<!Schemas>
           name: bool
           description: simple boolean
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_8
+    - !<!BooleanSchema> &ref_9
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -22,7 +22,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_2
+    - !<!NumberSchema> &ref_3
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -31,14 +31,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_1
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -49,7 +49,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_6
+    - !<!ConstantSchema> &ref_7
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -62,7 +62,17 @@ schemas: !<!Schemas>
           name: paths·6qykq·bool-true·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_7
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_8
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -76,14 +86,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_4
+    - !<!ObjectSchema> &ref_5
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: status
           language: !<!Languages> 
             default:
@@ -91,7 +101,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -109,8 +119,8 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_5
-    schema: *ref_3
+  - !<!Parameter> &ref_6
+    schema: *ref_1
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -134,9 +144,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -163,7 +188,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -185,12 +210,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_6
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -201,6 +226,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -227,7 +265,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -249,9 +287,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -278,7 +331,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -300,12 +353,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_7
+                schema: *ref_8
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -316,6 +369,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -342,7 +408,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -364,9 +430,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -379,7 +460,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -393,7 +474,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -415,9 +496,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -430,7 +526,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -444,7 +540,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-boolean/namer.yaml
+++ b/modelerfour/test/scenarios/body-boolean/namer.yaml
@@ -11,7 +11,7 @@ schemas: !<!Schemas>
           name: Bool
           description: simple boolean
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_8
+    - !<!BooleanSchema> &ref_9
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -22,7 +22,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -31,14 +31,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_1
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -49,7 +49,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_6
+    - !<!ConstantSchema> &ref_7
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -62,7 +62,17 @@ schemas: !<!Schemas>
           name: Constant0
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_7
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_8
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -72,18 +82,18 @@ schemas: !<!Schemas>
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant1
+          name: Constant2
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -91,7 +101,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -110,7 +120,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_1
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -137,6 +147,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -163,7 +188,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -190,7 +215,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_6
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -201,6 +226,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -227,7 +265,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -252,6 +290,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -278,7 +331,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -305,7 +358,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_7
+                schema: *ref_8
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -316,6 +369,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -342,7 +408,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -367,6 +433,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -379,7 +460,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -393,7 +474,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -418,6 +499,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -430,7 +526,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -444,7 +540,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-byte/flattened.yaml
+++ b/modelerfour/test/scenarios/body-byte/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-byte
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,8 +30,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_4
+    - !<!ByteArraySchema> &ref_5
       type: byte-array
       format: byte
       apiVersions:
@@ -43,14 +54,14 @@ schemas: !<!Schemas>
           description: The null byte value
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -58,7 +69,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -77,7 +88,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -104,6 +115,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -116,7 +142,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -130,7 +156,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -155,6 +181,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -167,7 +208,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -181,7 +222,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -206,6 +247,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -218,7 +274,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -232,7 +288,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -258,8 +314,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_4
+              - !<!Parameter> &ref_7
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -270,8 +326,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -297,7 +366,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -322,6 +391,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -334,7 +418,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -348,7 +432,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-byte/grouped.yaml
+++ b/modelerfour/test/scenarios/body-byte/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-byte
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,8 +30,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_4
+    - !<!ByteArraySchema> &ref_5
       type: byte-array
       format: byte
       apiVersions:
@@ -43,14 +54,14 @@ schemas: !<!Schemas>
           description: The null byte value
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -58,7 +69,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -77,7 +88,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -104,6 +115,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -116,7 +142,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -130,7 +156,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -155,6 +181,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -167,7 +208,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -181,7 +222,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -206,6 +247,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -218,7 +274,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -232,7 +288,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -258,8 +314,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_4
+              - !<!Parameter> &ref_7
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -270,8 +326,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -297,7 +366,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -322,6 +391,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -334,7 +418,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -348,7 +432,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-byte/modeler.yaml
+++ b/modelerfour/test/scenarios/body-byte/modeler.yaml
@@ -30,8 +30,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_3
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_3
+    - !<!ByteArraySchema> &ref_4
       type: byte-array
       format: byte
       apiVersions:
@@ -43,7 +54,7 @@ schemas: !<!Schemas>
           description: The null byte value
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_4
+    - !<!ObjectSchema> &ref_5
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -76,7 +87,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_5
+  - !<!Parameter> &ref_6
     schema: *ref_2
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -101,9 +112,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -116,7 +142,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -130,7 +156,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -152,9 +178,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -167,7 +208,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -181,7 +222,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -203,9 +244,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -218,7 +274,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -232,7 +288,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -254,12 +310,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_3
+              - !<!Parameter> &ref_7
+                schema: *ref_4
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -270,8 +326,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -297,7 +366,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -319,9 +388,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -334,7 +418,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -348,7 +432,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-byte/namer.yaml
+++ b/modelerfour/test/scenarios/body-byte/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-byte
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,8 +30,19 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_4
+    - !<!ByteArraySchema> &ref_5
       type: byte-array
       format: byte
       apiVersions:
@@ -43,14 +54,14 @@ schemas: !<!Schemas>
           description: The null byte value
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -58,7 +69,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -77,7 +88,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -104,6 +115,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -116,7 +142,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -130,7 +156,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -155,6 +181,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -167,7 +208,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -181,7 +222,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -206,6 +247,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -218,7 +274,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -232,7 +288,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -258,8 +314,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_4
+              - !<!Parameter> &ref_7
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -270,8 +326,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -297,7 +366,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -322,6 +391,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -334,7 +418,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -348,7 +432,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-complex/flattened.yaml
+++ b/modelerfour/test/scenarios/body-complex/flattened.yaml
@@ -379,6 +379,16 @@ schemas: !<!Schemas>
           description: Colors possible
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_70
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_68
       type: constant
       value: !<!ConstantValue> 
@@ -526,7 +536,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_70
+    - !<!ObjectSchema> &ref_71
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -567,7 +577,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_71
+    - !<!ObjectSchema> &ref_72
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -599,13 +609,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_74
+    - !<!ObjectSchema> &ref_75
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_76
+        - !<!Property> &ref_77
           schema: *ref_6
           serializedName: field1
           language: !<!Languages> 
@@ -613,7 +623,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_77
+        - !<!Property> &ref_78
           schema: *ref_6
           serializedName: field2
           language: !<!Languages> 
@@ -632,13 +642,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_80
+    - !<!ObjectSchema> &ref_81
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_82
+        - !<!Property> &ref_83
           schema: *ref_8
           serializedName: field1
           language: !<!Languages> 
@@ -646,7 +656,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_83
+        - !<!Property> &ref_84
           schema: *ref_8
           serializedName: field2
           language: !<!Languages> 
@@ -665,13 +675,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_86
+    - !<!ObjectSchema> &ref_87
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_88
+        - !<!Property> &ref_89
           schema: *ref_9
           serializedName: field1
           language: !<!Languages> 
@@ -679,7 +689,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_89
+        - !<!Property> &ref_90
           schema: *ref_9
           serializedName: field2
           language: !<!Languages> 
@@ -698,13 +708,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_92
+    - !<!ObjectSchema> &ref_93
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_94
+        - !<!Property> &ref_95
           schema: *ref_10
           serializedName: field1
           language: !<!Languages> 
@@ -712,7 +722,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_95
+        - !<!Property> &ref_96
           schema: *ref_10
           serializedName: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
           language: !<!Languages> 
@@ -731,13 +741,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_98
+    - !<!ObjectSchema> &ref_99
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_100
+        - !<!Property> &ref_101
           schema: *ref_11
           serializedName: field_true
           language: !<!Languages> 
@@ -745,7 +755,7 @@ schemas: !<!Schemas>
               name: field_true
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_101
+        - !<!Property> &ref_102
           schema: *ref_11
           serializedName: field_false
           language: !<!Languages> 
@@ -764,7 +774,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_104
+    - !<!ObjectSchema> &ref_105
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -805,13 +815,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_106
+    - !<!ObjectSchema> &ref_107
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_108
+        - !<!Property> &ref_109
           schema: *ref_15
           serializedName: field
           language: !<!Languages> 
@@ -819,7 +829,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_109
+        - !<!Property> &ref_110
           schema: *ref_16
           serializedName: leap
           language: !<!Languages> 
@@ -838,13 +848,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_112
+    - !<!ObjectSchema> &ref_113
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_114
+        - !<!Property> &ref_115
           schema: *ref_17
           serializedName: field
           language: !<!Languages> 
@@ -852,7 +862,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_115
+        - !<!Property> &ref_116
           schema: *ref_18
           serializedName: now
           language: !<!Languages> 
@@ -871,13 +881,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_118
+    - !<!ObjectSchema> &ref_119
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_120
+        - !<!Property> &ref_121
           schema: *ref_19
           serializedName: field
           language: !<!Languages> 
@@ -885,7 +895,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_121
+        - !<!Property> &ref_122
           schema: *ref_20
           serializedName: now
           language: !<!Languages> 
@@ -904,13 +914,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_124
+    - !<!ObjectSchema> &ref_125
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_126
+        - !<!Property> &ref_127
           schema: *ref_21
           serializedName: field
           language: !<!Languages> 
@@ -929,13 +939,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_128
+    - !<!ObjectSchema> &ref_129
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_130
+        - !<!Property> &ref_131
           schema: *ref_22
           serializedName: field
           language: !<!Languages> 
@@ -954,13 +964,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_132
+    - !<!ObjectSchema> &ref_133
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_134
+        - !<!Property> &ref_135
           schema: !<!ArraySchema> &ref_63
             type: array
             apiVersions:
@@ -989,13 +999,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_138
+    - !<!ObjectSchema> &ref_139
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_140
+        - !<!Property> &ref_141
           schema: *ref_24
           serializedName: defaultProgram
           language: !<!Languages> 
@@ -1574,7 +1584,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_146
+    - !<!ObjectSchema> &ref_147
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1644,7 +1654,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_51
     - *ref_33
-    - !<!ObjectSchema> &ref_151
+    - !<!ObjectSchema> &ref_152
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1659,7 +1669,7 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_153
+        - !<!Property> &ref_154
           schema: *ref_6
           serializedName: size
           language: !<!Languages> 
@@ -1796,7 +1806,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_72
+  - !<!Parameter> &ref_73
     schema: *ref_68
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -1821,6 +1831,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1833,7 +1858,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1847,7 +1872,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1870,12 +1895,12 @@ operationGroups:
             version: '2016-02-29'
         parameters:
           - *ref_69
-          - *ref_72
+          - *ref_73
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_73
-                schema: *ref_70
+              - !<!Parameter> &ref_74
+                schema: *ref_71
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1886,8 +1911,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_73
+              - *ref_74
             language: !<!Languages> 
               default:
                 name: ''
@@ -1913,7 +1951,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1938,6 +1976,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1950,7 +2003,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1964,7 +2017,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1989,6 +2042,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2001,7 +2069,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2015,7 +2083,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2040,6 +2108,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2052,7 +2135,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2066,7 +2149,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2091,6 +2174,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2103,7 +2201,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2117,7 +2215,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2150,6 +2248,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2162,7 +2275,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_74
+            schema: *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -2176,7 +2289,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2202,8 +2315,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_75
-                schema: *ref_74
+              - !<!Parameter> &ref_76
+                schema: *ref_75
                 flattened: true
                 implementation: Method
                 required: true
@@ -2215,31 +2328,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_78
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_79
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_75
+                originalParameter: *ref_76
                 pathToProperty: []
-                targetProperty: *ref_76
+                targetProperty: *ref_77
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_79
+              - !<!VirtualParameter> &ref_80
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_75
+                originalParameter: *ref_76
                 pathToProperty: []
-                targetProperty: *ref_77
+                targetProperty: *ref_78
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_78
               - *ref_79
+              - *ref_80
             language: !<!Languages> 
               default:
                 name: ''
@@ -2265,7 +2391,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2290,6 +2416,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2302,7 +2443,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_80
+            schema: *ref_81
             language: !<!Languages> 
               default:
                 name: ''
@@ -2316,7 +2457,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2342,8 +2483,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_81
-                schema: *ref_80
+              - !<!Parameter> &ref_82
+                schema: *ref_81
                 flattened: true
                 implementation: Method
                 required: true
@@ -2355,31 +2496,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_84
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_85
                 schema: *ref_8
                 implementation: Method
-                originalParameter: *ref_81
+                originalParameter: *ref_82
                 pathToProperty: []
-                targetProperty: *ref_82
+                targetProperty: *ref_83
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_85
+              - !<!VirtualParameter> &ref_86
                 schema: *ref_8
                 implementation: Method
-                originalParameter: *ref_81
+                originalParameter: *ref_82
                 pathToProperty: []
-                targetProperty: *ref_83
+                targetProperty: *ref_84
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_84
               - *ref_85
+              - *ref_86
             language: !<!Languages> 
               default:
                 name: ''
@@ -2405,7 +2559,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2430,6 +2584,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2442,7 +2611,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_86
+            schema: *ref_87
             language: !<!Languages> 
               default:
                 name: ''
@@ -2456,7 +2625,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2482,8 +2651,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_87
-                schema: *ref_86
+              - !<!Parameter> &ref_88
+                schema: *ref_87
                 flattened: true
                 implementation: Method
                 required: true
@@ -2495,31 +2664,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_90
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_91
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_87
+                originalParameter: *ref_88
                 pathToProperty: []
-                targetProperty: *ref_88
+                targetProperty: *ref_89
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_91
+              - !<!VirtualParameter> &ref_92
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_87
+                originalParameter: *ref_88
                 pathToProperty: []
-                targetProperty: *ref_89
+                targetProperty: *ref_90
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_90
               - *ref_91
+              - *ref_92
             language: !<!Languages> 
               default:
                 name: ''
@@ -2545,7 +2727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2570,6 +2752,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2582,7 +2779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_92
+            schema: *ref_93
             language: !<!Languages> 
               default:
                 name: ''
@@ -2596,7 +2793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2622,8 +2819,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_93
-                schema: *ref_92
+              - !<!Parameter> &ref_94
+                schema: *ref_93
                 flattened: true
                 implementation: Method
                 required: true
@@ -2635,31 +2832,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_96
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_97
                 schema: *ref_10
                 implementation: Method
-                originalParameter: *ref_93
+                originalParameter: *ref_94
                 pathToProperty: []
-                targetProperty: *ref_94
+                targetProperty: *ref_95
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_97
+              - !<!VirtualParameter> &ref_98
                 schema: *ref_10
                 implementation: Method
-                originalParameter: *ref_93
+                originalParameter: *ref_94
                 pathToProperty: []
-                targetProperty: *ref_95
+                targetProperty: *ref_96
                 language: !<!Languages> 
                   default:
                     name: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_96
               - *ref_97
+              - *ref_98
             language: !<!Languages> 
               default:
                 name: ''
@@ -2685,7 +2895,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2710,6 +2920,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2722,7 +2947,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_98
+            schema: *ref_99
             language: !<!Languages> 
               default:
                 name: ''
@@ -2736,7 +2961,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2762,8 +2987,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_99
-                schema: *ref_98
+              - !<!Parameter> &ref_100
+                schema: *ref_99
                 flattened: true
                 implementation: Method
                 required: true
@@ -2775,31 +3000,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_102
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_103
                 schema: *ref_11
                 implementation: Method
-                originalParameter: *ref_99
+                originalParameter: *ref_100
                 pathToProperty: []
-                targetProperty: *ref_100
+                targetProperty: *ref_101
                 language: !<!Languages> 
                   default:
                     name: field_true
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_103
+              - !<!VirtualParameter> &ref_104
                 schema: *ref_11
                 implementation: Method
-                originalParameter: *ref_99
+                originalParameter: *ref_100
                 pathToProperty: []
-                targetProperty: *ref_101
+                targetProperty: *ref_102
                 language: !<!Languages> 
                   default:
                     name: field_false
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_102
               - *ref_103
+              - *ref_104
             language: !<!Languages> 
               default:
                 name: ''
@@ -2825,7 +3063,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2850,6 +3088,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2862,7 +3115,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_104
+            schema: *ref_105
             language: !<!Languages> 
               default:
                 name: ''
@@ -2876,7 +3129,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2902,8 +3155,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_105
-                schema: *ref_104
+              - !<!Parameter> &ref_106
+                schema: *ref_105
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2914,8 +3167,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_105
+              - *ref_106
             language: !<!Languages> 
               default:
                 name: ''
@@ -2941,7 +3207,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2966,6 +3232,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2978,7 +3259,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_106
+            schema: *ref_107
             language: !<!Languages> 
               default:
                 name: ''
@@ -2992,7 +3273,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3018,8 +3299,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_107
-                schema: *ref_106
+              - !<!Parameter> &ref_108
+                schema: *ref_107
                 flattened: true
                 implementation: Method
                 required: true
@@ -3031,31 +3312,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_110
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_111
                 schema: *ref_15
                 implementation: Method
-                originalParameter: *ref_107
+                originalParameter: *ref_108
                 pathToProperty: []
-                targetProperty: *ref_108
+                targetProperty: *ref_109
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_111
+              - !<!VirtualParameter> &ref_112
                 schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_107
+                originalParameter: *ref_108
                 pathToProperty: []
-                targetProperty: *ref_109
+                targetProperty: *ref_110
                 language: !<!Languages> 
                   default:
                     name: leap
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_110
               - *ref_111
+              - *ref_112
             language: !<!Languages> 
               default:
                 name: ''
@@ -3081,7 +3375,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3106,6 +3400,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3118,7 +3427,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_112
+            schema: *ref_113
             language: !<!Languages> 
               default:
                 name: ''
@@ -3132,7 +3441,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3158,8 +3467,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_113
-                schema: *ref_112
+              - !<!Parameter> &ref_114
+                schema: *ref_113
                 flattened: true
                 implementation: Method
                 required: true
@@ -3171,31 +3480,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_116
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_117
                 schema: *ref_17
                 implementation: Method
-                originalParameter: *ref_113
+                originalParameter: *ref_114
                 pathToProperty: []
-                targetProperty: *ref_114
+                targetProperty: *ref_115
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_117
+              - !<!VirtualParameter> &ref_118
                 schema: *ref_18
                 implementation: Method
-                originalParameter: *ref_113
+                originalParameter: *ref_114
                 pathToProperty: []
-                targetProperty: *ref_115
+                targetProperty: *ref_116
                 language: !<!Languages> 
                   default:
                     name: now
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_116
               - *ref_117
+              - *ref_118
             language: !<!Languages> 
               default:
                 name: ''
@@ -3221,7 +3543,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3246,6 +3568,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3258,7 +3595,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_118
+            schema: *ref_119
             language: !<!Languages> 
               default:
                 name: ''
@@ -3272,7 +3609,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3298,8 +3635,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_119
-                schema: *ref_118
+              - !<!Parameter> &ref_120
+                schema: *ref_119
                 flattened: true
                 implementation: Method
                 required: true
@@ -3311,31 +3648,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_122
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_123
                 schema: *ref_19
                 implementation: Method
-                originalParameter: *ref_119
+                originalParameter: *ref_120
                 pathToProperty: []
-                targetProperty: *ref_120
+                targetProperty: *ref_121
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_123
+              - !<!VirtualParameter> &ref_124
                 schema: *ref_20
                 implementation: Method
-                originalParameter: *ref_119
+                originalParameter: *ref_120
                 pathToProperty: []
-                targetProperty: *ref_121
+                targetProperty: *ref_122
                 language: !<!Languages> 
                   default:
                     name: now
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_122
               - *ref_123
+              - *ref_124
             language: !<!Languages> 
               default:
                 name: ''
@@ -3361,7 +3711,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3386,6 +3736,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3398,7 +3763,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_124
+            schema: *ref_125
             language: !<!Languages> 
               default:
                 name: ''
@@ -3412,7 +3777,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3438,8 +3803,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_125
-                schema: *ref_124
+              - !<!Parameter> &ref_126
+                schema: *ref_125
                 flattened: true
                 implementation: Method
                 required: true
@@ -3451,19 +3816,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_127
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_128
                 schema: *ref_21
                 implementation: Method
-                originalParameter: *ref_125
+                originalParameter: *ref_126
                 pathToProperty: []
-                targetProperty: *ref_126
+                targetProperty: *ref_127
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_127
+              - *ref_128
             language: !<!Languages> 
               default:
                 name: ''
@@ -3489,7 +3867,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3514,6 +3892,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3526,7 +3919,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_128
+            schema: *ref_129
             language: !<!Languages> 
               default:
                 name: ''
@@ -3540,7 +3933,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3566,8 +3959,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_129
-                schema: *ref_128
+              - !<!Parameter> &ref_130
+                schema: *ref_129
                 flattened: true
                 implementation: Method
                 required: true
@@ -3579,19 +3972,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_131
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_132
                 schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_129
+                originalParameter: *ref_130
                 pathToProperty: []
-                targetProperty: *ref_130
+                targetProperty: *ref_131
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_131
+              - *ref_132
             language: !<!Languages> 
               default:
                 name: ''
@@ -3617,7 +4023,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3650,6 +4056,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3662,7 +4083,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_132
+            schema: *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -3676,7 +4097,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3702,8 +4123,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_133
-                schema: *ref_132
+              - !<!Parameter> &ref_134
+                schema: *ref_133
                 flattened: true
                 implementation: Method
                 required: true
@@ -3715,19 +4136,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_135
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_136
                 schema: *ref_63
                 implementation: Method
-                originalParameter: *ref_133
+                originalParameter: *ref_134
                 pathToProperty: []
-                targetProperty: *ref_134
+                targetProperty: *ref_135
                 language: !<!Languages> 
                   default:
                     name: array
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_135
+              - *ref_136
             language: !<!Languages> 
               default:
                 name: ''
@@ -3753,7 +4187,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3778,6 +4212,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3790,7 +4239,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_132
+            schema: *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -3804,7 +4253,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3830,8 +4279,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_136
-                schema: *ref_132
+              - !<!Parameter> &ref_137
+                schema: *ref_133
                 flattened: true
                 implementation: Method
                 required: true
@@ -3843,19 +4292,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_137
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_138
                 schema: *ref_63
                 implementation: Method
-                originalParameter: *ref_136
+                originalParameter: *ref_137
                 pathToProperty: []
-                targetProperty: *ref_134
+                targetProperty: *ref_135
                 language: !<!Languages> 
                   default:
                     name: array
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_137
+              - *ref_138
             language: !<!Languages> 
               default:
                 name: ''
@@ -3881,7 +4343,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3906,6 +4368,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3918,7 +4395,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_132
+            schema: *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -3932,7 +4409,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3965,6 +4442,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3977,7 +4469,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_138
+            schema: *ref_139
             language: !<!Languages> 
               default:
                 name: ''
@@ -3991,7 +4483,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4017,8 +4509,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_139
-                schema: *ref_138
+              - !<!Parameter> &ref_140
+                schema: *ref_139
                 flattened: true
                 implementation: Method
                 required: true
@@ -4030,19 +4522,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_141
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_142
                 schema: *ref_24
                 implementation: Method
-                originalParameter: *ref_139
+                originalParameter: *ref_140
                 pathToProperty: []
-                targetProperty: *ref_140
+                targetProperty: *ref_141
                 language: !<!Languages> 
                   default:
                     name: defaultProgram
                     description: Dictionary of <string>
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_141
+              - *ref_142
             language: !<!Languages> 
               default:
                 name: ''
@@ -4068,7 +4573,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4093,6 +4598,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4105,7 +4625,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_138
+            schema: *ref_139
             language: !<!Languages> 
               default:
                 name: ''
@@ -4119,7 +4639,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4145,8 +4665,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_142
-                schema: *ref_138
+              - !<!Parameter> &ref_143
+                schema: *ref_139
                 flattened: true
                 implementation: Method
                 required: true
@@ -4158,19 +4678,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_143
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_144
                 schema: *ref_24
                 implementation: Method
-                originalParameter: *ref_142
+                originalParameter: *ref_143
                 pathToProperty: []
-                targetProperty: *ref_140
+                targetProperty: *ref_141
                 language: !<!Languages> 
                   default:
                     name: defaultProgram
                     description: Dictionary of <string>
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_143
+              - *ref_144
             language: !<!Languages> 
               default:
                 name: ''
@@ -4196,7 +4729,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4221,6 +4754,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4233,7 +4781,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_138
+            schema: *ref_139
             language: !<!Languages> 
               default:
                 name: ''
@@ -4247,7 +4795,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4272,6 +4820,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4284,7 +4847,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_138
+            schema: *ref_139
             language: !<!Languages> 
               default:
                 name: ''
@@ -4298,7 +4861,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4331,6 +4894,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4357,7 +4935,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4383,7 +4961,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_144
+              - !<!Parameter> &ref_145
                 schema: *ref_25
                 implementation: Method
                 required: true
@@ -4395,8 +4973,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_144
+              - *ref_145
             language: !<!Languages> 
               default:
                 name: ''
@@ -4422,7 +5013,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4455,6 +5046,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4481,7 +5087,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4507,7 +5113,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_145
+              - !<!Parameter> &ref_146
                 schema: *ref_35
                 implementation: Method
                 required: true
@@ -4552,8 +5158,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_145
+              - *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -4579,7 +5198,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4604,6 +5223,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4630,7 +5264,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4655,6 +5289,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4667,7 +5316,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_146
+            schema: *ref_147
             language: !<!Languages> 
               default:
                 name: ''
@@ -4681,7 +5330,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4706,6 +5355,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4718,7 +5382,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_146
+            schema: *ref_147
             language: !<!Languages> 
               default:
                 name: ''
@@ -4732,7 +5396,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4757,6 +5421,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4783,7 +5462,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4809,7 +5488,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_147
+              - !<!Parameter> &ref_148
                 schema: *ref_33
                 implementation: Method
                 required: true
@@ -4821,8 +5500,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_147
+              - *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -4848,7 +5540,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4874,7 +5566,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_148
+              - !<!Parameter> &ref_149
                 schema: *ref_33
                 implementation: Method
                 required: true
@@ -4886,8 +5578,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_148
+              - *ref_149
             language: !<!Languages> 
               default:
                 name: ''
@@ -4917,7 +5622,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4933,163 +5638,6 @@ operationGroups:
           default:
             name: putMissingDiscriminator
             description: 'Put complex types that are polymorphic, omitting the discriminator'
-        protocol: !<!Protocols> {}
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: '2016-02-29'
-        parameters:
-          - *ref_69
-        requests:
-          - !<!Request> 
-            parameters:
-              - !<!Parameter> &ref_149
-                schema: *ref_35
-                implementation: Method
-                required: true
-                language: !<!Languages> 
-                  default:
-                    name: complexBody
-                    description: |-
-                      Please put a salmon that looks like this:
-                      {
-                              'fishtype':'Salmon',
-                              'location':'alaska',
-                              'iswild':true,
-                              'species':'king',
-                              'length':1.0,
-                              'siblings':[
-                                {
-                                  'fishtype':'Shark',
-                                  'age':6,
-                                  'birthday': '2012-01-05T01:00:00Z',
-                                  'length':20.0,
-                                  'species':'predator',
-                                },
-                                {
-                                  'fishtype':'Sawshark',
-                                  'age':105,
-                                  'birthday': '1900-01-05T01:00:00Z',
-                                  'length':10.0,
-                                  'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-                                  'species':'dangerous',
-                                },
-                                {
-                                  'fishtype': 'goblin',
-                                  'age': 1,
-                                  'birthday': '2015-08-08T00:00:00Z',
-                                  'length': 30.0,
-                                  'species': 'scary',
-                                  'jawsize': 5
-                                }
-                              ]
-                            };
-                protocol: !<!Protocols> 
-                  http: !<!HttpParameter> 
-                    in: body
-                    style: json
-            signatureParameters:
-              - *ref_149
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpWithBodyRequest> 
-                path: /complex/polymorphism/missingrequired/invalid
-                method: put
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_71
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: putValidMissingRequired
-            description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
-        protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: polymorphism
-        description: ''
-    protocol: !<!Protocols> {}
-  - !<!OperationGroup> 
-    $key: polymorphicrecursive
-    operations:
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: '2016-02-29'
-        parameters:
-          - *ref_69
-        requests:
-          - !<!Request> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpRequest> 
-                path: /complex/polymorphicrecursive/valid
-                method: get
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!SchemaResponse> 
-            schema: *ref_35
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_71
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: getValid
-            description: Get complex types that are polymorphic and have recursive references
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
@@ -5145,8 +5693,206 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
               - *ref_150
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpWithBodyRequest> 
+                path: /complex/polymorphism/missingrequired/invalid
+                method: put
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_72
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: putValidMissingRequired
+            description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
+        protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: polymorphism
+        description: ''
+    protocol: !<!Protocols> {}
+  - !<!OperationGroup> 
+    $key: polymorphicrecursive
+    operations:
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: '2016-02-29'
+        parameters:
+          - *ref_69
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpRequest> 
+                path: /complex/polymorphicrecursive/valid
+                method: get
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!SchemaResponse> 
+            schema: *ref_35
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_72
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: getValid
+            description: Get complex types that are polymorphic and have recursive references
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: '2016-02-29'
+        parameters:
+          - *ref_69
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_151
+                schema: *ref_35
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: complexBody
+                    description: |-
+                      Please put a salmon that looks like this:
+                      {
+                              'fishtype':'Salmon',
+                              'location':'alaska',
+                              'iswild':true,
+                              'species':'king',
+                              'length':1.0,
+                              'siblings':[
+                                {
+                                  'fishtype':'Shark',
+                                  'age':6,
+                                  'birthday': '2012-01-05T01:00:00Z',
+                                  'length':20.0,
+                                  'species':'predator',
+                                },
+                                {
+                                  'fishtype':'Sawshark',
+                                  'age':105,
+                                  'birthday': '1900-01-05T01:00:00Z',
+                                  'length':10.0,
+                                  'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                                  'species':'dangerous',
+                                },
+                                {
+                                  'fishtype': 'goblin',
+                                  'age': 1,
+                                  'birthday': '2015-08-08T00:00:00Z',
+                                  'length': 30.0,
+                                  'species': 'scary',
+                                  'jawsize': 5
+                                }
+                              ]
+                            };
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters:
+              - *ref_151
             language: !<!Languages> 
               default:
                 name: ''
@@ -5172,7 +5918,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5205,6 +5951,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5217,7 +5978,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_151
+            schema: *ref_152
             language: !<!Languages> 
               default:
                 name: ''
@@ -5231,7 +5992,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5257,8 +6018,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_152
-                schema: *ref_151
+              - !<!Parameter> &ref_153
+                schema: *ref_152
                 flattened: true
                 implementation: Method
                 required: true
@@ -5270,19 +6031,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_154
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_155
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_152
+                originalParameter: *ref_153
                 pathToProperty: []
-                targetProperty: *ref_153
+                targetProperty: *ref_154
                 language: !<!Languages> 
                   default:
                     name: size
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_154
+              - *ref_155
             language: !<!Languages> 
               default:
                 name: ''
@@ -5308,7 +6082,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5341,6 +6115,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-complex/grouped.yaml
+++ b/modelerfour/test/scenarios/body-complex/grouped.yaml
@@ -379,6 +379,16 @@ schemas: !<!Schemas>
           description: Colors possible
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_70
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_68
       type: constant
       value: !<!ConstantValue> 
@@ -526,7 +536,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_70
+    - !<!ObjectSchema> &ref_71
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -567,7 +577,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_71
+    - !<!ObjectSchema> &ref_72
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -599,13 +609,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_74
+    - !<!ObjectSchema> &ref_75
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_76
+        - !<!Property> &ref_77
           schema: *ref_6
           serializedName: field1
           language: !<!Languages> 
@@ -613,7 +623,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_77
+        - !<!Property> &ref_78
           schema: *ref_6
           serializedName: field2
           language: !<!Languages> 
@@ -632,13 +642,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_80
+    - !<!ObjectSchema> &ref_81
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_82
+        - !<!Property> &ref_83
           schema: *ref_8
           serializedName: field1
           language: !<!Languages> 
@@ -646,7 +656,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_83
+        - !<!Property> &ref_84
           schema: *ref_8
           serializedName: field2
           language: !<!Languages> 
@@ -665,13 +675,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_86
+    - !<!ObjectSchema> &ref_87
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_88
+        - !<!Property> &ref_89
           schema: *ref_9
           serializedName: field1
           language: !<!Languages> 
@@ -679,7 +689,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_89
+        - !<!Property> &ref_90
           schema: *ref_9
           serializedName: field2
           language: !<!Languages> 
@@ -698,13 +708,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_92
+    - !<!ObjectSchema> &ref_93
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_94
+        - !<!Property> &ref_95
           schema: *ref_10
           serializedName: field1
           language: !<!Languages> 
@@ -712,7 +722,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_95
+        - !<!Property> &ref_96
           schema: *ref_10
           serializedName: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
           language: !<!Languages> 
@@ -731,13 +741,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_98
+    - !<!ObjectSchema> &ref_99
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_100
+        - !<!Property> &ref_101
           schema: *ref_11
           serializedName: field_true
           language: !<!Languages> 
@@ -745,7 +755,7 @@ schemas: !<!Schemas>
               name: field_true
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_101
+        - !<!Property> &ref_102
           schema: *ref_11
           serializedName: field_false
           language: !<!Languages> 
@@ -764,7 +774,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_104
+    - !<!ObjectSchema> &ref_105
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -805,13 +815,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_106
+    - !<!ObjectSchema> &ref_107
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_108
+        - !<!Property> &ref_109
           schema: *ref_15
           serializedName: field
           language: !<!Languages> 
@@ -819,7 +829,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_109
+        - !<!Property> &ref_110
           schema: *ref_16
           serializedName: leap
           language: !<!Languages> 
@@ -838,13 +848,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_112
+    - !<!ObjectSchema> &ref_113
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_114
+        - !<!Property> &ref_115
           schema: *ref_17
           serializedName: field
           language: !<!Languages> 
@@ -852,7 +862,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_115
+        - !<!Property> &ref_116
           schema: *ref_18
           serializedName: now
           language: !<!Languages> 
@@ -871,13 +881,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_118
+    - !<!ObjectSchema> &ref_119
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_120
+        - !<!Property> &ref_121
           schema: *ref_19
           serializedName: field
           language: !<!Languages> 
@@ -885,7 +895,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_121
+        - !<!Property> &ref_122
           schema: *ref_20
           serializedName: now
           language: !<!Languages> 
@@ -904,13 +914,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_124
+    - !<!ObjectSchema> &ref_125
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_126
+        - !<!Property> &ref_127
           schema: *ref_21
           serializedName: field
           language: !<!Languages> 
@@ -929,13 +939,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_128
+    - !<!ObjectSchema> &ref_129
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_130
+        - !<!Property> &ref_131
           schema: *ref_22
           serializedName: field
           language: !<!Languages> 
@@ -954,13 +964,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_132
+    - !<!ObjectSchema> &ref_133
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_134
+        - !<!Property> &ref_135
           schema: !<!ArraySchema> &ref_63
             type: array
             apiVersions:
@@ -989,13 +999,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_138
+    - !<!ObjectSchema> &ref_139
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_140
+        - !<!Property> &ref_141
           schema: *ref_24
           serializedName: defaultProgram
           language: !<!Languages> 
@@ -1574,7 +1584,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_146
+    - !<!ObjectSchema> &ref_147
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1644,7 +1654,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_51
     - *ref_33
-    - !<!ObjectSchema> &ref_151
+    - !<!ObjectSchema> &ref_152
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1659,7 +1669,7 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_153
+        - !<!Property> &ref_154
           schema: *ref_6
           serializedName: size
           language: !<!Languages> 
@@ -1796,7 +1806,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_72
+  - !<!Parameter> &ref_73
     schema: *ref_68
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -1821,6 +1831,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1833,7 +1858,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1847,7 +1872,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1870,12 +1895,12 @@ operationGroups:
             version: '2016-02-29'
         parameters:
           - *ref_69
-          - *ref_72
+          - *ref_73
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_73
-                schema: *ref_70
+              - !<!Parameter> &ref_74
+                schema: *ref_71
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1886,8 +1911,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_73
+              - *ref_74
             language: !<!Languages> 
               default:
                 name: ''
@@ -1913,7 +1951,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1938,6 +1976,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1950,7 +2003,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1964,7 +2017,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1989,6 +2042,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2001,7 +2069,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2015,7 +2083,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2040,6 +2108,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2052,7 +2135,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2066,7 +2149,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2091,6 +2174,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2103,7 +2201,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2117,7 +2215,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2150,6 +2248,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2162,7 +2275,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_74
+            schema: *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -2176,7 +2289,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2202,8 +2315,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_75
-                schema: *ref_74
+              - !<!Parameter> &ref_76
+                schema: *ref_75
                 flattened: true
                 implementation: Method
                 required: true
@@ -2215,31 +2328,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_78
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_79
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_75
+                originalParameter: *ref_76
                 pathToProperty: []
-                targetProperty: *ref_76
+                targetProperty: *ref_77
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_79
+              - !<!VirtualParameter> &ref_80
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_75
+                originalParameter: *ref_76
                 pathToProperty: []
-                targetProperty: *ref_77
+                targetProperty: *ref_78
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_78
               - *ref_79
+              - *ref_80
             language: !<!Languages> 
               default:
                 name: ''
@@ -2265,7 +2391,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2290,6 +2416,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2302,7 +2443,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_80
+            schema: *ref_81
             language: !<!Languages> 
               default:
                 name: ''
@@ -2316,7 +2457,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2342,8 +2483,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_81
-                schema: *ref_80
+              - !<!Parameter> &ref_82
+                schema: *ref_81
                 flattened: true
                 implementation: Method
                 required: true
@@ -2355,31 +2496,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_84
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_85
                 schema: *ref_8
                 implementation: Method
-                originalParameter: *ref_81
+                originalParameter: *ref_82
                 pathToProperty: []
-                targetProperty: *ref_82
+                targetProperty: *ref_83
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_85
+              - !<!VirtualParameter> &ref_86
                 schema: *ref_8
                 implementation: Method
-                originalParameter: *ref_81
+                originalParameter: *ref_82
                 pathToProperty: []
-                targetProperty: *ref_83
+                targetProperty: *ref_84
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_84
               - *ref_85
+              - *ref_86
             language: !<!Languages> 
               default:
                 name: ''
@@ -2405,7 +2559,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2430,6 +2584,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2442,7 +2611,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_86
+            schema: *ref_87
             language: !<!Languages> 
               default:
                 name: ''
@@ -2456,7 +2625,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2482,8 +2651,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_87
-                schema: *ref_86
+              - !<!Parameter> &ref_88
+                schema: *ref_87
                 flattened: true
                 implementation: Method
                 required: true
@@ -2495,31 +2664,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_90
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_91
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_87
+                originalParameter: *ref_88
                 pathToProperty: []
-                targetProperty: *ref_88
+                targetProperty: *ref_89
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_91
+              - !<!VirtualParameter> &ref_92
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_87
+                originalParameter: *ref_88
                 pathToProperty: []
-                targetProperty: *ref_89
+                targetProperty: *ref_90
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_90
               - *ref_91
+              - *ref_92
             language: !<!Languages> 
               default:
                 name: ''
@@ -2545,7 +2727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2570,6 +2752,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2582,7 +2779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_92
+            schema: *ref_93
             language: !<!Languages> 
               default:
                 name: ''
@@ -2596,7 +2793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2622,8 +2819,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_93
-                schema: *ref_92
+              - !<!Parameter> &ref_94
+                schema: *ref_93
                 flattened: true
                 implementation: Method
                 required: true
@@ -2635,31 +2832,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_96
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_97
                 schema: *ref_10
                 implementation: Method
-                originalParameter: *ref_93
+                originalParameter: *ref_94
                 pathToProperty: []
-                targetProperty: *ref_94
+                targetProperty: *ref_95
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_97
+              - !<!VirtualParameter> &ref_98
                 schema: *ref_10
                 implementation: Method
-                originalParameter: *ref_93
+                originalParameter: *ref_94
                 pathToProperty: []
-                targetProperty: *ref_95
+                targetProperty: *ref_96
                 language: !<!Languages> 
                   default:
                     name: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_96
               - *ref_97
+              - *ref_98
             language: !<!Languages> 
               default:
                 name: ''
@@ -2685,7 +2895,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2710,6 +2920,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2722,7 +2947,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_98
+            schema: *ref_99
             language: !<!Languages> 
               default:
                 name: ''
@@ -2736,7 +2961,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2762,8 +2987,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_99
-                schema: *ref_98
+              - !<!Parameter> &ref_100
+                schema: *ref_99
                 flattened: true
                 implementation: Method
                 required: true
@@ -2775,31 +3000,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_102
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_103
                 schema: *ref_11
                 implementation: Method
-                originalParameter: *ref_99
+                originalParameter: *ref_100
                 pathToProperty: []
-                targetProperty: *ref_100
+                targetProperty: *ref_101
                 language: !<!Languages> 
                   default:
                     name: field_true
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_103
+              - !<!VirtualParameter> &ref_104
                 schema: *ref_11
                 implementation: Method
-                originalParameter: *ref_99
+                originalParameter: *ref_100
                 pathToProperty: []
-                targetProperty: *ref_101
+                targetProperty: *ref_102
                 language: !<!Languages> 
                   default:
                     name: field_false
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_102
               - *ref_103
+              - *ref_104
             language: !<!Languages> 
               default:
                 name: ''
@@ -2825,7 +3063,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2850,6 +3088,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2862,7 +3115,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_104
+            schema: *ref_105
             language: !<!Languages> 
               default:
                 name: ''
@@ -2876,7 +3129,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2902,8 +3155,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_105
-                schema: *ref_104
+              - !<!Parameter> &ref_106
+                schema: *ref_105
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2914,8 +3167,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_105
+              - *ref_106
             language: !<!Languages> 
               default:
                 name: ''
@@ -2941,7 +3207,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2966,6 +3232,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2978,7 +3259,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_106
+            schema: *ref_107
             language: !<!Languages> 
               default:
                 name: ''
@@ -2992,7 +3273,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3018,8 +3299,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_107
-                schema: *ref_106
+              - !<!Parameter> &ref_108
+                schema: *ref_107
                 flattened: true
                 implementation: Method
                 required: true
@@ -3031,31 +3312,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_110
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_111
                 schema: *ref_15
                 implementation: Method
-                originalParameter: *ref_107
+                originalParameter: *ref_108
                 pathToProperty: []
-                targetProperty: *ref_108
+                targetProperty: *ref_109
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_111
+              - !<!VirtualParameter> &ref_112
                 schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_107
+                originalParameter: *ref_108
                 pathToProperty: []
-                targetProperty: *ref_109
+                targetProperty: *ref_110
                 language: !<!Languages> 
                   default:
                     name: leap
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_110
               - *ref_111
+              - *ref_112
             language: !<!Languages> 
               default:
                 name: ''
@@ -3081,7 +3375,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3106,6 +3400,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3118,7 +3427,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_112
+            schema: *ref_113
             language: !<!Languages> 
               default:
                 name: ''
@@ -3132,7 +3441,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3158,8 +3467,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_113
-                schema: *ref_112
+              - !<!Parameter> &ref_114
+                schema: *ref_113
                 flattened: true
                 implementation: Method
                 required: true
@@ -3171,31 +3480,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_116
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_117
                 schema: *ref_17
                 implementation: Method
-                originalParameter: *ref_113
+                originalParameter: *ref_114
                 pathToProperty: []
-                targetProperty: *ref_114
+                targetProperty: *ref_115
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_117
+              - !<!VirtualParameter> &ref_118
                 schema: *ref_18
                 implementation: Method
-                originalParameter: *ref_113
+                originalParameter: *ref_114
                 pathToProperty: []
-                targetProperty: *ref_115
+                targetProperty: *ref_116
                 language: !<!Languages> 
                   default:
                     name: now
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_116
               - *ref_117
+              - *ref_118
             language: !<!Languages> 
               default:
                 name: ''
@@ -3221,7 +3543,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3246,6 +3568,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3258,7 +3595,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_118
+            schema: *ref_119
             language: !<!Languages> 
               default:
                 name: ''
@@ -3272,7 +3609,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3298,8 +3635,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_119
-                schema: *ref_118
+              - !<!Parameter> &ref_120
+                schema: *ref_119
                 flattened: true
                 implementation: Method
                 required: true
@@ -3311,31 +3648,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_122
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_123
                 schema: *ref_19
                 implementation: Method
-                originalParameter: *ref_119
+                originalParameter: *ref_120
                 pathToProperty: []
-                targetProperty: *ref_120
+                targetProperty: *ref_121
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_123
+              - !<!VirtualParameter> &ref_124
                 schema: *ref_20
                 implementation: Method
-                originalParameter: *ref_119
+                originalParameter: *ref_120
                 pathToProperty: []
-                targetProperty: *ref_121
+                targetProperty: *ref_122
                 language: !<!Languages> 
                   default:
                     name: now
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_122
               - *ref_123
+              - *ref_124
             language: !<!Languages> 
               default:
                 name: ''
@@ -3361,7 +3711,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3386,6 +3736,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3398,7 +3763,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_124
+            schema: *ref_125
             language: !<!Languages> 
               default:
                 name: ''
@@ -3412,7 +3777,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3438,8 +3803,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_125
-                schema: *ref_124
+              - !<!Parameter> &ref_126
+                schema: *ref_125
                 flattened: true
                 implementation: Method
                 required: true
@@ -3451,19 +3816,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_127
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_128
                 schema: *ref_21
                 implementation: Method
-                originalParameter: *ref_125
+                originalParameter: *ref_126
                 pathToProperty: []
-                targetProperty: *ref_126
+                targetProperty: *ref_127
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_127
+              - *ref_128
             language: !<!Languages> 
               default:
                 name: ''
@@ -3489,7 +3867,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3514,6 +3892,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3526,7 +3919,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_128
+            schema: *ref_129
             language: !<!Languages> 
               default:
                 name: ''
@@ -3540,7 +3933,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3566,8 +3959,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_129
-                schema: *ref_128
+              - !<!Parameter> &ref_130
+                schema: *ref_129
                 flattened: true
                 implementation: Method
                 required: true
@@ -3579,19 +3972,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_131
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_132
                 schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_129
+                originalParameter: *ref_130
                 pathToProperty: []
-                targetProperty: *ref_130
+                targetProperty: *ref_131
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_131
+              - *ref_132
             language: !<!Languages> 
               default:
                 name: ''
@@ -3617,7 +4023,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3650,6 +4056,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3662,7 +4083,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_132
+            schema: *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -3676,7 +4097,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3702,8 +4123,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_133
-                schema: *ref_132
+              - !<!Parameter> &ref_134
+                schema: *ref_133
                 flattened: true
                 implementation: Method
                 required: true
@@ -3715,19 +4136,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_135
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_136
                 schema: *ref_63
                 implementation: Method
-                originalParameter: *ref_133
+                originalParameter: *ref_134
                 pathToProperty: []
-                targetProperty: *ref_134
+                targetProperty: *ref_135
                 language: !<!Languages> 
                   default:
                     name: array
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_135
+              - *ref_136
             language: !<!Languages> 
               default:
                 name: ''
@@ -3753,7 +4187,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3778,6 +4212,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3790,7 +4239,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_132
+            schema: *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -3804,7 +4253,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3830,8 +4279,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_136
-                schema: *ref_132
+              - !<!Parameter> &ref_137
+                schema: *ref_133
                 flattened: true
                 implementation: Method
                 required: true
@@ -3843,19 +4292,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_137
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_138
                 schema: *ref_63
                 implementation: Method
-                originalParameter: *ref_136
+                originalParameter: *ref_137
                 pathToProperty: []
-                targetProperty: *ref_134
+                targetProperty: *ref_135
                 language: !<!Languages> 
                   default:
                     name: array
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_137
+              - *ref_138
             language: !<!Languages> 
               default:
                 name: ''
@@ -3881,7 +4343,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3906,6 +4368,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3918,7 +4395,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_132
+            schema: *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -3932,7 +4409,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3965,6 +4442,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3977,7 +4469,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_138
+            schema: *ref_139
             language: !<!Languages> 
               default:
                 name: ''
@@ -3991,7 +4483,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4017,8 +4509,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_139
-                schema: *ref_138
+              - !<!Parameter> &ref_140
+                schema: *ref_139
                 flattened: true
                 implementation: Method
                 required: true
@@ -4030,19 +4522,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_141
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_142
                 schema: *ref_24
                 implementation: Method
-                originalParameter: *ref_139
+                originalParameter: *ref_140
                 pathToProperty: []
-                targetProperty: *ref_140
+                targetProperty: *ref_141
                 language: !<!Languages> 
                   default:
                     name: defaultProgram
                     description: Dictionary of <string>
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_141
+              - *ref_142
             language: !<!Languages> 
               default:
                 name: ''
@@ -4068,7 +4573,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4093,6 +4598,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4105,7 +4625,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_138
+            schema: *ref_139
             language: !<!Languages> 
               default:
                 name: ''
@@ -4119,7 +4639,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4145,8 +4665,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_142
-                schema: *ref_138
+              - !<!Parameter> &ref_143
+                schema: *ref_139
                 flattened: true
                 implementation: Method
                 required: true
@@ -4158,19 +4678,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_143
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_144
                 schema: *ref_24
                 implementation: Method
-                originalParameter: *ref_142
+                originalParameter: *ref_143
                 pathToProperty: []
-                targetProperty: *ref_140
+                targetProperty: *ref_141
                 language: !<!Languages> 
                   default:
                     name: defaultProgram
                     description: Dictionary of <string>
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_143
+              - *ref_144
             language: !<!Languages> 
               default:
                 name: ''
@@ -4196,7 +4729,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4221,6 +4754,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4233,7 +4781,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_138
+            schema: *ref_139
             language: !<!Languages> 
               default:
                 name: ''
@@ -4247,7 +4795,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4272,6 +4820,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4284,7 +4847,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_138
+            schema: *ref_139
             language: !<!Languages> 
               default:
                 name: ''
@@ -4298,7 +4861,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4331,6 +4894,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4357,7 +4935,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4383,7 +4961,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_144
+              - !<!Parameter> &ref_145
                 schema: *ref_25
                 implementation: Method
                 required: true
@@ -4395,8 +4973,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_144
+              - *ref_145
             language: !<!Languages> 
               default:
                 name: ''
@@ -4422,7 +5013,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4455,6 +5046,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4481,7 +5087,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4507,7 +5113,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_145
+              - !<!Parameter> &ref_146
                 schema: *ref_35
                 implementation: Method
                 required: true
@@ -4552,8 +5158,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_145
+              - *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -4579,7 +5198,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4604,6 +5223,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4630,7 +5264,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4655,6 +5289,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4667,7 +5316,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_146
+            schema: *ref_147
             language: !<!Languages> 
               default:
                 name: ''
@@ -4681,7 +5330,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4706,6 +5355,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4718,7 +5382,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_146
+            schema: *ref_147
             language: !<!Languages> 
               default:
                 name: ''
@@ -4732,7 +5396,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4757,6 +5421,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4783,7 +5462,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4809,7 +5488,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_147
+              - !<!Parameter> &ref_148
                 schema: *ref_33
                 implementation: Method
                 required: true
@@ -4821,8 +5500,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_147
+              - *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -4848,7 +5540,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4874,7 +5566,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_148
+              - !<!Parameter> &ref_149
                 schema: *ref_33
                 implementation: Method
                 required: true
@@ -4886,8 +5578,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_148
+              - *ref_149
             language: !<!Languages> 
               default:
                 name: ''
@@ -4917,7 +5622,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4933,163 +5638,6 @@ operationGroups:
           default:
             name: putMissingDiscriminator
             description: 'Put complex types that are polymorphic, omitting the discriminator'
-        protocol: !<!Protocols> {}
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: '2016-02-29'
-        parameters:
-          - *ref_69
-        requests:
-          - !<!Request> 
-            parameters:
-              - !<!Parameter> &ref_149
-                schema: *ref_35
-                implementation: Method
-                required: true
-                language: !<!Languages> 
-                  default:
-                    name: complexBody
-                    description: |-
-                      Please put a salmon that looks like this:
-                      {
-                              'fishtype':'Salmon',
-                              'location':'alaska',
-                              'iswild':true,
-                              'species':'king',
-                              'length':1.0,
-                              'siblings':[
-                                {
-                                  'fishtype':'Shark',
-                                  'age':6,
-                                  'birthday': '2012-01-05T01:00:00Z',
-                                  'length':20.0,
-                                  'species':'predator',
-                                },
-                                {
-                                  'fishtype':'Sawshark',
-                                  'age':105,
-                                  'birthday': '1900-01-05T01:00:00Z',
-                                  'length':10.0,
-                                  'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-                                  'species':'dangerous',
-                                },
-                                {
-                                  'fishtype': 'goblin',
-                                  'age': 1,
-                                  'birthday': '2015-08-08T00:00:00Z',
-                                  'length': 30.0,
-                                  'species': 'scary',
-                                  'jawsize': 5
-                                }
-                              ]
-                            };
-                protocol: !<!Protocols> 
-                  http: !<!HttpParameter> 
-                    in: body
-                    style: json
-            signatureParameters:
-              - *ref_149
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpWithBodyRequest> 
-                path: /complex/polymorphism/missingrequired/invalid
-                method: put
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_71
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: putValidMissingRequired
-            description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
-        protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: polymorphism
-        description: ''
-    protocol: !<!Protocols> {}
-  - !<!OperationGroup> 
-    $key: polymorphicrecursive
-    operations:
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: '2016-02-29'
-        parameters:
-          - *ref_69
-        requests:
-          - !<!Request> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpRequest> 
-                path: /complex/polymorphicrecursive/valid
-                method: get
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!SchemaResponse> 
-            schema: *ref_35
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_71
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: getValid
-            description: Get complex types that are polymorphic and have recursive references
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
@@ -5145,8 +5693,206 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
               - *ref_150
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpWithBodyRequest> 
+                path: /complex/polymorphism/missingrequired/invalid
+                method: put
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_72
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: putValidMissingRequired
+            description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
+        protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: polymorphism
+        description: ''
+    protocol: !<!Protocols> {}
+  - !<!OperationGroup> 
+    $key: polymorphicrecursive
+    operations:
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: '2016-02-29'
+        parameters:
+          - *ref_69
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpRequest> 
+                path: /complex/polymorphicrecursive/valid
+                method: get
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!SchemaResponse> 
+            schema: *ref_35
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_72
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: getValid
+            description: Get complex types that are polymorphic and have recursive references
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: '2016-02-29'
+        parameters:
+          - *ref_69
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_151
+                schema: *ref_35
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: complexBody
+                    description: |-
+                      Please put a salmon that looks like this:
+                      {
+                              'fishtype':'Salmon',
+                              'location':'alaska',
+                              'iswild':true,
+                              'species':'king',
+                              'length':1.0,
+                              'siblings':[
+                                {
+                                  'fishtype':'Shark',
+                                  'age':6,
+                                  'birthday': '2012-01-05T01:00:00Z',
+                                  'length':20.0,
+                                  'species':'predator',
+                                },
+                                {
+                                  'fishtype':'Sawshark',
+                                  'age':105,
+                                  'birthday': '1900-01-05T01:00:00Z',
+                                  'length':10.0,
+                                  'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                                  'species':'dangerous',
+                                },
+                                {
+                                  'fishtype': 'goblin',
+                                  'age': 1,
+                                  'birthday': '2015-08-08T00:00:00Z',
+                                  'length': 30.0,
+                                  'species': 'scary',
+                                  'jawsize': 5
+                                }
+                              ]
+                            };
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters:
+              - *ref_151
             language: !<!Languages> 
               default:
                 name: ''
@@ -5172,7 +5918,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5205,6 +5951,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5217,7 +5978,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_151
+            schema: *ref_152
             language: !<!Languages> 
               default:
                 name: ''
@@ -5231,7 +5992,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5257,8 +6018,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_152
-                schema: *ref_151
+              - !<!Parameter> &ref_153
+                schema: *ref_152
                 flattened: true
                 implementation: Method
                 required: true
@@ -5270,19 +6031,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_154
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_155
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_152
+                originalParameter: *ref_153
                 pathToProperty: []
-                targetProperty: *ref_153
+                targetProperty: *ref_154
                 language: !<!Languages> 
                   default:
                     name: size
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_154
+              - *ref_155
             language: !<!Languages> 
               default:
                 name: ''
@@ -5308,7 +6082,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5341,6 +6115,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-complex/modeler.yaml
+++ b/modelerfour/test/scenarios/body-complex/modeler.yaml
@@ -379,7 +379,17 @@ schemas: !<!Schemas>
           description: Colors possible
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_72
+    - !<!ConstantSchema> &ref_69
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_73
       type: constant
       value: !<!ConstantValue> 
         value: '2016-02-29'
@@ -526,7 +536,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_69
+    - !<!ObjectSchema> &ref_70
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -567,7 +577,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_70
+    - !<!ObjectSchema> &ref_71
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -599,7 +609,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_74
+    - !<!ObjectSchema> &ref_75
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -632,7 +642,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_76
+    - !<!ObjectSchema> &ref_77
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -665,7 +675,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_78
+    - !<!ObjectSchema> &ref_79
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -698,7 +708,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_80
+    - !<!ObjectSchema> &ref_81
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -731,7 +741,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_82
+    - !<!ObjectSchema> &ref_83
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -764,7 +774,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_84
+    - !<!ObjectSchema> &ref_85
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -805,7 +815,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_86
+    - !<!ObjectSchema> &ref_87
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -838,7 +848,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_88
+    - !<!ObjectSchema> &ref_89
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -871,7 +881,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_90
+    - !<!ObjectSchema> &ref_91
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -904,7 +914,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_92
+    - !<!ObjectSchema> &ref_93
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -929,7 +939,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_94
+    - !<!ObjectSchema> &ref_95
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -954,7 +964,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_96
+    - !<!ObjectSchema> &ref_97
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -989,7 +999,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_99
+    - !<!ObjectSchema> &ref_100
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1574,7 +1584,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_104
+    - !<!ObjectSchema> &ref_105
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1644,7 +1654,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_39
     - *ref_27
-    - !<!ObjectSchema> &ref_109
+    - !<!ObjectSchema> &ref_110
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1803,7 +1813,7 @@ schemas: !<!Schemas>
     - *ref_65
     - *ref_66
 globalParameters:
-  - !<!Parameter> &ref_71
+  - !<!Parameter> &ref_72
     schema: *ref_1
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -1819,8 +1829,8 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_111
-    schema: *ref_72
+  - !<!Parameter> &ref_112
+    schema: *ref_73
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
     required: true
@@ -1841,9 +1851,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1856,7 +1881,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_69
+            schema: *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -1870,7 +1895,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1892,13 +1917,13 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
-          - *ref_111
+          - *ref_72
+          - *ref_112
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_73
-                schema: *ref_69
+              - !<!Parameter> &ref_74
+                schema: *ref_70
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1909,8 +1934,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_73
+              - *ref_74
             language: !<!Languages> 
               default:
                 name: ''
@@ -1936,7 +1974,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1958,9 +1996,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1973,7 +2026,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_69
+            schema: *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -1987,7 +2040,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2009,9 +2062,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2024,7 +2092,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_69
+            schema: *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -2038,7 +2106,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2060,9 +2128,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2075,7 +2158,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_69
+            schema: *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -2089,7 +2172,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2111,9 +2194,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2126,7 +2224,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_69
+            schema: *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -2140,7 +2238,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2170,9 +2268,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2185,7 +2298,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_74
+            schema: *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -2199,7 +2312,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2221,12 +2334,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_75
-                schema: *ref_74
+              - !<!Parameter> &ref_76
+                schema: *ref_75
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2237,8 +2350,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_75
+              - *ref_76
             language: !<!Languages> 
               default:
                 name: ''
@@ -2264,7 +2390,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2286,9 +2412,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2301,7 +2442,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_76
+            schema: *ref_77
             language: !<!Languages> 
               default:
                 name: ''
@@ -2315,7 +2456,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2337,12 +2478,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_77
-                schema: *ref_76
+              - !<!Parameter> &ref_78
+                schema: *ref_77
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2353,8 +2494,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_77
+              - *ref_78
             language: !<!Languages> 
               default:
                 name: ''
@@ -2380,7 +2534,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2402,9 +2556,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2417,7 +2586,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_78
+            schema: *ref_79
             language: !<!Languages> 
               default:
                 name: ''
@@ -2431,7 +2600,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2453,12 +2622,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_79
-                schema: *ref_78
+              - !<!Parameter> &ref_80
+                schema: *ref_79
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2469,8 +2638,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_79
+              - *ref_80
             language: !<!Languages> 
               default:
                 name: ''
@@ -2496,7 +2678,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2518,9 +2700,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2533,7 +2730,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_80
+            schema: *ref_81
             language: !<!Languages> 
               default:
                 name: ''
@@ -2547,7 +2744,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2569,12 +2766,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_81
-                schema: *ref_80
+              - !<!Parameter> &ref_82
+                schema: *ref_81
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2585,8 +2782,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_81
+              - *ref_82
             language: !<!Languages> 
               default:
                 name: ''
@@ -2612,7 +2822,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2634,9 +2844,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2649,7 +2874,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_82
+            schema: *ref_83
             language: !<!Languages> 
               default:
                 name: ''
@@ -2663,7 +2888,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2685,12 +2910,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_83
-                schema: *ref_82
+              - !<!Parameter> &ref_84
+                schema: *ref_83
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2701,8 +2926,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_83
+              - *ref_84
             language: !<!Languages> 
               default:
                 name: ''
@@ -2728,7 +2966,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2750,9 +2988,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2765,7 +3018,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_84
+            schema: *ref_85
             language: !<!Languages> 
               default:
                 name: ''
@@ -2779,7 +3032,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2801,12 +3054,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_85
-                schema: *ref_84
+              - !<!Parameter> &ref_86
+                schema: *ref_85
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2817,8 +3070,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_85
+              - *ref_86
             language: !<!Languages> 
               default:
                 name: ''
@@ -2844,7 +3110,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2866,9 +3132,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2881,7 +3162,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_86
+            schema: *ref_87
             language: !<!Languages> 
               default:
                 name: ''
@@ -2895,7 +3176,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2917,12 +3198,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_87
-                schema: *ref_86
+              - !<!Parameter> &ref_88
+                schema: *ref_87
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2933,8 +3214,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_87
+              - *ref_88
             language: !<!Languages> 
               default:
                 name: ''
@@ -2960,7 +3254,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2982,9 +3276,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2997,7 +3306,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_88
+            schema: *ref_89
             language: !<!Languages> 
               default:
                 name: ''
@@ -3011,7 +3320,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3033,12 +3342,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_89
-                schema: *ref_88
+              - !<!Parameter> &ref_90
+                schema: *ref_89
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3049,8 +3358,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_89
+              - *ref_90
             language: !<!Languages> 
               default:
                 name: ''
@@ -3076,7 +3398,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3098,9 +3420,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3113,7 +3450,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_90
+            schema: *ref_91
             language: !<!Languages> 
               default:
                 name: ''
@@ -3127,7 +3464,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3149,12 +3486,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_91
-                schema: *ref_90
+              - !<!Parameter> &ref_92
+                schema: *ref_91
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3165,8 +3502,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_91
+              - *ref_92
             language: !<!Languages> 
               default:
                 name: ''
@@ -3192,7 +3542,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3214,9 +3564,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3229,7 +3594,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_92
+            schema: *ref_93
             language: !<!Languages> 
               default:
                 name: ''
@@ -3243,7 +3608,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3265,12 +3630,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_93
-                schema: *ref_92
+              - !<!Parameter> &ref_94
+                schema: *ref_93
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3281,8 +3646,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_93
+              - *ref_94
             language: !<!Languages> 
               default:
                 name: ''
@@ -3308,7 +3686,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3330,9 +3708,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3345,7 +3738,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_94
+            schema: *ref_95
             language: !<!Languages> 
               default:
                 name: ''
@@ -3359,7 +3752,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3381,12 +3774,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_95
-                schema: *ref_94
+              - !<!Parameter> &ref_96
+                schema: *ref_95
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3397,8 +3790,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_95
+              - *ref_96
             language: !<!Languages> 
               default:
                 name: ''
@@ -3424,7 +3830,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3454,9 +3860,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3469,7 +3890,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_96
+            schema: *ref_97
             language: !<!Languages> 
               default:
                 name: ''
@@ -3483,7 +3904,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3505,12 +3926,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_97
-                schema: *ref_96
+              - !<!Parameter> &ref_98
+                schema: *ref_97
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3521,8 +3942,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_97
+              - *ref_98
             language: !<!Languages> 
               default:
                 name: ''
@@ -3548,7 +3982,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3570,9 +4004,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3585,7 +4034,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_96
+            schema: *ref_97
             language: !<!Languages> 
               default:
                 name: ''
@@ -3599,7 +4048,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3621,12 +4070,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_98
-                schema: *ref_96
+              - !<!Parameter> &ref_99
+                schema: *ref_97
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3637,8 +4086,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_98
+              - *ref_99
             language: !<!Languages> 
               default:
                 name: ''
@@ -3664,7 +4126,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3686,9 +4148,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3701,7 +4178,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_96
+            schema: *ref_97
             language: !<!Languages> 
               default:
                 name: ''
@@ -3715,7 +4192,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3745,9 +4222,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3760,7 +4252,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_100
             language: !<!Languages> 
               default:
                 name: ''
@@ -3774,7 +4266,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3796,12 +4288,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_100
-                schema: *ref_99
+              - !<!Parameter> &ref_101
+                schema: *ref_100
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3812,8 +4304,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_100
+              - *ref_101
             language: !<!Languages> 
               default:
                 name: ''
@@ -3839,7 +4344,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3861,9 +4366,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3876,7 +4396,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_100
             language: !<!Languages> 
               default:
                 name: ''
@@ -3890,7 +4410,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3912,12 +4432,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_101
-                schema: *ref_99
+              - !<!Parameter> &ref_102
+                schema: *ref_100
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3928,8 +4448,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_101
+              - *ref_102
             language: !<!Languages> 
               default:
                 name: ''
@@ -3955,7 +4488,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -3977,9 +4510,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3992,7 +4540,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_100
             language: !<!Languages> 
               default:
                 name: ''
@@ -4006,7 +4554,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4028,9 +4576,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4043,7 +4606,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_99
+            schema: *ref_100
             language: !<!Languages> 
               default:
                 name: ''
@@ -4057,7 +4620,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4087,9 +4650,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4116,7 +4694,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4138,11 +4716,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_102
+              - !<!Parameter> &ref_103
                 schema: *ref_19
                 implementation: Method
                 required: true
@@ -4154,8 +4732,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_102
+              - *ref_103
             language: !<!Languages> 
               default:
                 name: ''
@@ -4181,7 +4772,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4211,9 +4802,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4240,7 +4846,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4262,11 +4868,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_103
+              - !<!Parameter> &ref_104
                 schema: *ref_23
                 implementation: Method
                 required: true
@@ -4311,8 +4917,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_103
+              - *ref_104
             language: !<!Languages> 
               default:
                 name: ''
@@ -4338,7 +4957,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4360,9 +4979,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4389,7 +5023,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4411,9 +5045,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4426,7 +5075,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_104
+            schema: *ref_105
             language: !<!Languages> 
               default:
                 name: ''
@@ -4440,7 +5089,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4462,9 +5111,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4477,7 +5141,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_104
+            schema: *ref_105
             language: !<!Languages> 
               default:
                 name: ''
@@ -4491,7 +5155,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4513,9 +5177,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4542,7 +5221,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4564,11 +5243,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_105
+              - !<!Parameter> &ref_106
                 schema: *ref_27
                 implementation: Method
                 required: true
@@ -4580,8 +5259,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_105
+              - *ref_106
             language: !<!Languages> 
               default:
                 name: ''
@@ -4607,7 +5299,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4629,11 +5321,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_106
+              - !<!Parameter> &ref_107
                 schema: *ref_27
                 implementation: Method
                 required: true
@@ -4645,8 +5337,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_106
+              - *ref_107
             language: !<!Languages> 
               default:
                 name: ''
@@ -4676,7 +5381,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4698,164 +5403,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
-        requests:
-          - !<!Request> 
-            parameters:
-              - !<!Parameter> &ref_107
-                schema: *ref_23
-                implementation: Method
-                required: true
-                language: !<!Languages> 
-                  default:
-                    name: complexBody
-                    description: |-
-                      Please put a salmon that looks like this:
-                      {
-                              'fishtype':'Salmon',
-                              'location':'alaska',
-                              'iswild':true,
-                              'species':'king',
-                              'length':1.0,
-                              'siblings':[
-                                {
-                                  'fishtype':'Shark',
-                                  'age':6,
-                                  'birthday': '2012-01-05T01:00:00Z',
-                                  'length':20.0,
-                                  'species':'predator',
-                                },
-                                {
-                                  'fishtype':'Sawshark',
-                                  'age':105,
-                                  'birthday': '1900-01-05T01:00:00Z',
-                                  'length':10.0,
-                                  'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-                                  'species':'dangerous',
-                                },
-                                {
-                                  'fishtype': 'goblin',
-                                  'age': 1,
-                                  'birthday': '2015-08-08T00:00:00Z',
-                                  'length': 30.0,
-                                  'species': 'scary',
-                                  'jawsize': 5
-                                }
-                              ]
-                            };
-                protocol: !<!Protocols> 
-                  http: !<!HttpParameter> 
-                    in: body
-                    style: json
-            signatureParameters:
-              - *ref_107
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpWithBodyRequest> 
-                path: /complex/polymorphism/missingrequired/invalid
-                method: put
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_70
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: putValidMissingRequired
-            description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
-        protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: polymorphism
-        description: ''
-    protocol: !<!Protocols> {}
-  - !<!OperationGroup> 
-    $key: polymorphicrecursive
-    operations:
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: '2016-02-29'
-        parameters:
-          - *ref_71
-        requests:
-          - !<!Request> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpRequest> 
-                path: /complex/polymorphicrecursive/valid
-                method: get
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!SchemaResponse> 
-            schema: *ref_23
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_70
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: getValid
-            description: Get complex types that are polymorphic and have recursive references
-        protocol: !<!Protocols> {}
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: '2016-02-29'
-        parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
@@ -4904,8 +5452,206 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
               - *ref_108
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpWithBodyRequest> 
+                path: /complex/polymorphism/missingrequired/invalid
+                method: put
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_71
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: putValidMissingRequired
+            description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
+        protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: polymorphism
+        description: ''
+    protocol: !<!Protocols> {}
+  - !<!OperationGroup> 
+    $key: polymorphicrecursive
+    operations:
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: '2016-02-29'
+        parameters:
+          - *ref_72
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpRequest> 
+                path: /complex/polymorphicrecursive/valid
+                method: get
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!SchemaResponse> 
+            schema: *ref_23
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_71
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: getValid
+            description: Get complex types that are polymorphic and have recursive references
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: '2016-02-29'
+        parameters:
+          - *ref_72
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_109
+                schema: *ref_23
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: complexBody
+                    description: |-
+                      Please put a salmon that looks like this:
+                      {
+                              'fishtype':'Salmon',
+                              'location':'alaska',
+                              'iswild':true,
+                              'species':'king',
+                              'length':1.0,
+                              'siblings':[
+                                {
+                                  'fishtype':'Shark',
+                                  'age':6,
+                                  'birthday': '2012-01-05T01:00:00Z',
+                                  'length':20.0,
+                                  'species':'predator',
+                                },
+                                {
+                                  'fishtype':'Sawshark',
+                                  'age':105,
+                                  'birthday': '1900-01-05T01:00:00Z',
+                                  'length':10.0,
+                                  'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                                  'species':'dangerous',
+                                },
+                                {
+                                  'fishtype': 'goblin',
+                                  'age': 1,
+                                  'birthday': '2015-08-08T00:00:00Z',
+                                  'length': 30.0,
+                                  'species': 'scary',
+                                  'jawsize': 5
+                                }
+                              ]
+                            };
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters:
+              - *ref_109
             language: !<!Languages> 
               default:
                 name: ''
@@ -4931,7 +5677,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -4961,9 +5707,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4976,7 +5737,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_109
+            schema: *ref_110
             language: !<!Languages> 
               default:
                 name: ''
@@ -4990,7 +5751,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -5012,12 +5773,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_110
-                schema: *ref_109
+              - !<!Parameter> &ref_111
+                schema: *ref_110
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -5028,8 +5789,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_110
+              - *ref_111
             language: !<!Languages> 
               default:
                 name: ''
@@ -5055,7 +5829,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -5085,9 +5859,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-02-29'
         parameters:
-          - *ref_71
+          - *ref_72
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_69
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-complex/namer.yaml
+++ b/modelerfour/test/scenarios/body-complex/namer.yaml
@@ -379,6 +379,16 @@ schemas: !<!Schemas>
           description: Colors possible
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_70
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_68
       type: constant
       value: !<!ConstantValue> 
@@ -526,7 +536,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_70
+    - !<!ObjectSchema> &ref_71
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -567,7 +577,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_71
+    - !<!ObjectSchema> &ref_72
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -599,13 +609,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_74
+    - !<!ObjectSchema> &ref_75
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_76
+        - !<!Property> &ref_77
           schema: *ref_6
           serializedName: field1
           language: !<!Languages> 
@@ -613,7 +623,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_77
+        - !<!Property> &ref_78
           schema: *ref_6
           serializedName: field2
           language: !<!Languages> 
@@ -632,13 +642,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_80
+    - !<!ObjectSchema> &ref_81
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_82
+        - !<!Property> &ref_83
           schema: *ref_8
           serializedName: field1
           language: !<!Languages> 
@@ -646,7 +656,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_83
+        - !<!Property> &ref_84
           schema: *ref_8
           serializedName: field2
           language: !<!Languages> 
@@ -665,13 +675,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_86
+    - !<!ObjectSchema> &ref_87
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_88
+        - !<!Property> &ref_89
           schema: *ref_9
           serializedName: field1
           language: !<!Languages> 
@@ -679,7 +689,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_89
+        - !<!Property> &ref_90
           schema: *ref_9
           serializedName: field2
           language: !<!Languages> 
@@ -698,13 +708,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_92
+    - !<!ObjectSchema> &ref_93
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_94
+        - !<!Property> &ref_95
           schema: *ref_10
           serializedName: field1
           language: !<!Languages> 
@@ -712,7 +722,7 @@ schemas: !<!Schemas>
               name: field1
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_95
+        - !<!Property> &ref_96
           schema: *ref_10
           serializedName: field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
           language: !<!Languages> 
@@ -731,13 +741,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_98
+    - !<!ObjectSchema> &ref_99
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_100
+        - !<!Property> &ref_101
           schema: *ref_11
           serializedName: field_true
           language: !<!Languages> 
@@ -745,7 +755,7 @@ schemas: !<!Schemas>
               name: fieldTrue
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_101
+        - !<!Property> &ref_102
           schema: *ref_11
           serializedName: field_false
           language: !<!Languages> 
@@ -764,7 +774,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_104
+    - !<!ObjectSchema> &ref_105
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -805,13 +815,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_106
+    - !<!ObjectSchema> &ref_107
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_108
+        - !<!Property> &ref_109
           schema: *ref_15
           serializedName: field
           language: !<!Languages> 
@@ -819,7 +829,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_109
+        - !<!Property> &ref_110
           schema: *ref_16
           serializedName: leap
           language: !<!Languages> 
@@ -838,13 +848,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_112
+    - !<!ObjectSchema> &ref_113
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_114
+        - !<!Property> &ref_115
           schema: *ref_17
           serializedName: field
           language: !<!Languages> 
@@ -852,7 +862,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_115
+        - !<!Property> &ref_116
           schema: *ref_18
           serializedName: now
           language: !<!Languages> 
@@ -871,13 +881,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_118
+    - !<!ObjectSchema> &ref_119
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_120
+        - !<!Property> &ref_121
           schema: *ref_19
           serializedName: field
           language: !<!Languages> 
@@ -885,7 +895,7 @@ schemas: !<!Schemas>
               name: field
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_121
+        - !<!Property> &ref_122
           schema: *ref_20
           serializedName: now
           language: !<!Languages> 
@@ -904,13 +914,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_124
+    - !<!ObjectSchema> &ref_125
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_126
+        - !<!Property> &ref_127
           schema: *ref_21
           serializedName: field
           language: !<!Languages> 
@@ -929,13 +939,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_128
+    - !<!ObjectSchema> &ref_129
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_130
+        - !<!Property> &ref_131
           schema: *ref_22
           serializedName: field
           language: !<!Languages> 
@@ -954,13 +964,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_132
+    - !<!ObjectSchema> &ref_133
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_134
+        - !<!Property> &ref_135
           schema: !<!ArraySchema> &ref_63
             type: array
             apiVersions:
@@ -989,13 +999,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_138
+    - !<!ObjectSchema> &ref_139
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2016-02-29'
       properties:
-        - !<!Property> &ref_140
+        - !<!Property> &ref_141
           schema: *ref_24
           serializedName: defaultProgram
           language: !<!Languages> 
@@ -1574,7 +1584,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_146
+    - !<!ObjectSchema> &ref_147
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1644,7 +1654,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_51
     - *ref_33
-    - !<!ObjectSchema> &ref_151
+    - !<!ObjectSchema> &ref_152
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1659,7 +1669,7 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_153
+        - !<!Property> &ref_154
           schema: *ref_6
           serializedName: size
           language: !<!Languages> 
@@ -1796,7 +1806,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_72
+  - !<!Parameter> &ref_73
     schema: *ref_68
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -1821,6 +1831,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1833,7 +1858,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1847,7 +1872,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1870,12 +1895,12 @@ operationGroups:
             version: '2016-02-29'
         parameters:
           - *ref_69
-          - *ref_72
+          - *ref_73
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_73
-                schema: *ref_70
+              - !<!Parameter> &ref_74
+                schema: *ref_71
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1886,8 +1911,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_73
+              - *ref_74
             language: !<!Languages> 
               default:
                 name: ''
@@ -1913,7 +1951,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1938,6 +1976,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1950,7 +2003,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -1964,7 +2017,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -1989,6 +2042,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2001,7 +2069,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2015,7 +2083,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2040,6 +2108,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2052,7 +2135,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2066,7 +2149,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2091,6 +2174,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2103,7 +2201,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_70
+            schema: *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -2117,7 +2215,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2150,6 +2248,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2162,7 +2275,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_74
+            schema: *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -2176,7 +2289,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2202,8 +2315,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_75
-                schema: *ref_74
+              - !<!Parameter> &ref_76
+                schema: *ref_75
                 flattened: true
                 implementation: Method
                 required: true
@@ -2215,31 +2328,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_78
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_79
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_75
+                originalParameter: *ref_76
                 pathToProperty: []
-                targetProperty: *ref_76
+                targetProperty: *ref_77
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_79
+              - !<!VirtualParameter> &ref_80
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_75
+                originalParameter: *ref_76
                 pathToProperty: []
-                targetProperty: *ref_77
+                targetProperty: *ref_78
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_78
               - *ref_79
+              - *ref_80
             language: !<!Languages> 
               default:
                 name: ''
@@ -2265,7 +2391,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2290,6 +2416,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2302,7 +2443,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_80
+            schema: *ref_81
             language: !<!Languages> 
               default:
                 name: ''
@@ -2316,7 +2457,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2342,8 +2483,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_81
-                schema: *ref_80
+              - !<!Parameter> &ref_82
+                schema: *ref_81
                 flattened: true
                 implementation: Method
                 required: true
@@ -2355,31 +2496,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_84
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_85
                 schema: *ref_8
                 implementation: Method
-                originalParameter: *ref_81
+                originalParameter: *ref_82
                 pathToProperty: []
-                targetProperty: *ref_82
+                targetProperty: *ref_83
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_85
+              - !<!VirtualParameter> &ref_86
                 schema: *ref_8
                 implementation: Method
-                originalParameter: *ref_81
+                originalParameter: *ref_82
                 pathToProperty: []
-                targetProperty: *ref_83
+                targetProperty: *ref_84
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_84
               - *ref_85
+              - *ref_86
             language: !<!Languages> 
               default:
                 name: ''
@@ -2405,7 +2559,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2430,6 +2584,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2442,7 +2611,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_86
+            schema: *ref_87
             language: !<!Languages> 
               default:
                 name: ''
@@ -2456,7 +2625,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2482,8 +2651,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_87
-                schema: *ref_86
+              - !<!Parameter> &ref_88
+                schema: *ref_87
                 flattened: true
                 implementation: Method
                 required: true
@@ -2495,31 +2664,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_90
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_91
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_87
+                originalParameter: *ref_88
                 pathToProperty: []
-                targetProperty: *ref_88
+                targetProperty: *ref_89
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_91
+              - !<!VirtualParameter> &ref_92
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_87
+                originalParameter: *ref_88
                 pathToProperty: []
-                targetProperty: *ref_89
+                targetProperty: *ref_90
                 language: !<!Languages> 
                   default:
                     name: field2
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_90
               - *ref_91
+              - *ref_92
             language: !<!Languages> 
               default:
                 name: ''
@@ -2545,7 +2727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2570,6 +2752,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2582,7 +2779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_92
+            schema: *ref_93
             language: !<!Languages> 
               default:
                 name: ''
@@ -2596,7 +2793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2622,8 +2819,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_93
-                schema: *ref_92
+              - !<!Parameter> &ref_94
+                schema: *ref_93
                 flattened: true
                 implementation: Method
                 required: true
@@ -2635,31 +2832,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_96
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_97
                 schema: *ref_10
                 implementation: Method
-                originalParameter: *ref_93
+                originalParameter: *ref_94
                 pathToProperty: []
-                targetProperty: *ref_94
+                targetProperty: *ref_95
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_97
+              - !<!VirtualParameter> &ref_98
                 schema: *ref_10
                 implementation: Method
-                originalParameter: *ref_93
+                originalParameter: *ref_94
                 pathToProperty: []
-                targetProperty: *ref_95
+                targetProperty: *ref_96
                 language: !<!Languages> 
                   default:
                     name: field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_96
               - *ref_97
+              - *ref_98
             language: !<!Languages> 
               default:
                 name: ''
@@ -2685,7 +2895,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2710,6 +2920,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2722,7 +2947,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_98
+            schema: *ref_99
             language: !<!Languages> 
               default:
                 name: ''
@@ -2736,7 +2961,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2762,8 +2987,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_99
-                schema: *ref_98
+              - !<!Parameter> &ref_100
+                schema: *ref_99
                 flattened: true
                 implementation: Method
                 required: true
@@ -2775,31 +3000,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_102
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_103
                 schema: *ref_11
                 implementation: Method
-                originalParameter: *ref_99
+                originalParameter: *ref_100
                 pathToProperty: []
-                targetProperty: *ref_100
+                targetProperty: *ref_101
                 language: !<!Languages> 
                   default:
                     name: fieldTrue
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_103
+              - !<!VirtualParameter> &ref_104
                 schema: *ref_11
                 implementation: Method
-                originalParameter: *ref_99
+                originalParameter: *ref_100
                 pathToProperty: []
-                targetProperty: *ref_101
+                targetProperty: *ref_102
                 language: !<!Languages> 
                   default:
                     name: fieldFalse
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_102
               - *ref_103
+              - *ref_104
             language: !<!Languages> 
               default:
                 name: ''
@@ -2825,7 +3063,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2850,6 +3088,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2862,7 +3115,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_104
+            schema: *ref_105
             language: !<!Languages> 
               default:
                 name: ''
@@ -2876,7 +3129,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2902,8 +3155,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_105
-                schema: *ref_104
+              - !<!Parameter> &ref_106
+                schema: *ref_105
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2914,8 +3167,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_105
+              - *ref_106
             language: !<!Languages> 
               default:
                 name: ''
@@ -2941,7 +3207,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2966,6 +3232,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2978,7 +3259,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_106
+            schema: *ref_107
             language: !<!Languages> 
               default:
                 name: ''
@@ -2992,7 +3273,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3018,8 +3299,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_107
-                schema: *ref_106
+              - !<!Parameter> &ref_108
+                schema: *ref_107
                 flattened: true
                 implementation: Method
                 required: true
@@ -3031,31 +3312,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_110
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_111
                 schema: *ref_15
                 implementation: Method
-                originalParameter: *ref_107
+                originalParameter: *ref_108
                 pathToProperty: []
-                targetProperty: *ref_108
+                targetProperty: *ref_109
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_111
+              - !<!VirtualParameter> &ref_112
                 schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_107
+                originalParameter: *ref_108
                 pathToProperty: []
-                targetProperty: *ref_109
+                targetProperty: *ref_110
                 language: !<!Languages> 
                   default:
                     name: leap
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_110
               - *ref_111
+              - *ref_112
             language: !<!Languages> 
               default:
                 name: ''
@@ -3081,7 +3375,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3106,6 +3400,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3118,7 +3427,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_112
+            schema: *ref_113
             language: !<!Languages> 
               default:
                 name: ''
@@ -3132,7 +3441,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3158,8 +3467,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_113
-                schema: *ref_112
+              - !<!Parameter> &ref_114
+                schema: *ref_113
                 flattened: true
                 implementation: Method
                 required: true
@@ -3171,31 +3480,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_116
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_117
                 schema: *ref_17
                 implementation: Method
-                originalParameter: *ref_113
+                originalParameter: *ref_114
                 pathToProperty: []
-                targetProperty: *ref_114
+                targetProperty: *ref_115
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_117
+              - !<!VirtualParameter> &ref_118
                 schema: *ref_18
                 implementation: Method
-                originalParameter: *ref_113
+                originalParameter: *ref_114
                 pathToProperty: []
-                targetProperty: *ref_115
+                targetProperty: *ref_116
                 language: !<!Languages> 
                   default:
                     name: now
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_116
               - *ref_117
+              - *ref_118
             language: !<!Languages> 
               default:
                 name: ''
@@ -3221,7 +3543,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3246,6 +3568,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3258,7 +3595,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_118
+            schema: *ref_119
             language: !<!Languages> 
               default:
                 name: ''
@@ -3272,7 +3609,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3298,8 +3635,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_119
-                schema: *ref_118
+              - !<!Parameter> &ref_120
+                schema: *ref_119
                 flattened: true
                 implementation: Method
                 required: true
@@ -3311,31 +3648,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_122
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_123
                 schema: *ref_19
                 implementation: Method
-                originalParameter: *ref_119
+                originalParameter: *ref_120
                 pathToProperty: []
-                targetProperty: *ref_120
+                targetProperty: *ref_121
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_123
+              - !<!VirtualParameter> &ref_124
                 schema: *ref_20
                 implementation: Method
-                originalParameter: *ref_119
+                originalParameter: *ref_120
                 pathToProperty: []
-                targetProperty: *ref_121
+                targetProperty: *ref_122
                 language: !<!Languages> 
                   default:
                     name: now
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_122
               - *ref_123
+              - *ref_124
             language: !<!Languages> 
               default:
                 name: ''
@@ -3361,7 +3711,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3386,6 +3736,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3398,7 +3763,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_124
+            schema: *ref_125
             language: !<!Languages> 
               default:
                 name: ''
@@ -3412,7 +3777,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3438,8 +3803,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_125
-                schema: *ref_124
+              - !<!Parameter> &ref_126
+                schema: *ref_125
                 flattened: true
                 implementation: Method
                 required: true
@@ -3451,19 +3816,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_127
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_128
                 schema: *ref_21
                 implementation: Method
-                originalParameter: *ref_125
+                originalParameter: *ref_126
                 pathToProperty: []
-                targetProperty: *ref_126
+                targetProperty: *ref_127
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_127
+              - *ref_128
             language: !<!Languages> 
               default:
                 name: ''
@@ -3489,7 +3867,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3514,6 +3892,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3526,7 +3919,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_128
+            schema: *ref_129
             language: !<!Languages> 
               default:
                 name: ''
@@ -3540,7 +3933,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3566,8 +3959,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_129
-                schema: *ref_128
+              - !<!Parameter> &ref_130
+                schema: *ref_129
                 flattened: true
                 implementation: Method
                 required: true
@@ -3579,19 +3972,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_131
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_132
                 schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_129
+                originalParameter: *ref_130
                 pathToProperty: []
-                targetProperty: *ref_130
+                targetProperty: *ref_131
                 language: !<!Languages> 
                   default:
                     name: field
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_131
+              - *ref_132
             language: !<!Languages> 
               default:
                 name: ''
@@ -3617,7 +4023,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3650,6 +4056,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3662,7 +4083,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_132
+            schema: *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -3676,7 +4097,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3702,8 +4123,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_133
-                schema: *ref_132
+              - !<!Parameter> &ref_134
+                schema: *ref_133
                 flattened: true
                 implementation: Method
                 required: true
@@ -3715,19 +4136,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_135
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_136
                 schema: *ref_63
                 implementation: Method
-                originalParameter: *ref_133
+                originalParameter: *ref_134
                 pathToProperty: []
-                targetProperty: *ref_134
+                targetProperty: *ref_135
                 language: !<!Languages> 
                   default:
                     name: array
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_135
+              - *ref_136
             language: !<!Languages> 
               default:
                 name: ''
@@ -3753,7 +4187,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3778,6 +4212,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3790,7 +4239,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_132
+            schema: *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -3804,7 +4253,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3830,8 +4279,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_136
-                schema: *ref_132
+              - !<!Parameter> &ref_137
+                schema: *ref_133
                 flattened: true
                 implementation: Method
                 required: true
@@ -3843,19 +4292,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_137
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_138
                 schema: *ref_63
                 implementation: Method
-                originalParameter: *ref_136
+                originalParameter: *ref_137
                 pathToProperty: []
-                targetProperty: *ref_134
+                targetProperty: *ref_135
                 language: !<!Languages> 
                   default:
                     name: array
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_137
+              - *ref_138
             language: !<!Languages> 
               default:
                 name: ''
@@ -3881,7 +4343,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3906,6 +4368,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3918,7 +4395,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_132
+            schema: *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -3932,7 +4409,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -3965,6 +4442,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3977,7 +4469,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_138
+            schema: *ref_139
             language: !<!Languages> 
               default:
                 name: ''
@@ -3991,7 +4483,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4017,8 +4509,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_139
-                schema: *ref_138
+              - !<!Parameter> &ref_140
+                schema: *ref_139
                 flattened: true
                 implementation: Method
                 required: true
@@ -4030,19 +4522,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_141
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_142
                 schema: *ref_24
                 implementation: Method
-                originalParameter: *ref_139
+                originalParameter: *ref_140
                 pathToProperty: []
-                targetProperty: *ref_140
+                targetProperty: *ref_141
                 language: !<!Languages> 
                   default:
                     name: defaultProgram
                     description: Dictionary of <string>
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_141
+              - *ref_142
             language: !<!Languages> 
               default:
                 name: ''
@@ -4068,7 +4573,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4093,6 +4598,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4105,7 +4625,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_138
+            schema: *ref_139
             language: !<!Languages> 
               default:
                 name: ''
@@ -4119,7 +4639,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4145,8 +4665,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_142
-                schema: *ref_138
+              - !<!Parameter> &ref_143
+                schema: *ref_139
                 flattened: true
                 implementation: Method
                 required: true
@@ -4158,19 +4678,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_143
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_144
                 schema: *ref_24
                 implementation: Method
-                originalParameter: *ref_142
+                originalParameter: *ref_143
                 pathToProperty: []
-                targetProperty: *ref_140
+                targetProperty: *ref_141
                 language: !<!Languages> 
                   default:
                     name: defaultProgram
                     description: Dictionary of <string>
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_143
+              - *ref_144
             language: !<!Languages> 
               default:
                 name: ''
@@ -4196,7 +4729,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4221,6 +4754,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4233,7 +4781,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_138
+            schema: *ref_139
             language: !<!Languages> 
               default:
                 name: ''
@@ -4247,7 +4795,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4272,6 +4820,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4284,7 +4847,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_138
+            schema: *ref_139
             language: !<!Languages> 
               default:
                 name: ''
@@ -4298,7 +4861,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4331,6 +4894,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4357,7 +4935,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4383,7 +4961,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_144
+              - !<!Parameter> &ref_145
                 schema: *ref_25
                 implementation: Method
                 required: true
@@ -4395,8 +4973,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_144
+              - *ref_145
             language: !<!Languages> 
               default:
                 name: ''
@@ -4422,7 +5013,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4455,6 +5046,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4481,7 +5087,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4507,7 +5113,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_145
+              - !<!Parameter> &ref_146
                 schema: *ref_35
                 implementation: Method
                 required: true
@@ -4552,8 +5158,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_145
+              - *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -4579,7 +5198,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4604,6 +5223,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4630,7 +5264,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4655,6 +5289,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4667,7 +5316,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_146
+            schema: *ref_147
             language: !<!Languages> 
               default:
                 name: ''
@@ -4681,7 +5330,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4706,6 +5355,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4718,7 +5382,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_146
+            schema: *ref_147
             language: !<!Languages> 
               default:
                 name: ''
@@ -4732,7 +5396,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4757,6 +5421,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4783,7 +5462,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4809,7 +5488,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_147
+              - !<!Parameter> &ref_148
                 schema: *ref_33
                 implementation: Method
                 required: true
@@ -4821,8 +5500,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_147
+              - *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -4848,7 +5540,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4874,7 +5566,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_148
+              - !<!Parameter> &ref_149
                 schema: *ref_33
                 implementation: Method
                 required: true
@@ -4886,8 +5578,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_148
+              - *ref_149
             language: !<!Languages> 
               default:
                 name: ''
@@ -4917,7 +5622,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -4933,163 +5638,6 @@ operationGroups:
           default:
             name: PutMissingDiscriminator
             description: 'Put complex types that are polymorphic, omitting the discriminator'
-        protocol: !<!Protocols> {}
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: '2016-02-29'
-        parameters:
-          - *ref_69
-        requests:
-          - !<!Request> 
-            parameters:
-              - !<!Parameter> &ref_149
-                schema: *ref_35
-                implementation: Method
-                required: true
-                language: !<!Languages> 
-                  default:
-                    name: complexBody
-                    description: |-
-                      Please put a salmon that looks like this:
-                      {
-                              'fishtype':'Salmon',
-                              'location':'alaska',
-                              'iswild':true,
-                              'species':'king',
-                              'length':1.0,
-                              'siblings':[
-                                {
-                                  'fishtype':'Shark',
-                                  'age':6,
-                                  'birthday': '2012-01-05T01:00:00Z',
-                                  'length':20.0,
-                                  'species':'predator',
-                                },
-                                {
-                                  'fishtype':'Sawshark',
-                                  'age':105,
-                                  'birthday': '1900-01-05T01:00:00Z',
-                                  'length':10.0,
-                                  'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-                                  'species':'dangerous',
-                                },
-                                {
-                                  'fishtype': 'goblin',
-                                  'age': 1,
-                                  'birthday': '2015-08-08T00:00:00Z',
-                                  'length': 30.0,
-                                  'species': 'scary',
-                                  'jawsize': 5
-                                }
-                              ]
-                            };
-                protocol: !<!Protocols> 
-                  http: !<!HttpParameter> 
-                    in: body
-                    style: json
-            signatureParameters:
-              - *ref_149
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpWithBodyRequest> 
-                path: /complex/polymorphism/missingrequired/invalid
-                method: put
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_71
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: PutValidMissingRequired
-            description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
-        protocol: !<!Protocols> {}
-    language: !<!Languages> 
-      default:
-        name: Polymorphism
-        description: ''
-    protocol: !<!Protocols> {}
-  - !<!OperationGroup> 
-    $key: polymorphicrecursive
-    operations:
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: '2016-02-29'
-        parameters:
-          - *ref_69
-        requests:
-          - !<!Request> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpRequest> 
-                path: /complex/polymorphicrecursive/valid
-                method: get
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!SchemaResponse> 
-            schema: *ref_35
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - '200'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_71
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: GetValid
-            description: Get complex types that are polymorphic and have recursive references
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
@@ -5145,8 +5693,206 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
               - *ref_150
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpWithBodyRequest> 
+                path: /complex/polymorphism/missingrequired/invalid
+                method: put
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_72
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: PutValidMissingRequired
+            description: 'Put complex types that are polymorphic, attempting to omit required ''birthday'' field - the request should not be allowed from the client'
+        protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: Polymorphism
+        description: ''
+    protocol: !<!Protocols> {}
+  - !<!OperationGroup> 
+    $key: polymorphicrecursive
+    operations:
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: '2016-02-29'
+        parameters:
+          - *ref_69
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpRequest> 
+                path: /complex/polymorphicrecursive/valid
+                method: get
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!SchemaResponse> 
+            schema: *ref_35
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_72
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: GetValid
+            description: Get complex types that are polymorphic and have recursive references
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: '2016-02-29'
+        parameters:
+          - *ref_69
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_151
+                schema: *ref_35
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: complexBody
+                    description: |-
+                      Please put a salmon that looks like this:
+                      {
+                              'fishtype':'Salmon',
+                              'location':'alaska',
+                              'iswild':true,
+                              'species':'king',
+                              'length':1.0,
+                              'siblings':[
+                                {
+                                  'fishtype':'Shark',
+                                  'age':6,
+                                  'birthday': '2012-01-05T01:00:00Z',
+                                  'length':20.0,
+                                  'species':'predator',
+                                },
+                                {
+                                  'fishtype':'Sawshark',
+                                  'age':105,
+                                  'birthday': '1900-01-05T01:00:00Z',
+                                  'length':10.0,
+                                  'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                                  'species':'dangerous',
+                                },
+                                {
+                                  'fishtype': 'goblin',
+                                  'age': 1,
+                                  'birthday': '2015-08-08T00:00:00Z',
+                                  'length': 30.0,
+                                  'species': 'scary',
+                                  'jawsize': 5
+                                }
+                              ]
+                            };
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: json
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters:
+              - *ref_151
             language: !<!Languages> 
               default:
                 name: ''
@@ -5172,7 +5918,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5205,6 +5951,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5217,7 +5978,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_151
+            schema: *ref_152
             language: !<!Languages> 
               default:
                 name: ''
@@ -5231,7 +5992,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5257,8 +6018,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_152
-                schema: *ref_151
+              - !<!Parameter> &ref_153
+                schema: *ref_152
                 flattened: true
                 implementation: Method
                 required: true
@@ -5270,19 +6031,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_154
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_155
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_152
+                originalParameter: *ref_153
                 pathToProperty: []
-                targetProperty: *ref_153
+                targetProperty: *ref_154
                 language: !<!Languages> 
                   default:
                     name: size
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_154
+              - *ref_155
             language: !<!Languages> 
               default:
                 name: ''
@@ -5308,7 +6082,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_71
+            schema: *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5341,6 +6115,21 @@ operationGroups:
           - *ref_69
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_70
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-date/flattened.yaml
+++ b/modelerfour/test/scenarios/body-date/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-date
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -31,6 +31,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -38,7 +48,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: '0000-01-01'
-      valueType: !<!DateSchema> &ref_0
+      valueType: !<!DateSchema> &ref_1
         type: date
         apiVersions:
           - !<!ApiVersion> 
@@ -54,16 +64,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   dates:
-    - *ref_0
+    - *ref_1
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -71,7 +81,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -90,7 +100,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -117,6 +127,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -129,7 +154,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -143,7 +168,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -168,6 +193,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -180,7 +220,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,7 +234,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,6 +259,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -231,7 +286,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -245,7 +300,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -270,6 +325,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +352,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -296,7 +366,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -322,8 +392,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_0
+              - !<!Parameter> &ref_7
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -334,8 +404,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -361,7 +444,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -386,6 +469,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,7 +496,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -412,7 +510,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -438,8 +536,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_0
+              - !<!Parameter> &ref_8
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -450,8 +548,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -477,7 +588,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -502,6 +613,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -514,7 +640,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -528,7 +654,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-date/grouped.yaml
+++ b/modelerfour/test/scenarios/body-date/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-date
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -31,6 +31,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -38,7 +48,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: '0000-01-01'
-      valueType: !<!DateSchema> &ref_0
+      valueType: !<!DateSchema> &ref_1
         type: date
         apiVersions:
           - !<!ApiVersion> 
@@ -54,16 +64,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   dates:
-    - *ref_0
+    - *ref_1
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -71,7 +81,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -90,7 +100,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -117,6 +127,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -129,7 +154,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -143,7 +168,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -168,6 +193,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -180,7 +220,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,7 +234,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,6 +259,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -231,7 +286,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -245,7 +300,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -270,6 +325,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +352,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -296,7 +366,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -322,8 +392,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_0
+              - !<!Parameter> &ref_7
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -334,8 +404,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -361,7 +444,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -386,6 +469,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,7 +496,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -412,7 +510,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -438,8 +536,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_0
+              - !<!Parameter> &ref_8
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -450,8 +548,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -477,7 +588,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -502,6 +613,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -514,7 +640,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -528,7 +654,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-date/modeler.yaml
+++ b/modelerfour/test/scenarios/body-date/modeler.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_2
       type: string
       language: !<!Languages> 
         default:
@@ -31,6 +31,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -38,7 +48,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: '0000-01-01'
-      valueType: !<!DateSchema> &ref_2
+      valueType: !<!DateSchema> &ref_3
         type: date
         apiVersions:
           - !<!ApiVersion> 
@@ -54,9 +64,9 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   dates:
-    - *ref_2
+    - *ref_3
   objects:
-    - !<!ObjectSchema> &ref_4
+    - !<!ObjectSchema> &ref_5
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -89,8 +99,8 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_5
-    schema: *ref_3
+  - !<!Parameter> &ref_6
+    schema: *ref_2
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -114,9 +124,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -129,7 +154,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -143,7 +168,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -165,9 +190,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -180,7 +220,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,7 +234,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -216,9 +256,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -231,7 +286,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -245,7 +300,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -267,9 +322,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +352,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -296,7 +366,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -318,12 +388,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_2
+              - !<!Parameter> &ref_7
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -334,8 +404,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -361,7 +444,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -383,9 +466,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,7 +496,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -412,7 +510,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -434,12 +532,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_2
+              - !<!Parameter> &ref_8
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -450,8 +548,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -477,7 +588,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -499,9 +610,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -514,7 +640,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -528,7 +654,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-date/namer.yaml
+++ b/modelerfour/test/scenarios/body-date/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-date
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -31,6 +31,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -38,7 +48,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: '0000-01-01'
-      valueType: !<!DateSchema> &ref_0
+      valueType: !<!DateSchema> &ref_1
         type: date
         apiVersions:
           - !<!ApiVersion> 
@@ -50,20 +60,20 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       language: !<!Languages> 
         default:
-          name: Constant0
+          name: Constant1
           description: ''
       protocol: !<!Protocols> {}
   dates:
-    - *ref_0
+    - *ref_1
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -71,7 +81,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -90,7 +100,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -117,6 +127,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -129,7 +154,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -143,7 +168,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -168,6 +193,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -180,7 +220,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,7 +234,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,6 +259,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -231,7 +286,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -245,7 +300,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -270,6 +325,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +352,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -296,7 +366,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -322,8 +392,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_0
+              - !<!Parameter> &ref_7
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -334,8 +404,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -361,7 +444,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -386,6 +469,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,7 +496,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -412,7 +510,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -438,8 +536,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_0
+              - !<!Parameter> &ref_8
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -450,8 +548,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -477,7 +588,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -502,6 +613,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -514,7 +640,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -528,7 +654,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/flattened.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-datetime-rfc1123
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -31,6 +31,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -38,7 +48,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 'Sun, 1 Jan 0001 00:00:00 GMT'
-      valueType: !<!DateTimeSchema> &ref_0
+      valueType: !<!DateTimeSchema> &ref_1
         type: date-time
         format: date-time-rfc1123
         apiVersions:
@@ -55,16 +65,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   dateTimes:
-    - *ref_0
+    - *ref_1
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -72,7 +82,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -91,7 +101,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -118,6 +128,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -130,7 +155,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -144,7 +169,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -169,6 +194,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -181,7 +221,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -195,7 +235,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -220,6 +260,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -232,7 +287,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -246,7 +301,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -271,6 +326,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -283,7 +353,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -297,7 +367,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -323,8 +393,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_0
+              - !<!Parameter> &ref_7
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -335,8 +405,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -362,7 +445,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -387,6 +470,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -399,7 +497,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -413,7 +511,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -438,6 +536,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -450,7 +563,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -464,7 +577,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -490,8 +603,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_0
+              - !<!Parameter> &ref_8
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -502,8 +615,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -529,7 +655,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -554,6 +680,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -566,7 +707,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -580,7 +721,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/grouped.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-datetime-rfc1123
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -31,6 +31,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -38,7 +48,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 'Sun, 1 Jan 0001 00:00:00 GMT'
-      valueType: !<!DateTimeSchema> &ref_0
+      valueType: !<!DateTimeSchema> &ref_1
         type: date-time
         format: date-time-rfc1123
         apiVersions:
@@ -55,16 +65,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   dateTimes:
-    - *ref_0
+    - *ref_1
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -72,7 +82,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -91,7 +101,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -118,6 +128,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -130,7 +155,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -144,7 +169,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -169,6 +194,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -181,7 +221,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -195,7 +235,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -220,6 +260,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -232,7 +287,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -246,7 +301,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -271,6 +326,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -283,7 +353,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -297,7 +367,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -323,8 +393,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_0
+              - !<!Parameter> &ref_7
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -335,8 +405,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -362,7 +445,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -387,6 +470,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -399,7 +497,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -413,7 +511,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -438,6 +536,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -450,7 +563,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -464,7 +577,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -490,8 +603,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_0
+              - !<!Parameter> &ref_8
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -502,8 +615,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -529,7 +655,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -554,6 +680,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -566,7 +707,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -580,7 +721,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/modeler.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/modeler.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_2
       type: string
       language: !<!Languages> 
         default:
@@ -31,6 +31,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -38,7 +48,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 'Sun, 1 Jan 0001 00:00:00 GMT'
-      valueType: !<!DateTimeSchema> &ref_2
+      valueType: !<!DateTimeSchema> &ref_3
         type: date-time
         format: date-time-rfc1123
         apiVersions:
@@ -55,9 +65,9 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   dateTimes:
-    - *ref_2
+    - *ref_3
   objects:
-    - !<!ObjectSchema> &ref_4
+    - !<!ObjectSchema> &ref_5
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -90,8 +100,8 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_5
-    schema: *ref_3
+  - !<!Parameter> &ref_6
+    schema: *ref_2
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -115,9 +125,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -130,7 +155,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -144,7 +169,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -166,9 +191,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -181,7 +221,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -195,7 +235,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -217,9 +257,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -232,7 +287,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -246,7 +301,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -268,9 +323,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -283,7 +353,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -297,7 +367,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -319,12 +389,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_2
+              - !<!Parameter> &ref_7
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -335,8 +405,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -362,7 +445,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -384,9 +467,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -399,7 +497,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -413,7 +511,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -435,9 +533,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -450,7 +563,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -464,7 +577,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -486,12 +599,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_2
+              - !<!Parameter> &ref_8
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -502,8 +615,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -529,7 +655,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -551,9 +677,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -566,7 +707,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -580,7 +721,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-datetime-rfc1123/namer.yaml
+++ b/modelerfour/test/scenarios/body-datetime-rfc1123/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-datetime-rfc1123
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -31,6 +31,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -38,7 +48,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 'Sun, 1 Jan 0001 00:00:00 GMT'
-      valueType: !<!DateTimeSchema> &ref_0
+      valueType: !<!DateTimeSchema> &ref_1
         type: date-time
         format: date-time-rfc1123
         apiVersions:
@@ -51,20 +61,20 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       language: !<!Languages> 
         default:
-          name: Constant0
+          name: Constant1
           description: ''
       protocol: !<!Protocols> {}
   dateTimes:
-    - *ref_0
+    - *ref_1
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -72,7 +82,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -91,7 +101,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -118,6 +128,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -130,7 +155,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -144,7 +169,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -169,6 +194,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -181,7 +221,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -195,7 +235,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -220,6 +260,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -232,7 +287,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -246,7 +301,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -271,6 +326,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -283,7 +353,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -297,7 +367,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -323,8 +393,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_0
+              - !<!Parameter> &ref_7
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -335,8 +405,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -362,7 +445,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -387,6 +470,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -399,7 +497,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -413,7 +511,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -438,6 +536,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -450,7 +563,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -464,7 +577,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -490,8 +603,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_0
+              - !<!Parameter> &ref_8
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -502,8 +615,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -529,7 +655,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -554,6 +680,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -566,7 +707,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -580,7 +721,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-datetime/flattened.yaml
+++ b/modelerfour/test/scenarios/body-datetime/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-datetime
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -31,6 +31,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -38,7 +48,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: '0001-01-01T00:00:00Z'
-      valueType: !<!DateTimeSchema> &ref_0
+      valueType: !<!DateTimeSchema> &ref_1
         type: date-time
         format: date-time
         apiVersions:
@@ -61,23 +71,23 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: '0001-01-01t00:00:00+14:00'
-      valueType: *ref_0
+      valueType: *ref_1
       language: !<!Languages> 
         default:
           name: paths·gfehvp·datetime-min-localpositiveoffset·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
   dateTimes:
-    - *ref_0
+    - *ref_1
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -85,7 +95,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -104,7 +114,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -131,6 +141,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -143,7 +168,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -157,7 +182,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -182,6 +207,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,7 +234,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -208,7 +248,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -233,6 +273,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -245,7 +300,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -259,7 +314,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -284,6 +339,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -296,7 +366,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -310,7 +380,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -336,8 +406,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_0
+              - !<!Parameter> &ref_7
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -348,8 +418,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -375,7 +458,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -401,8 +484,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_0
+              - !<!Parameter> &ref_8
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -413,8 +496,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -440,7 +536,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -466,6 +562,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -478,7 +589,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -492,7 +603,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -517,6 +628,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -529,7 +655,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -543,7 +669,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -568,6 +694,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -580,7 +721,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -594,7 +735,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -621,8 +762,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_0
+              - !<!Parameter> &ref_9
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -633,8 +774,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -660,7 +814,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -685,6 +839,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -697,7 +866,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -711,7 +880,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -736,6 +905,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -748,7 +932,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -762,7 +946,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -788,8 +972,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_0
+              - !<!Parameter> &ref_10
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -800,8 +984,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -827,7 +1024,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -852,6 +1049,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -864,7 +1076,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -878,7 +1090,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -903,6 +1115,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -915,7 +1142,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -929,7 +1156,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -955,8 +1182,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_0
+              - !<!Parameter> &ref_11
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -967,8 +1194,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -994,7 +1234,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1019,6 +1259,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1031,7 +1286,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -1045,7 +1300,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1071,8 +1326,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_11
-                schema: *ref_0
+              - !<!Parameter> &ref_12
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1083,8 +1338,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_11
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1110,7 +1378,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1135,6 +1403,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1147,7 +1430,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -1161,7 +1444,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1187,8 +1470,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_12
-                schema: *ref_0
+              - !<!Parameter> &ref_13
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1199,8 +1482,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1226,7 +1522,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1251,6 +1547,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1263,7 +1574,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -1277,7 +1588,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-datetime/grouped.yaml
+++ b/modelerfour/test/scenarios/body-datetime/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-datetime
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -31,6 +31,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -38,7 +48,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: '0001-01-01T00:00:00Z'
-      valueType: !<!DateTimeSchema> &ref_0
+      valueType: !<!DateTimeSchema> &ref_1
         type: date-time
         format: date-time
         apiVersions:
@@ -61,23 +71,23 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: '0001-01-01t00:00:00+14:00'
-      valueType: *ref_0
+      valueType: *ref_1
       language: !<!Languages> 
         default:
           name: paths·gfehvp·datetime-min-localpositiveoffset·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
   dateTimes:
-    - *ref_0
+    - *ref_1
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -85,7 +95,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -104,7 +114,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -131,6 +141,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -143,7 +168,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -157,7 +182,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -182,6 +207,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,7 +234,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -208,7 +248,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -233,6 +273,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -245,7 +300,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -259,7 +314,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -284,6 +339,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -296,7 +366,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -310,7 +380,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -336,8 +406,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_0
+              - !<!Parameter> &ref_7
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -348,8 +418,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -375,7 +458,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -401,8 +484,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_0
+              - !<!Parameter> &ref_8
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -413,8 +496,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -440,7 +536,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -466,6 +562,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -478,7 +589,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -492,7 +603,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -517,6 +628,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -529,7 +655,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -543,7 +669,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -568,6 +694,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -580,7 +721,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -594,7 +735,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -621,8 +762,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_0
+              - !<!Parameter> &ref_9
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -633,8 +774,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -660,7 +814,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -685,6 +839,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -697,7 +866,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -711,7 +880,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -736,6 +905,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -748,7 +932,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -762,7 +946,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -788,8 +972,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_0
+              - !<!Parameter> &ref_10
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -800,8 +984,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -827,7 +1024,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -852,6 +1049,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -864,7 +1076,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -878,7 +1090,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -903,6 +1115,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -915,7 +1142,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -929,7 +1156,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -955,8 +1182,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_0
+              - !<!Parameter> &ref_11
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -967,8 +1194,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -994,7 +1234,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1019,6 +1259,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1031,7 +1286,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -1045,7 +1300,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1071,8 +1326,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_11
-                schema: *ref_0
+              - !<!Parameter> &ref_12
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1083,8 +1338,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_11
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1110,7 +1378,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1135,6 +1403,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1147,7 +1430,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -1161,7 +1444,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1187,8 +1470,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_12
-                schema: *ref_0
+              - !<!Parameter> &ref_13
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1199,8 +1482,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1226,7 +1522,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1251,6 +1547,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1263,7 +1574,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -1277,7 +1588,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-datetime/modeler.yaml
+++ b/modelerfour/test/scenarios/body-datetime/modeler.yaml
@@ -13,7 +13,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_2
       type: string
       language: !<!Languages> 
         default:
@@ -31,6 +31,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -38,7 +48,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: '0001-01-01T00:00:00Z'
-      valueType: !<!DateTimeSchema> &ref_2
+      valueType: !<!DateTimeSchema> &ref_3
         type: date-time
         format: date-time
         apiVersions:
@@ -61,16 +71,16 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: '0001-01-01t00:00:00+14:00'
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·gfehvp·datetime-min-localpositiveoffset·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
   dateTimes:
-    - *ref_2
+    - *ref_3
   objects:
-    - !<!ObjectSchema> &ref_4
+    - !<!ObjectSchema> &ref_5
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -103,8 +113,8 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_5
-    schema: *ref_3
+  - !<!Parameter> &ref_6
+    schema: *ref_2
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -128,9 +138,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -143,7 +168,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -157,7 +182,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -179,9 +204,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,7 +234,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -208,7 +248,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -230,9 +270,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -245,7 +300,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -259,7 +314,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -281,9 +336,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -296,7 +366,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -310,7 +380,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -332,12 +402,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_2
+              - !<!Parameter> &ref_7
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -348,8 +418,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -375,7 +458,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -397,12 +480,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_2
+              - !<!Parameter> &ref_8
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -413,8 +496,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -440,7 +536,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -463,9 +559,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -478,7 +589,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -492,7 +603,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -514,9 +625,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -529,7 +655,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -543,7 +669,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -565,9 +691,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -580,7 +721,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -594,7 +735,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -617,12 +758,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_2
+              - !<!Parameter> &ref_9
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -633,8 +774,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -660,7 +814,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -682,9 +836,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -697,7 +866,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -711,7 +880,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -733,9 +902,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -748,7 +932,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -762,7 +946,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -784,12 +968,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_2
+              - !<!Parameter> &ref_10
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -800,8 +984,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -827,7 +1024,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -849,9 +1046,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -864,7 +1076,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -878,7 +1090,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -900,9 +1112,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -915,7 +1142,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -929,7 +1156,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -951,12 +1178,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_2
+              - !<!Parameter> &ref_11
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -967,8 +1194,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -994,7 +1234,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -1016,9 +1256,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1031,7 +1286,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1045,7 +1300,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -1067,12 +1322,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_11
-                schema: *ref_2
+              - !<!Parameter> &ref_12
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1083,8 +1338,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_11
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1110,7 +1378,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -1132,9 +1400,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1147,7 +1430,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1161,7 +1444,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -1183,12 +1466,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_12
-                schema: *ref_2
+              - !<!Parameter> &ref_13
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1199,8 +1482,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1226,7 +1522,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -1248,9 +1544,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1263,7 +1574,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1277,7 +1588,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-datetime/namer.yaml
+++ b/modelerfour/test/scenarios/body-datetime/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-datetime
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -31,6 +31,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -38,7 +48,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: '0001-01-01T00:00:00Z'
-      valueType: !<!DateTimeSchema> &ref_0
+      valueType: !<!DateTimeSchema> &ref_1
         type: date-time
         format: date-time
         apiVersions:
@@ -51,7 +61,7 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       language: !<!Languages> 
         default:
-          name: Constant0
+          name: Constant1
           description: ''
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
@@ -61,23 +71,23 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: '0001-01-01t00:00:00+14:00'
-      valueType: *ref_0
+      valueType: *ref_1
       language: !<!Languages> 
         default:
-          name: Constant1
+          name: Constant2
           description: ''
       protocol: !<!Protocols> {}
   dateTimes:
-    - *ref_0
+    - *ref_1
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -85,7 +95,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -104,7 +114,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -131,6 +141,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -143,7 +168,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -157,7 +182,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -182,6 +207,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,7 +234,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -208,7 +248,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -233,6 +273,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -245,7 +300,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -259,7 +314,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -284,6 +339,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -296,7 +366,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -310,7 +380,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -336,8 +406,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_0
+              - !<!Parameter> &ref_7
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -348,8 +418,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -375,7 +458,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -401,8 +484,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_0
+              - !<!Parameter> &ref_8
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -413,8 +496,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -440,7 +536,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -466,6 +562,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -478,7 +589,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -492,7 +603,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -517,6 +628,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -529,7 +655,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -543,7 +669,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -568,6 +694,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -580,7 +721,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -594,7 +735,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -621,8 +762,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_0
+              - !<!Parameter> &ref_9
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -633,8 +774,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -660,7 +814,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -685,6 +839,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -697,7 +866,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -711,7 +880,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -736,6 +905,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -748,7 +932,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -762,7 +946,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -788,8 +972,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_0
+              - !<!Parameter> &ref_10
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -800,8 +984,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -827,7 +1024,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -852,6 +1049,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -864,7 +1076,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -878,7 +1090,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -903,6 +1115,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -915,7 +1142,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -929,7 +1156,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -955,8 +1182,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_0
+              - !<!Parameter> &ref_11
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -967,8 +1194,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -994,7 +1234,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1019,6 +1259,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1031,7 +1286,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -1045,7 +1300,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1071,8 +1326,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_11
-                schema: *ref_0
+              - !<!Parameter> &ref_12
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1083,8 +1338,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_11
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1110,7 +1378,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1135,6 +1403,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1147,7 +1430,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -1161,7 +1444,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1187,8 +1470,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_12
-                schema: *ref_0
+              - !<!Parameter> &ref_13
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1199,8 +1482,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1226,7 +1522,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1251,6 +1547,21 @@ operationGroups:
           - *ref_4
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1263,7 +1574,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -1277,7 +1588,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-dictionary/flattened.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-dictionary
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_2
+    - !<!BooleanSchema> &ref_3
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -26,7 +26,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_6
+    - !<!NumberSchema> &ref_7
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -34,7 +34,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_3
+    - !<!NumberSchema> &ref_4
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -45,7 +45,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_4
+    - !<!NumberSchema> &ref_5
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -56,7 +56,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_5
+    - !<!NumberSchema> &ref_6
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -68,14 +68,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_22
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_17
+    - !<!StringSchema> &ref_18
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -85,7 +85,7 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -95,7 +95,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_8
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -105,7 +105,7 @@ schemas: !<!Schemas>
           name: Widget-string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -115,7 +115,7 @@ schemas: !<!Schemas>
           name: get-200-application-json-additionalPropertiesItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_9
+    - !<!StringSchema> &ref_10
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -125,58 +125,69 @@ schemas: !<!Schemas>
           name: put-content-schema-itemsItem
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_24
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_24
+    - !<!DictionarySchema> &ref_25
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: paths·fzeo9k·dictionary-null·get·responses·200·content·application-json·schema
           description: The null dictionary value
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_26
+    - !<!DictionarySchema> &ref_27
       type: dictionary
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·11jfjdc·dictionary-nullvalue·get·responses·200·content·application-json·schema
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_28
+    - !<!DictionarySchema> &ref_29
       type: dictionary
-      elementType: *ref_2
+      elementType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·ylv7la·dictionary-prim-boolean-tfft·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": true, "1": false, "2": false, "3": true }'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_31
+    - !<!DictionarySchema> &ref_32
       type: dictionary
-      elementType: *ref_3
+      elementType: *ref_4
       language: !<!Languages> 
         default:
           name: paths·1spopx·dictionary-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_33
+    - !<!DictionarySchema> &ref_34
       type: dictionary
-      elementType: *ref_4
+      elementType: *ref_5
       language: !<!Languages> 
         default:
           name: paths·1cl7936·dictionary-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_35
+    - !<!DictionarySchema> &ref_36
       type: dictionary
-      elementType: *ref_5
+      elementType: *ref_6
       language: !<!Languages> 
         default:
           name: paths·1g7bjtn·dictionary-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_38
+    - !<!DictionarySchema> &ref_39
       type: dictionary
-      elementType: !<!DateSchema> &ref_15
+      elementType: !<!DateSchema> &ref_16
         type: date
         apiVersions:
           - !<!ApiVersion> 
@@ -191,9 +202,9 @@ schemas: !<!Schemas>
           name: paths·prhgt9·dictionary-prim-date-valid·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_40
+    - !<!DictionarySchema> &ref_41
       type: dictionary
-      elementType: !<!DateTimeSchema> &ref_13
+      elementType: !<!DateTimeSchema> &ref_14
         type: date-time
         format: date-time
         apiVersions:
@@ -209,9 +220,9 @@ schemas: !<!Schemas>
           name: paths·mxba4v·dictionary-prim-date_time-valid·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_42
+    - !<!DictionarySchema> &ref_43
       type: dictionary
-      elementType: !<!DateTimeSchema> &ref_14
+      elementType: !<!DateTimeSchema> &ref_15
         type: date-time
         format: date-time-rfc1123
         apiVersions:
@@ -227,9 +238,9 @@ schemas: !<!Schemas>
           name: paths·rodv1u·dictionary-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_44
+    - !<!DictionarySchema> &ref_45
       type: dictionary
-      elementType: !<!DurationSchema> &ref_16
+      elementType: !<!DurationSchema> &ref_17
         type: duration
         apiVersions:
           - !<!ApiVersion> 
@@ -244,9 +255,9 @@ schemas: !<!Schemas>
           name: paths·1gpdne2·dictionary-prim-duration-valid·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_46
+    - !<!DictionarySchema> &ref_47
       type: dictionary
-      elementType: !<!ByteArraySchema> &ref_11
+      elementType: !<!ByteArraySchema> &ref_12
         type: byte-array
         format: byte
         apiVersions:
@@ -262,9 +273,9 @@ schemas: !<!Schemas>
           name: paths·u6rzbk·dictionary-prim-byte-valid·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_48
+    - !<!DictionarySchema> &ref_49
       type: dictionary
-      elementType: !<!ByteArraySchema> &ref_12
+      elementType: !<!ByteArraySchema> &ref_13
         type: byte-array
         format: base64url
         apiVersions:
@@ -280,16 +291,16 @@ schemas: !<!Schemas>
           name: paths·1ihizsp·dictionary-prim-base64url-valid·get·responses·200·content·application-json·schema
           description: 'The base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_49
+    - !<!DictionarySchema> &ref_50
       type: dictionary
-      elementType: !<!ObjectSchema> &ref_18
+      elementType: !<!ObjectSchema> &ref_19
         type: object
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
         properties:
           - !<!Property> 
-            schema: *ref_6
+            schema: *ref_7
             serializedName: integer
             language: !<!Languages> 
               default:
@@ -297,7 +308,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_7
+            schema: *ref_8
             serializedName: string
             language: !<!Languages> 
               default:
@@ -320,14 +331,14 @@ schemas: !<!Schemas>
           name: paths·15simd7·dictionary-complex-null·get·responses·200·content·application-json·schema
           description: Dictionary of complex type with null value
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_51
+    - !<!DictionarySchema> &ref_52
       type: dictionary
-      elementType: !<!ArraySchema> &ref_19
+      elementType: !<!ArraySchema> &ref_20
         type: array
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-        elementType: *ref_8
+        elementType: *ref_9
         language: !<!Languages> 
           default:
             name: paths·1y9iid6·dictionary-array-null·get·responses·200·content·application-json·schema·additionalproperties
@@ -338,14 +349,14 @@ schemas: !<!Schemas>
           name: paths·yhrhd1·dictionary-array-null·get·responses·200·content·application-json·schema
           description: a null array
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_52
+    - !<!DictionarySchema> &ref_53
       type: dictionary
-      elementType: !<!ArraySchema> &ref_20
+      elementType: !<!ArraySchema> &ref_21
         type: array
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-        elementType: *ref_1
+        elementType: *ref_2
         language: !<!Languages> 
           default:
             name: paths·afa1hv·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties
@@ -356,14 +367,14 @@ schemas: !<!Schemas>
           name: paths·6cuxrs·dictionary-array-empty·get·responses·200·content·application-json·schema
           description: 'An empty dictionary {}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_53
+    - !<!DictionarySchema> &ref_54
       type: dictionary
-      elementType: !<!ArraySchema> &ref_21
+      elementType: !<!ArraySchema> &ref_22
         type: array
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-        elementType: *ref_9
+        elementType: *ref_10
         language: !<!Languages> 
           default:
             name: paths·1dxz488·dictionary-array-valid·put·requestbody·content·application-json·schema·additionalproperties
@@ -374,9 +385,9 @@ schemas: !<!Schemas>
           name: paths·ax5up1·dictionary-array-valid·put·requestbody·content·application-json·schema
           description: 'An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_55
+    - !<!DictionarySchema> &ref_56
       type: dictionary
-      elementType: !<!AnySchema> &ref_10
+      elementType: !<!AnySchema> &ref_11
         type: any
         language: !<!Languages> 
           default:
@@ -389,26 +400,26 @@ schemas: !<!Schemas>
           description: An dictionaries of dictionaries with value null
       protocol: !<!Protocols> {}
   any:
-    - *ref_10
-  byteArrays:
     - *ref_11
+  byteArrays:
     - *ref_12
-  dateTimes:
     - *ref_13
+  dateTimes:
     - *ref_14
-  dates:
     - *ref_15
-  durations:
+  dates:
     - *ref_16
+  durations:
+    - *ref_17
   objects:
-    - !<!ObjectSchema> &ref_25
+    - !<!ObjectSchema> &ref_26
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_6
+          schema: *ref_7
           serializedName: status
           language: !<!Languages> 
             default:
@@ -416,7 +427,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_17
+          schema: *ref_18
           serializedName: message
           language: !<!Languages> 
             default:
@@ -433,14 +444,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_18
-  arrays:
     - *ref_19
+  arrays:
     - *ref_20
     - *ref_21
+    - *ref_22
 globalParameters:
   - !<!Parameter> &ref_23
-    schema: *ref_22
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -467,6 +478,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -479,7 +505,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -493,7 +519,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -518,6 +544,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -530,7 +571,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -544,7 +585,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -570,8 +611,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_27
-                schema: *ref_26
+              - !<!Parameter> &ref_28
+                schema: *ref_27
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -582,8 +623,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_27
+              - *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -609,7 +663,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -634,6 +688,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -646,7 +715,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -660,7 +729,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -685,6 +754,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -697,7 +781,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -711,7 +795,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -736,6 +820,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -748,7 +847,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -762,7 +861,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -787,6 +886,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -799,7 +913,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -813,7 +927,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -838,6 +952,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -850,7 +979,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -864,7 +993,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -890,8 +1019,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_29
-                schema: *ref_28
+              - !<!Parameter> &ref_30
+                schema: *ref_29
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -902,8 +1031,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_29
+              - *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -929,7 +1071,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -954,6 +1096,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -966,7 +1123,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -980,7 +1137,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1005,6 +1162,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1017,7 +1189,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1031,7 +1203,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1056,6 +1228,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1068,7 +1255,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1082,7 +1269,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1108,8 +1295,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_30
-                schema: *ref_24
+              - !<!Parameter> &ref_31
+                schema: *ref_25
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1120,8 +1307,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_30
+              - *ref_31
             language: !<!Languages> 
               default:
                 name: ''
@@ -1147,7 +1347,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1172,6 +1372,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1184,7 +1399,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1198,7 +1413,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1223,6 +1438,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1235,7 +1465,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1249,7 +1479,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1274,6 +1504,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1286,7 +1531,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_31
+            schema: *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -1300,7 +1545,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1326,8 +1571,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_32
-                schema: *ref_31
+              - !<!Parameter> &ref_33
+                schema: *ref_32
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1338,8 +1583,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_32
+              - *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -1365,7 +1623,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1390,6 +1648,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1402,7 +1675,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_31
+            schema: *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -1416,7 +1689,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1441,6 +1714,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1453,7 +1741,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_31
+            schema: *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -1467,7 +1755,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1492,6 +1780,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1504,7 +1807,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_33
+            schema: *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1518,7 +1821,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1544,8 +1847,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
-                schema: *ref_33
+              - !<!Parameter> &ref_35
+                schema: *ref_34
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1556,8 +1859,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -1583,7 +1899,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1608,6 +1924,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1620,7 +1951,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_33
+            schema: *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1634,7 +1965,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1659,6 +1990,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1671,7 +2017,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_33
+            schema: *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1685,7 +2031,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1710,6 +2056,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1722,7 +2083,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1736,7 +2097,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1762,8 +2123,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_35
+              - !<!Parameter> &ref_37
+                schema: *ref_36
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1774,8 +2135,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -1801,7 +2175,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1826,6 +2200,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1838,7 +2227,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1852,7 +2241,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1877,6 +2266,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1889,7 +2293,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1903,7 +2307,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1928,6 +2332,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1940,7 +2359,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1954,7 +2373,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1980,8 +2399,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_37
-                schema: *ref_26
+              - !<!Parameter> &ref_38
+                schema: *ref_27
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1992,8 +2411,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_37
+              - *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -2019,7 +2451,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2044,6 +2476,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2056,7 +2503,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2070,7 +2517,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2095,6 +2542,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2107,7 +2569,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2121,7 +2583,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2146,6 +2608,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2158,7 +2635,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_38
+            schema: *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -2172,7 +2649,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2198,8 +2675,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_39
-                schema: *ref_38
+              - !<!Parameter> &ref_40
+                schema: *ref_39
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2210,8 +2687,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_39
+              - *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -2237,7 +2727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2262,6 +2752,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2274,7 +2779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_38
+            schema: *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -2288,7 +2793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2313,6 +2818,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2325,7 +2845,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_38
+            schema: *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -2339,7 +2859,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2364,6 +2884,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2376,7 +2911,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -2390,7 +2925,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2416,8 +2951,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_41
-                schema: *ref_40
+              - !<!Parameter> &ref_42
+                schema: *ref_41
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2428,8 +2963,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_41
+              - *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -2455,7 +3003,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2480,6 +3028,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2492,7 +3055,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -2506,7 +3069,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2531,6 +3094,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2543,7 +3121,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -2557,7 +3135,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2582,6 +3160,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2594,7 +3187,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_42
+            schema: *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -2608,7 +3201,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2634,8 +3227,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_43
-                schema: *ref_42
+              - !<!Parameter> &ref_44
+                schema: *ref_43
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2646,8 +3239,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_43
+              - *ref_44
             language: !<!Languages> 
               default:
                 name: ''
@@ -2673,7 +3279,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2698,6 +3304,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2710,7 +3331,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_44
+            schema: *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -2724,7 +3345,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2750,8 +3371,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_45
-                schema: *ref_44
+              - !<!Parameter> &ref_46
+                schema: *ref_45
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2762,8 +3383,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -2789,7 +3423,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2814,6 +3448,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2826,7 +3475,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2840,7 +3489,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2866,8 +3515,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_47
-                schema: *ref_46
+              - !<!Parameter> &ref_48
+                schema: *ref_47
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2878,8 +3527,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_47
+              - *ref_48
             language: !<!Languages> 
               default:
                 name: ''
@@ -2905,7 +3567,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2930,6 +3592,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2942,7 +3619,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2956,7 +3633,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2981,6 +3658,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2993,7 +3685,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -3007,7 +3699,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3032,6 +3724,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3044,7 +3751,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3058,7 +3765,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3083,6 +3790,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3095,7 +3817,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3109,7 +3831,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3134,6 +3856,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3146,7 +3883,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3160,7 +3897,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3185,6 +3922,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3197,7 +3949,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3211,7 +3963,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3236,6 +3988,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3248,7 +4015,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3262,7 +4029,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3288,8 +4055,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_50
-                schema: *ref_49
+              - !<!Parameter> &ref_51
+                schema: *ref_50
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3300,8 +4067,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_50
+              - *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -3327,7 +4107,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3352,6 +4132,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3364,7 +4159,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_51
+            schema: *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -3378,7 +4173,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3403,6 +4198,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3415,7 +4225,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3429,7 +4239,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3454,6 +4264,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3466,7 +4291,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3480,7 +4305,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3505,6 +4330,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3517,7 +4357,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3531,7 +4371,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3556,6 +4396,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3568,7 +4423,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3582,7 +4437,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3608,8 +4463,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_54
-                schema: *ref_53
+              - !<!Parameter> &ref_55
+                schema: *ref_54
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3620,8 +4475,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_54
+              - *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -3647,7 +4515,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3672,6 +4540,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3684,7 +4567,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3698,7 +4581,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3723,6 +4606,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3735,7 +4633,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3749,7 +4647,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3774,6 +4672,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3786,7 +4699,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3800,7 +4713,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3825,6 +4738,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3837,7 +4765,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3851,7 +4779,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3876,6 +4804,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3888,7 +4831,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3902,7 +4845,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3928,8 +4871,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_56
-                schema: *ref_55
+              - !<!Parameter> &ref_57
+                schema: *ref_56
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3940,8 +4883,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_56
+              - *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3967,7 +4923,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-dictionary/grouped.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-dictionary
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_2
+    - !<!BooleanSchema> &ref_3
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -26,7 +26,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_6
+    - !<!NumberSchema> &ref_7
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -34,7 +34,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_3
+    - !<!NumberSchema> &ref_4
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -45,7 +45,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_4
+    - !<!NumberSchema> &ref_5
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -56,7 +56,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_5
+    - !<!NumberSchema> &ref_6
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -68,14 +68,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_22
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_17
+    - !<!StringSchema> &ref_18
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -85,7 +85,7 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -95,7 +95,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_8
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -105,7 +105,7 @@ schemas: !<!Schemas>
           name: Widget-string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -115,7 +115,7 @@ schemas: !<!Schemas>
           name: get-200-application-json-additionalPropertiesItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_9
+    - !<!StringSchema> &ref_10
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -125,58 +125,69 @@ schemas: !<!Schemas>
           name: put-content-schema-itemsItem
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_24
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_24
+    - !<!DictionarySchema> &ref_25
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: paths·fzeo9k·dictionary-null·get·responses·200·content·application-json·schema
           description: The null dictionary value
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_26
+    - !<!DictionarySchema> &ref_27
       type: dictionary
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·11jfjdc·dictionary-nullvalue·get·responses·200·content·application-json·schema
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_28
+    - !<!DictionarySchema> &ref_29
       type: dictionary
-      elementType: *ref_2
+      elementType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·ylv7la·dictionary-prim-boolean-tfft·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": true, "1": false, "2": false, "3": true }'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_31
+    - !<!DictionarySchema> &ref_32
       type: dictionary
-      elementType: *ref_3
+      elementType: *ref_4
       language: !<!Languages> 
         default:
           name: paths·1spopx·dictionary-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_33
+    - !<!DictionarySchema> &ref_34
       type: dictionary
-      elementType: *ref_4
+      elementType: *ref_5
       language: !<!Languages> 
         default:
           name: paths·1cl7936·dictionary-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_35
+    - !<!DictionarySchema> &ref_36
       type: dictionary
-      elementType: *ref_5
+      elementType: *ref_6
       language: !<!Languages> 
         default:
           name: paths·1g7bjtn·dictionary-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_38
+    - !<!DictionarySchema> &ref_39
       type: dictionary
-      elementType: !<!DateSchema> &ref_15
+      elementType: !<!DateSchema> &ref_16
         type: date
         apiVersions:
           - !<!ApiVersion> 
@@ -191,9 +202,9 @@ schemas: !<!Schemas>
           name: paths·prhgt9·dictionary-prim-date-valid·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_40
+    - !<!DictionarySchema> &ref_41
       type: dictionary
-      elementType: !<!DateTimeSchema> &ref_13
+      elementType: !<!DateTimeSchema> &ref_14
         type: date-time
         format: date-time
         apiVersions:
@@ -209,9 +220,9 @@ schemas: !<!Schemas>
           name: paths·mxba4v·dictionary-prim-date_time-valid·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_42
+    - !<!DictionarySchema> &ref_43
       type: dictionary
-      elementType: !<!DateTimeSchema> &ref_14
+      elementType: !<!DateTimeSchema> &ref_15
         type: date-time
         format: date-time-rfc1123
         apiVersions:
@@ -227,9 +238,9 @@ schemas: !<!Schemas>
           name: paths·rodv1u·dictionary-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_44
+    - !<!DictionarySchema> &ref_45
       type: dictionary
-      elementType: !<!DurationSchema> &ref_16
+      elementType: !<!DurationSchema> &ref_17
         type: duration
         apiVersions:
           - !<!ApiVersion> 
@@ -244,9 +255,9 @@ schemas: !<!Schemas>
           name: paths·1gpdne2·dictionary-prim-duration-valid·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_46
+    - !<!DictionarySchema> &ref_47
       type: dictionary
-      elementType: !<!ByteArraySchema> &ref_11
+      elementType: !<!ByteArraySchema> &ref_12
         type: byte-array
         format: byte
         apiVersions:
@@ -262,9 +273,9 @@ schemas: !<!Schemas>
           name: paths·u6rzbk·dictionary-prim-byte-valid·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_48
+    - !<!DictionarySchema> &ref_49
       type: dictionary
-      elementType: !<!ByteArraySchema> &ref_12
+      elementType: !<!ByteArraySchema> &ref_13
         type: byte-array
         format: base64url
         apiVersions:
@@ -280,16 +291,16 @@ schemas: !<!Schemas>
           name: paths·1ihizsp·dictionary-prim-base64url-valid·get·responses·200·content·application-json·schema
           description: 'The base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_49
+    - !<!DictionarySchema> &ref_50
       type: dictionary
-      elementType: !<!ObjectSchema> &ref_18
+      elementType: !<!ObjectSchema> &ref_19
         type: object
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
         properties:
           - !<!Property> 
-            schema: *ref_6
+            schema: *ref_7
             serializedName: integer
             language: !<!Languages> 
               default:
@@ -297,7 +308,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_7
+            schema: *ref_8
             serializedName: string
             language: !<!Languages> 
               default:
@@ -320,14 +331,14 @@ schemas: !<!Schemas>
           name: paths·15simd7·dictionary-complex-null·get·responses·200·content·application-json·schema
           description: Dictionary of complex type with null value
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_51
+    - !<!DictionarySchema> &ref_52
       type: dictionary
-      elementType: !<!ArraySchema> &ref_19
+      elementType: !<!ArraySchema> &ref_20
         type: array
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-        elementType: *ref_8
+        elementType: *ref_9
         language: !<!Languages> 
           default:
             name: paths·1y9iid6·dictionary-array-null·get·responses·200·content·application-json·schema·additionalproperties
@@ -338,14 +349,14 @@ schemas: !<!Schemas>
           name: paths·yhrhd1·dictionary-array-null·get·responses·200·content·application-json·schema
           description: a null array
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_52
+    - !<!DictionarySchema> &ref_53
       type: dictionary
-      elementType: !<!ArraySchema> &ref_20
+      elementType: !<!ArraySchema> &ref_21
         type: array
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-        elementType: *ref_1
+        elementType: *ref_2
         language: !<!Languages> 
           default:
             name: paths·afa1hv·dictionary-array-empty·get·responses·200·content·application-json·schema·additionalproperties
@@ -356,14 +367,14 @@ schemas: !<!Schemas>
           name: paths·6cuxrs·dictionary-array-empty·get·responses·200·content·application-json·schema
           description: 'An empty dictionary {}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_53
+    - !<!DictionarySchema> &ref_54
       type: dictionary
-      elementType: !<!ArraySchema> &ref_21
+      elementType: !<!ArraySchema> &ref_22
         type: array
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-        elementType: *ref_9
+        elementType: *ref_10
         language: !<!Languages> 
           default:
             name: paths·1dxz488·dictionary-array-valid·put·requestbody·content·application-json·schema·additionalproperties
@@ -374,9 +385,9 @@ schemas: !<!Schemas>
           name: paths·ax5up1·dictionary-array-valid·put·requestbody·content·application-json·schema
           description: 'An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_55
+    - !<!DictionarySchema> &ref_56
       type: dictionary
-      elementType: !<!AnySchema> &ref_10
+      elementType: !<!AnySchema> &ref_11
         type: any
         language: !<!Languages> 
           default:
@@ -389,26 +400,26 @@ schemas: !<!Schemas>
           description: An dictionaries of dictionaries with value null
       protocol: !<!Protocols> {}
   any:
-    - *ref_10
-  byteArrays:
     - *ref_11
+  byteArrays:
     - *ref_12
-  dateTimes:
     - *ref_13
+  dateTimes:
     - *ref_14
-  dates:
     - *ref_15
-  durations:
+  dates:
     - *ref_16
+  durations:
+    - *ref_17
   objects:
-    - !<!ObjectSchema> &ref_25
+    - !<!ObjectSchema> &ref_26
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_6
+          schema: *ref_7
           serializedName: status
           language: !<!Languages> 
             default:
@@ -416,7 +427,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_17
+          schema: *ref_18
           serializedName: message
           language: !<!Languages> 
             default:
@@ -433,14 +444,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_18
-  arrays:
     - *ref_19
+  arrays:
     - *ref_20
     - *ref_21
+    - *ref_22
 globalParameters:
   - !<!Parameter> &ref_23
-    schema: *ref_22
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -467,6 +478,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -479,7 +505,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -493,7 +519,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -518,6 +544,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -530,7 +571,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -544,7 +585,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -570,8 +611,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_27
-                schema: *ref_26
+              - !<!Parameter> &ref_28
+                schema: *ref_27
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -582,8 +623,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_27
+              - *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -609,7 +663,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -634,6 +688,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -646,7 +715,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -660,7 +729,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -685,6 +754,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -697,7 +781,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -711,7 +795,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -736,6 +820,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -748,7 +847,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -762,7 +861,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -787,6 +886,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -799,7 +913,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -813,7 +927,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -838,6 +952,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -850,7 +979,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -864,7 +993,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -890,8 +1019,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_29
-                schema: *ref_28
+              - !<!Parameter> &ref_30
+                schema: *ref_29
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -902,8 +1031,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_29
+              - *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -929,7 +1071,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -954,6 +1096,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -966,7 +1123,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -980,7 +1137,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1005,6 +1162,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1017,7 +1189,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1031,7 +1203,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1056,6 +1228,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1068,7 +1255,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1082,7 +1269,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1108,8 +1295,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_30
-                schema: *ref_24
+              - !<!Parameter> &ref_31
+                schema: *ref_25
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1120,8 +1307,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_30
+              - *ref_31
             language: !<!Languages> 
               default:
                 name: ''
@@ -1147,7 +1347,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1172,6 +1372,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1184,7 +1399,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1198,7 +1413,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1223,6 +1438,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1235,7 +1465,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1249,7 +1479,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1274,6 +1504,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1286,7 +1531,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_31
+            schema: *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -1300,7 +1545,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1326,8 +1571,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_32
-                schema: *ref_31
+              - !<!Parameter> &ref_33
+                schema: *ref_32
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1338,8 +1583,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_32
+              - *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -1365,7 +1623,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1390,6 +1648,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1402,7 +1675,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_31
+            schema: *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -1416,7 +1689,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1441,6 +1714,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1453,7 +1741,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_31
+            schema: *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -1467,7 +1755,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1492,6 +1780,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1504,7 +1807,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_33
+            schema: *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1518,7 +1821,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1544,8 +1847,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
-                schema: *ref_33
+              - !<!Parameter> &ref_35
+                schema: *ref_34
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1556,8 +1859,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -1583,7 +1899,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1608,6 +1924,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1620,7 +1951,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_33
+            schema: *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1634,7 +1965,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1659,6 +1990,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1671,7 +2017,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_33
+            schema: *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1685,7 +2031,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1710,6 +2056,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1722,7 +2083,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1736,7 +2097,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1762,8 +2123,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_35
+              - !<!Parameter> &ref_37
+                schema: *ref_36
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1774,8 +2135,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -1801,7 +2175,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1826,6 +2200,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1838,7 +2227,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1852,7 +2241,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1877,6 +2266,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1889,7 +2293,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1903,7 +2307,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1928,6 +2332,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1940,7 +2359,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1954,7 +2373,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1980,8 +2399,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_37
-                schema: *ref_26
+              - !<!Parameter> &ref_38
+                schema: *ref_27
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1992,8 +2411,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_37
+              - *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -2019,7 +2451,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2044,6 +2476,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2056,7 +2503,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2070,7 +2517,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2095,6 +2542,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2107,7 +2569,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2121,7 +2583,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2146,6 +2608,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2158,7 +2635,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_38
+            schema: *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -2172,7 +2649,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2198,8 +2675,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_39
-                schema: *ref_38
+              - !<!Parameter> &ref_40
+                schema: *ref_39
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2210,8 +2687,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_39
+              - *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -2237,7 +2727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2262,6 +2752,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2274,7 +2779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_38
+            schema: *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -2288,7 +2793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2313,6 +2818,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2325,7 +2845,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_38
+            schema: *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -2339,7 +2859,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2364,6 +2884,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2376,7 +2911,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -2390,7 +2925,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2416,8 +2951,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_41
-                schema: *ref_40
+              - !<!Parameter> &ref_42
+                schema: *ref_41
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2428,8 +2963,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_41
+              - *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -2455,7 +3003,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2480,6 +3028,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2492,7 +3055,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -2506,7 +3069,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2531,6 +3094,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2543,7 +3121,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -2557,7 +3135,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2582,6 +3160,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2594,7 +3187,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_42
+            schema: *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -2608,7 +3201,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2634,8 +3227,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_43
-                schema: *ref_42
+              - !<!Parameter> &ref_44
+                schema: *ref_43
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2646,8 +3239,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_43
+              - *ref_44
             language: !<!Languages> 
               default:
                 name: ''
@@ -2673,7 +3279,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2698,6 +3304,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2710,7 +3331,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_44
+            schema: *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -2724,7 +3345,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2750,8 +3371,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_45
-                schema: *ref_44
+              - !<!Parameter> &ref_46
+                schema: *ref_45
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2762,8 +3383,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -2789,7 +3423,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2814,6 +3448,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2826,7 +3475,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2840,7 +3489,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2866,8 +3515,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_47
-                schema: *ref_46
+              - !<!Parameter> &ref_48
+                schema: *ref_47
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2878,8 +3527,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_47
+              - *ref_48
             language: !<!Languages> 
               default:
                 name: ''
@@ -2905,7 +3567,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2930,6 +3592,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2942,7 +3619,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2956,7 +3633,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2981,6 +3658,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2993,7 +3685,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -3007,7 +3699,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3032,6 +3724,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3044,7 +3751,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3058,7 +3765,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3083,6 +3790,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3095,7 +3817,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3109,7 +3831,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3134,6 +3856,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3146,7 +3883,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3160,7 +3897,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3185,6 +3922,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3197,7 +3949,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3211,7 +3963,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3236,6 +3988,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3248,7 +4015,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3262,7 +4029,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3288,8 +4055,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_50
-                schema: *ref_49
+              - !<!Parameter> &ref_51
+                schema: *ref_50
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3300,8 +4067,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_50
+              - *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -3327,7 +4107,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3352,6 +4132,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3364,7 +4159,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_51
+            schema: *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -3378,7 +4173,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3403,6 +4198,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3415,7 +4225,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3429,7 +4239,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3454,6 +4264,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3466,7 +4291,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3480,7 +4305,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3505,6 +4330,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3517,7 +4357,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3531,7 +4371,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3556,6 +4396,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3568,7 +4423,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3582,7 +4437,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3608,8 +4463,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_54
-                schema: *ref_53
+              - !<!Parameter> &ref_55
+                schema: *ref_54
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3620,8 +4475,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_54
+              - *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -3647,7 +4515,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3672,6 +4540,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3684,7 +4567,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3698,7 +4581,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3723,6 +4606,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3735,7 +4633,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3749,7 +4647,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3774,6 +4672,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3786,7 +4699,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3800,7 +4713,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3825,6 +4738,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3837,7 +4765,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3851,7 +4779,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3876,6 +4804,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3888,7 +4831,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3902,7 +4845,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3928,8 +4871,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_56
-                schema: *ref_55
+              - !<!Parameter> &ref_57
+                schema: *ref_56
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3940,8 +4883,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_56
+              - *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3967,7 +4923,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-dictionary/modeler.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/modeler.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-dictionary
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_11
+    - !<!BooleanSchema> &ref_12
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -68,7 +68,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_22
+    - !<!StringSchema> &ref_11
       type: string
       language: !<!Languages> 
         default:
@@ -125,8 +125,19 @@ schemas: !<!Schemas>
           name: put-content-schema-itemsItem
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_23
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_11
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_23
+    - !<!DictionarySchema> &ref_24
       type: dictionary
       elementType: *ref_0
       language: !<!Languages> 
@@ -134,7 +145,7 @@ schemas: !<!Schemas>
           name: paths·fzeo9k·dictionary-null·get·responses·200·content·application-json·schema
           description: The null dictionary value
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_26
+    - !<!DictionarySchema> &ref_27
       type: dictionary
       elementType: *ref_1
       language: !<!Languages> 
@@ -142,15 +153,15 @@ schemas: !<!Schemas>
           name: paths·11jfjdc·dictionary-nullvalue·get·responses·200·content·application-json·schema
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_28
+    - !<!DictionarySchema> &ref_29
       type: dictionary
-      elementType: *ref_11
+      elementType: *ref_12
       language: !<!Languages> 
         default:
           name: paths·ylv7la·dictionary-prim-boolean-tfft·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": true, "1": false, "2": false, "3": true }'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_31
+    - !<!DictionarySchema> &ref_32
       type: dictionary
       elementType: *ref_2
       language: !<!Languages> 
@@ -158,7 +169,7 @@ schemas: !<!Schemas>
           name: paths·1spopx·dictionary-prim-long-1-_1-3-300·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_33
+    - !<!DictionarySchema> &ref_34
       type: dictionary
       elementType: *ref_3
       language: !<!Languages> 
@@ -166,7 +177,7 @@ schemas: !<!Schemas>
           name: paths·1cl7936·dictionary-prim-float-0_0-01_1-2e20·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_35
+    - !<!DictionarySchema> &ref_36
       type: dictionary
       elementType: *ref_4
       language: !<!Languages> 
@@ -174,9 +185,9 @@ schemas: !<!Schemas>
           name: paths·1g7bjtn·dictionary-prim-double-0_0-01_1-2e20·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_38
+    - !<!DictionarySchema> &ref_39
       type: dictionary
-      elementType: !<!DateSchema> &ref_12
+      elementType: !<!DateSchema> &ref_13
         type: date
         apiVersions:
           - !<!ApiVersion> 
@@ -191,9 +202,9 @@ schemas: !<!Schemas>
           name: paths·prhgt9·dictionary-prim-date-valid·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_40
+    - !<!DictionarySchema> &ref_41
       type: dictionary
-      elementType: !<!DateTimeSchema> &ref_13
+      elementType: !<!DateTimeSchema> &ref_14
         type: date-time
         format: date-time
         apiVersions:
@@ -209,9 +220,9 @@ schemas: !<!Schemas>
           name: paths·mxba4v·dictionary-prim-date_time-valid·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_42
+    - !<!DictionarySchema> &ref_43
       type: dictionary
-      elementType: !<!DateTimeSchema> &ref_14
+      elementType: !<!DateTimeSchema> &ref_15
         type: date-time
         format: date-time-rfc1123
         apiVersions:
@@ -227,9 +238,9 @@ schemas: !<!Schemas>
           name: paths·rodv1u·dictionary-prim-date_time_rfc1123-valid·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_44
+    - !<!DictionarySchema> &ref_45
       type: dictionary
-      elementType: !<!DurationSchema> &ref_15
+      elementType: !<!DurationSchema> &ref_16
         type: duration
         apiVersions:
           - !<!ApiVersion> 
@@ -244,9 +255,9 @@ schemas: !<!Schemas>
           name: paths·1gpdne2·dictionary-prim-duration-valid·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_46
+    - !<!DictionarySchema> &ref_47
       type: dictionary
-      elementType: !<!ByteArraySchema> &ref_16
+      elementType: !<!ByteArraySchema> &ref_17
         type: byte-array
         format: byte
         apiVersions:
@@ -262,9 +273,9 @@ schemas: !<!Schemas>
           name: paths·u6rzbk·dictionary-prim-byte-valid·get·responses·200·content·application-json·schema
           description: 'The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_48
+    - !<!DictionarySchema> &ref_49
       type: dictionary
-      elementType: !<!ByteArraySchema> &ref_17
+      elementType: !<!ByteArraySchema> &ref_18
         type: byte-array
         format: base64url
         apiVersions:
@@ -280,7 +291,7 @@ schemas: !<!Schemas>
           name: paths·1ihizsp·dictionary-prim-base64url-valid·get·responses·200·content·application-json·schema
           description: 'The base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_49
+    - !<!DictionarySchema> &ref_50
       type: dictionary
       elementType: !<!ObjectSchema> &ref_10
         type: object
@@ -320,9 +331,9 @@ schemas: !<!Schemas>
           name: paths·15simd7·dictionary-complex-null·get·responses·200·content·application-json·schema
           description: Dictionary of complex type with null value
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_51
+    - !<!DictionarySchema> &ref_52
       type: dictionary
-      elementType: !<!ArraySchema> &ref_18
+      elementType: !<!ArraySchema> &ref_19
         type: array
         apiVersions:
           - !<!ApiVersion> 
@@ -338,9 +349,9 @@ schemas: !<!Schemas>
           name: paths·yhrhd1·dictionary-array-null·get·responses·200·content·application-json·schema
           description: a null array
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_52
+    - !<!DictionarySchema> &ref_53
       type: dictionary
-      elementType: !<!ArraySchema> &ref_19
+      elementType: !<!ArraySchema> &ref_20
         type: array
         apiVersions:
           - !<!ApiVersion> 
@@ -356,9 +367,9 @@ schemas: !<!Schemas>
           name: paths·6cuxrs·dictionary-array-empty·get·responses·200·content·application-json·schema
           description: 'An empty dictionary {}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_53
+    - !<!DictionarySchema> &ref_54
       type: dictionary
-      elementType: !<!ArraySchema> &ref_20
+      elementType: !<!ArraySchema> &ref_21
         type: array
         apiVersions:
           - !<!ApiVersion> 
@@ -374,9 +385,9 @@ schemas: !<!Schemas>
           name: paths·ax5up1·dictionary-array-valid·put·requestbody·content·application-json·schema
           description: 'An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_55
+    - !<!DictionarySchema> &ref_56
       type: dictionary
-      elementType: !<!AnySchema> &ref_21
+      elementType: !<!AnySchema> &ref_22
         type: any
         language: !<!Languages> 
           default:
@@ -389,19 +400,19 @@ schemas: !<!Schemas>
           description: An dictionaries of dictionaries with value null
       protocol: !<!Protocols> {}
   any:
-    - *ref_21
+    - *ref_22
   byteArrays:
-    - *ref_16
     - *ref_17
+    - *ref_18
   dateTimes:
-    - *ref_13
     - *ref_14
-  dates:
-    - *ref_12
-  durations:
     - *ref_15
+  dates:
+    - *ref_13
+  durations:
+    - *ref_16
   objects:
-    - !<!ObjectSchema> &ref_24
+    - !<!ObjectSchema> &ref_25
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -435,12 +446,12 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_10
   arrays:
-    - *ref_18
     - *ref_19
     - *ref_20
+    - *ref_21
 globalParameters:
-  - !<!Parameter> &ref_25
-    schema: *ref_22
+  - !<!Parameter> &ref_26
+    schema: *ref_11
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -464,9 +475,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -479,7 +505,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -493,7 +519,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -515,9 +541,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -530,7 +571,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -544,7 +585,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -566,12 +607,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_27
-                schema: *ref_26
+              - !<!Parameter> &ref_28
+                schema: *ref_27
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -582,8 +623,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_27
+              - *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -609,7 +663,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -631,9 +685,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -646,7 +715,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -660,7 +729,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -682,9 +751,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -697,7 +781,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -711,7 +795,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -733,9 +817,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -748,7 +847,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -762,7 +861,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -784,9 +883,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -799,7 +913,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -813,7 +927,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -835,9 +949,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -850,7 +979,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -864,7 +993,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -886,12 +1015,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_29
-                schema: *ref_28
+              - !<!Parameter> &ref_30
+                schema: *ref_29
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -902,8 +1031,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_29
+              - *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -929,7 +1071,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -951,9 +1093,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -966,7 +1123,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -980,7 +1137,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1002,9 +1159,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1017,7 +1189,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1031,7 +1203,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1053,9 +1225,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1068,7 +1255,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -1082,7 +1269,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1104,12 +1291,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_30
-                schema: *ref_23
+              - !<!Parameter> &ref_31
+                schema: *ref_24
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1120,8 +1307,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_30
+              - *ref_31
             language: !<!Languages> 
               default:
                 name: ''
@@ -1147,7 +1347,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1169,9 +1369,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1184,7 +1399,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -1198,7 +1413,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1220,9 +1435,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1235,7 +1465,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -1249,7 +1479,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1271,9 +1501,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1286,7 +1531,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_31
+            schema: *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -1300,7 +1545,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1322,12 +1567,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_32
-                schema: *ref_31
+              - !<!Parameter> &ref_33
+                schema: *ref_32
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1338,8 +1583,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_32
+              - *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -1365,7 +1623,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1387,9 +1645,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1402,7 +1675,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_31
+            schema: *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -1416,7 +1689,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1438,9 +1711,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1453,7 +1741,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_31
+            schema: *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -1467,7 +1755,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1489,9 +1777,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1504,7 +1807,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_33
+            schema: *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1518,7 +1821,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1540,12 +1843,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
-                schema: *ref_33
+              - !<!Parameter> &ref_35
+                schema: *ref_34
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1556,8 +1859,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -1583,7 +1899,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1605,9 +1921,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1620,7 +1951,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_33
+            schema: *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1634,7 +1965,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1656,9 +1987,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1671,7 +2017,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_33
+            schema: *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1685,7 +2031,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1707,9 +2053,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1722,7 +2083,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1736,7 +2097,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1758,12 +2119,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_35
+              - !<!Parameter> &ref_37
+                schema: *ref_36
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1774,8 +2135,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -1801,7 +2175,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1823,9 +2197,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1838,7 +2227,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1852,7 +2241,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1874,9 +2263,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1889,7 +2293,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1903,7 +2307,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1925,9 +2329,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1940,7 +2359,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1954,7 +2373,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1976,12 +2395,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_37
-                schema: *ref_26
+              - !<!Parameter> &ref_38
+                schema: *ref_27
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1992,8 +2411,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_37
+              - *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -2019,7 +2451,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2041,9 +2473,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2056,7 +2503,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2070,7 +2517,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2092,9 +2539,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2107,7 +2569,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2121,7 +2583,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2143,9 +2605,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2158,7 +2635,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_38
+            schema: *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -2172,7 +2649,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2194,12 +2671,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_39
-                schema: *ref_38
+              - !<!Parameter> &ref_40
+                schema: *ref_39
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2210,8 +2687,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_39
+              - *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -2237,7 +2727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2259,9 +2749,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2274,7 +2779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_38
+            schema: *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -2288,7 +2793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2310,9 +2815,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2325,7 +2845,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_38
+            schema: *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -2339,7 +2859,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2361,9 +2881,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2376,7 +2911,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -2390,7 +2925,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2412,12 +2947,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_41
-                schema: *ref_40
+              - !<!Parameter> &ref_42
+                schema: *ref_41
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2428,8 +2963,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_41
+              - *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -2455,7 +3003,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2477,9 +3025,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2492,7 +3055,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -2506,7 +3069,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2528,9 +3091,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2543,7 +3121,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -2557,7 +3135,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2579,9 +3157,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2594,7 +3187,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_42
+            schema: *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -2608,7 +3201,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2630,12 +3223,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_43
-                schema: *ref_42
+              - !<!Parameter> &ref_44
+                schema: *ref_43
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2646,8 +3239,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_43
+              - *ref_44
             language: !<!Languages> 
               default:
                 name: ''
@@ -2673,7 +3279,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2695,9 +3301,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2710,7 +3331,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_44
+            schema: *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -2724,7 +3345,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2746,12 +3367,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_45
-                schema: *ref_44
+              - !<!Parameter> &ref_46
+                schema: *ref_45
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2762,8 +3383,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -2789,7 +3423,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2811,9 +3445,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2826,7 +3475,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2840,7 +3489,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2862,12 +3511,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_47
-                schema: *ref_46
+              - !<!Parameter> &ref_48
+                schema: *ref_47
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2878,8 +3527,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_47
+              - *ref_48
             language: !<!Languages> 
               default:
                 name: ''
@@ -2905,7 +3567,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2927,9 +3589,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2942,7 +3619,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2956,7 +3633,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -2978,9 +3655,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2993,7 +3685,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -3007,7 +3699,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3029,9 +3721,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3044,7 +3751,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3058,7 +3765,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3080,9 +3787,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3095,7 +3817,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3109,7 +3831,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3131,9 +3853,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3146,7 +3883,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3160,7 +3897,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3182,9 +3919,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3197,7 +3949,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3211,7 +3963,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3233,9 +3985,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3248,7 +4015,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3262,7 +4029,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3284,12 +4051,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_50
-                schema: *ref_49
+              - !<!Parameter> &ref_51
+                schema: *ref_50
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3300,8 +4067,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_50
+              - *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -3327,7 +4107,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3349,9 +4129,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3364,7 +4159,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_51
+            schema: *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -3378,7 +4173,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3400,9 +4195,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3415,7 +4225,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3429,7 +4239,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3451,9 +4261,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3466,7 +4291,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3480,7 +4305,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3502,9 +4327,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3517,7 +4357,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3531,7 +4371,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3553,9 +4393,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3568,7 +4423,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3582,7 +4437,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3604,12 +4459,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_54
-                schema: *ref_53
+              - !<!Parameter> &ref_55
+                schema: *ref_54
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3620,8 +4475,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_54
+              - *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -3647,7 +4515,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3669,9 +4537,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3684,7 +4567,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3698,7 +4581,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3720,9 +4603,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3735,7 +4633,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3749,7 +4647,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3771,9 +4669,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3786,7 +4699,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3800,7 +4713,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3822,9 +4735,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3837,7 +4765,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3851,7 +4779,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3873,9 +4801,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3888,7 +4831,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3902,7 +4845,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -3924,12 +4867,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_25
+          - *ref_26
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_56
-                schema: *ref_55
+              - !<!Parameter> &ref_57
+                schema: *ref_56
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3940,8 +4883,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_23
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_56
+              - *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3967,7 +4923,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-dictionary/namer.yaml
+++ b/modelerfour/test/scenarios/body-dictionary/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-dictionary
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_2
+    - !<!BooleanSchema> &ref_3
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -26,7 +26,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_6
+    - !<!NumberSchema> &ref_7
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -34,7 +34,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_3
+    - !<!NumberSchema> &ref_4
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -45,7 +45,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_4
+    - !<!NumberSchema> &ref_5
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -56,7 +56,7 @@ schemas: !<!Schemas>
           name: Number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_5
+    - !<!NumberSchema> &ref_6
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -68,14 +68,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_22
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_17
+    - !<!StringSchema> &ref_18
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -85,7 +85,7 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -95,7 +95,7 @@ schemas: !<!Schemas>
           name: String
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_8
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -105,7 +105,7 @@ schemas: !<!Schemas>
           name: WidgetString
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -115,7 +115,7 @@ schemas: !<!Schemas>
           name: Get200ApplicationJsonAdditionalPropertiesItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_9
+    - !<!StringSchema> &ref_10
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -125,48 +125,51 @@ schemas: !<!Schemas>
           name: PutContentSchemaItemsItem
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_24
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_24
+    - !<!DictionarySchema> &ref_25
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: DictionaryOfInteger
           description: The null dictionary value
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_26
+    - !<!DictionarySchema> &ref_27
       type: dictionary
-      elementType: *ref_1
+      elementType: *ref_2
       language: !<!Languages> 
         default:
           name: DictionaryOfString
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_28
+    - !<!DictionarySchema> &ref_29
       type: dictionary
-      elementType: *ref_2
+      elementType: *ref_3
       language: !<!Languages> 
         default:
           name: DictionaryOfBoolean
           description: 'The dictionary value {"0": true, "1": false, "2": false, "3": true }'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_31
+    - !<!DictionarySchema> &ref_32
       type: dictionary
-      elementType: *ref_3
+      elementType: *ref_4
       language: !<!Languages> 
         default:
           name: DictionaryOfInteger
           description: 'The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_33
-      type: dictionary
-      elementType: *ref_4
-      language: !<!Languages> 
-        default:
-          name: DictionaryOfNumber
-          description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
-      protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_35
+    - !<!DictionarySchema> &ref_34
       type: dictionary
       elementType: *ref_5
       language: !<!Languages> 
@@ -174,9 +177,17 @@ schemas: !<!Schemas>
           name: DictionaryOfNumber
           description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_38
+    - !<!DictionarySchema> &ref_36
       type: dictionary
-      elementType: !<!DateSchema> &ref_15
+      elementType: *ref_6
+      language: !<!Languages> 
+        default:
+          name: DictionaryOfNumber
+          description: 'The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}'
+      protocol: !<!Protocols> {}
+    - !<!DictionarySchema> &ref_39
+      type: dictionary
+      elementType: !<!DateSchema> &ref_16
         type: date
         apiVersions:
           - !<!ApiVersion> 
@@ -191,9 +202,9 @@ schemas: !<!Schemas>
           name: DictionaryOfDate
           description: 'The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_40
+    - !<!DictionarySchema> &ref_41
       type: dictionary
-      elementType: !<!DateTimeSchema> &ref_13
+      elementType: !<!DateTimeSchema> &ref_14
         type: date-time
         format: date-time
         apiVersions:
@@ -209,9 +220,9 @@ schemas: !<!Schemas>
           name: DictionaryOfDateTime
           description: 'The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_42
+    - !<!DictionarySchema> &ref_43
       type: dictionary
-      elementType: !<!DateTimeSchema> &ref_14
+      elementType: !<!DateTimeSchema> &ref_15
         type: date-time
         format: date-time-rfc1123
         apiVersions:
@@ -227,9 +238,9 @@ schemas: !<!Schemas>
           name: DictionaryOfDateTime
           description: 'The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_44
+    - !<!DictionarySchema> &ref_45
       type: dictionary
-      elementType: !<!DurationSchema> &ref_16
+      elementType: !<!DurationSchema> &ref_17
         type: duration
         apiVersions:
           - !<!ApiVersion> 
@@ -244,9 +255,9 @@ schemas: !<!Schemas>
           name: DictionaryOfDuration
           description: 'The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_46
+    - !<!DictionarySchema> &ref_47
       type: dictionary
-      elementType: !<!ByteArraySchema> &ref_11
+      elementType: !<!ByteArraySchema> &ref_12
         type: byte-array
         format: byte
         apiVersions:
@@ -262,9 +273,9 @@ schemas: !<!Schemas>
           name: DictionaryOfByteArray
           description: 'The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_48
+    - !<!DictionarySchema> &ref_49
       type: dictionary
-      elementType: !<!ByteArraySchema> &ref_12
+      elementType: !<!ByteArraySchema> &ref_13
         type: byte-array
         format: base64url
         apiVersions:
@@ -280,16 +291,16 @@ schemas: !<!Schemas>
           name: DictionaryOfByteArray
           description: 'The base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_49
+    - !<!DictionarySchema> &ref_50
       type: dictionary
-      elementType: !<!ObjectSchema> &ref_18
+      elementType: !<!ObjectSchema> &ref_19
         type: object
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
         properties:
           - !<!Property> 
-            schema: *ref_6
+            schema: *ref_7
             serializedName: integer
             language: !<!Languages> 
               default:
@@ -297,7 +308,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           - !<!Property> 
-            schema: *ref_7
+            schema: *ref_8
             serializedName: string
             language: !<!Languages> 
               default:
@@ -320,14 +331,14 @@ schemas: !<!Schemas>
           name: DictionaryOfWidget
           description: Dictionary of complex type with null value
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_51
+    - !<!DictionarySchema> &ref_52
       type: dictionary
-      elementType: !<!ArraySchema> &ref_19
+      elementType: !<!ArraySchema> &ref_20
         type: array
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-        elementType: *ref_8
+        elementType: *ref_9
         language: !<!Languages> 
           default:
             name: ArrayOfGet200ApplicationJsonAdditionalPropertiesItem
@@ -338,14 +349,14 @@ schemas: !<!Schemas>
           name: DictionaryOfpaths1Y9Iid6DictionaryArrayNullGetResponses200ContentApplicationJsonSchemaAdditionalproperties
           description: a null array
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_52
+    - !<!DictionarySchema> &ref_53
       type: dictionary
-      elementType: !<!ArraySchema> &ref_20
+      elementType: !<!ArraySchema> &ref_21
         type: array
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-        elementType: *ref_1
+        elementType: *ref_2
         language: !<!Languages> 
           default:
             name: ArrayOfString
@@ -356,14 +367,14 @@ schemas: !<!Schemas>
           name: DictionaryOfpathsAfa1HvDictionaryArrayEmptyGetResponses200ContentApplicationJsonSchemaAdditionalproperties
           description: 'An empty dictionary {}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_53
+    - !<!DictionarySchema> &ref_54
       type: dictionary
-      elementType: !<!ArraySchema> &ref_21
+      elementType: !<!ArraySchema> &ref_22
         type: array
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
-        elementType: *ref_9
+        elementType: *ref_10
         language: !<!Languages> 
           default:
             name: ArrayOfPutContentSchemaItemsItem
@@ -374,9 +385,9 @@ schemas: !<!Schemas>
           name: DictionaryOfpaths1Dxz488DictionaryArrayValidPutRequestbodyContentApplicationJsonSchemaAdditionalproperties
           description: 'An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}'
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_55
+    - !<!DictionarySchema> &ref_56
       type: dictionary
-      elementType: !<!AnySchema> &ref_10
+      elementType: !<!AnySchema> &ref_11
         type: any
         language: !<!Languages> 
           default:
@@ -389,26 +400,26 @@ schemas: !<!Schemas>
           description: An dictionaries of dictionaries with value null
       protocol: !<!Protocols> {}
   any:
-    - *ref_10
-  byteArrays:
     - *ref_11
+  byteArrays:
     - *ref_12
-  dateTimes:
     - *ref_13
+  dateTimes:
     - *ref_14
-  dates:
     - *ref_15
-  durations:
+  dates:
     - *ref_16
+  durations:
+    - *ref_17
   objects:
-    - !<!ObjectSchema> &ref_25
+    - !<!ObjectSchema> &ref_26
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_6
+          schema: *ref_7
           serializedName: status
           language: !<!Languages> 
             default:
@@ -416,7 +427,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_17
+          schema: *ref_18
           serializedName: message
           language: !<!Languages> 
             default:
@@ -433,14 +444,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_18
-  arrays:
     - *ref_19
+  arrays:
     - *ref_20
     - *ref_21
+    - *ref_22
 globalParameters:
   - !<!Parameter> &ref_23
-    schema: *ref_22
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -467,6 +478,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -479,7 +505,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -493,7 +519,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -518,6 +544,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -530,7 +571,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -544,7 +585,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -570,8 +611,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_27
-                schema: *ref_26
+              - !<!Parameter> &ref_28
+                schema: *ref_27
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -582,8 +623,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_27
+              - *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -609,7 +663,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -634,6 +688,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -646,7 +715,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -660,7 +729,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -685,6 +754,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -697,7 +781,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -711,7 +795,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -736,6 +820,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -748,7 +847,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -762,7 +861,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -787,6 +886,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -799,7 +913,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -813,7 +927,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -838,6 +952,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -850,7 +979,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -864,7 +993,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -890,8 +1019,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_29
-                schema: *ref_28
+              - !<!Parameter> &ref_30
+                schema: *ref_29
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -902,8 +1031,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_29
+              - *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -929,7 +1071,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -954,6 +1096,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -966,7 +1123,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -980,7 +1137,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1005,6 +1162,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1017,7 +1189,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1031,7 +1203,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1056,6 +1228,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1068,7 +1255,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1082,7 +1269,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1108,8 +1295,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_30
-                schema: *ref_24
+              - !<!Parameter> &ref_31
+                schema: *ref_25
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1120,8 +1307,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_30
+              - *ref_31
             language: !<!Languages> 
               default:
                 name: ''
@@ -1147,7 +1347,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1172,6 +1372,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1184,7 +1399,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1198,7 +1413,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1223,6 +1438,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1235,7 +1465,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1249,7 +1479,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1274,6 +1504,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1286,7 +1531,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_31
+            schema: *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -1300,7 +1545,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1326,8 +1571,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_32
-                schema: *ref_31
+              - !<!Parameter> &ref_33
+                schema: *ref_32
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1338,8 +1583,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_32
+              - *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -1365,7 +1623,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1390,6 +1648,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1402,7 +1675,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_31
+            schema: *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -1416,7 +1689,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1441,6 +1714,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1453,7 +1741,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_31
+            schema: *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -1467,7 +1755,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1492,6 +1780,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1504,7 +1807,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_33
+            schema: *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1518,7 +1821,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1544,8 +1847,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
-                schema: *ref_33
+              - !<!Parameter> &ref_35
+                schema: *ref_34
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1556,8 +1859,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -1583,7 +1899,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1608,6 +1924,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1620,7 +1951,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_33
+            schema: *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1634,7 +1965,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1659,6 +1990,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1671,7 +2017,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_33
+            schema: *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1685,7 +2031,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1710,6 +2056,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1722,7 +2083,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1736,7 +2097,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1762,8 +2123,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_35
+              - !<!Parameter> &ref_37
+                schema: *ref_36
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1774,8 +2135,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -1801,7 +2175,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1826,6 +2200,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1838,7 +2227,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1852,7 +2241,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1877,6 +2266,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1889,7 +2293,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1903,7 +2307,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1928,6 +2332,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1940,7 +2359,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1954,7 +2373,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1980,8 +2399,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_37
-                schema: *ref_26
+              - !<!Parameter> &ref_38
+                schema: *ref_27
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1992,8 +2411,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_37
+              - *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -2019,7 +2451,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2044,6 +2476,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2056,7 +2503,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2070,7 +2517,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2095,6 +2542,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2107,7 +2569,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2121,7 +2583,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2146,6 +2608,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2158,7 +2635,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_38
+            schema: *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -2172,7 +2649,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2198,8 +2675,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_39
-                schema: *ref_38
+              - !<!Parameter> &ref_40
+                schema: *ref_39
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2210,8 +2687,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_39
+              - *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -2237,7 +2727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2262,6 +2752,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2274,7 +2779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_38
+            schema: *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -2288,7 +2793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2313,6 +2818,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2325,7 +2845,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_38
+            schema: *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -2339,7 +2859,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2364,6 +2884,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2376,7 +2911,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -2390,7 +2925,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2416,8 +2951,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_41
-                schema: *ref_40
+              - !<!Parameter> &ref_42
+                schema: *ref_41
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2428,8 +2963,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_41
+              - *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -2455,7 +3003,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2480,6 +3028,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2492,7 +3055,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -2506,7 +3069,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2531,6 +3094,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2543,7 +3121,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -2557,7 +3135,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2582,6 +3160,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2594,7 +3187,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_42
+            schema: *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -2608,7 +3201,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2634,8 +3227,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_43
-                schema: *ref_42
+              - !<!Parameter> &ref_44
+                schema: *ref_43
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2646,8 +3239,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_43
+              - *ref_44
             language: !<!Languages> 
               default:
                 name: ''
@@ -2673,7 +3279,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2698,6 +3304,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2710,7 +3331,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_44
+            schema: *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -2724,7 +3345,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2750,8 +3371,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_45
-                schema: *ref_44
+              - !<!Parameter> &ref_46
+                schema: *ref_45
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2762,8 +3383,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -2789,7 +3423,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2814,6 +3448,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2826,7 +3475,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2840,7 +3489,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2866,8 +3515,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_47
-                schema: *ref_46
+              - !<!Parameter> &ref_48
+                schema: *ref_47
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2878,8 +3527,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_47
+              - *ref_48
             language: !<!Languages> 
               default:
                 name: ''
@@ -2905,7 +3567,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2930,6 +3592,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2942,7 +3619,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2956,7 +3633,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -2981,6 +3658,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2993,7 +3685,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -3007,7 +3699,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3032,6 +3724,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3044,7 +3751,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3058,7 +3765,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3083,6 +3790,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3095,7 +3817,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3109,7 +3831,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3134,6 +3856,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3146,7 +3883,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3160,7 +3897,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3185,6 +3922,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3197,7 +3949,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3211,7 +3963,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3236,6 +3988,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3248,7 +4015,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_49
+            schema: *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3262,7 +4029,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3288,8 +4055,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_50
-                schema: *ref_49
+              - !<!Parameter> &ref_51
+                schema: *ref_50
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3300,8 +4067,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_50
+              - *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -3327,7 +4107,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3352,6 +4132,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3364,7 +4159,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_51
+            schema: *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -3378,7 +4173,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3403,6 +4198,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3415,7 +4225,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3429,7 +4239,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3454,6 +4264,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3466,7 +4291,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3480,7 +4305,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3505,6 +4330,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3517,7 +4357,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3531,7 +4371,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3556,6 +4396,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3568,7 +4423,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_52
+            schema: *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3582,7 +4437,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3608,8 +4463,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_54
-                schema: *ref_53
+              - !<!Parameter> &ref_55
+                schema: *ref_54
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3620,8 +4475,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_54
+              - *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -3647,7 +4515,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3672,6 +4540,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3684,7 +4567,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3698,7 +4581,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3723,6 +4606,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3735,7 +4633,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3749,7 +4647,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3774,6 +4672,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3786,7 +4699,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3800,7 +4713,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3825,6 +4738,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3837,7 +4765,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3851,7 +4779,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3876,6 +4804,21 @@ operationGroups:
           - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3888,7 +4831,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3902,7 +4845,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -3928,8 +4871,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_56
-                schema: *ref_55
+              - !<!Parameter> &ref_57
+                schema: *ref_56
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3940,8 +4883,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_56
+              - *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3967,7 +4923,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-duration/flattened.yaml
+++ b/modelerfour/test/scenarios/body-duration/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-duration
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,8 +30,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   durations:
-    - !<!DurationSchema> &ref_4
+    - !<!DurationSchema> &ref_5
       type: duration
       apiVersions:
         - !<!ApiVersion> 
@@ -42,14 +53,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -57,7 +68,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -76,7 +87,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -103,6 +114,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -115,7 +141,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -129,7 +155,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -155,8 +181,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_4
+              - !<!Parameter> &ref_7
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -167,8 +193,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,7 +233,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,6 +258,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -231,7 +285,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -245,7 +299,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -270,6 +324,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +351,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -296,7 +365,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-duration/grouped.yaml
+++ b/modelerfour/test/scenarios/body-duration/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-duration
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,8 +30,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   durations:
-    - !<!DurationSchema> &ref_4
+    - !<!DurationSchema> &ref_5
       type: duration
       apiVersions:
         - !<!ApiVersion> 
@@ -42,14 +53,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -57,7 +68,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -76,7 +87,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -103,6 +114,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -115,7 +141,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -129,7 +155,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -155,8 +181,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_4
+              - !<!Parameter> &ref_7
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -167,8 +193,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,7 +233,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,6 +258,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -231,7 +285,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -245,7 +299,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -270,6 +324,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +351,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -296,7 +365,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-duration/modeler.yaml
+++ b/modelerfour/test/scenarios/body-duration/modeler.yaml
@@ -30,8 +30,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_3
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   durations:
-    - !<!DurationSchema> &ref_3
+    - !<!DurationSchema> &ref_4
       type: duration
       apiVersions:
         - !<!ApiVersion> 
@@ -42,7 +53,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_4
+    - !<!ObjectSchema> &ref_5
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -75,7 +86,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_5
+  - !<!Parameter> &ref_6
     schema: *ref_2
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -100,9 +111,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -115,7 +141,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -129,7 +155,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -151,12 +177,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_3
+              - !<!Parameter> &ref_7
+                schema: *ref_4
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -167,8 +193,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,7 +233,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -216,9 +255,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -231,7 +285,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -245,7 +299,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -267,9 +321,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +351,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -296,7 +365,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-duration/namer.yaml
+++ b/modelerfour/test/scenarios/body-duration/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-duration
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,8 +30,19 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   durations:
-    - !<!DurationSchema> &ref_4
+    - !<!DurationSchema> &ref_5
       type: duration
       apiVersions:
         - !<!ApiVersion> 
@@ -42,14 +53,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -57,7 +68,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -76,7 +87,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -103,6 +114,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -115,7 +141,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -129,7 +155,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -155,8 +181,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_4
+              - !<!Parameter> &ref_7
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -167,8 +193,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,7 +233,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,6 +258,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -231,7 +285,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -245,7 +299,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -270,6 +324,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +351,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -296,7 +365,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-file/flattened.yaml
+++ b/modelerfour/test/scenarios/body-file/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-file
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,15 +30,26 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'image/png, application/json'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: image/png, application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_4
+    - !<!ObjectSchema> &ref_5
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -46,7 +57,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -65,7 +76,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -92,6 +103,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -119,7 +145,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -144,6 +170,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -171,7 +212,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -196,6 +237,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -223,7 +279,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-file/grouped.yaml
+++ b/modelerfour/test/scenarios/body-file/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-file
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,15 +30,26 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'image/png, application/json'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: image/png, application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_4
+    - !<!ObjectSchema> &ref_5
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -46,7 +57,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -65,7 +76,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -92,6 +103,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -119,7 +145,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -144,6 +170,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -171,7 +212,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -196,6 +237,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -223,7 +279,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-file/modeler.yaml
+++ b/modelerfour/test/scenarios/body-file/modeler.yaml
@@ -30,8 +30,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_3
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'image/png, application/json'
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: image/png, application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_3
+    - !<!ObjectSchema> &ref_4
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -64,7 +75,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_4
+  - !<!Parameter> &ref_5
     schema: *ref_2
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -89,9 +100,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_4
+          - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -119,7 +145,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -141,9 +167,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_4
+          - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -171,7 +212,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -193,9 +234,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_4
+          - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -223,7 +279,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-file/namer.yaml
+++ b/modelerfour/test/scenarios/body-file/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-file
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,15 +30,26 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'image/png, application/json'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: image/png, application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_4
+    - !<!ObjectSchema> &ref_5
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -46,7 +57,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -65,7 +76,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -92,6 +103,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -119,7 +145,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -144,6 +170,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -171,7 +212,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -196,6 +237,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -223,7 +279,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-formdata/flattened.yaml
+++ b/modelerfour/test/scenarios/body-formdata/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-formdata
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_4
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: post-content-schema-fileName
           description: File name to upload. Name has to be spelled exactly as written here.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -40,8 +40,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'application/octet-stream, application/json'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/octet-stream, application/json'
+      protocol: !<!Protocols> {}
   binaries:
-    - !<!BinarySchema> &ref_2
+    - !<!BinarySchema> &ref_3
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -51,7 +62,7 @@ schemas: !<!Schemas>
           name: binary
           description: File to upload.
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_9
+    - !<!BinarySchema> &ref_10
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -62,14 +73,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_8
+    - !<!ObjectSchema> &ref_9
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -77,7 +88,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -101,7 +112,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           required: true
           serializedName: fileContent
           language: !<!Languages> 
@@ -110,7 +121,7 @@ schemas: !<!Schemas>
               description: File to upload.
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_3
+          schema: *ref_4
           required: true
           serializedName: fileName
           language: !<!Languages> 
@@ -126,7 +137,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_5
-    schema: *ref_4
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -154,8 +165,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_2
+              - !<!Parameter> &ref_7
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -166,8 +177,8 @@ operationGroups:
                 protocol: !<!Protocols> 
                   http: !<!HttpParameter> 
                     in: body
-              - !<!Parameter> &ref_7
-                schema: *ref_3
+              - !<!Parameter> &ref_8
+                schema: *ref_4
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -178,9 +189,22 @@ operationGroups:
                 protocol: !<!Protocols> 
                   http: !<!HttpParameter> 
                     in: body
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
               - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -212,7 +236,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -238,8 +262,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_9
+              - !<!Parameter> &ref_11
+                schema: *ref_10
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -250,8 +274,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -283,7 +320,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-formdata/grouped.yaml
+++ b/modelerfour/test/scenarios/body-formdata/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-formdata
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_4
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: post-content-schema-fileName
           description: File name to upload. Name has to be spelled exactly as written here.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -40,8 +40,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'application/octet-stream, application/json'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/octet-stream, application/json'
+      protocol: !<!Protocols> {}
   binaries:
-    - !<!BinarySchema> &ref_2
+    - !<!BinarySchema> &ref_3
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -51,7 +62,7 @@ schemas: !<!Schemas>
           name: binary
           description: File to upload.
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_9
+    - !<!BinarySchema> &ref_10
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -62,14 +73,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_8
+    - !<!ObjectSchema> &ref_9
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -77,7 +88,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -101,7 +112,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           required: true
           serializedName: fileContent
           language: !<!Languages> 
@@ -110,7 +121,7 @@ schemas: !<!Schemas>
               description: File to upload.
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_3
+          schema: *ref_4
           required: true
           serializedName: fileName
           language: !<!Languages> 
@@ -126,7 +137,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_5
-    schema: *ref_4
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -154,8 +165,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_2
+              - !<!Parameter> &ref_7
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -166,8 +177,8 @@ operationGroups:
                 protocol: !<!Protocols> 
                   http: !<!HttpParameter> 
                     in: body
-              - !<!Parameter> &ref_7
-                schema: *ref_3
+              - !<!Parameter> &ref_8
+                schema: *ref_4
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -178,9 +189,22 @@ operationGroups:
                 protocol: !<!Protocols> 
                   http: !<!HttpParameter> 
                     in: body
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
               - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -212,7 +236,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -238,8 +262,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_9
+              - !<!Parameter> &ref_11
+                schema: *ref_10
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -250,8 +274,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -283,7 +320,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-formdata/modeler.yaml
+++ b/modelerfour/test/scenarios/body-formdata/modeler.yaml
@@ -40,6 +40,17 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'application/octet-stream, application/json'
+      valueType: *ref_4
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/octet-stream, application/json'
+      protocol: !<!Protocols> {}
   binaries:
     - !<!BinarySchema> &ref_1
       type: binary
@@ -51,7 +62,7 @@ schemas: !<!Schemas>
           name: binary
           description: File to upload.
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_9
+    - !<!BinarySchema> &ref_10
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -62,7 +73,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -125,7 +136,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_8
+  - !<!Parameter> &ref_9
     schema: *ref_4
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -150,11 +161,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_8
+          - *ref_9
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_5
+              - !<!Parameter> &ref_6
                 schema: *ref_1
                 implementation: Method
                 required: true
@@ -166,7 +177,7 @@ operationGroups:
                 protocol: !<!Protocols> 
                   http: !<!HttpParameter> 
                     in: body
-              - !<!Parameter> &ref_6
+              - !<!Parameter> &ref_7
                 schema: *ref_2
                 implementation: Method
                 required: true
@@ -178,9 +189,22 @@ operationGroups:
                 protocol: !<!Protocols> 
                   http: !<!HttpParameter> 
                     in: body
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_5
               - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -212,7 +236,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -234,12 +258,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_8
+          - *ref_9
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_9
+              - !<!Parameter> &ref_11
+                schema: *ref_10
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -250,8 +274,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -283,7 +320,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-formdata/namer.yaml
+++ b/modelerfour/test/scenarios/body-formdata/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-formdata
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_4
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: PostContentSchemaFileName
           description: File name to upload. Name has to be spelled exactly as written here.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -40,8 +40,19 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'application/octet-stream, application/json'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/octet-stream, application/json'
+      protocol: !<!Protocols> {}
   binaries:
-    - !<!BinarySchema> &ref_2
+    - !<!BinarySchema> &ref_3
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -51,7 +62,7 @@ schemas: !<!Schemas>
           name: binary
           description: File to upload.
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_9
+    - !<!BinarySchema> &ref_10
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -62,14 +73,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_8
+    - !<!ObjectSchema> &ref_9
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -77,7 +88,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -101,7 +112,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           required: true
           serializedName: fileContent
           language: !<!Languages> 
@@ -110,7 +121,7 @@ schemas: !<!Schemas>
               description: File to upload.
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_3
+          schema: *ref_4
           required: true
           serializedName: fileName
           language: !<!Languages> 
@@ -126,7 +137,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_5
-    schema: *ref_4
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -154,8 +165,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_6
-                schema: *ref_2
+              - !<!Parameter> &ref_7
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -166,8 +177,8 @@ operationGroups:
                 protocol: !<!Protocols> 
                   http: !<!HttpParameter> 
                     in: body
-              - !<!Parameter> &ref_7
-                schema: *ref_3
+              - !<!Parameter> &ref_8
+                schema: *ref_4
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -178,9 +189,22 @@ operationGroups:
                 protocol: !<!Protocols> 
                   http: !<!HttpParameter> 
                     in: body
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_6
               - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -212,7 +236,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -238,8 +262,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_9
+              - !<!Parameter> &ref_11
+                schema: *ref_10
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -250,8 +274,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -283,7 +320,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-integer/flattened.yaml
+++ b/modelerfour/test/scenarios/body-integer/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-integer
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_4
+    - !<!NumberSchema> &ref_5
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_6
+    - !<!NumberSchema> &ref_7
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -35,14 +35,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -52,8 +52,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   unixtimes:
-    - !<!UnixTimeSchema> &ref_11
+    - !<!UnixTimeSchema> &ref_12
       type: unixtime
       apiVersions:
         - !<!ApiVersion> 
@@ -64,14 +75,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -79,7 +90,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -98,7 +109,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -125,6 +136,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -137,7 +163,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -151,7 +177,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -176,6 +202,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -188,7 +229,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -202,7 +243,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -227,6 +268,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -239,7 +295,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -253,7 +309,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -278,6 +334,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -290,7 +361,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -304,7 +375,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -329,6 +400,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -341,7 +427,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -355,7 +441,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -380,6 +466,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -392,7 +493,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -406,7 +507,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -432,8 +533,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_4
+              - !<!Parameter> &ref_8
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -444,8 +545,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -471,7 +585,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -497,8 +611,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_6
+              - !<!Parameter> &ref_9
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -509,8 +623,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -536,7 +663,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -562,8 +689,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_4
+              - !<!Parameter> &ref_10
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -574,8 +701,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -601,7 +741,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -627,8 +767,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_6
+              - !<!Parameter> &ref_11
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -639,8 +779,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -666,7 +819,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -691,6 +844,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -703,7 +871,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -717,7 +885,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -743,8 +911,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_12
-                schema: *ref_11
+              - !<!Parameter> &ref_13
+                schema: *ref_12
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -755,8 +923,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -782,7 +963,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -807,6 +988,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -819,7 +1015,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -833,7 +1029,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -858,6 +1054,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -870,7 +1081,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -884,7 +1095,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-integer/grouped.yaml
+++ b/modelerfour/test/scenarios/body-integer/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-integer
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_4
+    - !<!NumberSchema> &ref_5
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_6
+    - !<!NumberSchema> &ref_7
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -35,14 +35,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -52,8 +52,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   unixtimes:
-    - !<!UnixTimeSchema> &ref_11
+    - !<!UnixTimeSchema> &ref_12
       type: unixtime
       apiVersions:
         - !<!ApiVersion> 
@@ -64,14 +75,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -79,7 +90,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -98,7 +109,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -125,6 +136,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -137,7 +163,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -151,7 +177,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -176,6 +202,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -188,7 +229,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -202,7 +243,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -227,6 +268,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -239,7 +295,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -253,7 +309,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -278,6 +334,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -290,7 +361,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -304,7 +375,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -329,6 +400,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -341,7 +427,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -355,7 +441,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -380,6 +466,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -392,7 +493,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -406,7 +507,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -432,8 +533,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_4
+              - !<!Parameter> &ref_8
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -444,8 +545,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -471,7 +585,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -497,8 +611,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_6
+              - !<!Parameter> &ref_9
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -509,8 +623,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -536,7 +663,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -562,8 +689,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_4
+              - !<!Parameter> &ref_10
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -574,8 +701,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -601,7 +741,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -627,8 +767,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_6
+              - !<!Parameter> &ref_11
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -639,8 +779,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -666,7 +819,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -691,6 +844,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -703,7 +871,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -717,7 +885,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -743,8 +911,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_12
-                schema: *ref_11
+              - !<!Parameter> &ref_13
+                schema: *ref_12
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -755,8 +923,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -782,7 +963,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -807,6 +988,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -819,7 +1015,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -833,7 +1029,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -858,6 +1054,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -870,7 +1081,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -884,7 +1095,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-integer/modeler.yaml
+++ b/modelerfour/test/scenarios/body-integer/modeler.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-integer
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_3
+    - !<!NumberSchema> &ref_4
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_6
+    - !<!NumberSchema> &ref_7
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -52,8 +52,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_3
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   unixtimes:
-    - !<!UnixTimeSchema> &ref_11
+    - !<!UnixTimeSchema> &ref_12
       type: unixtime
       apiVersions:
         - !<!ApiVersion> 
@@ -64,7 +75,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_4
+    - !<!ObjectSchema> &ref_5
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -97,7 +108,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_5
+  - !<!Parameter> &ref_6
     schema: *ref_2
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -122,9 +133,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -137,7 +163,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -151,7 +177,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -173,9 +199,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -188,7 +229,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -202,7 +243,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -224,9 +265,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -239,7 +295,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -253,7 +309,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -275,9 +331,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -290,7 +361,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -304,7 +375,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -326,9 +397,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -341,7 +427,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -355,7 +441,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -377,9 +463,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -392,7 +493,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -406,7 +507,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -428,12 +529,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_3
+              - !<!Parameter> &ref_8
+                schema: *ref_4
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -444,8 +545,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -471,7 +585,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -493,12 +607,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_6
+              - !<!Parameter> &ref_9
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -509,8 +623,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -536,7 +663,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -558,12 +685,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_3
+              - !<!Parameter> &ref_10
+                schema: *ref_4
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -574,8 +701,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -601,7 +741,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -623,12 +763,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_6
+              - !<!Parameter> &ref_11
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -639,8 +779,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -666,7 +819,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -688,9 +841,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -703,7 +871,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -717,7 +885,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -739,12 +907,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_12
-                schema: *ref_11
+              - !<!Parameter> &ref_13
+                schema: *ref_12
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -755,8 +923,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -782,7 +963,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -804,9 +985,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -819,7 +1015,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -833,7 +1029,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -855,9 +1051,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_3
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -870,7 +1081,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -884,7 +1095,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-integer/namer.yaml
+++ b/modelerfour/test/scenarios/body-integer/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-integer
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_4
+    - !<!NumberSchema> &ref_5
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_6
+    - !<!NumberSchema> &ref_7
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -35,14 +35,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -52,8 +52,19 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   unixtimes:
-    - !<!UnixTimeSchema> &ref_11
+    - !<!UnixTimeSchema> &ref_12
       type: unixtime
       apiVersions:
         - !<!ApiVersion> 
@@ -64,14 +75,14 @@ schemas: !<!Schemas>
           description: 'date in seconds since 1970-01-01T00:00:00Z.'
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -79,7 +90,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -98,7 +109,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -125,6 +136,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -137,7 +163,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -151,7 +177,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -176,6 +202,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -188,7 +229,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -202,7 +243,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -227,6 +268,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -239,7 +295,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -253,7 +309,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -278,6 +334,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -290,7 +361,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -304,7 +375,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -329,6 +400,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -341,7 +427,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -355,7 +441,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -380,6 +466,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -392,7 +493,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -406,7 +507,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -432,8 +533,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_4
+              - !<!Parameter> &ref_8
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -444,8 +545,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -471,7 +585,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -497,8 +611,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_6
+              - !<!Parameter> &ref_9
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -509,8 +623,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -536,7 +663,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -562,8 +689,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_4
+              - !<!Parameter> &ref_10
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -574,8 +701,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -601,7 +741,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -627,8 +767,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_6
+              - !<!Parameter> &ref_11
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -639,8 +779,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -666,7 +819,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -691,6 +844,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -703,7 +871,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -717,7 +885,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -743,8 +911,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_12
-                schema: *ref_11
+              - !<!Parameter> &ref_13
+                schema: *ref_12
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -755,8 +923,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -782,7 +963,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -807,6 +988,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -819,7 +1015,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -833,7 +1029,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -858,6 +1054,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -870,7 +1081,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -884,7 +1095,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-number.quirks/flattened.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-number.quirks
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_3
+    - !<!NumberSchema> &ref_4
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -34,7 +34,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_2
+    - !<!NumberSchema> &ref_3
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -46,14 +46,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_4
+    - !<!StringSchema> &ref_5
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -64,6 +64,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_7
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -71,7 +81,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 340282300000000000000
-      valueType: *ref_0
+      valueType: *ref_1
       language: !<!Languages> 
         default:
           name: paths·10negkw·number-big-float-3-402823e-20·get·responses·200·content·application-json·schema
@@ -84,7 +94,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e+101
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·dxaw7j·number-big-double-2-5976931e-101·get·responses·200·content·application-json·schema
@@ -97,7 +107,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 99999999.99
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·1fncqqa·number-big-double-99999999-99·get·responses·200·content·application-json·schema
@@ -110,7 +120,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: -99999999.99
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·1t3xw1o·number-big-double-_99999999-99·get·responses·200·content·application-json·schema
@@ -123,7 +133,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e+101
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·sp96l1·number-big-decimal-2-5976931e-101·get·responses·200·content·application-json·schema
@@ -136,7 +146,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 99999999.99
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·nx3qab·number-big-decimal-99999999-99·get·responses·200·content·application-json·schema
@@ -149,7 +159,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: -99999999.99
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·ftntuv·number-big-decimal-_99999999-99·get·responses·200·content·application-json·schema
@@ -162,7 +172,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 3.402823e-20
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·5kz2jo·number-small-float-3-402823e_20·get·responses·200·content·application-json·schema
@@ -175,7 +185,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e-101
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·1o9bfir·number-small-double-2-5976931e_101·get·responses·200·content·application-json·schema
@@ -188,21 +198,21 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e-101
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·hlryvi·number-small-decimal-2-5976931e_101·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_3
+          schema: *ref_4
           serializedName: status
           language: !<!Languages> 
             default:
@@ -210,7 +220,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_4
+          schema: *ref_5
           serializedName: message
           language: !<!Languages> 
             default:
@@ -229,7 +239,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_6
-    schema: *ref_5
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -256,6 +266,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -268,7 +293,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +307,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -307,6 +332,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -319,7 +359,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -333,7 +373,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -358,6 +398,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -370,7 +425,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -384,7 +439,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -410,8 +465,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_0
+              - !<!Parameter> &ref_9
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -422,8 +477,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -449,7 +517,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -474,6 +542,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -486,7 +569,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -500,7 +583,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -526,8 +609,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_1
+              - !<!Parameter> &ref_10
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -538,8 +621,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -565,7 +661,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -590,6 +686,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -602,7 +713,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -616,7 +727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -642,8 +753,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_1
+              - !<!Parameter> &ref_11
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -654,8 +765,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -681,7 +805,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -706,6 +830,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -718,7 +857,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -732,7 +871,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -758,8 +897,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_11
-                schema: *ref_1
+              - !<!Parameter> &ref_12
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -770,8 +909,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_11
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -797,7 +949,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -822,6 +974,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -834,7 +1001,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -848,7 +1015,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -874,8 +1041,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_12
-                schema: *ref_2
+              - !<!Parameter> &ref_13
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -886,8 +1053,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -913,7 +1093,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -938,6 +1118,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -950,7 +1145,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -964,7 +1159,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -990,8 +1185,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_2
+              - !<!Parameter> &ref_14
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1002,8 +1197,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_13
+              - *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1029,7 +1237,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1054,6 +1262,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1066,7 +1289,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1080,7 +1303,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1106,8 +1329,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_14
-                schema: *ref_2
+              - !<!Parameter> &ref_15
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1118,8 +1341,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_14
+              - *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1145,7 +1381,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1170,6 +1406,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1182,7 +1433,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1196,7 +1447,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1222,8 +1473,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_0
+              - !<!Parameter> &ref_16
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1234,8 +1485,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1261,7 +1525,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1286,6 +1550,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1298,7 +1577,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1312,7 +1591,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1338,8 +1617,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_1
+              - !<!Parameter> &ref_17
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1350,8 +1629,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1377,7 +1669,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1402,6 +1694,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1414,7 +1721,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1428,7 +1735,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1454,8 +1761,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
-                schema: *ref_2
+              - !<!Parameter> &ref_18
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1466,8 +1773,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1493,7 +1813,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1518,6 +1838,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1530,7 +1865,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1544,7 +1879,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-number.quirks/grouped.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-number.quirks
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_3
+    - !<!NumberSchema> &ref_4
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -34,7 +34,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_2
+    - !<!NumberSchema> &ref_3
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -46,14 +46,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_4
+    - !<!StringSchema> &ref_5
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -64,6 +64,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_7
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -71,7 +81,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 340282300000000000000
-      valueType: *ref_0
+      valueType: *ref_1
       language: !<!Languages> 
         default:
           name: paths·10negkw·number-big-float-3-402823e-20·get·responses·200·content·application-json·schema
@@ -84,7 +94,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e+101
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·dxaw7j·number-big-double-2-5976931e-101·get·responses·200·content·application-json·schema
@@ -97,7 +107,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 99999999.99
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·1fncqqa·number-big-double-99999999-99·get·responses·200·content·application-json·schema
@@ -110,7 +120,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: -99999999.99
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·1t3xw1o·number-big-double-_99999999-99·get·responses·200·content·application-json·schema
@@ -123,7 +133,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e+101
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·sp96l1·number-big-decimal-2-5976931e-101·get·responses·200·content·application-json·schema
@@ -136,7 +146,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 99999999.99
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·nx3qab·number-big-decimal-99999999-99·get·responses·200·content·application-json·schema
@@ -149,7 +159,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: -99999999.99
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·ftntuv·number-big-decimal-_99999999-99·get·responses·200·content·application-json·schema
@@ -162,7 +172,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 3.402823e-20
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·5kz2jo·number-small-float-3-402823e_20·get·responses·200·content·application-json·schema
@@ -175,7 +185,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e-101
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·1o9bfir·number-small-double-2-5976931e_101·get·responses·200·content·application-json·schema
@@ -188,21 +198,21 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e-101
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·hlryvi·number-small-decimal-2-5976931e_101·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_3
+          schema: *ref_4
           serializedName: status
           language: !<!Languages> 
             default:
@@ -210,7 +220,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_4
+          schema: *ref_5
           serializedName: message
           language: !<!Languages> 
             default:
@@ -229,7 +239,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_6
-    schema: *ref_5
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -256,6 +266,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -268,7 +293,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +307,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -307,6 +332,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -319,7 +359,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -333,7 +373,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -358,6 +398,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -370,7 +425,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -384,7 +439,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -410,8 +465,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_0
+              - !<!Parameter> &ref_9
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -422,8 +477,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -449,7 +517,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -474,6 +542,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -486,7 +569,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -500,7 +583,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -526,8 +609,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_1
+              - !<!Parameter> &ref_10
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -538,8 +621,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -565,7 +661,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -590,6 +686,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -602,7 +713,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -616,7 +727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -642,8 +753,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_1
+              - !<!Parameter> &ref_11
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -654,8 +765,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -681,7 +805,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -706,6 +830,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -718,7 +857,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -732,7 +871,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -758,8 +897,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_11
-                schema: *ref_1
+              - !<!Parameter> &ref_12
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -770,8 +909,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_11
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -797,7 +949,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -822,6 +974,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -834,7 +1001,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -848,7 +1015,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -874,8 +1041,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_12
-                schema: *ref_2
+              - !<!Parameter> &ref_13
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -886,8 +1053,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -913,7 +1093,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -938,6 +1118,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -950,7 +1145,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -964,7 +1159,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -990,8 +1185,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_2
+              - !<!Parameter> &ref_14
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1002,8 +1197,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_13
+              - *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1029,7 +1237,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1054,6 +1262,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1066,7 +1289,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1080,7 +1303,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1106,8 +1329,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_14
-                schema: *ref_2
+              - !<!Parameter> &ref_15
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1118,8 +1341,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_14
+              - *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1145,7 +1381,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1170,6 +1406,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1182,7 +1433,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1196,7 +1447,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1222,8 +1473,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_0
+              - !<!Parameter> &ref_16
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1234,8 +1485,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1261,7 +1525,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1286,6 +1550,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1298,7 +1577,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1312,7 +1591,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1338,8 +1617,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_1
+              - !<!Parameter> &ref_17
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1350,8 +1629,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1377,7 +1669,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1402,6 +1694,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1414,7 +1721,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1428,7 +1735,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1454,8 +1761,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
-                schema: *ref_2
+              - !<!Parameter> &ref_18
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1466,8 +1773,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1493,7 +1813,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1518,6 +1838,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1530,7 +1865,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1544,7 +1879,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-number.quirks/modeler.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/modeler.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-number.quirks
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_2
+    - !<!NumberSchema> &ref_3
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_3
+    - !<!NumberSchema> &ref_4
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -34,7 +34,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_4
+    - !<!NumberSchema> &ref_5
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_2
       type: string
       language: !<!Languages> 
         default:
@@ -64,6 +64,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -71,7 +81,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 340282300000000000000
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·10negkw·number-big-float-3-402823e-20·get·responses·200·content·application-json·schema
@@ -84,7 +94,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e+101
-      valueType: *ref_3
+      valueType: *ref_4
       language: !<!Languages> 
         default:
           name: paths·dxaw7j·number-big-double-2-5976931e-101·get·responses·200·content·application-json·schema
@@ -97,7 +107,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 99999999.99
-      valueType: *ref_3
+      valueType: *ref_4
       language: !<!Languages> 
         default:
           name: paths·1fncqqa·number-big-double-99999999-99·get·responses·200·content·application-json·schema
@@ -110,7 +120,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: -99999999.99
-      valueType: *ref_3
+      valueType: *ref_4
       language: !<!Languages> 
         default:
           name: paths·1t3xw1o·number-big-double-_99999999-99·get·responses·200·content·application-json·schema
@@ -123,7 +133,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e+101
-      valueType: *ref_4
+      valueType: *ref_5
       language: !<!Languages> 
         default:
           name: paths·sp96l1·number-big-decimal-2-5976931e-101·get·responses·200·content·application-json·schema
@@ -136,7 +146,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 99999999.99
-      valueType: *ref_4
+      valueType: *ref_5
       language: !<!Languages> 
         default:
           name: paths·nx3qab·number-big-decimal-99999999-99·get·responses·200·content·application-json·schema
@@ -149,7 +159,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: -99999999.99
-      valueType: *ref_4
+      valueType: *ref_5
       language: !<!Languages> 
         default:
           name: paths·ftntuv·number-big-decimal-_99999999-99·get·responses·200·content·application-json·schema
@@ -162,7 +172,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 3.402823e-20
-      valueType: *ref_3
+      valueType: *ref_4
       language: !<!Languages> 
         default:
           name: paths·5kz2jo·number-small-float-3-402823e_20·get·responses·200·content·application-json·schema
@@ -175,7 +185,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e-101
-      valueType: *ref_3
+      valueType: *ref_4
       language: !<!Languages> 
         default:
           name: paths·1o9bfir·number-small-double-2-5976931e_101·get·responses·200·content·application-json·schema
@@ -188,14 +198,14 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e-101
-      valueType: *ref_4
+      valueType: *ref_5
       language: !<!Languages> 
         default:
           name: paths·hlryvi·number-small-decimal-2-5976931e_101·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_6
+    - !<!ObjectSchema> &ref_7
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -228,8 +238,8 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_7
-    schema: *ref_5
+  - !<!Parameter> &ref_8
+    schema: *ref_2
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -253,9 +263,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -268,7 +293,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +307,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -304,9 +329,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -319,7 +359,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -333,7 +373,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -355,9 +395,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -370,7 +425,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -384,7 +439,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -406,12 +461,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_2
+              - !<!Parameter> &ref_9
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -422,8 +477,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -449,7 +517,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -471,9 +539,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -486,7 +569,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -500,7 +583,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -522,12 +605,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_3
+              - !<!Parameter> &ref_10
+                schema: *ref_4
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -538,8 +621,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -565,7 +661,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -587,9 +683,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -602,7 +713,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -616,7 +727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -638,12 +749,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_3
+              - !<!Parameter> &ref_11
+                schema: *ref_4
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -654,8 +765,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -681,7 +805,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -703,9 +827,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -718,7 +857,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -732,7 +871,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -754,12 +893,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_11
-                schema: *ref_3
+              - !<!Parameter> &ref_12
+                schema: *ref_4
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -770,8 +909,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_11
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -797,7 +949,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -819,9 +971,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -834,7 +1001,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -848,7 +1015,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -870,12 +1037,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_12
-                schema: *ref_4
+              - !<!Parameter> &ref_13
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -886,8 +1053,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -913,7 +1093,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -935,9 +1115,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -950,7 +1145,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -964,7 +1159,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -986,12 +1181,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_4
+              - !<!Parameter> &ref_14
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1002,8 +1197,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_13
+              - *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1029,7 +1237,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1051,9 +1259,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1066,7 +1289,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -1080,7 +1303,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1102,12 +1325,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_14
-                schema: *ref_4
+              - !<!Parameter> &ref_15
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1118,8 +1341,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_14
+              - *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1145,7 +1381,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1167,9 +1403,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1182,7 +1433,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -1196,7 +1447,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1218,12 +1469,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_2
+              - !<!Parameter> &ref_16
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1234,8 +1485,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1261,7 +1525,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1283,9 +1547,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1298,7 +1577,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -1312,7 +1591,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1334,12 +1613,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_3
+              - !<!Parameter> &ref_17
+                schema: *ref_4
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1350,8 +1629,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1377,7 +1669,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1399,9 +1691,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1414,7 +1721,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -1428,7 +1735,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1450,12 +1757,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
-                schema: *ref_4
+              - !<!Parameter> &ref_18
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1466,8 +1773,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1493,7 +1813,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1515,9 +1835,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1530,7 +1865,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -1544,7 +1879,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-number.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-number.quirks/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-number.quirks
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           name: Number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_3
+    - !<!NumberSchema> &ref_4
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -34,7 +34,7 @@ schemas: !<!Schemas>
           name: Number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_2
+    - !<!NumberSchema> &ref_3
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -46,14 +46,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_4
+    - !<!StringSchema> &ref_5
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -64,18 +64,15 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> 
+    - !<!ConstantSchema> &ref_7
       type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
       value: !<!ConstantValue> 
-        value: 340282300000000000000
+        value: application/json
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant0
-          description: ''
+          name: Accept
+          description: 'Accept: application/json'
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
@@ -83,7 +80,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: 2.5976931e+101
+        value: 340282300000000000000
       valueType: *ref_1
       language: !<!Languages> 
         default:
@@ -96,8 +93,8 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: 99999999.99
-      valueType: *ref_1
+        value: 2.5976931e+101
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: Constant2
@@ -109,8 +106,8 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: -99999999.99
-      valueType: *ref_1
+        value: 99999999.99
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: Constant3
@@ -122,7 +119,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: 2.5976931e+101
+        value: -99999999.99
       valueType: *ref_2
       language: !<!Languages> 
         default:
@@ -135,8 +132,8 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: 99999999.99
-      valueType: *ref_2
+        value: 2.5976931e+101
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: Constant5
@@ -148,8 +145,8 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: -99999999.99
-      valueType: *ref_2
+        value: 99999999.99
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: Constant6
@@ -161,8 +158,8 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: 3.402823e-20
-      valueType: *ref_1
+        value: -99999999.99
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: Constant7
@@ -174,8 +171,8 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: 2.5976931e-101
-      valueType: *ref_1
+        value: 3.402823e-20
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: Constant8
@@ -194,15 +191,28 @@ schemas: !<!Schemas>
           name: Constant9
           description: ''
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> 
+      type: constant
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      value: !<!ConstantValue> 
+        value: 2.5976931e-101
+      valueType: *ref_3
+      language: !<!Languages> 
+        default:
+          name: Constant10
+          description: ''
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_3
+          schema: *ref_4
           serializedName: status
           language: !<!Languages> 
             default:
@@ -210,7 +220,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_4
+          schema: *ref_5
           serializedName: message
           language: !<!Languages> 
             default:
@@ -229,7 +239,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_6
-    schema: *ref_5
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -256,6 +266,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -268,7 +293,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +307,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -307,6 +332,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -319,7 +359,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -333,7 +373,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -358,6 +398,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -370,7 +425,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -384,7 +439,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -410,8 +465,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_0
+              - !<!Parameter> &ref_9
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -422,8 +477,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -449,7 +517,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -474,6 +542,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -486,7 +569,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -500,7 +583,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -526,8 +609,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_1
+              - !<!Parameter> &ref_10
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -538,8 +621,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -565,7 +661,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -590,6 +686,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -602,7 +713,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -616,7 +727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -642,8 +753,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_1
+              - !<!Parameter> &ref_11
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -654,8 +765,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -681,7 +805,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -706,6 +830,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -718,7 +857,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -732,7 +871,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -758,8 +897,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_11
-                schema: *ref_1
+              - !<!Parameter> &ref_12
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -770,8 +909,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_11
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -797,7 +949,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -822,6 +974,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -834,7 +1001,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -848,7 +1015,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -874,8 +1041,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_12
-                schema: *ref_2
+              - !<!Parameter> &ref_13
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -886,8 +1053,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -913,7 +1093,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -938,6 +1118,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -950,7 +1145,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -964,7 +1159,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -990,8 +1185,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_2
+              - !<!Parameter> &ref_14
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1002,8 +1197,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_13
+              - *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1029,7 +1237,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1054,6 +1262,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1066,7 +1289,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1080,7 +1303,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1106,8 +1329,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_14
-                schema: *ref_2
+              - !<!Parameter> &ref_15
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1118,8 +1341,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_14
+              - *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1145,7 +1381,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1170,6 +1406,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1182,7 +1433,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1196,7 +1447,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1222,8 +1473,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_0
+              - !<!Parameter> &ref_16
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1234,8 +1485,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1261,7 +1525,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1286,6 +1550,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1298,7 +1577,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1312,7 +1591,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1338,8 +1617,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_1
+              - !<!Parameter> &ref_17
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1350,8 +1629,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1377,7 +1669,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1402,6 +1694,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1414,7 +1721,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1428,7 +1735,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1454,8 +1761,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
-                schema: *ref_2
+              - !<!Parameter> &ref_18
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1466,8 +1773,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1493,7 +1813,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1518,6 +1838,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1530,7 +1865,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1544,7 +1879,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-number/flattened.yaml
+++ b/modelerfour/test/scenarios/body-number/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-number
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_3
+    - !<!NumberSchema> &ref_4
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -34,7 +34,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_2
+    - !<!NumberSchema> &ref_3
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -46,14 +46,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_4
+    - !<!StringSchema> &ref_5
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -64,6 +64,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_7
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -71,7 +81,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 340282300000000000000
-      valueType: *ref_0
+      valueType: *ref_1
       language: !<!Languages> 
         default:
           name: paths·10negkw·number-big-float-3-402823e-20·get·responses·200·content·application-json·schema
@@ -84,23 +94,10 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e+101
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·dxaw7j·number-big-double-2-5976931e-101·get·responses·200·content·application-json·schema
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_10
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      value: !<!ConstantValue> 
-        value: 99999999.99
-      valueType: *ref_1
-      language: !<!Languages> 
-        default:
-          name: paths·1fncqqa·number-big-double-99999999-99·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_11
@@ -109,8 +106,21 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
+        value: 99999999.99
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: paths·1fncqqa·number-big-double-99999999-99·get·responses·200·content·application-json·schema
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_12
+      type: constant
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      value: !<!ConstantValue> 
         value: -99999999.99
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·1t3xw1o·number-big-double-_99999999-99·get·responses·200·content·application-json·schema
@@ -123,23 +133,10 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e+101
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·sp96l1·number-big-decimal-2-5976931e-101·get·responses·200·content·application-json·schema
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_13
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      value: !<!ConstantValue> 
-        value: 99999999.99
-      valueType: *ref_2
-      language: !<!Languages> 
-        default:
-          name: paths·nx3qab·number-big-decimal-99999999-99·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_14
@@ -148,8 +145,21 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
+        value: 99999999.99
+      valueType: *ref_3
+      language: !<!Languages> 
+        default:
+          name: paths·nx3qab·number-big-decimal-99999999-99·get·responses·200·content·application-json·schema
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_15
+      type: constant
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      value: !<!ConstantValue> 
         value: -99999999.99
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·ftntuv·number-big-decimal-_99999999-99·get·responses·200·content·application-json·schema
@@ -162,7 +172,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 3.402823e-20
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·5kz2jo·number-small-float-3-402823e_20·get·responses·200·content·application-json·schema
@@ -175,7 +185,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e-101
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·1o9bfir·number-small-double-2-5976931e_101·get·responses·200·content·application-json·schema
@@ -188,21 +198,21 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e-101
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·hlryvi·number-small-decimal-2-5976931e_101·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_3
+          schema: *ref_4
           serializedName: status
           language: !<!Languages> 
             default:
@@ -210,7 +220,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_4
+          schema: *ref_5
           serializedName: message
           language: !<!Languages> 
             default:
@@ -229,7 +239,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_6
-    schema: *ref_5
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -256,6 +266,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -268,7 +293,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +307,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -307,6 +332,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -319,7 +359,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -333,7 +373,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -358,6 +398,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -370,7 +425,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -384,7 +439,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -409,6 +464,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -421,7 +491,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -435,7 +505,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -461,8 +531,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_0
+              - !<!Parameter> &ref_9
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -473,8 +543,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -500,7 +583,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -525,6 +608,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -537,7 +635,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -551,7 +649,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -577,8 +675,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_1
+              - !<!Parameter> &ref_10
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -589,8 +687,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -616,7 +727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -641,6 +752,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -653,7 +779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -667,7 +793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -694,7 +820,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_10
+                schema: *ref_11
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -705,6 +831,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -731,7 +870,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -756,6 +895,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -768,7 +922,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -782,7 +936,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -809,7 +963,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_11
+                schema: *ref_12
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -820,6 +974,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -846,7 +1013,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -871,6 +1038,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -883,7 +1065,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -897,7 +1079,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -923,8 +1105,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_12
-                schema: *ref_2
+              - !<!Parameter> &ref_13
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -935,8 +1117,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -962,7 +1157,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -987,6 +1182,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -999,7 +1209,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1013,7 +1223,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1040,7 +1250,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1051,6 +1261,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1077,7 +1300,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1102,6 +1325,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1114,7 +1352,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1128,7 +1366,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1155,7 +1393,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_14
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1166,6 +1404,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1192,7 +1443,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1217,6 +1468,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1229,7 +1495,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1243,7 +1509,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1269,8 +1535,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_0
+              - !<!Parameter> &ref_16
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1281,8 +1547,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1308,7 +1587,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1333,6 +1612,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1345,7 +1639,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1359,7 +1653,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1385,8 +1679,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_1
+              - !<!Parameter> &ref_17
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1397,8 +1691,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1424,7 +1731,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1449,6 +1756,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1461,7 +1783,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1475,7 +1797,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1501,8 +1823,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
-                schema: *ref_2
+              - !<!Parameter> &ref_18
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1513,8 +1835,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1540,7 +1875,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1565,6 +1900,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1577,7 +1927,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1591,7 +1941,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-number/grouped.yaml
+++ b/modelerfour/test/scenarios/body-number/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-number
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_3
+    - !<!NumberSchema> &ref_4
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -34,7 +34,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_2
+    - !<!NumberSchema> &ref_3
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -46,14 +46,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_4
+    - !<!StringSchema> &ref_5
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -64,6 +64,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_7
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -71,7 +81,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 340282300000000000000
-      valueType: *ref_0
+      valueType: *ref_1
       language: !<!Languages> 
         default:
           name: paths·10negkw·number-big-float-3-402823e-20·get·responses·200·content·application-json·schema
@@ -84,23 +94,10 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e+101
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·dxaw7j·number-big-double-2-5976931e-101·get·responses·200·content·application-json·schema
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_10
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      value: !<!ConstantValue> 
-        value: 99999999.99
-      valueType: *ref_1
-      language: !<!Languages> 
-        default:
-          name: paths·1fncqqa·number-big-double-99999999-99·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_11
@@ -109,8 +106,21 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
+        value: 99999999.99
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: paths·1fncqqa·number-big-double-99999999-99·get·responses·200·content·application-json·schema
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_12
+      type: constant
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      value: !<!ConstantValue> 
         value: -99999999.99
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·1t3xw1o·number-big-double-_99999999-99·get·responses·200·content·application-json·schema
@@ -123,23 +133,10 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e+101
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·sp96l1·number-big-decimal-2-5976931e-101·get·responses·200·content·application-json·schema
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_13
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      value: !<!ConstantValue> 
-        value: 99999999.99
-      valueType: *ref_2
-      language: !<!Languages> 
-        default:
-          name: paths·nx3qab·number-big-decimal-99999999-99·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_14
@@ -148,8 +145,21 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
+        value: 99999999.99
+      valueType: *ref_3
+      language: !<!Languages> 
+        default:
+          name: paths·nx3qab·number-big-decimal-99999999-99·get·responses·200·content·application-json·schema
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_15
+      type: constant
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      value: !<!ConstantValue> 
         value: -99999999.99
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·ftntuv·number-big-decimal-_99999999-99·get·responses·200·content·application-json·schema
@@ -162,7 +172,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 3.402823e-20
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·5kz2jo·number-small-float-3-402823e_20·get·responses·200·content·application-json·schema
@@ -175,7 +185,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e-101
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: paths·1o9bfir·number-small-double-2-5976931e_101·get·responses·200·content·application-json·schema
@@ -188,21 +198,21 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e-101
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·hlryvi·number-small-decimal-2-5976931e_101·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_3
+          schema: *ref_4
           serializedName: status
           language: !<!Languages> 
             default:
@@ -210,7 +220,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_4
+          schema: *ref_5
           serializedName: message
           language: !<!Languages> 
             default:
@@ -229,7 +239,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_6
-    schema: *ref_5
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -256,6 +266,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -268,7 +293,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +307,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -307,6 +332,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -319,7 +359,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -333,7 +373,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -358,6 +398,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -370,7 +425,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -384,7 +439,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -409,6 +464,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -421,7 +491,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -435,7 +505,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -461,8 +531,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_0
+              - !<!Parameter> &ref_9
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -473,8 +543,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -500,7 +583,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -525,6 +608,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -537,7 +635,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -551,7 +649,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -577,8 +675,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_1
+              - !<!Parameter> &ref_10
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -589,8 +687,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -616,7 +727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -641,6 +752,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -653,7 +779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -667,7 +793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -694,7 +820,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_10
+                schema: *ref_11
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -705,6 +831,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -731,7 +870,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -756,6 +895,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -768,7 +922,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -782,7 +936,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -809,7 +963,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_11
+                schema: *ref_12
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -820,6 +974,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -846,7 +1013,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -871,6 +1038,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -883,7 +1065,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -897,7 +1079,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -923,8 +1105,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_12
-                schema: *ref_2
+              - !<!Parameter> &ref_13
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -935,8 +1117,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -962,7 +1157,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -987,6 +1182,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -999,7 +1209,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1013,7 +1223,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1040,7 +1250,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1051,6 +1261,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1077,7 +1300,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1102,6 +1325,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1114,7 +1352,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1128,7 +1366,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1155,7 +1393,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_14
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1166,6 +1404,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1192,7 +1443,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1217,6 +1468,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1229,7 +1495,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1243,7 +1509,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1269,8 +1535,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_0
+              - !<!Parameter> &ref_16
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1281,8 +1547,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1308,7 +1587,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1333,6 +1612,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1345,7 +1639,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1359,7 +1653,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1385,8 +1679,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_1
+              - !<!Parameter> &ref_17
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1397,8 +1691,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1424,7 +1731,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1449,6 +1756,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1461,7 +1783,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1475,7 +1797,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1501,8 +1823,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
-                schema: *ref_2
+              - !<!Parameter> &ref_18
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1513,8 +1835,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1540,7 +1875,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1565,6 +1900,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1577,7 +1927,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1591,7 +1941,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-number/modeler.yaml
+++ b/modelerfour/test/scenarios/body-number/modeler.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-number
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_2
+    - !<!NumberSchema> &ref_3
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_3
+    - !<!NumberSchema> &ref_4
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -34,7 +34,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_4
+    - !<!NumberSchema> &ref_5
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_2
       type: string
       language: !<!Languages> 
         default:
@@ -64,6 +64,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -71,7 +81,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 340282300000000000000
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·10negkw·number-big-float-3-402823e-20·get·responses·200·content·application-json·schema
@@ -84,23 +94,10 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e+101
-      valueType: *ref_3
+      valueType: *ref_4
       language: !<!Languages> 
         default:
           name: paths·dxaw7j·number-big-double-2-5976931e-101·get·responses·200·content·application-json·schema
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_10
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      value: !<!ConstantValue> 
-        value: 99999999.99
-      valueType: *ref_3
-      language: !<!Languages> 
-        default:
-          name: paths·1fncqqa·number-big-double-99999999-99·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_11
@@ -109,8 +106,21 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
+        value: 99999999.99
+      valueType: *ref_4
+      language: !<!Languages> 
+        default:
+          name: paths·1fncqqa·number-big-double-99999999-99·get·responses·200·content·application-json·schema
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_12
+      type: constant
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      value: !<!ConstantValue> 
         value: -99999999.99
-      valueType: *ref_3
+      valueType: *ref_4
       language: !<!Languages> 
         default:
           name: paths·1t3xw1o·number-big-double-_99999999-99·get·responses·200·content·application-json·schema
@@ -123,23 +133,10 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e+101
-      valueType: *ref_4
+      valueType: *ref_5
       language: !<!Languages> 
         default:
           name: paths·sp96l1·number-big-decimal-2-5976931e-101·get·responses·200·content·application-json·schema
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_13
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      value: !<!ConstantValue> 
-        value: 99999999.99
-      valueType: *ref_4
-      language: !<!Languages> 
-        default:
-          name: paths·nx3qab·number-big-decimal-99999999-99·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_14
@@ -148,8 +145,21 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
+        value: 99999999.99
+      valueType: *ref_5
+      language: !<!Languages> 
+        default:
+          name: paths·nx3qab·number-big-decimal-99999999-99·get·responses·200·content·application-json·schema
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_15
+      type: constant
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      value: !<!ConstantValue> 
         value: -99999999.99
-      valueType: *ref_4
+      valueType: *ref_5
       language: !<!Languages> 
         default:
           name: paths·ftntuv·number-big-decimal-_99999999-99·get·responses·200·content·application-json·schema
@@ -162,7 +172,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 3.402823e-20
-      valueType: *ref_3
+      valueType: *ref_4
       language: !<!Languages> 
         default:
           name: paths·5kz2jo·number-small-float-3-402823e_20·get·responses·200·content·application-json·schema
@@ -175,7 +185,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e-101
-      valueType: *ref_3
+      valueType: *ref_4
       language: !<!Languages> 
         default:
           name: paths·1o9bfir·number-small-double-2-5976931e_101·get·responses·200·content·application-json·schema
@@ -188,14 +198,14 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e-101
-      valueType: *ref_4
+      valueType: *ref_5
       language: !<!Languages> 
         default:
           name: paths·hlryvi·number-small-decimal-2-5976931e_101·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_6
+    - !<!ObjectSchema> &ref_7
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -228,8 +238,8 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_7
-    schema: *ref_5
+  - !<!Parameter> &ref_8
+    schema: *ref_2
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -253,9 +263,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -268,7 +293,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +307,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -304,9 +329,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -319,7 +359,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -333,7 +373,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -355,9 +395,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -370,7 +425,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -384,7 +439,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -406,9 +461,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -421,7 +491,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -435,7 +505,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -457,12 +527,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_2
+              - !<!Parameter> &ref_9
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -473,8 +543,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -500,7 +583,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -522,9 +605,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -537,7 +635,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -551,7 +649,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -573,12 +671,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_3
+              - !<!Parameter> &ref_10
+                schema: *ref_4
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -589,8 +687,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -616,7 +727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -638,9 +749,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -653,7 +779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -667,7 +793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -689,12 +815,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_10
+                schema: *ref_11
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -705,6 +831,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -731,7 +870,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -753,9 +892,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -768,7 +922,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -782,7 +936,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -804,12 +958,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_11
+                schema: *ref_12
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -820,6 +974,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -846,7 +1013,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -868,9 +1035,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -883,7 +1065,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -897,7 +1079,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -919,12 +1101,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_12
-                schema: *ref_4
+              - !<!Parameter> &ref_13
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -935,8 +1117,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -962,7 +1157,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -984,9 +1179,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -999,7 +1209,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -1013,7 +1223,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1035,12 +1245,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1051,6 +1261,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1077,7 +1300,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1099,9 +1322,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1114,7 +1352,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -1128,7 +1366,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1150,12 +1388,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_14
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1166,6 +1404,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1192,7 +1443,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1214,9 +1465,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1229,7 +1495,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -1243,7 +1509,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1265,12 +1531,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_2
+              - !<!Parameter> &ref_16
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1281,8 +1547,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1308,7 +1587,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1330,9 +1609,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1345,7 +1639,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -1359,7 +1653,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1381,12 +1675,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_3
+              - !<!Parameter> &ref_17
+                schema: *ref_4
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1397,8 +1691,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1424,7 +1731,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1446,9 +1753,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1461,7 +1783,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_3
+            schema: *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -1475,7 +1797,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1497,12 +1819,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
-                schema: *ref_4
+              - !<!Parameter> &ref_18
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1513,8 +1835,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1540,7 +1875,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1562,9 +1897,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1577,7 +1927,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''
@@ -1591,7 +1941,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-number/namer.yaml
+++ b/modelerfour/test/scenarios/body-number/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: body-number
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           name: Number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_3
+    - !<!NumberSchema> &ref_4
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -34,7 +34,7 @@ schemas: !<!Schemas>
           name: Number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_2
+    - !<!NumberSchema> &ref_3
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -46,14 +46,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_4
+    - !<!StringSchema> &ref_5
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -64,6 +64,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_7
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
       apiVersions:
@@ -71,10 +81,10 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 340282300000000000000
-      valueType: *ref_0
+      valueType: *ref_1
       language: !<!Languages> 
         default:
-          name: Constant0
+          name: Constant1
           description: ''
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
@@ -84,20 +94,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e+101
-      valueType: *ref_1
-      language: !<!Languages> 
-        default:
-          name: Constant1
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_10
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      value: !<!ConstantValue> 
-        value: 99999999.99
-      valueType: *ref_1
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: Constant2
@@ -109,11 +106,24 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: -99999999.99
-      valueType: *ref_1
+        value: 99999999.99
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: Constant3
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_12
+      type: constant
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      value: !<!ConstantValue> 
+        value: -99999999.99
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: Constant4
           description: ''
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
@@ -123,20 +133,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       value: !<!ConstantValue> 
         value: 2.5976931e+101
-      valueType: *ref_2
-      language: !<!Languages> 
-        default:
-          name: Constant4
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_13
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      value: !<!ConstantValue> 
-        value: 99999999.99
-      valueType: *ref_2
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: Constant5
@@ -148,21 +145,21 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: -99999999.99
-      valueType: *ref_2
+        value: 99999999.99
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: Constant6
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> 
+    - !<!ConstantSchema> &ref_15
       type: constant
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: 3.402823e-20
-      valueType: *ref_1
+        value: -99999999.99
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: Constant7
@@ -174,8 +171,8 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: 2.5976931e-101
-      valueType: *ref_1
+        value: 3.402823e-20
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: Constant8
@@ -194,15 +191,28 @@ schemas: !<!Schemas>
           name: Constant9
           description: ''
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> 
+      type: constant
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      value: !<!ConstantValue> 
+        value: 2.5976931e-101
+      valueType: *ref_3
+      language: !<!Languages> 
+        default:
+          name: Constant10
+          description: ''
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_3
+          schema: *ref_4
           serializedName: status
           language: !<!Languages> 
             default:
@@ -210,7 +220,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_4
+          schema: *ref_5
           serializedName: message
           language: !<!Languages> 
             default:
@@ -229,7 +239,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_6
-    schema: *ref_5
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -256,6 +266,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -268,7 +293,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +307,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -307,6 +332,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -319,7 +359,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -333,7 +373,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -358,6 +398,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -370,7 +425,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -384,7 +439,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -409,6 +464,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -421,7 +491,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -435,7 +505,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -461,8 +531,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_0
+              - !<!Parameter> &ref_9
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -473,8 +543,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -500,7 +583,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -525,6 +608,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -537,7 +635,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -551,7 +649,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -577,8 +675,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_1
+              - !<!Parameter> &ref_10
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -589,8 +687,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -616,7 +727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -641,6 +752,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -653,7 +779,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -667,7 +793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -694,7 +820,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_10
+                schema: *ref_11
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -705,6 +831,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -731,7 +870,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -756,6 +895,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -768,7 +922,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -782,7 +936,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -809,7 +963,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_11
+                schema: *ref_12
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -820,6 +974,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -846,7 +1013,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -871,6 +1038,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -883,7 +1065,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -897,7 +1079,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -923,8 +1105,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_12
-                schema: *ref_2
+              - !<!Parameter> &ref_13
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -935,8 +1117,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -962,7 +1157,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -987,6 +1182,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -999,7 +1209,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1013,7 +1223,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1040,7 +1250,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1051,6 +1261,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1077,7 +1300,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1102,6 +1325,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1114,7 +1352,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1128,7 +1366,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1155,7 +1393,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_14
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1166,6 +1404,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1192,7 +1443,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1217,6 +1468,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1229,7 +1495,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1243,7 +1509,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1269,8 +1535,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_0
+              - !<!Parameter> &ref_16
+                schema: *ref_1
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1281,8 +1547,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1308,7 +1587,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1333,6 +1612,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1345,7 +1639,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1359,7 +1653,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1385,8 +1679,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_1
+              - !<!Parameter> &ref_17
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1397,8 +1691,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1424,7 +1731,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1449,6 +1756,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1461,7 +1783,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -1475,7 +1797,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1501,8 +1823,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
-                schema: *ref_2
+              - !<!Parameter> &ref_18
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1513,8 +1835,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1540,7 +1875,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1565,6 +1900,21 @@ operationGroups:
           - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1577,7 +1927,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -1591,7 +1941,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-string.quirks/flattened.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/flattened.yaml
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_8
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -51,7 +51,7 @@ schemas: !<!Schemas>
           description: Sample string.
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_14
+    - !<!SealedChoiceSchema> &ref_15
       choices:
         - !<!ChoiceValue> 
           value: red color
@@ -94,6 +94,16 @@ schemas: !<!Schemas>
         default:
           name: paths·1p4myr3·string-null·get·responses·200·content·application-json·schema
           description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
@@ -148,7 +158,7 @@ schemas: !<!Schemas>
           description: Referenced Color Constant Description.
       protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_12
+    - !<!ByteArraySchema> &ref_13
       type: byte-array
       format: base64url
       apiVersions:
@@ -160,7 +170,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_6
+    - !<!ObjectSchema> &ref_7
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -192,13 +202,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_17
+    - !<!ObjectSchema> &ref_18
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_19
+        - !<!Property> &ref_20
           schema: *ref_3
           required: true
           serializedName: ColorConstant
@@ -207,7 +217,7 @@ schemas: !<!Schemas>
               name: ColorConstant
               description: Referenced Color Constant Description.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_20
+        - !<!Property> &ref_21
           schema: *ref_4
           required: false
           serializedName: field1
@@ -256,6 +266,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +307,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -308,8 +333,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_7
+              - !<!Parameter> &ref_9
+                schema: *ref_8
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -320,8 +345,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -347,7 +385,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -372,6 +410,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,7 +451,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -424,8 +477,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_7
+              - !<!Parameter> &ref_10
+                schema: *ref_8
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -436,8 +489,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -463,7 +529,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -488,6 +554,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -514,7 +595,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -540,8 +621,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_7
+              - !<!Parameter> &ref_11
+                schema: *ref_8
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -552,8 +633,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -579,7 +673,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -604,6 +698,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -630,7 +739,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -656,8 +765,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_11
-                schema: *ref_7
+              - !<!Parameter> &ref_12
+                schema: *ref_8
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -668,8 +777,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_11
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -695,7 +817,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -720,6 +842,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -732,7 +869,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -746,7 +883,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -771,6 +908,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -783,7 +935,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -797,7 +949,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -822,6 +974,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -834,7 +1001,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -848,7 +1015,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -874,8 +1041,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_12
+              - !<!Parameter> &ref_14
+                schema: *ref_13
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -886,8 +1053,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_13
+              - *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -913,7 +1093,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -938,6 +1118,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -950,7 +1145,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -964,7 +1159,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -997,6 +1192,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1009,7 +1219,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1023,7 +1233,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1049,8 +1259,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_14
+              - !<!Parameter> &ref_16
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1061,8 +1271,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1088,7 +1311,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1113,6 +1336,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1125,7 +1363,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1139,7 +1377,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1165,8 +1403,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_14
+              - !<!Parameter> &ref_17
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1177,8 +1415,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1204,7 +1455,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1229,6 +1480,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1241,7 +1507,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1255,7 +1521,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1281,8 +1547,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_18
-                schema: *ref_17
+              - !<!Parameter> &ref_19
+                schema: *ref_18
                 flattened: true
                 implementation: Method
                 required: true
@@ -1294,32 +1560,45 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - !<!VirtualParameter> 
                 schema: *ref_3
                 implementation: Method
-                originalParameter: *ref_18
+                originalParameter: *ref_19
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_19
+                targetProperty: *ref_20
                 language: !<!Languages> 
                   default:
                     name: ColorConstant
                     description: Referenced Color Constant Description.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_21
+              - !<!VirtualParameter> &ref_22
                 schema: *ref_4
                 implementation: Method
-                originalParameter: *ref_18
+                originalParameter: *ref_19
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_20
+                targetProperty: *ref_21
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: Sample string.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -1345,7 +1624,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-string.quirks/grouped.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/grouped.yaml
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_8
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -51,7 +51,7 @@ schemas: !<!Schemas>
           description: Sample string.
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_14
+    - !<!SealedChoiceSchema> &ref_15
       choices:
         - !<!ChoiceValue> 
           value: red color
@@ -94,6 +94,16 @@ schemas: !<!Schemas>
         default:
           name: paths·1p4myr3·string-null·get·responses·200·content·application-json·schema
           description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
@@ -148,7 +158,7 @@ schemas: !<!Schemas>
           description: Referenced Color Constant Description.
       protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_12
+    - !<!ByteArraySchema> &ref_13
       type: byte-array
       format: base64url
       apiVersions:
@@ -160,7 +170,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_6
+    - !<!ObjectSchema> &ref_7
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -192,13 +202,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_17
+    - !<!ObjectSchema> &ref_18
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_19
+        - !<!Property> &ref_20
           schema: *ref_3
           required: true
           serializedName: ColorConstant
@@ -207,7 +217,7 @@ schemas: !<!Schemas>
               name: ColorConstant
               description: Referenced Color Constant Description.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_20
+        - !<!Property> &ref_21
           schema: *ref_4
           required: false
           serializedName: field1
@@ -256,6 +266,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +307,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -308,8 +333,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_7
+              - !<!Parameter> &ref_9
+                schema: *ref_8
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -320,8 +345,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -347,7 +385,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -372,6 +410,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,7 +451,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -424,8 +477,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_7
+              - !<!Parameter> &ref_10
+                schema: *ref_8
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -436,8 +489,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -463,7 +529,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -488,6 +554,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -514,7 +595,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -540,8 +621,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_7
+              - !<!Parameter> &ref_11
+                schema: *ref_8
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -552,8 +633,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -579,7 +673,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -604,6 +698,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -630,7 +739,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -656,8 +765,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_11
-                schema: *ref_7
+              - !<!Parameter> &ref_12
+                schema: *ref_8
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -668,8 +777,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_11
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -695,7 +817,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -720,6 +842,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -732,7 +869,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -746,7 +883,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -771,6 +908,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -783,7 +935,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -797,7 +949,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -822,6 +974,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -834,7 +1001,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -848,7 +1015,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -874,8 +1041,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_12
+              - !<!Parameter> &ref_14
+                schema: *ref_13
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -886,8 +1053,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_13
+              - *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -913,7 +1093,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -938,6 +1118,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -950,7 +1145,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -964,7 +1159,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -997,6 +1192,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1009,7 +1219,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1023,7 +1233,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1049,8 +1259,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_14
+              - !<!Parameter> &ref_16
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1061,8 +1271,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1088,7 +1311,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1113,6 +1336,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1125,7 +1363,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1139,7 +1377,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1165,8 +1403,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_14
+              - !<!Parameter> &ref_17
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1177,8 +1415,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1204,7 +1455,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1229,6 +1480,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1241,7 +1507,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1255,7 +1521,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1281,8 +1547,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_18
-                schema: *ref_17
+              - !<!Parameter> &ref_19
+                schema: *ref_18
                 flattened: true
                 implementation: Method
                 required: true
@@ -1294,32 +1560,45 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - !<!VirtualParameter> 
                 schema: *ref_3
                 implementation: Method
-                originalParameter: *ref_18
+                originalParameter: *ref_19
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_19
+                targetProperty: *ref_20
                 language: !<!Languages> 
                   default:
                     name: ColorConstant
                     description: Referenced Color Constant Description.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_21
+              - !<!VirtualParameter> &ref_22
                 schema: *ref_4
                 implementation: Method
-                originalParameter: *ref_18
+                originalParameter: *ref_19
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_20
+                targetProperty: *ref_21
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: Sample string.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -1345,7 +1624,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-string.quirks/modeler.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/modeler.yaml
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_8
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -51,7 +51,7 @@ schemas: !<!Schemas>
           description: Sample string.
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_14
+    - !<!SealedChoiceSchema> &ref_15
       choices:
         - !<!ChoiceValue> 
           value: red color
@@ -94,6 +94,16 @@ schemas: !<!Schemas>
         default:
           name: paths·1p4myr3·string-null·get·responses·200·content·application-json·schema
           description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
@@ -148,7 +158,7 @@ schemas: !<!Schemas>
           description: Referenced Color Constant Description.
       protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_12
+    - !<!ByteArraySchema> &ref_13
       type: byte-array
       format: base64url
       apiVersions:
@@ -160,7 +170,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -192,7 +202,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_17
+    - !<!ObjectSchema> &ref_18
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -228,7 +238,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_6
+  - !<!Parameter> &ref_7
     schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -253,9 +263,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +307,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -304,12 +329,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_7
+              - !<!Parameter> &ref_9
+                schema: *ref_8
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -320,8 +345,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -347,7 +385,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -369,9 +407,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,7 +451,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -420,12 +473,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_7
+              - !<!Parameter> &ref_10
+                schema: *ref_8
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -436,8 +489,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -463,7 +529,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -485,9 +551,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -514,7 +595,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -536,12 +617,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_7
+              - !<!Parameter> &ref_11
+                schema: *ref_8
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -552,8 +633,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -579,7 +673,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -601,9 +695,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -630,7 +739,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -652,12 +761,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_11
-                schema: *ref_7
+              - !<!Parameter> &ref_12
+                schema: *ref_8
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -668,8 +777,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_11
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -695,7 +817,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -717,9 +839,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -732,7 +869,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -746,7 +883,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -768,9 +905,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -783,7 +935,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -797,7 +949,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -819,9 +971,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -834,7 +1001,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -848,7 +1015,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -870,12 +1037,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_12
+              - !<!Parameter> &ref_14
+                schema: *ref_13
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -886,8 +1053,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_13
+              - *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -913,7 +1093,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -935,9 +1115,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -950,7 +1145,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -964,7 +1159,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -994,9 +1189,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1009,7 +1219,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1023,7 +1233,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1045,12 +1255,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_14
+              - !<!Parameter> &ref_16
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1061,8 +1271,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1088,7 +1311,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1110,9 +1333,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1125,7 +1363,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1139,7 +1377,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1161,12 +1399,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_14
+              - !<!Parameter> &ref_17
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1177,8 +1415,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1204,7 +1455,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1226,9 +1477,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1241,7 +1507,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1255,7 +1521,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1277,12 +1543,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_18
-                schema: *ref_17
+              - !<!Parameter> &ref_19
+                schema: *ref_18
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1293,8 +1559,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_18
+              - *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -1320,7 +1599,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-string.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/body-string.quirks/namer.yaml
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_8
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -51,7 +51,7 @@ schemas: !<!Schemas>
           description: Sample string.
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_14
+    - !<!SealedChoiceSchema> &ref_15
       choices:
         - !<!ChoiceValue> 
           value: red color
@@ -95,18 +95,15 @@ schemas: !<!Schemas>
           name: Constant1
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> 
+    - !<!ConstantSchema> &ref_6
       type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
       value: !<!ConstantValue> 
-        value: ''
+        value: application/json
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant2
-          description: ''
+          name: Accept
+          description: 'Accept: application/json'
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> 
       type: constant
@@ -114,7 +111,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: 啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€
+        value: ''
       valueType: *ref_0
       language: !<!Languages> 
         default:
@@ -127,11 +124,24 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: '    Now is the time for all good men to come to the aid of their country    '
+        value: 啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€
       valueType: *ref_0
       language: !<!Languages> 
         default:
           name: Constant4
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> 
+      type: constant
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      value: !<!ConstantValue> 
+        value: '    Now is the time for all good men to come to the aid of their country    '
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Constant5
           description: ''
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_3
@@ -148,7 +158,7 @@ schemas: !<!Schemas>
           description: Referenced Color Constant Description.
       protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_12
+    - !<!ByteArraySchema> &ref_13
       type: byte-array
       format: base64url
       apiVersions:
@@ -160,7 +170,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_6
+    - !<!ObjectSchema> &ref_7
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -192,13 +202,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_17
+    - !<!ObjectSchema> &ref_18
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_19
+        - !<!Property> &ref_20
           schema: *ref_3
           required: true
           serializedName: ColorConstant
@@ -207,7 +217,7 @@ schemas: !<!Schemas>
               name: colorConstant
               description: Referenced Color Constant Description.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_20
+        - !<!Property> &ref_21
           schema: *ref_4
           required: false
           serializedName: field1
@@ -256,6 +266,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,7 +307,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -308,8 +333,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_7
+              - !<!Parameter> &ref_9
+                schema: *ref_8
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -320,8 +345,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -347,7 +385,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -372,6 +410,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,7 +451,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -424,8 +477,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_7
+              - !<!Parameter> &ref_10
+                schema: *ref_8
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -436,8 +489,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -463,7 +529,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -488,6 +554,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -514,7 +595,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -540,8 +621,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_10
-                schema: *ref_7
+              - !<!Parameter> &ref_11
+                schema: *ref_8
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -552,8 +633,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -579,7 +673,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -604,6 +698,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -630,7 +739,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -656,8 +765,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_11
-                schema: *ref_7
+              - !<!Parameter> &ref_12
+                schema: *ref_8
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -668,8 +777,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_11
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -695,7 +817,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -720,6 +842,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -732,7 +869,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -746,7 +883,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -771,6 +908,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -783,7 +935,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -797,7 +949,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -822,6 +974,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -834,7 +1001,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -848,7 +1015,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -874,8 +1041,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_12
+              - !<!Parameter> &ref_14
+                schema: *ref_13
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -886,8 +1053,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_13
+              - *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -913,7 +1093,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -938,6 +1118,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -950,7 +1145,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -964,7 +1159,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -997,6 +1192,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1009,7 +1219,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1023,7 +1233,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1049,8 +1259,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_14
+              - !<!Parameter> &ref_16
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1061,8 +1271,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1088,7 +1311,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1113,6 +1336,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1125,7 +1363,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1139,7 +1377,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1165,8 +1403,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_14
+              - !<!Parameter> &ref_17
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1177,8 +1415,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1204,7 +1455,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1229,6 +1480,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1241,7 +1507,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1255,7 +1521,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1281,8 +1547,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_18
-                schema: *ref_17
+              - !<!Parameter> &ref_19
+                schema: *ref_18
                 flattened: true
                 implementation: Method
                 required: true
@@ -1294,32 +1560,45 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - !<!VirtualParameter> 
                 schema: *ref_3
                 implementation: Method
-                originalParameter: *ref_18
+                originalParameter: *ref_19
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_19
+                targetProperty: *ref_20
                 language: !<!Languages> 
                   default:
                     name: ColorConstant
                     description: Referenced Color Constant Description.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_21
+              - !<!VirtualParameter> &ref_22
                 schema: *ref_4
                 implementation: Method
-                originalParameter: *ref_18
+                originalParameter: *ref_19
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_20
+                targetProperty: *ref_21
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: Sample string.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -1345,7 +1624,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-string/flattened.yaml
+++ b/modelerfour/test/scenarios/body-string/flattened.yaml
@@ -20,7 +20,7 @@ schemas: !<!Schemas>
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -51,7 +51,7 @@ schemas: !<!Schemas>
           description: Sample string.
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_14
+    - !<!SealedChoiceSchema> &ref_15
       choices:
         - !<!ChoiceValue> 
           value: red color
@@ -82,7 +82,17 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_10
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_11
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -95,7 +105,7 @@ schemas: !<!Schemas>
           name: paths·16uxhh2·string-mbcs·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_11
+    - !<!ConstantSchema> &ref_12
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -122,7 +132,7 @@ schemas: !<!Schemas>
           description: Referenced Color Constant Description.
       protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_12
+    - !<!ByteArraySchema> &ref_13
       type: byte-array
       format: base64url
       apiVersions:
@@ -134,7 +144,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -166,13 +176,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_17
+    - !<!ObjectSchema> &ref_18
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_19
+        - !<!Property> &ref_20
           schema: *ref_3
           required: true
           serializedName: ColorConstant
@@ -181,7 +191,7 @@ schemas: !<!Schemas>
               name: ColorConstant
               description: Referenced Color Constant Description.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_20
+        - !<!Property> &ref_21
           schema: *ref_4
           required: false
           serializedName: field1
@@ -230,6 +240,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -242,7 +267,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -256,7 +281,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,8 +307,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_6
+              - !<!Parameter> &ref_9
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -294,8 +319,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -321,7 +359,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -346,6 +384,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -358,7 +411,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -372,7 +425,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,8 +451,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_6
+              - !<!Parameter> &ref_10
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -410,8 +463,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -437,7 +503,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -462,6 +528,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -488,7 +569,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -515,7 +596,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_10
+                schema: *ref_11
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -526,6 +607,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -552,7 +646,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -577,6 +671,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -603,7 +712,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -630,7 +739,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_11
+                schema: *ref_12
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -641,6 +750,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -667,7 +789,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -692,6 +814,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -704,7 +841,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -718,7 +855,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -743,6 +880,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -755,7 +907,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -769,7 +921,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -794,6 +946,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -806,7 +973,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -820,7 +987,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -846,8 +1013,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_12
+              - !<!Parameter> &ref_14
+                schema: *ref_13
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -858,8 +1025,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_13
+              - *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -885,7 +1065,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -910,6 +1090,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -922,7 +1117,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -936,7 +1131,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -969,6 +1164,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -981,7 +1191,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -995,7 +1205,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1021,8 +1231,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_14
+              - !<!Parameter> &ref_16
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1033,8 +1243,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1060,7 +1283,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1085,6 +1308,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1097,7 +1335,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1111,7 +1349,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1137,8 +1375,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_14
+              - !<!Parameter> &ref_17
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1149,8 +1387,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1176,7 +1427,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1201,6 +1452,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1213,7 +1479,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1227,7 +1493,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1253,8 +1519,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_18
-                schema: *ref_17
+              - !<!Parameter> &ref_19
+                schema: *ref_18
                 flattened: true
                 implementation: Method
                 required: true
@@ -1266,32 +1532,45 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - !<!VirtualParameter> 
                 schema: *ref_3
                 implementation: Method
-                originalParameter: *ref_18
+                originalParameter: *ref_19
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_19
+                targetProperty: *ref_20
                 language: !<!Languages> 
                   default:
                     name: ColorConstant
                     description: Referenced Color Constant Description.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_21
+              - !<!VirtualParameter> &ref_22
                 schema: *ref_4
                 implementation: Method
-                originalParameter: *ref_18
+                originalParameter: *ref_19
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_20
+                targetProperty: *ref_21
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: Sample string.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -1317,7 +1596,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-string/grouped.yaml
+++ b/modelerfour/test/scenarios/body-string/grouped.yaml
@@ -20,7 +20,7 @@ schemas: !<!Schemas>
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -51,7 +51,7 @@ schemas: !<!Schemas>
           description: Sample string.
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_14
+    - !<!SealedChoiceSchema> &ref_15
       choices:
         - !<!ChoiceValue> 
           value: red color
@@ -82,7 +82,17 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_10
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_11
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -95,7 +105,7 @@ schemas: !<!Schemas>
           name: paths·16uxhh2·string-mbcs·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_11
+    - !<!ConstantSchema> &ref_12
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -122,7 +132,7 @@ schemas: !<!Schemas>
           description: Referenced Color Constant Description.
       protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_12
+    - !<!ByteArraySchema> &ref_13
       type: byte-array
       format: base64url
       apiVersions:
@@ -134,7 +144,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -166,13 +176,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_17
+    - !<!ObjectSchema> &ref_18
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_19
+        - !<!Property> &ref_20
           schema: *ref_3
           required: true
           serializedName: ColorConstant
@@ -181,7 +191,7 @@ schemas: !<!Schemas>
               name: ColorConstant
               description: Referenced Color Constant Description.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_20
+        - !<!Property> &ref_21
           schema: *ref_4
           required: false
           serializedName: field1
@@ -230,6 +240,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -242,7 +267,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -256,7 +281,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,8 +307,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_6
+              - !<!Parameter> &ref_9
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -294,8 +319,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -321,7 +359,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -346,6 +384,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -358,7 +411,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -372,7 +425,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,8 +451,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_6
+              - !<!Parameter> &ref_10
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -410,8 +463,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -437,7 +503,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -462,6 +528,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -488,7 +569,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -515,7 +596,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_10
+                schema: *ref_11
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -526,6 +607,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -552,7 +646,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -577,6 +671,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -603,7 +712,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -630,7 +739,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_11
+                schema: *ref_12
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -641,6 +750,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -667,7 +789,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -692,6 +814,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -704,7 +841,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -718,7 +855,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -743,6 +880,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -755,7 +907,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -769,7 +921,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -794,6 +946,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -806,7 +973,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -820,7 +987,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -846,8 +1013,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_12
+              - !<!Parameter> &ref_14
+                schema: *ref_13
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -858,8 +1025,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_13
+              - *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -885,7 +1065,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -910,6 +1090,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -922,7 +1117,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -936,7 +1131,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -969,6 +1164,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -981,7 +1191,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -995,7 +1205,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1021,8 +1231,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_14
+              - !<!Parameter> &ref_16
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1033,8 +1243,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1060,7 +1283,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1085,6 +1308,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1097,7 +1335,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1111,7 +1349,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1137,8 +1375,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_14
+              - !<!Parameter> &ref_17
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1149,8 +1387,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1176,7 +1427,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1201,6 +1452,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1213,7 +1479,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1227,7 +1493,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1253,8 +1519,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_18
-                schema: *ref_17
+              - !<!Parameter> &ref_19
+                schema: *ref_18
                 flattened: true
                 implementation: Method
                 required: true
@@ -1266,32 +1532,45 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - !<!VirtualParameter> 
                 schema: *ref_3
                 implementation: Method
-                originalParameter: *ref_18
+                originalParameter: *ref_19
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_19
+                targetProperty: *ref_20
                 language: !<!Languages> 
                   default:
                     name: ColorConstant
                     description: Referenced Color Constant Description.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_21
+              - !<!VirtualParameter> &ref_22
                 schema: *ref_4
                 implementation: Method
-                originalParameter: *ref_18
+                originalParameter: *ref_19
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_20
+                targetProperty: *ref_21
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: Sample string.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -1317,7 +1596,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-string/modeler.yaml
+++ b/modelerfour/test/scenarios/body-string/modeler.yaml
@@ -20,7 +20,7 @@ schemas: !<!Schemas>
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_6
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -51,7 +51,7 @@ schemas: !<!Schemas>
           description: Sample string.
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_14
+    - !<!SealedChoiceSchema> &ref_15
       choices:
         - !<!ChoiceValue> 
           value: red color
@@ -82,7 +82,17 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_10
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_11
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -95,7 +105,7 @@ schemas: !<!Schemas>
           name: paths·16uxhh2·string-mbcs·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_11
+    - !<!ConstantSchema> &ref_12
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -122,7 +132,7 @@ schemas: !<!Schemas>
           description: Referenced Color Constant Description.
       protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_12
+    - !<!ByteArraySchema> &ref_13
       type: byte-array
       format: base64url
       apiVersions:
@@ -134,7 +144,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_6
+    - !<!ObjectSchema> &ref_7
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -166,7 +176,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_17
+    - !<!ObjectSchema> &ref_18
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -202,7 +212,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_7
+  - !<!Parameter> &ref_8
     schema: *ref_1
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -227,9 +237,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -242,7 +267,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -256,7 +281,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -278,12 +303,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_5
+              - !<!Parameter> &ref_9
+                schema: *ref_6
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -294,8 +319,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -321,7 +359,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -343,9 +381,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -358,7 +411,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -372,7 +425,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -394,12 +447,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_5
+              - !<!Parameter> &ref_10
+                schema: *ref_6
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -410,8 +463,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -437,7 +503,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -459,9 +525,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -488,7 +569,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -510,12 +591,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_10
+                schema: *ref_11
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -526,6 +607,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -552,7 +646,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -574,9 +668,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -603,7 +712,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -625,12 +734,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_11
+                schema: *ref_12
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -641,6 +750,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -667,7 +789,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -689,9 +811,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -704,7 +841,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -718,7 +855,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -740,9 +877,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -755,7 +907,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -769,7 +921,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -791,9 +943,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -806,7 +973,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -820,7 +987,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -842,12 +1009,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_12
+              - !<!Parameter> &ref_14
+                schema: *ref_13
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -858,8 +1025,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_13
+              - *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -885,7 +1065,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -907,9 +1087,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -922,7 +1117,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -936,7 +1131,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -966,9 +1161,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -981,7 +1191,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -995,7 +1205,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1017,12 +1227,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_14
+              - !<!Parameter> &ref_16
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1033,8 +1243,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1060,7 +1283,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1082,9 +1305,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1097,7 +1335,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1111,7 +1349,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1133,12 +1371,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_14
+              - !<!Parameter> &ref_17
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1149,8 +1387,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1176,7 +1427,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1198,9 +1449,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1213,7 +1479,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1227,7 +1493,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1249,12 +1515,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_18
-                schema: *ref_17
+              - !<!Parameter> &ref_19
+                schema: *ref_18
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1265,8 +1531,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_18
+              - *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -1292,7 +1571,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/body-string/namer.yaml
+++ b/modelerfour/test/scenarios/body-string/namer.yaml
@@ -20,7 +20,7 @@ schemas: !<!Schemas>
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -51,7 +51,7 @@ schemas: !<!Schemas>
           description: Sample string.
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_14
+    - !<!SealedChoiceSchema> &ref_15
       choices:
         - !<!ChoiceValue> 
           value: red color
@@ -82,7 +82,17 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_10
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_11
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -92,10 +102,10 @@ schemas: !<!Schemas>
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant1
+          name: Constant2
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_11
+    - !<!ConstantSchema> &ref_12
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -105,7 +115,7 @@ schemas: !<!Schemas>
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant2
+          name: Constant3
           description: ''
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_3
@@ -122,7 +132,7 @@ schemas: !<!Schemas>
           description: Referenced Color Constant Description.
       protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_12
+    - !<!ByteArraySchema> &ref_13
       type: byte-array
       format: base64url
       apiVersions:
@@ -134,7 +144,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -166,13 +176,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_17
+    - !<!ObjectSchema> &ref_18
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_19
+        - !<!Property> &ref_20
           schema: *ref_3
           required: true
           serializedName: ColorConstant
@@ -181,7 +191,7 @@ schemas: !<!Schemas>
               name: colorConstant
               description: Referenced Color Constant Description.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_20
+        - !<!Property> &ref_21
           schema: *ref_4
           required: false
           serializedName: field1
@@ -230,6 +240,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -242,7 +267,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -256,7 +281,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -282,8 +307,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_6
+              - !<!Parameter> &ref_9
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -294,8 +319,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -321,7 +359,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -346,6 +384,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -358,7 +411,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -372,7 +425,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -398,8 +451,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
-                schema: *ref_6
+              - !<!Parameter> &ref_10
+                schema: *ref_7
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -410,8 +463,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_9
+              - *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -437,7 +503,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -462,6 +528,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -488,7 +569,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -515,7 +596,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_10
+                schema: *ref_11
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -526,6 +607,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -552,7 +646,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -577,6 +671,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -603,7 +712,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -630,7 +739,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_11
+                schema: *ref_12
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -641,6 +750,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -667,7 +789,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -692,6 +814,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -704,7 +841,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -718,7 +855,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -743,6 +880,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -755,7 +907,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -769,7 +921,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -794,6 +946,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -806,7 +973,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -820,7 +987,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -846,8 +1013,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_12
+              - !<!Parameter> &ref_14
+                schema: *ref_13
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -858,8 +1025,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_13
+              - *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -885,7 +1065,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -910,6 +1090,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -922,7 +1117,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -936,7 +1131,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -969,6 +1164,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -981,7 +1191,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -995,7 +1205,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1021,8 +1231,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_14
+              - !<!Parameter> &ref_16
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1033,8 +1243,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1060,7 +1283,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1085,6 +1308,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1097,7 +1335,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1111,7 +1349,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1137,8 +1375,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_14
+              - !<!Parameter> &ref_17
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1149,8 +1387,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1176,7 +1427,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1201,6 +1452,21 @@ operationGroups:
           - *ref_5
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1213,7 +1479,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1227,7 +1493,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -1253,8 +1519,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_18
-                schema: *ref_17
+              - !<!Parameter> &ref_19
+                schema: *ref_18
                 flattened: true
                 implementation: Method
                 required: true
@@ -1266,32 +1532,45 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - !<!VirtualParameter> 
                 schema: *ref_3
                 implementation: Method
-                originalParameter: *ref_18
+                originalParameter: *ref_19
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_19
+                targetProperty: *ref_20
                 language: !<!Languages> 
                   default:
                     name: ColorConstant
                     description: Referenced Color Constant Description.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_21
+              - !<!VirtualParameter> &ref_22
                 schema: *ref_4
                 implementation: Method
-                originalParameter: *ref_18
+                originalParameter: *ref_19
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_20
+                targetProperty: *ref_21
                 language: !<!Languages> 
                   default:
                     name: field1
                     description: Sample string.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -1317,7 +1596,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/cognitive-search/flattened.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: SearchIndexClient
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_94
+    - !<!BooleanSchema> &ref_95
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -47,7 +47,7 @@ schemas: !<!Schemas>
             provides a better experience in some scenarios, it comes at a performance cost as fuzzy autocomplete queries are slower and consume more resources.
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_93
+    - !<!NumberSchema> &ref_94
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -58,7 +58,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_97
+    - !<!NumberSchema> &ref_98
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -69,7 +69,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_102
+    - !<!NumberSchema> &ref_103
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -760,6 +760,16 @@ schemas: !<!Schemas>
           name: ApiVersion-2019-05-06
           description: Api Version (2019-05-06)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_92
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_1
       type: dictionary
@@ -878,7 +888,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_122
+    - !<!ObjectSchema> &ref_123
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1193,7 +1203,7 @@ schemas: !<!Schemas>
     - *ref_29
     - *ref_30
     - *ref_31
-    - !<!ObjectSchema> &ref_144
+    - !<!ObjectSchema> &ref_145
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1267,7 +1277,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_35
-    - !<!ObjectSchema> &ref_145
+    - !<!ObjectSchema> &ref_146
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1378,13 +1388,13 @@ schemas: !<!Schemas>
           description: 'Parameters for filtering, sorting, fuzzy matching, and other suggestions query behaviors.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_148
+    - !<!ObjectSchema> &ref_149
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
       properties:
-        - !<!Property> &ref_150
+        - !<!Property> &ref_151
           schema: !<!ArraySchema> &ref_83
             type: array
             apiVersions:
@@ -1443,7 +1453,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_48
-    - !<!ObjectSchema> &ref_153
+    - !<!ObjectSchema> &ref_154
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1534,7 +1544,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_53
-    - !<!ObjectSchema> &ref_166
+    - !<!ObjectSchema> &ref_167
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1603,7 +1613,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_56
-    - !<!ObjectSchema> &ref_167
+    - !<!ObjectSchema> &ref_168
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1704,7 +1714,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_95
+    - !<!ArraySchema> &ref_96
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1715,7 +1725,7 @@ schemas: !<!Schemas>
           name: paths·1adzgki·docs·get·parameters·2·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_96
+    - !<!ArraySchema> &ref_97
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1726,7 +1736,7 @@ schemas: !<!Schemas>
           name: paths·18nrber·docs·get·parameters·4·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_98
+    - !<!ArraySchema> &ref_99
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1737,7 +1747,7 @@ schemas: !<!Schemas>
           name: paths·1qpycpw·docs·get·parameters·8·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_99
+    - !<!ArraySchema> &ref_100
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1748,7 +1758,7 @@ schemas: !<!Schemas>
           name: paths·1fk4czm·docs·get·parameters·10·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_100
+    - !<!ArraySchema> &ref_101
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1759,7 +1769,7 @@ schemas: !<!Schemas>
           name: paths·1ydkr4·docs·get·parameters·12·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_101
+    - !<!ArraySchema> &ref_102
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1775,7 +1785,7 @@ schemas: !<!Schemas>
     - *ref_75
     - *ref_76
     - *ref_77
-    - !<!ArraySchema> &ref_125
+    - !<!ArraySchema> &ref_126
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1786,7 +1796,7 @@ schemas: !<!Schemas>
           name: paths·12hj56k·docs-key·get·parameters·1·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_129
+    - !<!ArraySchema> &ref_130
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1797,7 +1807,7 @@ schemas: !<!Schemas>
           name: paths·8sf5uk·docs-search-suggest·get·parameters·7·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_130
+    - !<!ArraySchema> &ref_131
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1808,7 +1818,7 @@ schemas: !<!Schemas>
           name: paths·a27jtj·docs-search-suggest·get·parameters·8·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_131
+    - !<!ArraySchema> &ref_132
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1822,7 +1832,7 @@ schemas: !<!Schemas>
     - *ref_82
     - *ref_83
     - *ref_84
-    - !<!ArraySchema> &ref_154
+    - !<!ArraySchema> &ref_155
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1918,12 +1928,12 @@ operationGroups:
           - *ref_87
           - *ref_88
           - *ref_89
-          - !<!Parameter> &ref_92
+          - !<!Parameter> &ref_93
             schema: *ref_90
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: &ref_103
+              x-ms-parameter-grouping: &ref_104
                 name: search-request-options
             language: !<!Languages> 
               default:
@@ -1936,6 +1946,21 @@ operationGroups:
           - *ref_91
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_92
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1946,10 +1971,10 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_92
+          - *ref_93
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_93
+            schema: *ref_94
             language: !<!Languages> 
               default:
                 name: ''
@@ -1986,7 +2011,7 @@ operationGroups:
           - *ref_87
           - *ref_88
           - *ref_89
-          - !<!Parameter> &ref_104
+          - !<!Parameter> &ref_105
             schema: *ref_80
             implementation: Method
             language: !<!Languages> 
@@ -1997,8 +2022,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_105
-            schema: *ref_94
+          - !<!Parameter> &ref_106
+            schema: *ref_95
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2011,8 +2036,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_106
-            schema: *ref_95
+          - !<!Parameter> &ref_107
+            schema: *ref_96
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2027,7 +2052,7 @@ operationGroups:
                 explode: true
                 in: query
                 style: form
-          - !<!Parameter> &ref_107
+          - !<!Parameter> &ref_108
             schema: *ref_80
             implementation: Method
             extensions:
@@ -2041,8 +2066,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_108
-            schema: *ref_96
+          - !<!Parameter> &ref_109
+            schema: *ref_97
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2055,7 +2080,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_109
+          - !<!Parameter> &ref_110
             schema: *ref_80
             implementation: Method
             extensions:
@@ -2069,7 +2094,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_110
+          - !<!Parameter> &ref_111
             schema: *ref_80
             implementation: Method
             extensions:
@@ -2083,8 +2108,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_111
-            schema: *ref_97
+          - !<!Parameter> &ref_112
+            schema: *ref_98
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2099,8 +2124,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_112
-            schema: *ref_98
+          - !<!Parameter> &ref_113
+            schema: *ref_99
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2116,7 +2141,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_113
+          - !<!Parameter> &ref_114
             schema: *ref_16
             implementation: Method
             extensions:
@@ -2130,8 +2155,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_114
-            schema: *ref_99
+          - !<!Parameter> &ref_115
+            schema: *ref_100
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2148,7 +2173,7 @@ operationGroups:
                 explode: true
                 in: query
                 style: form
-          - !<!Parameter> &ref_115
+          - !<!Parameter> &ref_116
             schema: *ref_80
             implementation: Method
             extensions:
@@ -2162,8 +2187,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_116
-            schema: *ref_100
+          - !<!Parameter> &ref_117
+            schema: *ref_101
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2178,7 +2203,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_117
+          - !<!Parameter> &ref_118
             schema: *ref_21
             implementation: Method
             extensions:
@@ -2192,8 +2217,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_118
-            schema: *ref_101
+          - !<!Parameter> &ref_119
+            schema: *ref_102
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2206,8 +2231,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_119
-            schema: *ref_102
+          - !<!Parameter> &ref_120
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2222,8 +2247,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_120
-            schema: *ref_102
+          - !<!Parameter> &ref_121
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2239,12 +2264,12 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_91
-          - !<!Parameter> &ref_121
+          - !<!Parameter> &ref_122
             schema: *ref_90
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: *ref_103
+              x-ms-parameter-grouping: *ref_104
             language: !<!Languages> 
               default:
                 name: client-request-id
@@ -2255,6 +2280,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_92
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2265,7 +2305,6 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_104
           - *ref_105
           - *ref_106
           - *ref_107
@@ -2283,9 +2322,10 @@ operationGroups:
           - *ref_119
           - *ref_120
           - *ref_121
+          - *ref_122
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_122
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -2373,12 +2413,12 @@ operationGroups:
           - *ref_88
           - *ref_89
           - *ref_91
-          - !<!Parameter> &ref_124
+          - !<!Parameter> &ref_125
             schema: *ref_90
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: *ref_103
+              x-ms-parameter-grouping: *ref_104
             language: !<!Languages> 
               default:
                 name: client-request-id
@@ -2390,7 +2430,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_123
+              - !<!Parameter> &ref_124
                 schema: *ref_30
                 implementation: Method
                 required: true
@@ -2402,8 +2442,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_92
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_123
+              - *ref_124
             language: !<!Languages> 
               default:
                 name: ''
@@ -2417,10 +2470,10 @@ operationGroups:
                   - application/json
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_124
+          - *ref_125
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_122
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -2520,7 +2573,7 @@ operationGroups:
           - *ref_87
           - *ref_88
           - *ref_89
-          - !<!Parameter> &ref_126
+          - !<!Parameter> &ref_127
             schema: *ref_80
             implementation: Method
             required: true
@@ -2532,8 +2585,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_127
-            schema: *ref_125
+          - !<!Parameter> &ref_128
+            schema: *ref_126
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2544,12 +2597,12 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_91
-          - !<!Parameter> &ref_128
+          - !<!Parameter> &ref_129
             schema: *ref_90
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: *ref_103
+              x-ms-parameter-grouping: *ref_104
             language: !<!Languages> 
               default:
                 name: client-request-id
@@ -2560,6 +2613,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_92
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2570,9 +2638,9 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_126
           - *ref_127
           - *ref_128
+          - *ref_129
         responses:
           - !<!SchemaResponse> 
             schema: *ref_3
@@ -2619,7 +2687,7 @@ operationGroups:
           - *ref_87
           - *ref_88
           - *ref_89
-          - !<!Parameter> &ref_132
+          - !<!Parameter> &ref_133
             schema: *ref_80
             implementation: Method
             required: true
@@ -2631,7 +2699,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_133
+          - !<!Parameter> &ref_134
             schema: *ref_80
             implementation: Method
             required: true
@@ -2643,7 +2711,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_134
+          - !<!Parameter> &ref_135
             schema: *ref_80
             implementation: Method
             extensions:
@@ -2657,8 +2725,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_135
-            schema: *ref_94
+          - !<!Parameter> &ref_136
+            schema: *ref_95
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2673,7 +2741,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_136
+          - !<!Parameter> &ref_137
             schema: *ref_80
             implementation: Method
             extensions:
@@ -2687,7 +2755,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_137
+          - !<!Parameter> &ref_138
             schema: *ref_80
             implementation: Method
             extensions:
@@ -2701,8 +2769,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_138
-            schema: *ref_97
+          - !<!Parameter> &ref_139
+            schema: *ref_98
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2717,8 +2785,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_139
-            schema: *ref_129
+          - !<!Parameter> &ref_140
+            schema: *ref_130
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2734,8 +2802,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_140
-            schema: *ref_130
+          - !<!Parameter> &ref_141
+            schema: *ref_131
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2748,8 +2816,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_141
-            schema: *ref_131
+          - !<!Parameter> &ref_142
+            schema: *ref_132
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2762,8 +2830,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_142
-            schema: *ref_102
+          - !<!Parameter> &ref_143
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2777,12 +2845,12 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_91
-          - !<!Parameter> &ref_143
+          - !<!Parameter> &ref_144
             schema: *ref_90
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: *ref_103
+              x-ms-parameter-grouping: *ref_104
             language: !<!Languages> 
               default:
                 name: client-request-id
@@ -2793,6 +2861,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_92
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2803,7 +2886,6 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_132
           - *ref_133
           - *ref_134
           - *ref_135
@@ -2815,9 +2897,10 @@ operationGroups:
           - *ref_141
           - *ref_142
           - *ref_143
+          - *ref_144
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_144
+            schema: *ref_145
             language: !<!Languages> 
               default:
                 name: ''
@@ -2881,12 +2964,12 @@ operationGroups:
           - *ref_88
           - *ref_89
           - *ref_91
-          - !<!Parameter> &ref_147
+          - !<!Parameter> &ref_148
             schema: *ref_90
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: *ref_103
+              x-ms-parameter-grouping: *ref_104
             language: !<!Languages> 
               default:
                 name: client-request-id
@@ -2898,8 +2981,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_146
-                schema: *ref_145
+              - !<!Parameter> &ref_147
+                schema: *ref_146
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2910,8 +2993,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_92
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_146
+              - *ref_147
             language: !<!Languages> 
               default:
                 name: ''
@@ -2925,10 +3021,10 @@ operationGroups:
                   - application/json
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_147
+          - *ref_148
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_144
+            schema: *ref_145
             language: !<!Languages> 
               default:
                 name: ''
@@ -2985,12 +3081,12 @@ operationGroups:
           - *ref_88
           - *ref_89
           - *ref_91
-          - !<!Parameter> &ref_152
+          - !<!Parameter> &ref_153
             schema: *ref_90
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: *ref_103
+              x-ms-parameter-grouping: *ref_104
             language: !<!Languages> 
               default:
                 name: client-request-id
@@ -3002,8 +3098,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_149
-                schema: *ref_148
+              - !<!Parameter> &ref_150
+                schema: *ref_149
                 flattened: true
                 implementation: Method
                 required: true
@@ -3015,20 +3111,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_151
+              - !<!Parameter> 
+                schema: *ref_92
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_152
                 schema: *ref_83
                 implementation: Method
-                originalParameter: *ref_149
+                originalParameter: *ref_150
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_150
+                targetProperty: *ref_151
                 language: !<!Languages> 
                   default:
                     name: Actions
                     description: The actions in the batch.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_151
+              - *ref_152
             language: !<!Languages> 
               default:
                 name: ''
@@ -3042,10 +3151,10 @@ operationGroups:
                   - application/json
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_152
+          - *ref_153
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_153
+            schema: *ref_154
             language: !<!Languages> 
               default:
                 name: ''
@@ -3058,7 +3167,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_153
+            schema: *ref_154
             language: !<!Languages> 
               default:
                 name: ''
@@ -3145,12 +3254,12 @@ operationGroups:
           - *ref_87
           - *ref_88
           - *ref_89
-          - !<!Parameter> &ref_155
+          - !<!Parameter> &ref_156
             schema: *ref_90
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: *ref_103
+              x-ms-parameter-grouping: *ref_104
             language: !<!Languages> 
               default:
                 name: client-request-id
@@ -3160,7 +3269,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_91
-          - !<!Parameter> &ref_156
+          - !<!Parameter> &ref_157
             schema: *ref_80
             implementation: Method
             required: true
@@ -3172,7 +3281,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_157
+          - !<!Parameter> &ref_158
             schema: *ref_80
             implementation: Method
             required: true
@@ -3184,7 +3293,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_158
+          - !<!Parameter> &ref_159
             schema: *ref_58
             implementation: Method
             extensions:
@@ -3198,7 +3307,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_159
+          - !<!Parameter> &ref_160
             schema: *ref_80
             implementation: Method
             extensions:
@@ -3212,8 +3321,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_160
-            schema: *ref_94
+          - !<!Parameter> &ref_161
+            schema: *ref_95
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -3228,7 +3337,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_161
+          - !<!Parameter> &ref_162
             schema: *ref_80
             implementation: Method
             extensions:
@@ -3242,7 +3351,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_162
+          - !<!Parameter> &ref_163
             schema: *ref_80
             implementation: Method
             extensions:
@@ -3256,8 +3365,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_163
-            schema: *ref_97
+          - !<!Parameter> &ref_164
+            schema: *ref_98
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -3272,8 +3381,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_164
-            schema: *ref_154
+          - !<!Parameter> &ref_165
+            schema: *ref_155
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -3286,8 +3395,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_165
-            schema: *ref_102
+          - !<!Parameter> &ref_166
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -3302,6 +3411,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_92
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3312,7 +3436,6 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_155
           - *ref_156
           - *ref_157
           - *ref_158
@@ -3323,9 +3446,10 @@ operationGroups:
           - *ref_163
           - *ref_164
           - *ref_165
+          - *ref_166
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_166
+            schema: *ref_167
             language: !<!Languages> 
               default:
                 name: ''
@@ -3380,12 +3504,12 @@ operationGroups:
           - *ref_87
           - *ref_88
           - *ref_89
-          - !<!Parameter> &ref_169
+          - !<!Parameter> &ref_170
             schema: *ref_90
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: *ref_103
+              x-ms-parameter-grouping: *ref_104
             language: !<!Languages> 
               default:
                 name: client-request-id
@@ -3398,8 +3522,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_168
-                schema: *ref_167
+              - !<!Parameter> &ref_169
+                schema: *ref_168
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3410,8 +3534,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_92
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_168
+              - *ref_169
             language: !<!Languages> 
               default:
                 name: ''
@@ -3425,10 +3562,10 @@ operationGroups:
                   - application/json
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_169
+          - *ref_170
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_166
+            schema: *ref_167
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/cognitive-search/grouped.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/grouped.yaml
@@ -47,7 +47,7 @@ schemas: !<!Schemas>
             provides a better experience in some scenarios, it comes at a performance cost as fuzzy autocomplete queries are slower and consume more resources.
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_114
+    - !<!NumberSchema> &ref_115
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -760,6 +760,16 @@ schemas: !<!Schemas>
           name: ApiVersion-2019-05-06
           description: Api Version (2019-05-06)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_113
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_1
       type: dictionary
@@ -884,7 +894,7 @@ schemas: !<!Schemas>
           originalParameter:
             - !<!Parameter> &ref_111
               schema: *ref_86
-              groupedBy: !<!Parameter> &ref_113
+              groupedBy: !<!Parameter> &ref_114
                 schema: *ref_87
                 implementation: Method
                 language: !<!Languages> 
@@ -903,9 +913,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_131
+            - !<!Parameter> &ref_132
               schema: *ref_86
-              groupedBy: !<!Parameter> &ref_132
+              groupedBy: !<!Parameter> &ref_133
                 schema: *ref_87
                 implementation: Method
                 language: !<!Languages> 
@@ -924,9 +934,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_135
+            - !<!Parameter> &ref_136
               schema: *ref_86
-              groupedBy: !<!Parameter> &ref_136
+              groupedBy: !<!Parameter> &ref_137
                 schema: *ref_87
                 implementation: Method
                 language: !<!Languages> 
@@ -945,9 +955,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_139
+            - !<!Parameter> &ref_140
               schema: *ref_86
-              groupedBy: !<!Parameter> &ref_140
+              groupedBy: !<!Parameter> &ref_141
                 schema: *ref_87
                 implementation: Method
                 language: !<!Languages> 
@@ -966,9 +976,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_152
+            - !<!Parameter> &ref_153
               schema: *ref_86
-              groupedBy: !<!Parameter> &ref_153
+              groupedBy: !<!Parameter> &ref_154
                 schema: *ref_87
                 implementation: Method
                 language: !<!Languages> 
@@ -987,9 +997,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_157
+            - !<!Parameter> &ref_158
               schema: *ref_86
-              groupedBy: !<!Parameter> &ref_159
+              groupedBy: !<!Parameter> &ref_160
                 schema: *ref_87
                 implementation: Method
                 language: !<!Languages> 
@@ -1008,9 +1018,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_161
+            - !<!Parameter> &ref_162
               schema: *ref_86
-              groupedBy: !<!Parameter> &ref_165
+              groupedBy: !<!Parameter> &ref_166
                 schema: *ref_87
                 implementation: Method
                 language: !<!Languages> 
@@ -1029,9 +1039,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_168
+            - !<!Parameter> &ref_169
               schema: *ref_86
-              groupedBy: !<!Parameter> &ref_177
+              groupedBy: !<!Parameter> &ref_178
                 schema: *ref_87
                 implementation: Method
                 language: !<!Languages> 
@@ -1050,9 +1060,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_181
+            - !<!Parameter> &ref_182
               schema: *ref_86
-              groupedBy: !<!Parameter> &ref_183
+              groupedBy: !<!Parameter> &ref_184
                 schema: *ref_87
                 implementation: Method
                 language: !<!Languages> 
@@ -1090,7 +1100,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_88
           originalParameter:
-            - !<!Parameter> &ref_115
+            - !<!Parameter> &ref_116
               schema: *ref_88
               groupedBy: !<!Parameter> &ref_91
                 schema: *ref_89
@@ -1128,7 +1138,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_116
+            - !<!Parameter> &ref_117
               schema: *ref_90
               groupedBy: *ref_91
               implementation: Method
@@ -1151,7 +1161,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_80
           originalParameter:
-            - !<!Parameter> &ref_117
+            - !<!Parameter> &ref_118
               schema: *ref_80
               groupedBy: *ref_91
               implementation: Method
@@ -1182,7 +1192,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_118
+            - !<!Parameter> &ref_119
               schema: *ref_92
               groupedBy: *ref_91
               implementation: Method
@@ -1203,7 +1213,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_80
           originalParameter:
-            - !<!Parameter> &ref_119
+            - !<!Parameter> &ref_120
               schema: *ref_80
               groupedBy: *ref_91
               implementation: Method
@@ -1224,7 +1234,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_80
           originalParameter:
-            - !<!Parameter> &ref_120
+            - !<!Parameter> &ref_121
               schema: *ref_80
               groupedBy: *ref_91
               implementation: Method
@@ -1245,7 +1255,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_93
           originalParameter:
-            - !<!Parameter> &ref_121
+            - !<!Parameter> &ref_122
               schema: *ref_93
               groupedBy: *ref_91
               implementation: Method
@@ -1280,7 +1290,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_122
+            - !<!Parameter> &ref_123
               schema: *ref_94
               groupedBy: *ref_91
               implementation: Method
@@ -1307,7 +1317,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_16
           originalParameter:
-            - !<!Parameter> &ref_123
+            - !<!Parameter> &ref_124
               schema: *ref_16
               groupedBy: *ref_91
               implementation: Method
@@ -1338,7 +1348,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_124
+            - !<!Parameter> &ref_125
               schema: *ref_95
               groupedBy: *ref_91
               implementation: Method
@@ -1365,7 +1375,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_80
           originalParameter:
-            - !<!Parameter> &ref_125
+            - !<!Parameter> &ref_126
               schema: *ref_80
               groupedBy: *ref_91
               implementation: Method
@@ -1396,7 +1406,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_126
+            - !<!Parameter> &ref_127
               schema: *ref_96
               groupedBy: *ref_91
               implementation: Method
@@ -1421,7 +1431,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_21
           originalParameter:
-            - !<!Parameter> &ref_127
+            - !<!Parameter> &ref_128
               schema: *ref_21
               groupedBy: *ref_91
               implementation: Method
@@ -1452,7 +1462,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_128
+            - !<!Parameter> &ref_129
               schema: *ref_97
               groupedBy: *ref_91
               implementation: Method
@@ -1473,7 +1483,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_98
           originalParameter:
-            - !<!Parameter> &ref_129
+            - !<!Parameter> &ref_130
               schema: *ref_98
               groupedBy: *ref_91
               implementation: Method
@@ -1498,7 +1508,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_98
           originalParameter:
-            - !<!Parameter> &ref_130
+            - !<!Parameter> &ref_131
               schema: *ref_98
               groupedBy: *ref_91
               implementation: Method
@@ -1533,7 +1543,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_80
           originalParameter:
-            - !<!Parameter> &ref_143
+            - !<!Parameter> &ref_144
               schema: *ref_80
               groupedBy: !<!Parameter> &ref_100
                 schema: *ref_99
@@ -1561,7 +1571,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_88
           originalParameter:
-            - !<!Parameter> &ref_144
+            - !<!Parameter> &ref_145
               schema: *ref_88
               groupedBy: *ref_100
               implementation: Method
@@ -1586,7 +1596,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_80
           originalParameter:
-            - !<!Parameter> &ref_145
+            - !<!Parameter> &ref_146
               schema: *ref_80
               groupedBy: *ref_100
               implementation: Method
@@ -1607,7 +1617,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_80
           originalParameter:
-            - !<!Parameter> &ref_146
+            - !<!Parameter> &ref_147
               schema: *ref_80
               groupedBy: *ref_100
               implementation: Method
@@ -1628,7 +1638,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_93
           originalParameter:
-            - !<!Parameter> &ref_147
+            - !<!Parameter> &ref_148
               schema: *ref_93
               groupedBy: *ref_100
               implementation: Method
@@ -1663,7 +1673,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_148
+            - !<!Parameter> &ref_149
               schema: *ref_101
               groupedBy: *ref_100
               implementation: Method
@@ -1700,7 +1710,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_149
+            - !<!Parameter> &ref_150
               schema: *ref_102
               groupedBy: *ref_100
               implementation: Method
@@ -1731,7 +1741,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_150
+            - !<!Parameter> &ref_151
               schema: *ref_103
               groupedBy: *ref_100
               implementation: Method
@@ -1752,7 +1762,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_98
           originalParameter:
-            - !<!Parameter> &ref_151
+            - !<!Parameter> &ref_152
               schema: *ref_98
               groupedBy: *ref_100
               implementation: Method
@@ -1783,7 +1793,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_58
           originalParameter:
-            - !<!Parameter> &ref_169
+            - !<!Parameter> &ref_170
               schema: *ref_58
               groupedBy: !<!Parameter> &ref_105
                 schema: *ref_104
@@ -1811,7 +1821,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_80
           originalParameter:
-            - !<!Parameter> &ref_170
+            - !<!Parameter> &ref_171
               schema: *ref_80
               groupedBy: *ref_105
               implementation: Method
@@ -1832,7 +1842,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_88
           originalParameter:
-            - !<!Parameter> &ref_171
+            - !<!Parameter> &ref_172
               schema: *ref_88
               groupedBy: *ref_105
               implementation: Method
@@ -1857,7 +1867,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_80
           originalParameter:
-            - !<!Parameter> &ref_172
+            - !<!Parameter> &ref_173
               schema: *ref_80
               groupedBy: *ref_105
               implementation: Method
@@ -1878,7 +1888,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_80
           originalParameter:
-            - !<!Parameter> &ref_173
+            - !<!Parameter> &ref_174
               schema: *ref_80
               groupedBy: *ref_105
               implementation: Method
@@ -1899,7 +1909,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_93
           originalParameter:
-            - !<!Parameter> &ref_174
+            - !<!Parameter> &ref_175
               schema: *ref_93
               groupedBy: *ref_105
               implementation: Method
@@ -1934,7 +1944,7 @@ schemas: !<!Schemas>
                 description: ''
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_175
+            - !<!Parameter> &ref_176
               schema: *ref_106
               groupedBy: *ref_105
               implementation: Method
@@ -1955,7 +1965,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_98
           originalParameter:
-            - !<!Parameter> &ref_176
+            - !<!Parameter> &ref_177
               schema: *ref_98
               groupedBy: *ref_105
               implementation: Method
@@ -1983,7 +1993,7 @@ schemas: !<!Schemas>
   uuids:
     - *ref_86
   objects:
-    - !<!ObjectSchema> &ref_134
+    - !<!ObjectSchema> &ref_135
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2298,7 +2308,7 @@ schemas: !<!Schemas>
     - *ref_29
     - *ref_30
     - *ref_31
-    - !<!ObjectSchema> &ref_156
+    - !<!ObjectSchema> &ref_157
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2372,7 +2382,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_35
-    - !<!ObjectSchema> &ref_158
+    - !<!ObjectSchema> &ref_159
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2483,13 +2493,13 @@ schemas: !<!Schemas>
           description: 'Parameters for filtering, sorting, fuzzy matching, and other suggestions query behaviors.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_162
+    - !<!ObjectSchema> &ref_163
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
       properties:
-        - !<!Property> &ref_164
+        - !<!Property> &ref_165
           schema: !<!ArraySchema> &ref_83
             type: array
             apiVersions:
@@ -2548,7 +2558,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_48
-    - !<!ObjectSchema> &ref_167
+    - !<!ObjectSchema> &ref_168
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2639,7 +2649,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_53
-    - !<!ObjectSchema> &ref_180
+    - !<!ObjectSchema> &ref_181
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2708,7 +2718,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_56
-    - !<!ObjectSchema> &ref_182
+    - !<!ObjectSchema> &ref_183
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2820,7 +2830,7 @@ schemas: !<!Schemas>
     - *ref_75
     - *ref_76
     - *ref_77
-    - !<!ArraySchema> &ref_138
+    - !<!ArraySchema> &ref_139
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -2928,9 +2938,22 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_113
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_114
             signatureParameters:
-              - *ref_113
+              - *ref_114
             language: !<!Languages> 
               default:
                 name: ''
@@ -2943,7 +2966,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_114
+            schema: *ref_115
             language: !<!Languages> 
               default:
                 name: ''
@@ -2980,7 +3003,7 @@ operationGroups:
           - *ref_108
           - *ref_109
           - *ref_110
-          - !<!Parameter> &ref_133
+          - !<!Parameter> &ref_134
             schema: *ref_80
             implementation: Method
             language: !<!Languages> 
@@ -2991,7 +3014,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_115
           - *ref_116
           - *ref_117
           - *ref_118
@@ -3007,16 +3029,30 @@ operationGroups:
           - *ref_128
           - *ref_129
           - *ref_130
-          - *ref_112
           - *ref_131
+          - *ref_112
+          - *ref_132
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_91
-              - *ref_132
+              - *ref_133
             signatureParameters:
               - *ref_91
-              - *ref_132
+              - *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -3027,10 +3063,10 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_133
+          - *ref_134
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_134
+            schema: *ref_135
             language: !<!Languages> 
               default:
                 name: ''
@@ -3118,11 +3154,11 @@ operationGroups:
           - *ref_109
           - *ref_110
           - *ref_112
-          - *ref_135
+          - *ref_136
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_137
+              - !<!Parameter> &ref_138
                 schema: *ref_30
                 implementation: Method
                 required: true
@@ -3134,10 +3170,23 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - *ref_136
-            signatureParameters:
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_137
-              - *ref_136
+            signatureParameters:
+              - *ref_138
+              - *ref_137
             language: !<!Languages> 
               default:
                 name: ''
@@ -3153,7 +3202,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_134
+            schema: *ref_135
             language: !<!Languages> 
               default:
                 name: ''
@@ -3253,7 +3302,7 @@ operationGroups:
           - *ref_108
           - *ref_109
           - *ref_110
-          - !<!Parameter> &ref_141
+          - !<!Parameter> &ref_142
             schema: *ref_80
             implementation: Method
             required: true
@@ -3265,8 +3314,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_142
-            schema: *ref_138
+          - !<!Parameter> &ref_143
+            schema: *ref_139
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3277,13 +3326,26 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_112
-          - *ref_139
+          - *ref_140
         requests:
           - !<!Request> 
             parameters:
-              - *ref_140
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_141
             signatureParameters:
-              - *ref_140
+              - *ref_141
             language: !<!Languages> 
               default:
                 name: ''
@@ -3294,8 +3356,8 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_141
           - *ref_142
+          - *ref_143
         responses:
           - !<!SchemaResponse> 
             schema: *ref_3
@@ -3342,7 +3404,7 @@ operationGroups:
           - *ref_108
           - *ref_109
           - *ref_110
-          - !<!Parameter> &ref_154
+          - !<!Parameter> &ref_155
             schema: *ref_80
             implementation: Method
             required: true
@@ -3354,7 +3416,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_155
+          - !<!Parameter> &ref_156
             schema: *ref_80
             implementation: Method
             required: true
@@ -3366,7 +3428,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_143
           - *ref_144
           - *ref_145
           - *ref_146
@@ -3375,16 +3436,30 @@ operationGroups:
           - *ref_149
           - *ref_150
           - *ref_151
-          - *ref_112
           - *ref_152
+          - *ref_112
+          - *ref_153
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_100
-              - *ref_153
+              - *ref_154
             signatureParameters:
               - *ref_100
-              - *ref_153
+              - *ref_154
             language: !<!Languages> 
               default:
                 name: ''
@@ -3395,11 +3470,11 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_154
           - *ref_155
+          - *ref_156
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_156
+            schema: *ref_157
             language: !<!Languages> 
               default:
                 name: ''
@@ -3463,12 +3538,12 @@ operationGroups:
           - *ref_109
           - *ref_110
           - *ref_112
-          - *ref_157
+          - *ref_158
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_160
-                schema: *ref_158
+              - !<!Parameter> &ref_161
+                schema: *ref_159
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3479,10 +3554,23 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - *ref_159
-            signatureParameters:
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_160
-              - *ref_159
+            signatureParameters:
+              - *ref_161
+              - *ref_160
             language: !<!Languages> 
               default:
                 name: ''
@@ -3498,7 +3586,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_156
+            schema: *ref_157
             language: !<!Languages> 
               default:
                 name: ''
@@ -3555,12 +3643,12 @@ operationGroups:
           - *ref_109
           - *ref_110
           - *ref_112
-          - *ref_161
+          - *ref_162
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_163
-                schema: *ref_162
+              - !<!Parameter> &ref_164
+                schema: *ref_163
                 flattened: true
                 implementation: Method
                 required: true
@@ -3572,22 +3660,35 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_166
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_167
                 schema: *ref_83
                 implementation: Method
-                originalParameter: *ref_163
+                originalParameter: *ref_164
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_164
+                targetProperty: *ref_165
                 language: !<!Languages> 
                   default:
                     name: Actions
                     description: The actions in the batch.
                 protocol: !<!Protocols> {}
-              - *ref_165
-            signatureParameters:
               - *ref_166
-              - *ref_165
+            signatureParameters:
+              - *ref_167
+              - *ref_166
             language: !<!Languages> 
               default:
                 name: ''
@@ -3603,7 +3704,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_167
+            schema: *ref_168
             language: !<!Languages> 
               default:
                 name: ''
@@ -3616,7 +3717,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_167
+            schema: *ref_168
             language: !<!Languages> 
               default:
                 name: ''
@@ -3703,9 +3804,9 @@ operationGroups:
           - *ref_108
           - *ref_109
           - *ref_110
-          - *ref_168
+          - *ref_169
           - *ref_112
-          - !<!Parameter> &ref_178
+          - !<!Parameter> &ref_179
             schema: *ref_80
             implementation: Method
             required: true
@@ -3717,7 +3818,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_179
+          - !<!Parameter> &ref_180
             schema: *ref_80
             implementation: Method
             required: true
@@ -3729,7 +3830,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_169
           - *ref_170
           - *ref_171
           - *ref_172
@@ -3737,13 +3837,27 @@ operationGroups:
           - *ref_174
           - *ref_175
           - *ref_176
+          - *ref_177
         requests:
           - !<!Request> 
             parameters:
-              - *ref_177
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_178
               - *ref_105
             signatureParameters:
-              - *ref_177
+              - *ref_178
               - *ref_105
             language: !<!Languages> 
               default:
@@ -3755,11 +3869,11 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_178
           - *ref_179
+          - *ref_180
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_180
+            schema: *ref_181
             language: !<!Languages> 
               default:
                 name: ''
@@ -3814,13 +3928,13 @@ operationGroups:
           - *ref_108
           - *ref_109
           - *ref_110
-          - *ref_181
+          - *ref_182
           - *ref_112
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_184
-                schema: *ref_182
+              - !<!Parameter> &ref_185
+                schema: *ref_183
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3831,10 +3945,23 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - *ref_183
-            signatureParameters:
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_184
-              - *ref_183
+            signatureParameters:
+              - *ref_185
+              - *ref_184
             language: !<!Languages> 
               default:
                 name: ''
@@ -3850,7 +3977,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_180
+            schema: *ref_181
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/cognitive-search/modeler.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/modeler.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: SearchIndexClient
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_93
+    - !<!BooleanSchema> &ref_94
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -47,7 +47,7 @@ schemas: !<!Schemas>
             provides a better experience in some scenarios, it comes at a performance cost as fuzzy autocomplete queries are slower and consume more resources.
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_89
+    - !<!NumberSchema> &ref_90
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -58,7 +58,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_96
+    - !<!NumberSchema> &ref_97
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -69,7 +69,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_101
+    - !<!NumberSchema> &ref_102
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -760,6 +760,16 @@ schemas: !<!Schemas>
           name: ApiVersion-2019-05-06
           description: Api Version (2019-05-06)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_89
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_8
       type: dictionary
@@ -878,7 +888,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_122
+    - !<!ObjectSchema> &ref_123
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1193,7 +1203,7 @@ schemas: !<!Schemas>
     - *ref_52
     - *ref_53
     - *ref_54
-    - !<!ObjectSchema> &ref_144
+    - !<!ObjectSchema> &ref_145
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1267,7 +1277,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_57
-    - !<!ObjectSchema> &ref_146
+    - !<!ObjectSchema> &ref_147
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1378,7 +1388,7 @@ schemas: !<!Schemas>
           description: 'Parameters for filtering, sorting, fuzzy matching, and other suggestions query behaviors.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_149
+    - !<!ObjectSchema> &ref_150
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1443,7 +1453,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_69
-    - !<!ObjectSchema> &ref_151
+    - !<!ObjectSchema> &ref_152
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1534,7 +1544,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_71
-    - !<!ObjectSchema> &ref_164
+    - !<!ObjectSchema> &ref_165
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1603,7 +1613,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_73
-    - !<!ObjectSchema> &ref_166
+    - !<!ObjectSchema> &ref_167
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1704,7 +1714,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_94
+    - !<!ArraySchema> &ref_95
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1715,7 +1725,7 @@ schemas: !<!Schemas>
           name: paths·1adzgki·docs·get·parameters·2·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_95
+    - !<!ArraySchema> &ref_96
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1726,7 +1736,7 @@ schemas: !<!Schemas>
           name: paths·18nrber·docs·get·parameters·4·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_97
+    - !<!ArraySchema> &ref_98
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1737,7 +1747,7 @@ schemas: !<!Schemas>
           name: paths·1qpycpw·docs·get·parameters·8·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_98
+    - !<!ArraySchema> &ref_99
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1748,7 +1758,7 @@ schemas: !<!Schemas>
           name: paths·1fk4czm·docs·get·parameters·10·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_99
+    - !<!ArraySchema> &ref_100
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1759,7 +1769,7 @@ schemas: !<!Schemas>
           name: paths·1ydkr4·docs·get·parameters·12·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_100
+    - !<!ArraySchema> &ref_101
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1775,7 +1785,7 @@ schemas: !<!Schemas>
     - *ref_42
     - *ref_13
     - *ref_50
-    - !<!ArraySchema> &ref_125
+    - !<!ArraySchema> &ref_126
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1786,7 +1796,7 @@ schemas: !<!Schemas>
           name: paths·12hj56k·docs-key·get·parameters·1·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_129
+    - !<!ArraySchema> &ref_130
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1797,7 +1807,7 @@ schemas: !<!Schemas>
           name: paths·8sf5uk·docs-search-suggest·get·parameters·7·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_130
+    - !<!ArraySchema> &ref_131
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1808,7 +1818,7 @@ schemas: !<!Schemas>
           name: paths·a27jtj·docs-search-suggest·get·parameters·8·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_131
+    - !<!ArraySchema> &ref_132
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1822,7 +1832,7 @@ schemas: !<!Schemas>
     - *ref_55
     - *ref_68
     - *ref_70
-    - !<!ArraySchema> &ref_152
+    - !<!ArraySchema> &ref_153
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -1835,7 +1845,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_72
 globalParameters:
-  - !<!Parameter> &ref_90
+  - !<!Parameter> &ref_91
     schema: *ref_0
     implementation: Client
     required: true
@@ -1854,7 +1864,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_91
+  - !<!Parameter> &ref_92
     schema: *ref_0
     clientDefaultValue: search.windows.net
     implementation: Client
@@ -1874,7 +1884,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_92
+  - !<!Parameter> &ref_93
     schema: *ref_0
     implementation: Client
     required: true
@@ -1893,7 +1903,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_102
+  - !<!Parameter> &ref_103
     schema: *ref_87
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -1915,15 +1925,15 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-05-06'
         parameters:
-          - *ref_90
           - *ref_91
           - *ref_92
+          - *ref_93
           - !<!Parameter> &ref_88
             schema: *ref_86
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: &ref_103
+              x-ms-parameter-grouping: &ref_104
                 name: search-request-options
             language: !<!Languages> 
               default:
@@ -1933,9 +1943,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_102
+          - *ref_103
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_89
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1949,7 +1974,7 @@ operationGroups:
           - *ref_88
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_89
+            schema: *ref_90
             language: !<!Languages> 
               default:
                 name: ''
@@ -1983,10 +2008,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-05-06'
         parameters:
-          - *ref_90
           - *ref_91
           - *ref_92
-          - !<!Parameter> &ref_104
+          - *ref_93
+          - !<!Parameter> &ref_105
             schema: *ref_18
             implementation: Method
             language: !<!Languages> 
@@ -1997,8 +2022,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_105
-            schema: *ref_93
+          - !<!Parameter> &ref_106
+            schema: *ref_94
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2011,8 +2036,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_106
-            schema: *ref_94
+          - !<!Parameter> &ref_107
+            schema: *ref_95
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2027,7 +2052,7 @@ operationGroups:
                 explode: true
                 in: query
                 style: form
-          - !<!Parameter> &ref_107
+          - !<!Parameter> &ref_108
             schema: *ref_18
             implementation: Method
             extensions:
@@ -2041,8 +2066,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_108
-            schema: *ref_95
+          - !<!Parameter> &ref_109
+            schema: *ref_96
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2055,7 +2080,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_109
+          - !<!Parameter> &ref_110
             schema: *ref_18
             implementation: Method
             extensions:
@@ -2069,7 +2094,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_110
+          - !<!Parameter> &ref_111
             schema: *ref_18
             implementation: Method
             extensions:
@@ -2083,8 +2108,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_111
-            schema: *ref_96
+          - !<!Parameter> &ref_112
+            schema: *ref_97
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2099,8 +2124,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_112
-            schema: *ref_97
+          - !<!Parameter> &ref_113
+            schema: *ref_98
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2116,7 +2141,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_113
+          - !<!Parameter> &ref_114
             schema: *ref_41
             implementation: Method
             extensions:
@@ -2130,8 +2155,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_114
-            schema: *ref_98
+          - !<!Parameter> &ref_115
+            schema: *ref_99
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2148,7 +2173,7 @@ operationGroups:
                 explode: true
                 in: query
                 style: form
-          - !<!Parameter> &ref_115
+          - !<!Parameter> &ref_116
             schema: *ref_18
             implementation: Method
             extensions:
@@ -2162,8 +2187,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_116
-            schema: *ref_99
+          - !<!Parameter> &ref_117
+            schema: *ref_100
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2178,7 +2203,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_117
+          - !<!Parameter> &ref_118
             schema: *ref_46
             implementation: Method
             extensions:
@@ -2192,8 +2217,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_118
-            schema: *ref_100
+          - !<!Parameter> &ref_119
+            schema: *ref_101
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2206,8 +2231,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_119
-            schema: *ref_101
+          - !<!Parameter> &ref_120
+            schema: *ref_102
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2222,8 +2247,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_120
-            schema: *ref_101
+          - !<!Parameter> &ref_121
+            schema: *ref_102
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2238,13 +2263,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_102
-          - !<!Parameter> &ref_121
+          - *ref_103
+          - !<!Parameter> &ref_122
             schema: *ref_86
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: *ref_103
+              x-ms-parameter-grouping: *ref_104
             language: !<!Languages> 
               default:
                 name: client-request-id
@@ -2255,6 +2280,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_89
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2265,7 +2305,6 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_104
           - *ref_105
           - *ref_106
           - *ref_107
@@ -2283,9 +2322,10 @@ operationGroups:
           - *ref_119
           - *ref_120
           - *ref_121
+          - *ref_122
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_122
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -2369,16 +2409,16 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-05-06'
         parameters:
-          - *ref_90
           - *ref_91
           - *ref_92
-          - *ref_102
-          - !<!Parameter> &ref_123
+          - *ref_93
+          - *ref_103
+          - !<!Parameter> &ref_124
             schema: *ref_86
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: *ref_103
+              x-ms-parameter-grouping: *ref_104
             language: !<!Languages> 
               default:
                 name: client-request-id
@@ -2390,7 +2430,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_124
+              - !<!Parameter> &ref_125
                 schema: *ref_53
                 implementation: Method
                 required: true
@@ -2402,8 +2442,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_89
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_124
+              - *ref_125
             language: !<!Languages> 
               default:
                 name: ''
@@ -2417,10 +2470,10 @@ operationGroups:
                   - application/json
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_123
+          - *ref_124
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_122
+            schema: *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -2517,10 +2570,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-05-06'
         parameters:
-          - *ref_90
           - *ref_91
           - *ref_92
-          - !<!Parameter> &ref_126
+          - *ref_93
+          - !<!Parameter> &ref_127
             schema: *ref_18
             implementation: Method
             required: true
@@ -2532,8 +2585,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_127
-            schema: *ref_125
+          - !<!Parameter> &ref_128
+            schema: *ref_126
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2543,13 +2596,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_102
-          - !<!Parameter> &ref_128
+          - *ref_103
+          - !<!Parameter> &ref_129
             schema: *ref_86
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: *ref_103
+              x-ms-parameter-grouping: *ref_104
             language: !<!Languages> 
               default:
                 name: client-request-id
@@ -2560,6 +2613,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_89
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2570,9 +2638,9 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_126
           - *ref_127
           - *ref_128
+          - *ref_129
         responses:
           - !<!SchemaResponse> 
             schema: *ref_14
@@ -2616,10 +2684,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-05-06'
         parameters:
-          - *ref_90
           - *ref_91
           - *ref_92
-          - !<!Parameter> &ref_132
+          - *ref_93
+          - !<!Parameter> &ref_133
             schema: *ref_18
             implementation: Method
             required: true
@@ -2631,7 +2699,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_133
+          - !<!Parameter> &ref_134
             schema: *ref_18
             implementation: Method
             required: true
@@ -2643,7 +2711,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_134
+          - !<!Parameter> &ref_135
             schema: *ref_18
             implementation: Method
             extensions:
@@ -2657,8 +2725,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_135
-            schema: *ref_93
+          - !<!Parameter> &ref_136
+            schema: *ref_94
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2673,7 +2741,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_136
+          - !<!Parameter> &ref_137
             schema: *ref_18
             implementation: Method
             extensions:
@@ -2687,7 +2755,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_137
+          - !<!Parameter> &ref_138
             schema: *ref_18
             implementation: Method
             extensions:
@@ -2701,8 +2769,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_138
-            schema: *ref_96
+          - !<!Parameter> &ref_139
+            schema: *ref_97
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2717,8 +2785,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_139
-            schema: *ref_129
+          - !<!Parameter> &ref_140
+            schema: *ref_130
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2734,8 +2802,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_140
-            schema: *ref_130
+          - !<!Parameter> &ref_141
+            schema: *ref_131
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2748,8 +2816,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_141
-            schema: *ref_131
+          - !<!Parameter> &ref_142
+            schema: *ref_132
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2762,8 +2830,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_142
-            schema: *ref_101
+          - !<!Parameter> &ref_143
+            schema: *ref_102
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -2776,13 +2844,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_102
-          - !<!Parameter> &ref_143
+          - *ref_103
+          - !<!Parameter> &ref_144
             schema: *ref_86
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: *ref_103
+              x-ms-parameter-grouping: *ref_104
             language: !<!Languages> 
               default:
                 name: client-request-id
@@ -2793,6 +2861,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_89
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2803,7 +2886,6 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_132
           - *ref_133
           - *ref_134
           - *ref_135
@@ -2815,9 +2897,10 @@ operationGroups:
           - *ref_141
           - *ref_142
           - *ref_143
+          - *ref_144
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_144
+            schema: *ref_145
             language: !<!Languages> 
               default:
                 name: ''
@@ -2877,16 +2960,16 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-05-06'
         parameters:
-          - *ref_90
           - *ref_91
           - *ref_92
-          - *ref_102
-          - !<!Parameter> &ref_145
+          - *ref_93
+          - *ref_103
+          - !<!Parameter> &ref_146
             schema: *ref_86
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: *ref_103
+              x-ms-parameter-grouping: *ref_104
             language: !<!Languages> 
               default:
                 name: client-request-id
@@ -2898,8 +2981,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_147
-                schema: *ref_146
+              - !<!Parameter> &ref_148
+                schema: *ref_147
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2910,8 +2993,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_89
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_147
+              - *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -2925,10 +3021,10 @@ operationGroups:
                   - application/json
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_145
+          - *ref_146
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_144
+            schema: *ref_145
             language: !<!Languages> 
               default:
                 name: ''
@@ -2981,16 +3077,16 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-05-06'
         parameters:
-          - *ref_90
           - *ref_91
           - *ref_92
-          - *ref_102
-          - !<!Parameter> &ref_148
+          - *ref_93
+          - *ref_103
+          - !<!Parameter> &ref_149
             schema: *ref_86
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: *ref_103
+              x-ms-parameter-grouping: *ref_104
             language: !<!Languages> 
               default:
                 name: client-request-id
@@ -3002,8 +3098,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_150
-                schema: *ref_149
+              - !<!Parameter> &ref_151
+                schema: *ref_150
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3014,8 +3110,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_89
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_150
+              - *ref_151
             language: !<!Languages> 
               default:
                 name: ''
@@ -3029,10 +3138,10 @@ operationGroups:
                   - application/json
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_148
+          - *ref_149
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_151
+            schema: *ref_152
             language: !<!Languages> 
               default:
                 name: ''
@@ -3045,7 +3154,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_151
+            schema: *ref_152
             language: !<!Languages> 
               default:
                 name: ''
@@ -3129,15 +3238,15 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-05-06'
         parameters:
-          - *ref_90
           - *ref_91
           - *ref_92
-          - !<!Parameter> &ref_153
+          - *ref_93
+          - !<!Parameter> &ref_154
             schema: *ref_86
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: *ref_103
+              x-ms-parameter-grouping: *ref_104
             language: !<!Languages> 
               default:
                 name: client-request-id
@@ -3146,8 +3255,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_102
-          - !<!Parameter> &ref_154
+          - *ref_103
+          - !<!Parameter> &ref_155
             schema: *ref_18
             implementation: Method
             required: true
@@ -3159,7 +3268,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_155
+          - !<!Parameter> &ref_156
             schema: *ref_18
             implementation: Method
             required: true
@@ -3171,7 +3280,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_156
+          - !<!Parameter> &ref_157
             schema: *ref_75
             implementation: Method
             extensions:
@@ -3185,7 +3294,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_157
+          - !<!Parameter> &ref_158
             schema: *ref_18
             implementation: Method
             extensions:
@@ -3199,8 +3308,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_158
-            schema: *ref_93
+          - !<!Parameter> &ref_159
+            schema: *ref_94
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -3215,7 +3324,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_159
+          - !<!Parameter> &ref_160
             schema: *ref_18
             implementation: Method
             extensions:
@@ -3229,7 +3338,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_160
+          - !<!Parameter> &ref_161
             schema: *ref_18
             implementation: Method
             extensions:
@@ -3243,8 +3352,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_161
-            schema: *ref_96
+          - !<!Parameter> &ref_162
+            schema: *ref_97
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -3259,8 +3368,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_162
-            schema: *ref_152
+          - !<!Parameter> &ref_163
+            schema: *ref_153
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -3273,8 +3382,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_163
-            schema: *ref_101
+          - !<!Parameter> &ref_164
+            schema: *ref_102
             implementation: Method
             extensions:
               x-ms-parameter-grouping:
@@ -3289,6 +3398,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_89
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3299,7 +3423,6 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_153
           - *ref_154
           - *ref_155
           - *ref_156
@@ -3310,9 +3433,10 @@ operationGroups:
           - *ref_161
           - *ref_162
           - *ref_163
+          - *ref_164
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_164
+            schema: *ref_165
             language: !<!Languages> 
               default:
                 name: ''
@@ -3364,15 +3488,15 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-05-06'
         parameters:
-          - *ref_90
           - *ref_91
           - *ref_92
-          - !<!Parameter> &ref_165
+          - *ref_93
+          - !<!Parameter> &ref_166
             schema: *ref_86
             implementation: Method
             extensions:
               x-ms-client-request-id: true
-              x-ms-parameter-grouping: *ref_103
+              x-ms-parameter-grouping: *ref_104
             language: !<!Languages> 
               default:
                 name: client-request-id
@@ -3381,12 +3505,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_102
+          - *ref_103
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_167
-                schema: *ref_166
+              - !<!Parameter> &ref_168
+                schema: *ref_167
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3397,8 +3521,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_89
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_167
+              - *ref_168
             language: !<!Languages> 
               default:
                 name: ''
@@ -3412,10 +3549,10 @@ operationGroups:
                   - application/json
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_165
+          - *ref_166
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_164
+            schema: *ref_165
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/cognitive-search/namer.yaml
+++ b/modelerfour/test/scenarios/cognitive-search/namer.yaml
@@ -47,7 +47,7 @@ schemas: !<!Schemas>
             provides a better experience in some scenarios, it comes at a performance cost as fuzzy autocomplete queries are slower and consume more resources.
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_114
+    - !<!NumberSchema> &ref_115
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -760,6 +760,16 @@ schemas: !<!Schemas>
           name: ApiVersion20190506
           description: Api Version (2019-05-06)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_113
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_1
       type: dictionary
@@ -884,7 +894,7 @@ schemas: !<!Schemas>
           originalParameter:
             - !<!Parameter> &ref_111
               schema: *ref_5
-              groupedBy: !<!Parameter> &ref_113
+              groupedBy: !<!Parameter> &ref_114
                 schema: *ref_6
                 implementation: Method
                 language: !<!Languages> 
@@ -903,9 +913,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_131
+            - !<!Parameter> &ref_132
               schema: *ref_5
-              groupedBy: !<!Parameter> &ref_132
+              groupedBy: !<!Parameter> &ref_133
                 schema: *ref_6
                 implementation: Method
                 language: !<!Languages> 
@@ -924,9 +934,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_135
+            - !<!Parameter> &ref_136
               schema: *ref_5
-              groupedBy: !<!Parameter> &ref_136
+              groupedBy: !<!Parameter> &ref_137
                 schema: *ref_6
                 implementation: Method
                 language: !<!Languages> 
@@ -945,9 +955,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_139
+            - !<!Parameter> &ref_140
               schema: *ref_5
-              groupedBy: !<!Parameter> &ref_140
+              groupedBy: !<!Parameter> &ref_141
                 schema: *ref_6
                 implementation: Method
                 language: !<!Languages> 
@@ -966,9 +976,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_152
+            - !<!Parameter> &ref_153
               schema: *ref_5
-              groupedBy: !<!Parameter> &ref_153
+              groupedBy: !<!Parameter> &ref_154
                 schema: *ref_6
                 implementation: Method
                 language: !<!Languages> 
@@ -987,9 +997,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_157
+            - !<!Parameter> &ref_158
               schema: *ref_5
-              groupedBy: !<!Parameter> &ref_159
+              groupedBy: !<!Parameter> &ref_160
                 schema: *ref_6
                 implementation: Method
                 language: !<!Languages> 
@@ -1008,9 +1018,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_161
+            - !<!Parameter> &ref_162
               schema: *ref_5
-              groupedBy: !<!Parameter> &ref_165
+              groupedBy: !<!Parameter> &ref_166
                 schema: *ref_6
                 implementation: Method
                 language: !<!Languages> 
@@ -1029,9 +1039,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_168
+            - !<!Parameter> &ref_169
               schema: *ref_5
-              groupedBy: !<!Parameter> &ref_177
+              groupedBy: !<!Parameter> &ref_178
                 schema: *ref_6
                 implementation: Method
                 language: !<!Languages> 
@@ -1050,9 +1060,9 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: header
-            - !<!Parameter> &ref_181
+            - !<!Parameter> &ref_182
               schema: *ref_5
-              groupedBy: !<!Parameter> &ref_183
+              groupedBy: !<!Parameter> &ref_184
                 schema: *ref_6
                 implementation: Method
                 language: !<!Languages> 
@@ -1090,7 +1100,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_7
           originalParameter:
-            - !<!Parameter> &ref_115
+            - !<!Parameter> &ref_116
               schema: *ref_7
               groupedBy: !<!Parameter> &ref_11
                 schema: *ref_8
@@ -1128,7 +1138,7 @@ schemas: !<!Schemas>
                 description: Array of Get2ItemsItem
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_116
+            - !<!Parameter> &ref_117
               schema: *ref_10
               groupedBy: *ref_11
               implementation: Method
@@ -1151,7 +1161,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_12
           originalParameter:
-            - !<!Parameter> &ref_117
+            - !<!Parameter> &ref_118
               schema: *ref_12
               groupedBy: *ref_11
               implementation: Method
@@ -1182,7 +1192,7 @@ schemas: !<!Schemas>
                 description: Array of Get4ItemsItem
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_118
+            - !<!Parameter> &ref_119
               schema: *ref_14
               groupedBy: *ref_11
               implementation: Method
@@ -1203,7 +1213,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_12
           originalParameter:
-            - !<!Parameter> &ref_119
+            - !<!Parameter> &ref_120
               schema: *ref_12
               groupedBy: *ref_11
               implementation: Method
@@ -1224,7 +1234,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_12
           originalParameter:
-            - !<!Parameter> &ref_120
+            - !<!Parameter> &ref_121
               schema: *ref_12
               groupedBy: *ref_11
               implementation: Method
@@ -1245,7 +1255,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_15
           originalParameter:
-            - !<!Parameter> &ref_121
+            - !<!Parameter> &ref_122
               schema: *ref_15
               groupedBy: *ref_11
               implementation: Method
@@ -1280,7 +1290,7 @@ schemas: !<!Schemas>
                 description: Array of Get8ItemsItem
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_122
+            - !<!Parameter> &ref_123
               schema: *ref_17
               groupedBy: *ref_11
               implementation: Method
@@ -1307,7 +1317,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_18
           originalParameter:
-            - !<!Parameter> &ref_123
+            - !<!Parameter> &ref_124
               schema: *ref_18
               groupedBy: *ref_11
               implementation: Method
@@ -1338,7 +1348,7 @@ schemas: !<!Schemas>
                 description: Array of Get10ItemsItem
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_124
+            - !<!Parameter> &ref_125
               schema: *ref_20
               groupedBy: *ref_11
               implementation: Method
@@ -1365,7 +1375,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_12
           originalParameter:
-            - !<!Parameter> &ref_125
+            - !<!Parameter> &ref_126
               schema: *ref_12
               groupedBy: *ref_11
               implementation: Method
@@ -1396,7 +1406,7 @@ schemas: !<!Schemas>
                 description: Array of Get12ItemsItem
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_126
+            - !<!Parameter> &ref_127
               schema: *ref_22
               groupedBy: *ref_11
               implementation: Method
@@ -1421,7 +1431,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_23
           originalParameter:
-            - !<!Parameter> &ref_127
+            - !<!Parameter> &ref_128
               schema: *ref_23
               groupedBy: *ref_11
               implementation: Method
@@ -1452,7 +1462,7 @@ schemas: !<!Schemas>
                 description: Array of Get14ItemsItem
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_128
+            - !<!Parameter> &ref_129
               schema: *ref_25
               groupedBy: *ref_11
               implementation: Method
@@ -1473,7 +1483,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_26
           originalParameter:
-            - !<!Parameter> &ref_129
+            - !<!Parameter> &ref_130
               schema: *ref_26
               groupedBy: *ref_11
               implementation: Method
@@ -1498,7 +1508,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_26
           originalParameter:
-            - !<!Parameter> &ref_130
+            - !<!Parameter> &ref_131
               schema: *ref_26
               groupedBy: *ref_11
               implementation: Method
@@ -1533,7 +1543,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_12
           originalParameter:
-            - !<!Parameter> &ref_143
+            - !<!Parameter> &ref_144
               schema: *ref_12
               groupedBy: !<!Parameter> &ref_28
                 schema: *ref_27
@@ -1561,7 +1571,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_7
           originalParameter:
-            - !<!Parameter> &ref_144
+            - !<!Parameter> &ref_145
               schema: *ref_7
               groupedBy: *ref_28
               implementation: Method
@@ -1586,7 +1596,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_12
           originalParameter:
-            - !<!Parameter> &ref_145
+            - !<!Parameter> &ref_146
               schema: *ref_12
               groupedBy: *ref_28
               implementation: Method
@@ -1607,7 +1617,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_12
           originalParameter:
-            - !<!Parameter> &ref_146
+            - !<!Parameter> &ref_147
               schema: *ref_12
               groupedBy: *ref_28
               implementation: Method
@@ -1628,7 +1638,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_15
           originalParameter:
-            - !<!Parameter> &ref_147
+            - !<!Parameter> &ref_148
               schema: *ref_15
               groupedBy: *ref_28
               implementation: Method
@@ -1663,7 +1673,7 @@ schemas: !<!Schemas>
                 description: Array of Get7ItemsItem
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_148
+            - !<!Parameter> &ref_149
               schema: *ref_30
               groupedBy: *ref_28
               implementation: Method
@@ -1700,7 +1710,7 @@ schemas: !<!Schemas>
                 description: Array of String
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_149
+            - !<!Parameter> &ref_150
               schema: *ref_31
               groupedBy: *ref_28
               implementation: Method
@@ -1731,7 +1741,7 @@ schemas: !<!Schemas>
                 description: Array of Get9ItemsItem
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_150
+            - !<!Parameter> &ref_151
               schema: *ref_33
               groupedBy: *ref_28
               implementation: Method
@@ -1752,7 +1762,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_26
           originalParameter:
-            - !<!Parameter> &ref_151
+            - !<!Parameter> &ref_152
               schema: *ref_26
               groupedBy: *ref_28
               implementation: Method
@@ -1783,7 +1793,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_34
           originalParameter:
-            - !<!Parameter> &ref_169
+            - !<!Parameter> &ref_170
               schema: *ref_34
               groupedBy: !<!Parameter> &ref_36
                 schema: *ref_35
@@ -1811,7 +1821,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_12
           originalParameter:
-            - !<!Parameter> &ref_170
+            - !<!Parameter> &ref_171
               schema: *ref_12
               groupedBy: *ref_36
               implementation: Method
@@ -1832,7 +1842,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_7
           originalParameter:
-            - !<!Parameter> &ref_171
+            - !<!Parameter> &ref_172
               schema: *ref_7
               groupedBy: *ref_36
               implementation: Method
@@ -1857,7 +1867,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_12
           originalParameter:
-            - !<!Parameter> &ref_172
+            - !<!Parameter> &ref_173
               schema: *ref_12
               groupedBy: *ref_36
               implementation: Method
@@ -1878,7 +1888,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_12
           originalParameter:
-            - !<!Parameter> &ref_173
+            - !<!Parameter> &ref_174
               schema: *ref_12
               groupedBy: *ref_36
               implementation: Method
@@ -1899,7 +1909,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_15
           originalParameter:
-            - !<!Parameter> &ref_174
+            - !<!Parameter> &ref_175
               schema: *ref_15
               groupedBy: *ref_36
               implementation: Method
@@ -1934,7 +1944,7 @@ schemas: !<!Schemas>
                 description: Array of String
             protocol: !<!Protocols> {}
           originalParameter:
-            - !<!Parameter> &ref_175
+            - !<!Parameter> &ref_176
               schema: *ref_37
               groupedBy: *ref_36
               implementation: Method
@@ -1955,7 +1965,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_26
           originalParameter:
-            - !<!Parameter> &ref_176
+            - !<!Parameter> &ref_177
               schema: *ref_26
               groupedBy: *ref_36
               implementation: Method
@@ -1983,7 +1993,7 @@ schemas: !<!Schemas>
   uuids:
     - *ref_5
   objects:
-    - !<!ObjectSchema> &ref_134
+    - !<!ObjectSchema> &ref_135
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2298,7 +2308,7 @@ schemas: !<!Schemas>
     - *ref_60
     - *ref_61
     - *ref_62
-    - !<!ObjectSchema> &ref_156
+    - !<!ObjectSchema> &ref_157
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2372,7 +2382,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_66
-    - !<!ObjectSchema> &ref_158
+    - !<!ObjectSchema> &ref_159
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2483,13 +2493,13 @@ schemas: !<!Schemas>
           description: 'Parameters for filtering, sorting, fuzzy matching, and other suggestions query behaviors.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_162
+    - !<!ObjectSchema> &ref_163
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: '2019-05-06'
       properties:
-        - !<!Property> &ref_164
+        - !<!Property> &ref_165
           schema: !<!ArraySchema> &ref_104
             type: array
             apiVersions:
@@ -2548,7 +2558,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_79
-    - !<!ObjectSchema> &ref_167
+    - !<!ObjectSchema> &ref_168
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2639,7 +2649,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_84
-    - !<!ObjectSchema> &ref_180
+    - !<!ObjectSchema> &ref_181
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2708,7 +2718,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_87
-    - !<!ObjectSchema> &ref_182
+    - !<!ObjectSchema> &ref_183
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2820,7 +2830,7 @@ schemas: !<!Schemas>
     - *ref_99
     - *ref_100
     - *ref_101
-    - !<!ArraySchema> &ref_138
+    - !<!ArraySchema> &ref_139
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -2928,9 +2938,22 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - *ref_113
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_114
             signatureParameters:
-              - *ref_113
+              - *ref_114
             language: !<!Languages> 
               default:
                 name: ''
@@ -2943,7 +2966,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_114
+            schema: *ref_115
             language: !<!Languages> 
               default:
                 name: ''
@@ -2980,7 +3003,7 @@ operationGroups:
           - *ref_108
           - *ref_109
           - *ref_110
-          - !<!Parameter> &ref_133
+          - !<!Parameter> &ref_134
             schema: *ref_12
             implementation: Method
             language: !<!Languages> 
@@ -2991,7 +3014,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_115
           - *ref_116
           - *ref_117
           - *ref_118
@@ -3007,16 +3029,30 @@ operationGroups:
           - *ref_128
           - *ref_129
           - *ref_130
-          - *ref_112
           - *ref_131
+          - *ref_112
+          - *ref_132
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_11
-              - *ref_132
+              - *ref_133
             signatureParameters:
               - *ref_11
-              - *ref_132
+              - *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -3027,10 +3063,10 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_133
+          - *ref_134
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_134
+            schema: *ref_135
             language: !<!Languages> 
               default:
                 name: ''
@@ -3118,11 +3154,11 @@ operationGroups:
           - *ref_109
           - *ref_110
           - *ref_112
-          - *ref_135
+          - *ref_136
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_137
+              - !<!Parameter> &ref_138
                 schema: *ref_61
                 implementation: Method
                 required: true
@@ -3134,10 +3170,23 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - *ref_136
-            signatureParameters:
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_137
-              - *ref_136
+            signatureParameters:
+              - *ref_138
+              - *ref_137
             language: !<!Languages> 
               default:
                 name: ''
@@ -3153,7 +3202,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_134
+            schema: *ref_135
             language: !<!Languages> 
               default:
                 name: ''
@@ -3253,7 +3302,7 @@ operationGroups:
           - *ref_108
           - *ref_109
           - *ref_110
-          - !<!Parameter> &ref_141
+          - !<!Parameter> &ref_142
             schema: *ref_12
             implementation: Method
             required: true
@@ -3265,8 +3314,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_142
-            schema: *ref_138
+          - !<!Parameter> &ref_143
+            schema: *ref_139
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3277,13 +3326,26 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - *ref_112
-          - *ref_139
+          - *ref_140
         requests:
           - !<!Request> 
             parameters:
-              - *ref_140
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_141
             signatureParameters:
-              - *ref_140
+              - *ref_141
             language: !<!Languages> 
               default:
                 name: ''
@@ -3294,8 +3356,8 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_141
           - *ref_142
+          - *ref_143
         responses:
           - !<!SchemaResponse> 
             schema: *ref_3
@@ -3342,7 +3404,7 @@ operationGroups:
           - *ref_108
           - *ref_109
           - *ref_110
-          - !<!Parameter> &ref_154
+          - !<!Parameter> &ref_155
             schema: *ref_12
             implementation: Method
             required: true
@@ -3354,7 +3416,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_155
+          - !<!Parameter> &ref_156
             schema: *ref_12
             implementation: Method
             required: true
@@ -3366,7 +3428,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_143
           - *ref_144
           - *ref_145
           - *ref_146
@@ -3375,16 +3436,30 @@ operationGroups:
           - *ref_149
           - *ref_150
           - *ref_151
-          - *ref_112
           - *ref_152
+          - *ref_112
+          - *ref_153
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_28
-              - *ref_153
+              - *ref_154
             signatureParameters:
               - *ref_28
-              - *ref_153
+              - *ref_154
             language: !<!Languages> 
               default:
                 name: ''
@@ -3395,11 +3470,11 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_154
           - *ref_155
+          - *ref_156
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_156
+            schema: *ref_157
             language: !<!Languages> 
               default:
                 name: ''
@@ -3463,12 +3538,12 @@ operationGroups:
           - *ref_109
           - *ref_110
           - *ref_112
-          - *ref_157
+          - *ref_158
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_160
-                schema: *ref_158
+              - !<!Parameter> &ref_161
+                schema: *ref_159
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3479,10 +3554,23 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - *ref_159
-            signatureParameters:
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_160
-              - *ref_159
+            signatureParameters:
+              - *ref_161
+              - *ref_160
             language: !<!Languages> 
               default:
                 name: ''
@@ -3498,7 +3586,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_156
+            schema: *ref_157
             language: !<!Languages> 
               default:
                 name: ''
@@ -3555,12 +3643,12 @@ operationGroups:
           - *ref_109
           - *ref_110
           - *ref_112
-          - *ref_161
+          - *ref_162
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_163
-                schema: *ref_162
+              - !<!Parameter> &ref_164
+                schema: *ref_163
                 flattened: true
                 implementation: Method
                 required: true
@@ -3572,22 +3660,35 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_166
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_167
                 schema: *ref_104
                 implementation: Method
-                originalParameter: *ref_163
+                originalParameter: *ref_164
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_164
+                targetProperty: *ref_165
                 language: !<!Languages> 
                   default:
                     name: actions
                     description: The actions in the batch.
                 protocol: !<!Protocols> {}
-              - *ref_165
-            signatureParameters:
               - *ref_166
-              - *ref_165
+            signatureParameters:
+              - *ref_167
+              - *ref_166
             language: !<!Languages> 
               default:
                 name: ''
@@ -3603,7 +3704,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_167
+            schema: *ref_168
             language: !<!Languages> 
               default:
                 name: ''
@@ -3616,7 +3717,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_167
+            schema: *ref_168
             language: !<!Languages> 
               default:
                 name: ''
@@ -3703,9 +3804,9 @@ operationGroups:
           - *ref_108
           - *ref_109
           - *ref_110
-          - *ref_168
+          - *ref_169
           - *ref_112
-          - !<!Parameter> &ref_178
+          - !<!Parameter> &ref_179
             schema: *ref_12
             implementation: Method
             required: true
@@ -3717,7 +3818,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_179
+          - !<!Parameter> &ref_180
             schema: *ref_12
             implementation: Method
             required: true
@@ -3729,7 +3830,6 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_169
           - *ref_170
           - *ref_171
           - *ref_172
@@ -3737,13 +3837,27 @@ operationGroups:
           - *ref_174
           - *ref_175
           - *ref_176
+          - *ref_177
         requests:
           - !<!Request> 
             parameters:
-              - *ref_177
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - *ref_178
               - *ref_36
             signatureParameters:
-              - *ref_177
+              - *ref_178
               - *ref_36
             language: !<!Languages> 
               default:
@@ -3755,11 +3869,11 @@ operationGroups:
                 method: get
                 uri: 'https://{searchServiceName}.{searchDnsSuffix}/indexes(''{indexName}'')'
         signatureParameters:
-          - *ref_178
           - *ref_179
+          - *ref_180
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_180
+            schema: *ref_181
             language: !<!Languages> 
               default:
                 name: ''
@@ -3814,13 +3928,13 @@ operationGroups:
           - *ref_108
           - *ref_109
           - *ref_110
-          - *ref_181
+          - *ref_182
           - *ref_112
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_184
-                schema: *ref_182
+              - !<!Parameter> &ref_185
+                schema: *ref_183
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3831,10 +3945,23 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - *ref_183
-            signatureParameters:
+              - !<!Parameter> 
+                schema: *ref_113
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_184
-              - *ref_183
+            signatureParameters:
+              - *ref_185
+              - *ref_184
             language: !<!Languages> 
               default:
                 name: ''
@@ -3850,7 +3977,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_180
+            schema: *ref_181
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/complex-model/flattened.yaml
+++ b/modelerfour/test/scenarios/complex-model/flattened.yaml
@@ -112,6 +112,16 @@ schemas: !<!Schemas>
           name: ApiVersion-2014-04-01-preview
           description: Api Version (2014-04-01-preview)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_21
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_9
       type: dictionary
@@ -204,7 +214,7 @@ schemas: !<!Schemas>
           description: Dictionary of <Product>
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_22
+    - !<!ObjectSchema> &ref_23
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -239,7 +249,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_6
-    - !<!ObjectSchema> &ref_23
+    - !<!ObjectSchema> &ref_24
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -271,13 +281,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_24
+    - !<!ObjectSchema> &ref_25
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 2014-04-01-preview
       properties:
-        - !<!Property> &ref_26
+        - !<!Property> &ref_27
           schema: *ref_9
           serializedName: productDictionaryOfArray
           language: !<!Languages> 
@@ -295,7 +305,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_30
+    - !<!ObjectSchema> &ref_31
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -319,13 +329,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_31
+    - !<!ObjectSchema> &ref_32
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 2014-04-01-preview
       properties:
-        - !<!Property> &ref_33
+        - !<!Property> &ref_34
           schema: !<!ArraySchema> &ref_14
             type: array
             apiVersions:
@@ -412,7 +422,7 @@ operationGroups:
         parameters:
           - *ref_17
           - *ref_18
-          - !<!Parameter> &ref_21
+          - !<!Parameter> &ref_22
             schema: *ref_19
             implementation: Method
             required: true
@@ -427,6 +437,21 @@ operationGroups:
           - *ref_20
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_21
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -437,10 +462,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_21
+          - *ref_22
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -454,7 +479,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -478,7 +503,7 @@ operationGroups:
             version: 2014-04-01-preview
         parameters:
           - *ref_17
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_19
             implementation: Method
             required: true
@@ -490,7 +515,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_29
+          - !<!Parameter> &ref_30
             schema: *ref_19
             implementation: Method
             required: true
@@ -506,8 +531,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_25
-                schema: *ref_24
+              - !<!Parameter> &ref_26
+                schema: *ref_25
                 flattened: true
                 implementation: Method
                 required: true
@@ -519,19 +544,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_27
+              - !<!Parameter> 
+                schema: *ref_21
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_28
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_25
+                originalParameter: *ref_26
                 pathToProperty: []
-                targetProperty: *ref_26
+                targetProperty: *ref_27
                 language: !<!Languages> 
                   default:
                     name: productDictionaryOfArray
                     description: Dictionary of Array of product
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_27
+              - *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -545,11 +583,11 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
           - *ref_29
+          - *ref_30
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_30
+            schema: *ref_31
             language: !<!Languages> 
               default:
                 name: ''
@@ -563,7 +601,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -587,7 +625,7 @@ operationGroups:
             version: 2014-04-01-preview
         parameters:
           - *ref_17
-          - !<!Parameter> &ref_35
+          - !<!Parameter> &ref_36
             schema: *ref_19
             implementation: Method
             required: true
@@ -599,7 +637,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_36
+          - !<!Parameter> &ref_37
             schema: *ref_19
             implementation: Method
             required: true
@@ -615,8 +653,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_32
-                schema: *ref_31
+              - !<!Parameter> &ref_33
+                schema: *ref_32
                 flattened: true
                 implementation: Method
                 required: true
@@ -628,19 +666,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_34
+              - !<!Parameter> 
+                schema: *ref_21
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_35
                 schema: *ref_14
                 implementation: Method
-                originalParameter: *ref_32
+                originalParameter: *ref_33
                 pathToProperty: []
-                targetProperty: *ref_33
+                targetProperty: *ref_34
                 language: !<!Languages> 
                   default:
                     name: productArrayOfDictionary
                     description: Array of dictionary of products
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -654,11 +705,11 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_35
           - *ref_36
+          - *ref_37
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -672,7 +723,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/complex-model/grouped.yaml
+++ b/modelerfour/test/scenarios/complex-model/grouped.yaml
@@ -112,6 +112,16 @@ schemas: !<!Schemas>
           name: ApiVersion-2014-04-01-preview
           description: Api Version (2014-04-01-preview)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_21
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_9
       type: dictionary
@@ -204,7 +214,7 @@ schemas: !<!Schemas>
           description: Dictionary of <Product>
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_22
+    - !<!ObjectSchema> &ref_23
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -239,7 +249,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_6
-    - !<!ObjectSchema> &ref_23
+    - !<!ObjectSchema> &ref_24
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -271,13 +281,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_24
+    - !<!ObjectSchema> &ref_25
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 2014-04-01-preview
       properties:
-        - !<!Property> &ref_26
+        - !<!Property> &ref_27
           schema: *ref_9
           serializedName: productDictionaryOfArray
           language: !<!Languages> 
@@ -295,7 +305,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_30
+    - !<!ObjectSchema> &ref_31
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -319,13 +329,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_31
+    - !<!ObjectSchema> &ref_32
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 2014-04-01-preview
       properties:
-        - !<!Property> &ref_33
+        - !<!Property> &ref_34
           schema: !<!ArraySchema> &ref_14
             type: array
             apiVersions:
@@ -412,7 +422,7 @@ operationGroups:
         parameters:
           - *ref_17
           - *ref_18
-          - !<!Parameter> &ref_21
+          - !<!Parameter> &ref_22
             schema: *ref_19
             implementation: Method
             required: true
@@ -427,6 +437,21 @@ operationGroups:
           - *ref_20
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_21
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -437,10 +462,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_21
+          - *ref_22
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -454,7 +479,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -478,7 +503,7 @@ operationGroups:
             version: 2014-04-01-preview
         parameters:
           - *ref_17
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_19
             implementation: Method
             required: true
@@ -490,7 +515,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_29
+          - !<!Parameter> &ref_30
             schema: *ref_19
             implementation: Method
             required: true
@@ -506,8 +531,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_25
-                schema: *ref_24
+              - !<!Parameter> &ref_26
+                schema: *ref_25
                 flattened: true
                 implementation: Method
                 required: true
@@ -519,19 +544,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_27
+              - !<!Parameter> 
+                schema: *ref_21
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_28
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_25
+                originalParameter: *ref_26
                 pathToProperty: []
-                targetProperty: *ref_26
+                targetProperty: *ref_27
                 language: !<!Languages> 
                   default:
                     name: productDictionaryOfArray
                     description: Dictionary of Array of product
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_27
+              - *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -545,11 +583,11 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
           - *ref_29
+          - *ref_30
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_30
+            schema: *ref_31
             language: !<!Languages> 
               default:
                 name: ''
@@ -563,7 +601,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -587,7 +625,7 @@ operationGroups:
             version: 2014-04-01-preview
         parameters:
           - *ref_17
-          - !<!Parameter> &ref_35
+          - !<!Parameter> &ref_36
             schema: *ref_19
             implementation: Method
             required: true
@@ -599,7 +637,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_36
+          - !<!Parameter> &ref_37
             schema: *ref_19
             implementation: Method
             required: true
@@ -615,8 +653,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_32
-                schema: *ref_31
+              - !<!Parameter> &ref_33
+                schema: *ref_32
                 flattened: true
                 implementation: Method
                 required: true
@@ -628,19 +666,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_34
+              - !<!Parameter> 
+                schema: *ref_21
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_35
                 schema: *ref_14
                 implementation: Method
-                originalParameter: *ref_32
+                originalParameter: *ref_33
                 pathToProperty: []
-                targetProperty: *ref_33
+                targetProperty: *ref_34
                 language: !<!Languages> 
                   default:
                     name: productArrayOfDictionary
                     description: Array of dictionary of products
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -654,11 +705,11 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_35
           - *ref_36
+          - *ref_37
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -672,7 +723,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/complex-model/modeler.yaml
+++ b/modelerfour/test/scenarios/complex-model/modeler.yaml
@@ -112,6 +112,16 @@ schemas: !<!Schemas>
           name: ApiVersion-2014-04-01-preview
           description: Api Version (2014-04-01-preview)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_19
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_12
       type: dictionary
@@ -204,7 +214,7 @@ schemas: !<!Schemas>
           description: Dictionary of <Product>
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_19
+    - !<!ObjectSchema> &ref_20
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -239,7 +249,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_6
-    - !<!ObjectSchema> &ref_20
+    - !<!ObjectSchema> &ref_21
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -271,7 +281,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_25
+    - !<!ObjectSchema> &ref_26
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -295,7 +305,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_27
+    - !<!ObjectSchema> &ref_28
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -319,7 +329,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_30
+    - !<!ObjectSchema> &ref_31
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -358,7 +368,7 @@ schemas: !<!Schemas>
     - *ref_9
     - *ref_10
 globalParameters:
-  - !<!Parameter> &ref_32
+  - !<!Parameter> &ref_33
     schema: *ref_15
     implementation: Client
     required: true
@@ -372,7 +382,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: path
-  - !<!Parameter> &ref_21
+  - !<!Parameter> &ref_22
     schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -388,7 +398,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_22
+  - !<!Parameter> &ref_23
     schema: *ref_17
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -410,8 +420,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2014-04-01-preview
         parameters:
-          - *ref_21
-          - *ref_32
+          - *ref_22
+          - *ref_33
           - !<!Parameter> &ref_18
             schema: *ref_16
             implementation: Method
@@ -424,9 +434,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_22
+          - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_19
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -440,7 +465,7 @@ operationGroups:
           - *ref_18
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_19
+            schema: *ref_20
             language: !<!Languages> 
               default:
                 name: ''
@@ -454,7 +479,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -477,8 +502,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2014-04-01-preview
         parameters:
-          - *ref_21
-          - !<!Parameter> &ref_23
+          - *ref_22
+          - !<!Parameter> &ref_24
             schema: *ref_16
             implementation: Method
             required: true
@@ -490,7 +515,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_24
+          - !<!Parameter> &ref_25
             schema: *ref_16
             implementation: Method
             required: true
@@ -502,12 +527,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_22
+          - *ref_23
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_26
-                schema: *ref_25
+              - !<!Parameter> &ref_27
+                schema: *ref_26
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -518,8 +543,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_19
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_26
+              - *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -533,11 +571,11 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_23
           - *ref_24
+          - *ref_25
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -551,7 +589,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -574,8 +612,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2014-04-01-preview
         parameters:
-          - *ref_21
-          - !<!Parameter> &ref_28
+          - *ref_22
+          - !<!Parameter> &ref_29
             schema: *ref_16
             implementation: Method
             required: true
@@ -587,7 +625,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_29
+          - !<!Parameter> &ref_30
             schema: *ref_16
             implementation: Method
             required: true
@@ -599,12 +637,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_22
+          - *ref_23
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
-                schema: *ref_30
+              - !<!Parameter> &ref_32
+                schema: *ref_31
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -615,8 +653,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_19
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_31
+              - *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -630,11 +681,11 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
           - *ref_29
+          - *ref_30
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_19
+            schema: *ref_20
             language: !<!Languages> 
               default:
                 name: ''
@@ -648,7 +699,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_20
+            schema: *ref_21
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/complex-model/namer.yaml
+++ b/modelerfour/test/scenarios/complex-model/namer.yaml
@@ -112,6 +112,16 @@ schemas: !<!Schemas>
           name: ApiVersion20140401Preview
           description: Api Version (2014-04-01-preview)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_21
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_9
       type: dictionary
@@ -204,7 +214,7 @@ schemas: !<!Schemas>
           description: Dictionary of <Product>
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_22
+    - !<!ObjectSchema> &ref_23
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -239,7 +249,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_6
-    - !<!ObjectSchema> &ref_23
+    - !<!ObjectSchema> &ref_24
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -271,13 +281,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_24
+    - !<!ObjectSchema> &ref_25
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 2014-04-01-preview
       properties:
-        - !<!Property> &ref_26
+        - !<!Property> &ref_27
           schema: *ref_9
           serializedName: productDictionaryOfArray
           language: !<!Languages> 
@@ -295,7 +305,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_30
+    - !<!ObjectSchema> &ref_31
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -319,13 +329,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_31
+    - !<!ObjectSchema> &ref_32
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 2014-04-01-preview
       properties:
-        - !<!Property> &ref_33
+        - !<!Property> &ref_34
           schema: !<!ArraySchema> &ref_14
             type: array
             apiVersions:
@@ -412,7 +422,7 @@ operationGroups:
         parameters:
           - *ref_17
           - *ref_18
-          - !<!Parameter> &ref_21
+          - !<!Parameter> &ref_22
             schema: *ref_19
             implementation: Method
             required: true
@@ -427,6 +437,21 @@ operationGroups:
           - *ref_20
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_21
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -437,10 +462,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_21
+          - *ref_22
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -454,7 +479,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -478,7 +503,7 @@ operationGroups:
             version: 2014-04-01-preview
         parameters:
           - *ref_17
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_19
             implementation: Method
             required: true
@@ -490,7 +515,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_29
+          - !<!Parameter> &ref_30
             schema: *ref_19
             implementation: Method
             required: true
@@ -506,8 +531,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_25
-                schema: *ref_24
+              - !<!Parameter> &ref_26
+                schema: *ref_25
                 flattened: true
                 implementation: Method
                 required: true
@@ -519,19 +544,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_27
+              - !<!Parameter> 
+                schema: *ref_21
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_28
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_25
+                originalParameter: *ref_26
                 pathToProperty: []
-                targetProperty: *ref_26
+                targetProperty: *ref_27
                 language: !<!Languages> 
                   default:
                     name: productDictionaryOfArray
                     description: Dictionary of Array of product
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_27
+              - *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -545,11 +583,11 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
           - *ref_29
+          - *ref_30
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_30
+            schema: *ref_31
             language: !<!Languages> 
               default:
                 name: ''
@@ -563,7 +601,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -587,7 +625,7 @@ operationGroups:
             version: 2014-04-01-preview
         parameters:
           - *ref_17
-          - !<!Parameter> &ref_35
+          - !<!Parameter> &ref_36
             schema: *ref_19
             implementation: Method
             required: true
@@ -599,7 +637,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_36
+          - !<!Parameter> &ref_37
             schema: *ref_19
             implementation: Method
             required: true
@@ -615,8 +653,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_32
-                schema: *ref_31
+              - !<!Parameter> &ref_33
+                schema: *ref_32
                 flattened: true
                 implementation: Method
                 required: true
@@ -628,19 +666,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_34
+              - !<!Parameter> 
+                schema: *ref_21
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_35
                 schema: *ref_14
                 implementation: Method
-                originalParameter: *ref_32
+                originalParameter: *ref_33
                 pathToProperty: []
-                targetProperty: *ref_33
+                targetProperty: *ref_34
                 language: !<!Languages> 
                   default:
                     name: productArrayOfDictionary
                     description: Array of dictionary of products
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -654,11 +705,11 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_35
           - *ref_36
+          - *ref_37
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_22
+            schema: *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -672,7 +723,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/flattened.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: custom-baseUrl-more-options
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -41,7 +41,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -62,15 +62,26 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_7
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_11
+    - !<!ObjectSchema> &ref_12
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -78,7 +89,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -97,7 +108,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_5
-    schema: *ref_2
+    schema: *ref_3
     implementation: Client
     required: true
     extensions:
@@ -111,7 +122,7 @@ globalParameters:
       http: !<!HttpParameter> 
         in: path
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: host
     implementation: Client
     required: true
@@ -139,8 +150,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - !<!Parameter> &ref_7
-            schema: *ref_3
+          - !<!Parameter> &ref_8
+            schema: *ref_0
             implementation: Method
             required: true
             extensions:
@@ -157,8 +168,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_8
-            schema: *ref_3
+          - !<!Parameter> &ref_9
+            schema: *ref_0
             implementation: Method
             required: true
             extensions:
@@ -176,8 +187,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: uri
           - *ref_4
-          - !<!Parameter> &ref_9
-            schema: *ref_2
+          - !<!Parameter> &ref_10
+            schema: *ref_3
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -189,7 +200,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - *ref_5
-          - !<!Parameter> &ref_10
+          - !<!Parameter> &ref_11
             schema: *ref_6
             implementation: Method
             language: !<!Languages> 
@@ -202,6 +213,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -212,10 +238,10 @@ operationGroups:
                 method: get
                 uri: '{vault}{secret}{dnsSuffix}'
         signatureParameters:
-          - *ref_7
           - *ref_8
           - *ref_9
           - *ref_10
+          - *ref_11
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -228,7 +254,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/grouped.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: custom-baseUrl-more-options
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -41,7 +41,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -62,15 +62,26 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_7
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_11
+    - !<!ObjectSchema> &ref_12
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -78,7 +89,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -97,7 +108,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_5
-    schema: *ref_2
+    schema: *ref_3
     implementation: Client
     required: true
     extensions:
@@ -111,7 +122,7 @@ globalParameters:
       http: !<!HttpParameter> 
         in: path
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: host
     implementation: Client
     required: true
@@ -139,8 +150,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - !<!Parameter> &ref_7
-            schema: *ref_3
+          - !<!Parameter> &ref_8
+            schema: *ref_0
             implementation: Method
             required: true
             extensions:
@@ -157,8 +168,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_8
-            schema: *ref_3
+          - !<!Parameter> &ref_9
+            schema: *ref_0
             implementation: Method
             required: true
             extensions:
@@ -176,8 +187,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: uri
           - *ref_4
-          - !<!Parameter> &ref_9
-            schema: *ref_2
+          - !<!Parameter> &ref_10
+            schema: *ref_3
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -189,7 +200,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - *ref_5
-          - !<!Parameter> &ref_10
+          - !<!Parameter> &ref_11
             schema: *ref_6
             implementation: Method
             language: !<!Languages> 
@@ -202,6 +213,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -212,10 +238,10 @@ operationGroups:
                 method: get
                 uri: '{vault}{secret}{dnsSuffix}'
         signatureParameters:
-          - *ref_7
           - *ref_8
           - *ref_9
           - *ref_10
+          - *ref_11
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -228,7 +254,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/modeler.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/modeler.yaml
@@ -62,8 +62,19 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_9
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_9
+    - !<!ObjectSchema> &ref_10
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -96,7 +107,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_10
+  - !<!Parameter> &ref_11
     schema: *ref_3
     implementation: Client
     required: true
@@ -110,7 +121,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: path
-  - !<!Parameter> &ref_11
+  - !<!Parameter> &ref_12
     schema: *ref_2
     clientDefaultValue: host
     implementation: Client
@@ -175,7 +186,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - *ref_11
+          - *ref_12
           - !<!Parameter> &ref_7
             schema: *ref_3
             implementation: Method
@@ -188,7 +199,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_10
+          - *ref_11
           - !<!Parameter> &ref_8
             schema: *ref_4
             implementation: Method
@@ -202,6 +213,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -228,7 +254,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/custom-baseUrl-more-options/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-more-options/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: custom-baseUrl-more-options
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -41,7 +41,7 @@ schemas: !<!Schemas>
           name: String
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -62,15 +62,26 @@ schemas: !<!Schemas>
           name: String
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_7
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_11
+    - !<!ObjectSchema> &ref_12
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -78,7 +89,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -97,7 +108,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_5
-    schema: *ref_2
+    schema: *ref_3
     implementation: Client
     required: true
     extensions:
@@ -111,7 +122,7 @@ globalParameters:
       http: !<!HttpParameter> 
         in: path
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: host
     implementation: Client
     required: true
@@ -139,8 +150,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - !<!Parameter> &ref_7
-            schema: *ref_3
+          - !<!Parameter> &ref_8
+            schema: *ref_0
             implementation: Method
             required: true
             extensions:
@@ -157,8 +168,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_8
-            schema: *ref_3
+          - !<!Parameter> &ref_9
+            schema: *ref_0
             implementation: Method
             required: true
             extensions:
@@ -176,8 +187,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: uri
           - *ref_4
-          - !<!Parameter> &ref_9
-            schema: *ref_2
+          - !<!Parameter> &ref_10
+            schema: *ref_3
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -189,7 +200,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - *ref_5
-          - !<!Parameter> &ref_10
+          - !<!Parameter> &ref_11
             schema: *ref_6
             implementation: Method
             language: !<!Languages> 
@@ -202,6 +213,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -212,10 +238,10 @@ operationGroups:
                 method: get
                 uri: '{vault}{secret}{dnsSuffix}'
         signatureParameters:
-          - *ref_7
           - *ref_8
           - *ref_9
           - *ref_10
+          - *ref_11
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -228,7 +254,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/custom-baseUrl-paging/flattened.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-paging/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: custom-baseUrl-paging
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: Product-properties-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -40,7 +40,7 @@ schemas: !<!Schemas>
           name: ProductResult-nextLink
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_12
+    - !<!StringSchema> &ref_13
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -61,7 +61,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_6
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -71,34 +71,45 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_9
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_10
+    - !<!ObjectSchema> &ref_11
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: !<!ArraySchema> &ref_6
+          schema: !<!ArraySchema> &ref_7
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            elementType: !<!ObjectSchema> &ref_3
+            elementType: !<!ObjectSchema> &ref_4
               type: object
               apiVersions:
                 - !<!ApiVersion> 
                   version: 1.0.0
               properties:
                 - !<!Property> 
-                  schema: !<!ObjectSchema> &ref_4
+                  schema: !<!ObjectSchema> &ref_5
                     type: object
                     apiVersions:
                       - !<!ApiVersion> 
                         version: 1.0.0
                     properties:
                       - !<!Property> 
-                        schema: *ref_0
+                        schema: *ref_1
                         serializedName: id
                         language: !<!Languages> 
                           default:
@@ -106,7 +117,7 @@ schemas: !<!Schemas>
                             description: ''
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_1
+                        schema: *ref_2
                         serializedName: name
                         language: !<!Languages> 
                           default:
@@ -151,7 +162,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: nextLink
           language: !<!Languages> 
             default:
@@ -168,8 +179,8 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_3
     - *ref_4
+    - *ref_5
     - !<!ObjectSchema> 
       type: object
       apiVersions:
@@ -177,7 +188,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -185,7 +196,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           serializedName: message
           language: !<!Languages> 
             default:
@@ -199,10 +210,10 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - *ref_6
+    - *ref_7
 globalParameters:
   - !<!Parameter> &ref_8
-    schema: *ref_7
+    schema: *ref_0
     clientDefaultValue: host
     implementation: Client
     required: true
@@ -230,8 +241,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - !<!Parameter> &ref_9
-            schema: *ref_7
+          - !<!Parameter> &ref_10
+            schema: *ref_0
             implementation: Method
             required: true
             extensions:
@@ -251,6 +262,21 @@ operationGroups:
           - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -261,10 +287,10 @@ operationGroups:
                 method: get
                 uri: 'http://{accountName}{host}'
         signatureParameters:
-          - *ref_9
+          - *ref_10
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -303,8 +329,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - !<!Parameter> &ref_11
-            schema: *ref_7
+          - !<!Parameter> &ref_12
+            schema: *ref_0
             implementation: Method
             required: true
             extensions:
@@ -324,6 +350,21 @@ operationGroups:
           - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -334,10 +375,10 @@ operationGroups:
                 method: get
                 uri: 'http://{accountName}{host}'
         signatureParameters:
-          - *ref_11
+          - *ref_12
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -373,13 +414,13 @@ operationGroups:
               itemName: values
               member: getPagesPartialUrlOperationNext
               nextLinkName: nextLink
-              nextLinkOperation: !<!Operation> &ref_15
+              nextLinkOperation: !<!Operation> &ref_16
                 apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
                 parameters:
-                  - !<!Parameter> &ref_13
-                    schema: *ref_7
+                  - !<!Parameter> &ref_14
+                    schema: *ref_0
                     implementation: Method
                     required: true
                     extensions:
@@ -397,8 +438,8 @@ operationGroups:
                       http: !<!HttpParameter> 
                         in: uri
                   - *ref_8
-                  - !<!Parameter> &ref_14
-                    schema: *ref_12
+                  - !<!Parameter> &ref_15
+                    schema: *ref_13
                     implementation: Method
                     required: true
                     extensions:
@@ -413,6 +454,21 @@ operationGroups:
                         in: path
                 requests:
                   - !<!Request> 
+                    parameters:
+                      - !<!Parameter> 
+                        schema: *ref_9
+                        implementation: Method
+                        origin: 'modelerfour:synthesized/accept'
+                        required: true
+                        language: !<!Languages> 
+                          default:
+                            name: accept
+                            description: Accept header
+                            serializedName: Accept
+                        protocol: !<!Protocols> 
+                          http: !<!HttpParameter> 
+                            in: header
+                    signatureParameters: []
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -423,11 +479,11 @@ operationGroups:
                         method: get
                         uri: 'http://{accountName}{host}'
                 signatureParameters:
-                  - *ref_13
                   - *ref_14
+                  - *ref_15
                 responses:
                   - !<!SchemaResponse> 
-                    schema: *ref_10
+                    schema: *ref_11
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -463,10 +519,10 @@ operationGroups:
                       itemName: values
                       member: getPagesPartialUrlOperationNext
                       nextLinkName: nextLink
-                      nextLinkOperation: *ref_15
+                      nextLinkOperation: *ref_16
                 protocol: !<!Protocols> {}
         protocol: !<!Protocols> {}
-      - *ref_15
+      - *ref_16
     language: !<!Languages> 
       default:
         name: Paging

--- a/modelerfour/test/scenarios/custom-baseUrl-paging/grouped.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-paging/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: custom-baseUrl-paging
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: Product-properties-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -40,7 +40,7 @@ schemas: !<!Schemas>
           name: ProductResult-nextLink
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_12
+    - !<!StringSchema> &ref_13
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -61,7 +61,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_6
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -71,34 +71,45 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_9
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_10
+    - !<!ObjectSchema> &ref_11
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: !<!ArraySchema> &ref_6
+          schema: !<!ArraySchema> &ref_7
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            elementType: !<!ObjectSchema> &ref_3
+            elementType: !<!ObjectSchema> &ref_4
               type: object
               apiVersions:
                 - !<!ApiVersion> 
                   version: 1.0.0
               properties:
                 - !<!Property> 
-                  schema: !<!ObjectSchema> &ref_4
+                  schema: !<!ObjectSchema> &ref_5
                     type: object
                     apiVersions:
                       - !<!ApiVersion> 
                         version: 1.0.0
                     properties:
                       - !<!Property> 
-                        schema: *ref_0
+                        schema: *ref_1
                         serializedName: id
                         language: !<!Languages> 
                           default:
@@ -106,7 +117,7 @@ schemas: !<!Schemas>
                             description: ''
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_1
+                        schema: *ref_2
                         serializedName: name
                         language: !<!Languages> 
                           default:
@@ -151,7 +162,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: nextLink
           language: !<!Languages> 
             default:
@@ -168,8 +179,8 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_3
     - *ref_4
+    - *ref_5
     - !<!ObjectSchema> 
       type: object
       apiVersions:
@@ -177,7 +188,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -185,7 +196,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           serializedName: message
           language: !<!Languages> 
             default:
@@ -199,10 +210,10 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - *ref_6
+    - *ref_7
 globalParameters:
   - !<!Parameter> &ref_8
-    schema: *ref_7
+    schema: *ref_0
     clientDefaultValue: host
     implementation: Client
     required: true
@@ -230,8 +241,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - !<!Parameter> &ref_9
-            schema: *ref_7
+          - !<!Parameter> &ref_10
+            schema: *ref_0
             implementation: Method
             required: true
             extensions:
@@ -251,6 +262,21 @@ operationGroups:
           - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -261,10 +287,10 @@ operationGroups:
                 method: get
                 uri: 'http://{accountName}{host}'
         signatureParameters:
-          - *ref_9
+          - *ref_10
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -303,8 +329,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - !<!Parameter> &ref_11
-            schema: *ref_7
+          - !<!Parameter> &ref_12
+            schema: *ref_0
             implementation: Method
             required: true
             extensions:
@@ -324,6 +350,21 @@ operationGroups:
           - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -334,10 +375,10 @@ operationGroups:
                 method: get
                 uri: 'http://{accountName}{host}'
         signatureParameters:
-          - *ref_11
+          - *ref_12
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -373,13 +414,13 @@ operationGroups:
               itemName: values
               member: getPagesPartialUrlOperationNext
               nextLinkName: nextLink
-              nextLinkOperation: !<!Operation> &ref_15
+              nextLinkOperation: !<!Operation> &ref_16
                 apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
                 parameters:
-                  - !<!Parameter> &ref_13
-                    schema: *ref_7
+                  - !<!Parameter> &ref_14
+                    schema: *ref_0
                     implementation: Method
                     required: true
                     extensions:
@@ -397,8 +438,8 @@ operationGroups:
                       http: !<!HttpParameter> 
                         in: uri
                   - *ref_8
-                  - !<!Parameter> &ref_14
-                    schema: *ref_12
+                  - !<!Parameter> &ref_15
+                    schema: *ref_13
                     implementation: Method
                     required: true
                     extensions:
@@ -413,6 +454,21 @@ operationGroups:
                         in: path
                 requests:
                   - !<!Request> 
+                    parameters:
+                      - !<!Parameter> 
+                        schema: *ref_9
+                        implementation: Method
+                        origin: 'modelerfour:synthesized/accept'
+                        required: true
+                        language: !<!Languages> 
+                          default:
+                            name: accept
+                            description: Accept header
+                            serializedName: Accept
+                        protocol: !<!Protocols> 
+                          http: !<!HttpParameter> 
+                            in: header
+                    signatureParameters: []
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -423,11 +479,11 @@ operationGroups:
                         method: get
                         uri: 'http://{accountName}{host}'
                 signatureParameters:
-                  - *ref_13
                   - *ref_14
+                  - *ref_15
                 responses:
                   - !<!SchemaResponse> 
-                    schema: *ref_10
+                    schema: *ref_11
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -463,10 +519,10 @@ operationGroups:
                       itemName: values
                       member: getPagesPartialUrlOperationNext
                       nextLinkName: nextLink
-                      nextLinkOperation: *ref_15
+                      nextLinkOperation: *ref_16
                 protocol: !<!Protocols> {}
         protocol: !<!Protocols> {}
-      - *ref_15
+      - *ref_16
     language: !<!Languages> 
       default:
         name: Paging

--- a/modelerfour/test/scenarios/custom-baseUrl-paging/modeler.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-paging/modeler.yaml
@@ -40,7 +40,7 @@ schemas: !<!Schemas>
           name: ProductResult-nextLink
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_12
+    - !<!StringSchema> &ref_13
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -71,8 +71,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_9
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_7
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_9
+    - !<!ObjectSchema> &ref_10
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -201,7 +212,7 @@ schemas: !<!Schemas>
   arrays:
     - *ref_6
 globalParameters:
-  - !<!Parameter> &ref_11
+  - !<!Parameter> &ref_12
     schema: *ref_7
     clientDefaultValue: host
     implementation: Client
@@ -248,9 +259,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - *ref_11
+          - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -264,7 +290,7 @@ operationGroups:
           - *ref_8
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -303,7 +329,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - !<!Parameter> &ref_15
+          - !<!Parameter> &ref_16
             schema: *ref_7
             implementation: Method
             required: true
@@ -321,9 +347,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - *ref_11
+          - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -334,10 +375,10 @@ operationGroups:
                 method: get
                 uri: 'http://{accountName}{host}'
         signatureParameters:
-          - *ref_15
+          - *ref_16
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -373,12 +414,12 @@ operationGroups:
               itemName: values
               member: getPagesPartialUrlOperationNext
               nextLinkName: nextLink
-              nextLinkOperation: !<!Operation> &ref_10
+              nextLinkOperation: !<!Operation> &ref_11
                 apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
                 parameters:
-                  - !<!Parameter> &ref_13
+                  - !<!Parameter> &ref_14
                     schema: *ref_7
                     implementation: Method
                     required: true
@@ -396,9 +437,9 @@ operationGroups:
                     protocol: !<!Protocols> 
                       http: !<!HttpParameter> 
                         in: uri
-                  - *ref_11
-                  - !<!Parameter> &ref_14
-                    schema: *ref_12
+                  - *ref_12
+                  - !<!Parameter> &ref_15
+                    schema: *ref_13
                     implementation: Method
                     required: true
                     extensions:
@@ -413,6 +454,21 @@ operationGroups:
                         in: path
                 requests:
                   - !<!Request> 
+                    parameters:
+                      - !<!Parameter> 
+                        schema: *ref_9
+                        implementation: Method
+                        origin: 'modelerfour:synthesized/accept'
+                        required: true
+                        language: !<!Languages> 
+                          default:
+                            name: accept
+                            description: Accept header
+                            serializedName: Accept
+                        protocol: !<!Protocols> 
+                          http: !<!HttpParameter> 
+                            in: header
+                    signatureParameters: []
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -423,11 +479,11 @@ operationGroups:
                         method: get
                         uri: 'http://{accountName}{host}'
                 signatureParameters:
-                  - *ref_13
                   - *ref_14
+                  - *ref_15
                 responses:
                   - !<!SchemaResponse> 
-                    schema: *ref_9
+                    schema: *ref_10
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -463,10 +519,10 @@ operationGroups:
                       itemName: values
                       member: getPagesPartialUrlOperationNext
                       nextLinkName: nextLink
-                      nextLinkOperation: *ref_10
+                      nextLinkOperation: *ref_11
                 protocol: !<!Protocols> {}
         protocol: !<!Protocols> {}
-      - *ref_10
+      - *ref_11
     language: !<!Languages> 
       default:
         name: Paging

--- a/modelerfour/test/scenarios/custom-baseUrl-paging/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl-paging/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: custom-baseUrl-paging
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: ProductPropertiesName
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -40,7 +40,7 @@ schemas: !<!Schemas>
           name: ProductResultNextLink
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_12
+    - !<!StringSchema> &ref_13
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -61,7 +61,7 @@ schemas: !<!Schemas>
           name: String
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_6
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -71,34 +71,45 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_9
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_10
+    - !<!ObjectSchema> &ref_11
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: !<!ArraySchema> &ref_6
+          schema: !<!ArraySchema> &ref_7
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            elementType: !<!ObjectSchema> &ref_3
+            elementType: !<!ObjectSchema> &ref_4
               type: object
               apiVersions:
                 - !<!ApiVersion> 
                   version: 1.0.0
               properties:
                 - !<!Property> 
-                  schema: !<!ObjectSchema> &ref_4
+                  schema: !<!ObjectSchema> &ref_5
                     type: object
                     apiVersions:
                       - !<!ApiVersion> 
                         version: 1.0.0
                     properties:
                       - !<!Property> 
-                        schema: *ref_0
+                        schema: *ref_1
                         serializedName: id
                         language: !<!Languages> 
                           default:
@@ -106,7 +117,7 @@ schemas: !<!Schemas>
                             description: ''
                         protocol: !<!Protocols> {}
                       - !<!Property> 
-                        schema: *ref_1
+                        schema: *ref_2
                         serializedName: name
                         language: !<!Languages> 
                           default:
@@ -151,7 +162,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: nextLink
           language: !<!Languages> 
             default:
@@ -168,8 +179,8 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_3
     - *ref_4
+    - *ref_5
     - !<!ObjectSchema> 
       type: object
       apiVersions:
@@ -177,7 +188,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -185,7 +196,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_5
+          schema: *ref_6
           serializedName: message
           language: !<!Languages> 
             default:
@@ -199,10 +210,10 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - *ref_6
+    - *ref_7
 globalParameters:
   - !<!Parameter> &ref_8
-    schema: *ref_7
+    schema: *ref_0
     clientDefaultValue: host
     implementation: Client
     required: true
@@ -230,8 +241,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - !<!Parameter> &ref_9
-            schema: *ref_7
+          - !<!Parameter> &ref_10
+            schema: *ref_0
             implementation: Method
             required: true
             extensions:
@@ -251,6 +262,21 @@ operationGroups:
           - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -261,10 +287,10 @@ operationGroups:
                 method: get
                 uri: 'http://{accountName}{host}'
         signatureParameters:
-          - *ref_9
+          - *ref_10
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -303,8 +329,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - !<!Parameter> &ref_11
-            schema: *ref_7
+          - !<!Parameter> &ref_12
+            schema: *ref_0
             implementation: Method
             required: true
             extensions:
@@ -324,6 +350,21 @@ operationGroups:
           - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -334,10 +375,10 @@ operationGroups:
                 method: get
                 uri: 'http://{accountName}{host}'
         signatureParameters:
-          - *ref_11
+          - *ref_12
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -373,13 +414,13 @@ operationGroups:
               itemName: values
               member: GetPagesPartialUrlOperationNext
               nextLinkName: nextLink
-              nextLinkOperation: !<!Operation> &ref_15
+              nextLinkOperation: !<!Operation> &ref_16
                 apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
                 parameters:
-                  - !<!Parameter> &ref_13
-                    schema: *ref_7
+                  - !<!Parameter> &ref_14
+                    schema: *ref_0
                     implementation: Method
                     required: true
                     extensions:
@@ -397,8 +438,8 @@ operationGroups:
                       http: !<!HttpParameter> 
                         in: uri
                   - *ref_8
-                  - !<!Parameter> &ref_14
-                    schema: *ref_12
+                  - !<!Parameter> &ref_15
+                    schema: *ref_13
                     implementation: Method
                     required: true
                     extensions:
@@ -413,6 +454,21 @@ operationGroups:
                         in: path
                 requests:
                   - !<!Request> 
+                    parameters:
+                      - !<!Parameter> 
+                        schema: *ref_9
+                        implementation: Method
+                        origin: 'modelerfour:synthesized/accept'
+                        required: true
+                        language: !<!Languages> 
+                          default:
+                            name: Accept
+                            description: Accept header
+                            serializedName: Accept
+                        protocol: !<!Protocols> 
+                          http: !<!HttpParameter> 
+                            in: header
+                    signatureParameters: []
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -423,11 +479,11 @@ operationGroups:
                         method: get
                         uri: 'http://{accountName}{host}'
                 signatureParameters:
-                  - *ref_13
                   - *ref_14
+                  - *ref_15
                 responses:
                   - !<!SchemaResponse> 
-                    schema: *ref_10
+                    schema: *ref_11
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -463,10 +519,10 @@ operationGroups:
                       itemName: values
                       member: GetPagesPartialUrlOperationNext
                       nextLinkName: nextLink
-                      nextLinkOperation: *ref_15
+                      nextLinkOperation: *ref_16
                 protocol: !<!Protocols> {}
         protocol: !<!Protocols> {}
-      - *ref_15
+      - *ref_16
     language: !<!Languages> 
       default:
         name: Paging

--- a/modelerfour/test/scenarios/custom-baseUrl/flattened.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: custom-baseUrl
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -41,15 +41,26 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -57,7 +68,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -76,7 +87,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: host
     implementation: Client
     required: true
@@ -104,8 +115,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - !<!Parameter> &ref_4
-            schema: *ref_2
+          - !<!Parameter> &ref_5
+            schema: *ref_0
             implementation: Method
             required: true
             extensions:
@@ -125,6 +136,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -135,7 +161,7 @@ operationGroups:
                 method: get
                 uri: 'http://{accountName}{host}'
         signatureParameters:
-          - *ref_4
+          - *ref_5
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -148,7 +174,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/custom-baseUrl/grouped.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: custom-baseUrl
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -41,15 +41,26 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -57,7 +68,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -76,7 +87,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: host
     implementation: Client
     required: true
@@ -104,8 +115,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - !<!Parameter> &ref_4
-            schema: *ref_2
+          - !<!Parameter> &ref_5
+            schema: *ref_0
             implementation: Method
             required: true
             extensions:
@@ -125,6 +136,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -135,7 +161,7 @@ operationGroups:
                 method: get
                 uri: 'http://{accountName}{host}'
         signatureParameters:
-          - *ref_4
+          - *ref_5
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -148,7 +174,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/custom-baseUrl/modeler.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/modeler.yaml
@@ -41,8 +41,19 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_4
+    - !<!ObjectSchema> &ref_5
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -75,7 +86,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_5
+  - !<!Parameter> &ref_6
     schema: *ref_2
     clientDefaultValue: host
     implementation: Client
@@ -122,9 +133,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - *ref_5
+          - *ref_6
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -148,7 +174,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/custom-baseUrl/namer.yaml
+++ b/modelerfour/test/scenarios/custom-baseUrl/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: custom-baseUrl
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -41,15 +41,26 @@ schemas: !<!Schemas>
           name: String
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -57,7 +68,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -76,7 +87,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_3
-    schema: *ref_2
+    schema: *ref_0
     clientDefaultValue: host
     implementation: Client
     required: true
@@ -104,8 +115,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - !<!Parameter> &ref_4
-            schema: *ref_2
+          - !<!Parameter> &ref_5
+            schema: *ref_0
             implementation: Method
             required: true
             extensions:
@@ -125,6 +136,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -135,7 +161,7 @@ operationGroups:
                 method: get
                 uri: 'http://{accountName}{host}'
         signatureParameters:
-          - *ref_4
+          - *ref_5
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -148,7 +174,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/datalake-storage/flattened.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: Azure Data Lake Storage REST API
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_85
+    - !<!BooleanSchema> &ref_86
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -43,19 +43,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_140
-      type: integer
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: ''
-          header: Content-Length
-      protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_142
+    - !<!NumberSchema> &ref_141
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -72,6 +60,18 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: '2019-10-31'
+      precision: 64
+      language: !<!Languages> 
+        default:
+          name: integer
+          description: ''
+          header: Content-Length
+      protocol: !<!Protocols> {}
+    - !<!NumberSchema> &ref_144
+      type: integer
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
       minimum: 0
       precision: 64
       language: !<!Languages> 
@@ -79,7 +79,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_193
+    - !<!NumberSchema> &ref_194
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -90,7 +90,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_243
+    - !<!NumberSchema> &ref_245
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -102,7 +102,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_262
+    - !<!NumberSchema> &ref_264
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -114,7 +114,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_298
+    - !<!NumberSchema> &ref_300
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -157,7 +157,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_33
+    - !<!StringSchema> &ref_34
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -168,7 +168,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_34
+    - !<!StringSchema> &ref_35
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -179,7 +179,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-continuation
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_35
+    - !<!StringSchema> &ref_36
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -220,7 +220,7 @@ schemas: !<!Schemas>
           name: Filesystem-eTag
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_37
+    - !<!StringSchema> &ref_38
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -232,7 +232,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_38
+    - !<!StringSchema> &ref_39
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -263,7 +263,7 @@ schemas: !<!Schemas>
           name: DataLakeStorageError-error-message
           description: The service error message.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_39
+    - !<!StringSchema> &ref_40
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -276,7 +276,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_41
+    - !<!StringSchema> &ref_42
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -288,7 +288,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_42
+    - !<!StringSchema> &ref_43
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -298,17 +298,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_48
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_49
       type: string
@@ -319,7 +308,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_50
       type: string
@@ -330,7 +319,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_51
       type: string
@@ -341,7 +330,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-namespace-enabled
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_52
       type: string
@@ -352,9 +341,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Date
+          header: x-ms-namespace-enabled
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_60
+    - !<!StringSchema> &ref_53
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -363,7 +352,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_61
       type: string
@@ -374,9 +363,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_62
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_63
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -388,7 +388,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_63
+    - !<!StringSchema> &ref_64
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -399,7 +399,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_84
+    - !<!StringSchema> &ref_85
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -410,7 +410,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_96
+    - !<!StringSchema> &ref_97
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -421,7 +421,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_97
+    - !<!StringSchema> &ref_98
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -432,7 +432,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_98
+    - !<!StringSchema> &ref_99
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -444,7 +444,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_99
+    - !<!StringSchema> &ref_100
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -455,7 +455,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_100
+    - !<!StringSchema> &ref_101
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -526,17 +526,6 @@ schemas: !<!Schemas>
           name: Path-permissions
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_68
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_69
       type: string
       apiVersions:
@@ -546,7 +535,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_70
       type: string
@@ -557,9 +546,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_71
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_72
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -570,17 +570,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_72
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_73
       type: string
@@ -591,7 +580,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-properties
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_74
       type: string
@@ -602,7 +591,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-namespace-enabled
+          header: x-ms-properties
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_75
       type: string
@@ -613,9 +602,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-namespace-enabled
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_76
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_82
+    - !<!StringSchema> &ref_83
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -627,18 +627,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_83
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_101
+    - !<!StringSchema> &ref_84
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -654,23 +643,23 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_103
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
       pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
       language: !<!Languages> 
         default:
           name: string
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_136
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_137
       type: string
@@ -681,7 +670,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_138
       type: string
@@ -692,7 +681,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_139
       type: string
@@ -703,9 +692,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_140
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-continuation
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_144
+    - !<!StringSchema> &ref_145
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -716,7 +716,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_145
+    - !<!StringSchema> &ref_146
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -727,17 +727,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_176
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_177
       type: string
@@ -748,7 +737,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_178
       type: string
@@ -759,7 +748,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Accept-Ranges
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_179
       type: string
@@ -770,7 +759,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Cache-Control
+          header: Accept-Ranges
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_180
       type: string
@@ -781,7 +770,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Disposition
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_181
       type: string
@@ -792,7 +781,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Encoding
+          header: Content-Disposition
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_182
       type: string
@@ -803,7 +792,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_183
       type: string
@@ -814,7 +803,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Range
+          header: Content-Language
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_184
       type: string
@@ -825,7 +814,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Type
+          header: Content-Range
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_185
       type: string
@@ -836,7 +825,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-MD5
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_186
       type: string
@@ -847,7 +836,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-properties
+          header: Content-MD5
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_187
       type: string
@@ -858,7 +847,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-properties
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_188
       type: string
@@ -869,7 +858,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-MD5
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_189
       type: string
@@ -880,9 +869,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Date
+          header: Content-MD5
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_190
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_191
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -894,7 +894,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_191
+    - !<!StringSchema> &ref_192
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -905,7 +905,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_194
+    - !<!StringSchema> &ref_195
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -917,7 +917,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_195
+    - !<!StringSchema> &ref_196
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -927,17 +927,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_210
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_211
       type: string
@@ -948,7 +937,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_212
       type: string
@@ -959,9 +948,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_213
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_214
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -972,17 +972,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-lease-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_214
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_215
       type: string
@@ -993,7 +982,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_216
       type: string
@@ -1004,9 +993,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_217
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_218
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1018,7 +1018,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_218
+    - !<!StringSchema> &ref_219
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1029,7 +1029,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_219
+    - !<!StringSchema> &ref_220
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1041,7 +1041,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-lease-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_220
+    - !<!StringSchema> &ref_221
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1052,7 +1052,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_221
+    - !<!StringSchema> &ref_222
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1063,7 +1063,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_222
+    - !<!StringSchema> &ref_223
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1074,17 +1074,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_223
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_224
       type: string
@@ -1095,7 +1084,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-lease-time
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_225
       type: string
@@ -1106,9 +1095,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Accept-Ranges
+          header: x-ms-lease-time
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_226
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Accept-Ranges
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_227
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1119,28 +1119,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_239
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Cache-Control
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_240
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Disposition
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_241
       type: string
@@ -1151,7 +1129,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Encoding
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_242
       type: string
@@ -1162,7 +1140,18 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
+          header: Content-Disposition
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_243
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_244
       type: string
@@ -1173,18 +1162,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Range
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_245
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Type
+          header: Content-Language
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_246
       type: string
@@ -1195,7 +1173,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-MD5
+          header: Content-Range
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_247
       type: string
@@ -1206,7 +1184,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Date
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_248
       type: string
@@ -1217,7 +1195,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Content-MD5
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_249
       type: string
@@ -1228,7 +1206,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_250
       type: string
@@ -1239,7 +1217,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_251
       type: string
@@ -1250,7 +1228,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-resource-type
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_252
       type: string
@@ -1261,7 +1239,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-properties
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_253
       type: string
@@ -1272,7 +1250,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-lease-duration
+          header: x-ms-resource-type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_254
       type: string
@@ -1283,7 +1261,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-lease-state
+          header: x-ms-properties
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_255
       type: string
@@ -1294,7 +1272,18 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-lease-status
+          header: x-ms-lease-duration
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_256
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-state
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_257
       type: string
@@ -1305,18 +1294,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Accept-Ranges
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_258
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Cache-Control
+          header: x-ms-lease-status
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_259
       type: string
@@ -1327,7 +1305,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Disposition
+          header: Accept-Ranges
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_260
       type: string
@@ -1338,7 +1316,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Encoding
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_261
       type: string
@@ -1349,209 +1327,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_263
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Range
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_264
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Type
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_265
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-MD5
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_266
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-content-md5
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_267
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_268
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_269
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Last-Modified
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_270
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_271
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_272
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-resource-type
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_273
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-properties
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_274
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-duration
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_275
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-state
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_276
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-status
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_279
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Accept-Ranges
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_280
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_294
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Cache-Control
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_295
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
           header: Content-Disposition
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_296
+    - !<!StringSchema> &ref_262
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1562,7 +1340,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Encoding
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_297
+    - !<!StringSchema> &ref_263
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1573,7 +1351,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Language
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_299
+    - !<!StringSchema> &ref_265
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1584,7 +1362,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Range
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_300
+    - !<!StringSchema> &ref_266
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1595,7 +1373,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_301
+    - !<!StringSchema> &ref_267
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1606,7 +1384,18 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_302
+    - !<!StringSchema> &ref_268
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-content-md5
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_269
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1617,7 +1406,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_303
+    - !<!StringSchema> &ref_270
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1628,7 +1417,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_304
+    - !<!StringSchema> &ref_271
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1639,128 +1428,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_305
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_306
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-resource-type
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_307
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-properties
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_308
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-owner
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_309
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-group
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_310
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-permissions
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_311
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-acl
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_312
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-duration
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_313
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-state
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_314
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-status
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_315
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_316
+    - !<!StringSchema> &ref_272
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1772,7 +1440,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_329
+    - !<!StringSchema> &ref_273
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1783,7 +1451,339 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_330
+    - !<!StringSchema> &ref_274
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-resource-type
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_275
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-properties
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_276
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-duration
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_277
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-state
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_278
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-status
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_281
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Accept-Ranges
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_282
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_296
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Cache-Control
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_297
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Disposition
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_298
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Encoding
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_299
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Language
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_301
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Range
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_302
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Type
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_303
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-MD5
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_304
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_305
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: ETag
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_306
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_307
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_308
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-resource-type
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_309
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-properties
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_310
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-owner
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_311
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-group
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_312
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-permissions
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_313
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-acl
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_314
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-duration
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_315
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-state
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_316
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-status
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_317
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_318
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_331
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_332
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1816,7 +1816,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_103
+    - !<!SealedChoiceSchema> &ref_104
       choices:
         - !<!ChoiceValue> 
           value: directory
@@ -1840,7 +1840,7 @@ schemas: !<!Schemas>
           name: PathResourceType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_104
+    - !<!SealedChoiceSchema> &ref_105
       choices:
         - !<!ChoiceValue> 
           value: legacy
@@ -1864,7 +1864,7 @@ schemas: !<!Schemas>
           name: PathRenameMode
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_141
+    - !<!SealedChoiceSchema> &ref_142
       choices:
         - !<!ChoiceValue> 
           value: append
@@ -1900,7 +1900,7 @@ schemas: !<!Schemas>
           name: PathUpdateAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_192
+    - !<!SealedChoiceSchema> &ref_193
       choices:
         - !<!ChoiceValue> 
           value: acquire
@@ -1942,7 +1942,7 @@ schemas: !<!Schemas>
           name: PathLeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_278
+    - !<!SealedChoiceSchema> &ref_280
       choices:
         - !<!ChoiceValue> 
           value: getAccessControl
@@ -1983,7 +1983,17 @@ schemas: !<!Schemas>
           name: AccountResourceType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_40
+    - !<!ConstantSchema> &ref_26
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_41
       type: constant
       value: !<!ConstantValue> 
         value: filesystem
@@ -1993,8 +2003,18 @@ schemas: !<!Schemas>
           name: FilesystemResourceType
           description: ''
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_228
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'application/octet-stream, application/json, text/plain'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/octet-stream, application/json, text/plain'
+      protocol: !<!Protocols> {}
   binaries:
-    - !<!BinarySchema> &ref_146
+    - !<!BinarySchema> &ref_147
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -2004,7 +2024,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_256
+    - !<!BinarySchema> &ref_258
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -2014,7 +2034,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_277
+    - !<!BinarySchema> &ref_279
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -2025,7 +2045,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_32
+    - !<!ObjectSchema> &ref_33
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2099,7 +2119,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_4
-    - !<!ObjectSchema> &ref_36
+    - !<!ObjectSchema> &ref_37
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2155,7 +2175,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_7
-    - !<!ObjectSchema> &ref_95
+    - !<!ObjectSchema> &ref_96
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2348,7 +2368,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_26
+          - !<!Parameter> &ref_27
             schema: *ref_19
             implementation: Method
             language: !<!Languages> 
@@ -2359,7 +2379,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_27
+          - !<!Parameter> &ref_28
             schema: *ref_19
             implementation: Method
             language: !<!Languages> 
@@ -2372,7 +2392,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -2383,7 +2403,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_29
+          - !<!Parameter> &ref_30
             schema: *ref_24
             implementation: Method
             extensions:
@@ -2396,7 +2416,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_30
+          - !<!Parameter> &ref_31
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -2407,7 +2427,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_31
+          - !<!Parameter> &ref_32
             schema: *ref_19
             implementation: Method
             language: !<!Languages> 
@@ -2421,6 +2441,21 @@ operationGroups:
           - *ref_25
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2431,15 +2466,15 @@ operationGroups:
                 method: get
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_26
           - *ref_27
           - *ref_28
           - *ref_29
           - *ref_30
           - *ref_31
+          - *ref_32
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_32
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -2462,14 +2497,14 @@ operationGroups:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_33
+                    schema: *ref_34
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_34
+                    schema: *ref_35
                     header: x-ms-continuation
                     language:
                       default:
@@ -2478,7 +2513,7 @@ operationGroups:
                           If the number of filesystems to be listed exceeds the maxResults limit, a continuation token is returned in this response header.  When a continuation token is returned in the response, it must be specified in a
                           subsequent invocation of the list operation to continue listing the filesystems.
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Content-Type
                     language:
                       default:
@@ -2491,7 +2526,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -2500,14 +2535,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -2538,8 +2573,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_43
-            schema: *ref_39
+          - !<!Parameter> &ref_44
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2553,7 +2588,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_40
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2564,8 +2599,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_44
-            schema: *ref_41
+          - !<!Parameter> &ref_45
+            schema: *ref_42
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -2577,7 +2612,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_45
+          - !<!Parameter> &ref_46
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -2588,8 +2623,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_46
-            schema: *ref_42
+          - !<!Parameter> &ref_47
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2600,8 +2635,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_47
-            schema: *ref_42
+          - !<!Parameter> &ref_48
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2615,6 +2650,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2625,11 +2675,11 @@ operationGroups:
                 method: put
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_43
           - *ref_44
           - *ref_45
           - *ref_46
           - *ref_47
+          - *ref_48
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2640,42 +2690,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_42
+                    schema: *ref_43
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_48
+                    schema: *ref_49
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the filesystem.
                   - !<!HttpHeader> 
-                    schema: *ref_49
+                    schema: *ref_50
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the filesystem was last modified.  Operations on files and directories do not affect the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_41
+                    schema: *ref_42
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_50
+                    schema: *ref_51
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_51
+                    schema: *ref_52
                     header: x-ms-namespace-enabled
                     language:
                       default:
@@ -2685,7 +2735,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -2694,14 +2744,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -2725,8 +2775,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_53
-            schema: *ref_39
+          - !<!Parameter> &ref_54
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2740,7 +2790,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_40
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2751,8 +2801,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_54
-            schema: *ref_41
+          - !<!Parameter> &ref_55
+            schema: *ref_42
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -2764,7 +2814,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_55
+          - !<!Parameter> &ref_56
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -2775,8 +2825,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_56
-            schema: *ref_42
+          - !<!Parameter> &ref_57
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2787,8 +2837,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_57
-            schema: *ref_52
+          - !<!Parameter> &ref_58
+            schema: *ref_53
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2801,8 +2851,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_58
-            schema: *ref_52
+          - !<!Parameter> &ref_59
+            schema: *ref_53
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2812,8 +2862,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_59
-            schema: *ref_52
+          - !<!Parameter> &ref_60
+            schema: *ref_53
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2825,6 +2875,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2835,13 +2900,13 @@ operationGroups:
                 method: patch
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_53
           - *ref_54
           - *ref_55
           - *ref_56
           - *ref_57
           - *ref_58
           - *ref_59
+          - *ref_60
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2852,35 +2917,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_52
+                    schema: *ref_53
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_60
+                    schema: *ref_61
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'An HTTP entity tag associated with the filesystem.  Changes to filesystem properties affect the entity tag, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_61
+                    schema: *ref_62
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'The data and time the filesystem was last modified.  Changes to filesystem properties update the last modified time, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_62
+                    schema: *ref_63
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_63
+                    schema: *ref_64
                     header: x-ms-version
                     language:
                       default:
@@ -2890,7 +2955,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -2899,14 +2964,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -2932,8 +2997,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_64
-            schema: *ref_39
+          - !<!Parameter> &ref_65
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2947,7 +3012,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_40
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2958,8 +3023,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_65
-            schema: *ref_41
+          - !<!Parameter> &ref_66
+            schema: *ref_42
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -2971,7 +3036,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_66
+          - !<!Parameter> &ref_67
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -2982,8 +3047,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_67
-            schema: *ref_42
+          - !<!Parameter> &ref_68
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2996,6 +3061,21 @@ operationGroups:
           - *ref_25
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3006,10 +3086,10 @@ operationGroups:
                 method: head
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_64
           - *ref_65
           - *ref_66
           - *ref_67
+          - *ref_68
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3020,42 +3100,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_68
+                    schema: *ref_69
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_69
+                    schema: *ref_70
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'An HTTP entity tag associated with the filesystem.  Changes to filesystem properties affect the entity tag, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_70
+                    schema: *ref_71
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'The data and time the filesystem was last modified.  Changes to filesystem properties update the last modified time, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_71
+                    schema: *ref_72
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_72
+                    schema: *ref_73
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_73
+                    schema: *ref_74
                     header: x-ms-properties
                     language:
                       default:
@@ -3064,7 +3144,7 @@ operationGroups:
                           The user-defined properties associated with the filesystem.  A comma-separated list of name and value pairs in the format "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the string may
                           only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_74
+                    schema: *ref_75
                     header: x-ms-namespace-enabled
                     language:
                       default:
@@ -3074,7 +3154,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -3083,14 +3163,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -3114,8 +3194,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_76
-            schema: *ref_39
+          - !<!Parameter> &ref_77
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3129,7 +3209,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_40
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3140,8 +3220,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_77
-            schema: *ref_41
+          - !<!Parameter> &ref_78
+            schema: *ref_42
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -3153,7 +3233,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_78
+          - !<!Parameter> &ref_79
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -3164,8 +3244,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_79
-            schema: *ref_42
+          - !<!Parameter> &ref_80
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3176,8 +3256,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_80
-            schema: *ref_75
+          - !<!Parameter> &ref_81
+            schema: *ref_76
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3187,8 +3267,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_81
-            schema: *ref_75
+          - !<!Parameter> &ref_82
+            schema: *ref_76
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3200,6 +3280,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3210,12 +3305,12 @@ operationGroups:
                 method: delete
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_76
           - *ref_77
           - *ref_78
           - *ref_79
           - *ref_80
           - *ref_81
+          - *ref_82
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3226,21 +3321,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_82
+                    schema: *ref_83
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_75
+                    schema: *ref_76
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_83
+                    schema: *ref_84
                     header: Date
                     language:
                       default:
@@ -3250,7 +3345,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -3259,14 +3354,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -3302,8 +3397,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_86
-            schema: *ref_39
+          - !<!Parameter> &ref_87
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3317,7 +3412,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_40
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3328,8 +3423,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_87
-            schema: *ref_41
+          - !<!Parameter> &ref_88
+            schema: *ref_42
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -3341,7 +3436,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_88
+          - !<!Parameter> &ref_89
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -3352,8 +3447,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_89
-            schema: *ref_42
+          - !<!Parameter> &ref_90
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3364,8 +3459,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_90
-            schema: *ref_84
+          - !<!Parameter> &ref_91
+            schema: *ref_85
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3375,8 +3470,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_91
-            schema: *ref_85
+          - !<!Parameter> &ref_92
+            schema: *ref_86
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3387,8 +3482,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_92
-            schema: *ref_84
+          - !<!Parameter> &ref_93
+            schema: *ref_85
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3400,7 +3495,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_93
+          - !<!Parameter> &ref_94
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -3411,8 +3506,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_94
-            schema: *ref_85
+          - !<!Parameter> &ref_95
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3427,6 +3522,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3437,7 +3547,6 @@ operationGroups:
                 method: get
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_86
           - *ref_87
           - *ref_88
           - *ref_89
@@ -3446,9 +3555,10 @@ operationGroups:
           - *ref_92
           - *ref_93
           - *ref_94
+          - *ref_95
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_95
+            schema: *ref_96
             language: !<!Languages> 
               default:
                 name: ''
@@ -3457,42 +3567,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_84
+                    schema: *ref_85
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_96
+                    schema: *ref_97
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'An HTTP entity tag associated with the filesystem.  Changes to filesystem properties affect the entity tag, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_97
+                    schema: *ref_98
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'The data and time the filesystem was last modified.  Changes to filesystem properties update the last modified time, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_98
+                    schema: *ref_99
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_99
+                    schema: *ref_100
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_100
+                    schema: *ref_101
                     header: x-ms-continuation
                     language:
                       default:
@@ -3507,7 +3617,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -3516,14 +3626,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -3554,8 +3664,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_105
-            schema: *ref_39
+          - !<!Parameter> &ref_106
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3566,8 +3676,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_106
-            schema: *ref_101
+          - !<!Parameter> &ref_107
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3578,8 +3688,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_107
-            schema: *ref_102
+          - !<!Parameter> &ref_108
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -3591,7 +3701,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_108
+          - !<!Parameter> &ref_109
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -3602,8 +3712,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_109
-            schema: *ref_101
+          - !<!Parameter> &ref_110
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3614,8 +3724,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_110
-            schema: *ref_103
+          - !<!Parameter> &ref_111
+            schema: *ref_104
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3625,8 +3735,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_111
-            schema: *ref_101
+          - !<!Parameter> &ref_112
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3638,8 +3748,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_112
-            schema: *ref_104
+          - !<!Parameter> &ref_113
+            schema: *ref_105
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3649,8 +3759,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_113
-            schema: *ref_101
+          - !<!Parameter> &ref_114
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3660,8 +3770,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_114
-            schema: *ref_101
+          - !<!Parameter> &ref_115
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3671,8 +3781,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_115
-            schema: *ref_101
+          - !<!Parameter> &ref_116
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3682,8 +3792,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_116
-            schema: *ref_101
+          - !<!Parameter> &ref_117
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3693,8 +3803,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_117
-            schema: *ref_101
+          - !<!Parameter> &ref_118
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3704,8 +3814,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_118
-            schema: *ref_101
+          - !<!Parameter> &ref_119
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3715,8 +3825,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_119
-            schema: *ref_101
+          - !<!Parameter> &ref_120
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3726,8 +3836,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_120
-            schema: *ref_101
+          - !<!Parameter> &ref_121
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3737,8 +3847,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_121
-            schema: *ref_101
+          - !<!Parameter> &ref_122
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3748,8 +3858,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_122
-            schema: *ref_101
+          - !<!Parameter> &ref_123
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3761,8 +3871,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_123
-            schema: *ref_102
+          - !<!Parameter> &ref_124
+            schema: *ref_103
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3772,8 +3882,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_124
-            schema: *ref_102
+          - !<!Parameter> &ref_125
+            schema: *ref_103
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3783,8 +3893,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_125
-            schema: *ref_101
+          - !<!Parameter> &ref_126
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3796,8 +3906,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_126
-            schema: *ref_101
+          - !<!Parameter> &ref_127
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3809,8 +3919,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_127
-            schema: *ref_101
+          - !<!Parameter> &ref_128
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3823,8 +3933,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_128
-            schema: *ref_101
+          - !<!Parameter> &ref_129
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3834,8 +3944,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_129
-            schema: *ref_101
+          - !<!Parameter> &ref_130
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3845,8 +3955,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_130
-            schema: *ref_101
+          - !<!Parameter> &ref_131
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3856,8 +3966,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_131
-            schema: *ref_101
+          - !<!Parameter> &ref_132
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3867,8 +3977,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_132
-            schema: *ref_101
+          - !<!Parameter> &ref_133
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3878,8 +3988,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_133
-            schema: *ref_101
+          - !<!Parameter> &ref_134
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3889,8 +3999,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_134
-            schema: *ref_101
+          - !<!Parameter> &ref_135
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3900,8 +4010,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_135
-            schema: *ref_101
+          - !<!Parameter> &ref_136
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3913,6 +4023,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3923,7 +4048,6 @@ operationGroups:
                 method: put
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_105
           - *ref_106
           - *ref_107
           - *ref_108
@@ -3954,6 +4078,7 @@ operationGroups:
           - *ref_133
           - *ref_134
           - *ref_135
+          - *ref_136
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3964,42 +4089,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_101
+                    schema: *ref_102
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_136
+                    schema: *ref_137
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_137
+                    schema: *ref_138
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_102
+                    schema: *ref_103
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_138
+                    schema: *ref_139
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_139
+                    schema: *ref_140
                     header: x-ms-continuation
                     language:
                       default:
@@ -4008,7 +4133,7 @@ operationGroups:
                           When renaming a directory, the number of paths that are renamed with each invocation is limited.  If the number of paths to be renamed exceeds this limit, a continuation token is returned in this response header. 
                           When a continuation token is returned in the response, it must be specified in a subsequent invocation of the rename operation to continue renaming the directory.
                   - !<!HttpHeader> 
-                    schema: *ref_140
+                    schema: *ref_141
                     header: Content-Length
                     language:
                       default:
@@ -4018,7 +4143,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -4027,14 +4152,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -4061,8 +4186,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_149
-            schema: *ref_39
+          - !<!Parameter> &ref_150
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4073,8 +4198,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_150
-            schema: *ref_101
+          - !<!Parameter> &ref_151
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4085,8 +4210,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_151
-            schema: *ref_102
+          - !<!Parameter> &ref_152
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -4098,7 +4223,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_152
+          - !<!Parameter> &ref_153
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -4109,8 +4234,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_153
-            schema: *ref_101
+          - !<!Parameter> &ref_154
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4121,8 +4246,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_154
-            schema: *ref_141
+          - !<!Parameter> &ref_155
+            schema: *ref_142
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4136,8 +4261,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_155
-            schema: *ref_142
+          - !<!Parameter> &ref_156
+            schema: *ref_143
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4150,8 +4275,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_156
-            schema: *ref_85
+          - !<!Parameter> &ref_157
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4163,8 +4288,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_157
-            schema: *ref_85
+          - !<!Parameter> &ref_158
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4178,8 +4303,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_158
-            schema: *ref_143
+          - !<!Parameter> &ref_159
+            schema: *ref_144
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4189,8 +4314,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_159
-            schema: *ref_144
+          - !<!Parameter> &ref_160
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4203,8 +4328,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_160
-            schema: *ref_145
+          - !<!Parameter> &ref_161
+            schema: *ref_146
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4214,8 +4339,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_161
-            schema: *ref_144
+          - !<!Parameter> &ref_162
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4225,8 +4350,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_162
-            schema: *ref_144
+          - !<!Parameter> &ref_163
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4236,8 +4361,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_163
-            schema: *ref_144
+          - !<!Parameter> &ref_164
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4247,8 +4372,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_164
-            schema: *ref_144
+          - !<!Parameter> &ref_165
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4258,8 +4383,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_165
-            schema: *ref_144
+          - !<!Parameter> &ref_166
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4269,8 +4394,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_166
-            schema: *ref_144
+          - !<!Parameter> &ref_167
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4282,8 +4407,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_167
-            schema: *ref_144
+          - !<!Parameter> &ref_168
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4297,8 +4422,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_168
-            schema: *ref_144
+          - !<!Parameter> &ref_169
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4308,8 +4433,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_169
-            schema: *ref_144
+          - !<!Parameter> &ref_170
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4319,8 +4444,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_170
-            schema: *ref_144
+          - !<!Parameter> &ref_171
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4332,8 +4457,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_171
-            schema: *ref_144
+          - !<!Parameter> &ref_172
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4351,8 +4476,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_172
-            schema: *ref_144
+          - !<!Parameter> &ref_173
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4364,8 +4489,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_173
-            schema: *ref_144
+          - !<!Parameter> &ref_174
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4377,8 +4502,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_174
-            schema: *ref_144
+          - !<!Parameter> &ref_175
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4388,8 +4513,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_175
-            schema: *ref_144
+          - !<!Parameter> &ref_176
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4402,8 +4527,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_147
-                schema: *ref_146
+              - !<!Parameter> &ref_148
+                schema: *ref_147
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -4414,8 +4539,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_147
+              - *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -4431,7 +4569,7 @@ operationGroups:
                 uri: 'https://{accountName}.{dnsSuffix}'
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_148
+              - !<!Parameter> &ref_149
                 schema: *ref_0
                 implementation: Method
                 required: true
@@ -4443,8 +4581,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_148
+              - *ref_149
             language: !<!Languages> 
               default:
                 name: ''
@@ -4459,7 +4610,6 @@ operationGroups:
                   - text/plain
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_149
           - *ref_150
           - *ref_151
           - *ref_152
@@ -4486,6 +4636,7 @@ operationGroups:
           - *ref_173
           - *ref_174
           - *ref_175
+          - *ref_176
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4496,84 +4647,84 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_144
+                    schema: *ref_145
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_176
+                    schema: *ref_177
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_177
+                    schema: *ref_178
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_178
+                    schema: *ref_179
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_179
+                    schema: *ref_180
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_180
+                    schema: *ref_181
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_181
+                    schema: *ref_182
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_182
+                    schema: *ref_183
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_142
+                    schema: *ref_143
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_183
+                    schema: *ref_184
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_184
+                    schema: *ref_185
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_185
+                    schema: *ref_186
                     header: Content-MD5
                     language:
                       default:
@@ -4582,7 +4733,7 @@ operationGroups:
                           An MD5 hash of the request content. This header is only returned for "Flush" operation. This header is returned so that the client can check for message content integrity. This header refers to the content of the
                           request, not actual file content.
                   - !<!HttpHeader> 
-                    schema: *ref_186
+                    schema: *ref_187
                     header: x-ms-properties
                     language:
                       default:
@@ -4591,14 +4742,14 @@ operationGroups:
                           User-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the string
                           may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_145
+                    schema: *ref_146
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_187
+                    schema: *ref_188
                     header: x-ms-version
                     language:
                       default:
@@ -4615,7 +4766,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_188
+                    schema: *ref_189
                     header: Content-MD5
                     language:
                       default:
@@ -4624,21 +4775,21 @@ operationGroups:
                           An MD5 hash of the request content. This header is only returned for "Append" operation. This header is returned so that the client can check for message content integrity. The value of this header is computed by
                           the service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_189
+                    schema: *ref_190
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_190
+                    schema: *ref_191
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_191
+                    schema: *ref_192
                     header: x-ms-version
                     language:
                       default:
@@ -4648,7 +4799,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -4657,14 +4808,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -4691,8 +4842,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_196
-            schema: *ref_39
+          - !<!Parameter> &ref_197
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4703,8 +4854,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_197
-            schema: *ref_101
+          - !<!Parameter> &ref_198
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4715,8 +4866,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_198
-            schema: *ref_102
+          - !<!Parameter> &ref_199
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -4728,7 +4879,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_199
+          - !<!Parameter> &ref_200
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -4739,8 +4890,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_200
-            schema: *ref_101
+          - !<!Parameter> &ref_201
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4751,8 +4902,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_201
-            schema: *ref_192
+          - !<!Parameter> &ref_202
+            schema: *ref_193
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4767,8 +4918,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_202
-            schema: *ref_193
+          - !<!Parameter> &ref_203
+            schema: *ref_194
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4778,8 +4929,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_203
-            schema: *ref_193
+          - !<!Parameter> &ref_204
+            schema: *ref_194
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4789,8 +4940,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_204
-            schema: *ref_194
+          - !<!Parameter> &ref_205
+            schema: *ref_195
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4800,8 +4951,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_205
-            schema: *ref_194
+          - !<!Parameter> &ref_206
+            schema: *ref_195
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4811,8 +4962,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_206
-            schema: *ref_195
+          - !<!Parameter> &ref_207
+            schema: *ref_196
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4822,8 +4973,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_207
-            schema: *ref_195
+          - !<!Parameter> &ref_208
+            schema: *ref_196
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4833,8 +4984,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_208
-            schema: *ref_195
+          - !<!Parameter> &ref_209
+            schema: *ref_196
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4844,8 +4995,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_209
-            schema: *ref_195
+          - !<!Parameter> &ref_210
+            schema: *ref_196
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4857,6 +5008,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4867,7 +5033,6 @@ operationGroups:
                 method: post
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_196
           - *ref_197
           - *ref_198
           - *ref_199
@@ -4881,6 +5046,7 @@ operationGroups:
           - *ref_207
           - *ref_208
           - *ref_209
+          - *ref_210
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4891,42 +5057,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_195
+                    schema: *ref_196
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_210
+                    schema: *ref_211
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file.
                   - !<!HttpHeader> 
-                    schema: *ref_211
+                    schema: *ref_212
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file was last modified.  Write operations on the file update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_194
+                    schema: *ref_195
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_212
+                    schema: *ref_213
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_213
+                    schema: *ref_214
                     header: x-ms-lease-id
                     language:
                       default:
@@ -4943,42 +5109,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_214
+                    schema: *ref_215
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_215
+                    schema: *ref_216
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_216
+                    schema: *ref_217
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_217
+                    schema: *ref_218
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_218
+                    schema: *ref_219
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_219
+                    schema: *ref_220
                     header: x-ms-lease-id
                     language:
                       default:
@@ -4995,35 +5161,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_220
+                    schema: *ref_221
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_221
+                    schema: *ref_222
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_222
+                    schema: *ref_223
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_223
+                    schema: *ref_224
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_224
+                    schema: *ref_225
                     header: x-ms-lease-time
                     language:
                       default:
@@ -5033,7 +5199,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -5042,14 +5208,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -5075,8 +5241,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_227
-            schema: *ref_39
+          - !<!Parameter> &ref_229
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -5087,8 +5253,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_228
-            schema: *ref_101
+          - !<!Parameter> &ref_230
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -5099,8 +5265,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_229
-            schema: *ref_102
+          - !<!Parameter> &ref_231
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -5112,7 +5278,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_230
+          - !<!Parameter> &ref_232
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -5123,8 +5289,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_231
-            schema: *ref_101
+          - !<!Parameter> &ref_233
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5135,8 +5301,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_232
-            schema: *ref_225
+          - !<!Parameter> &ref_234
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5146,8 +5312,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_233
-            schema: *ref_226
+          - !<!Parameter> &ref_235
+            schema: *ref_227
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5159,8 +5325,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_234
-            schema: *ref_85
+          - !<!Parameter> &ref_236
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5172,8 +5338,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_235
-            schema: *ref_225
+          - !<!Parameter> &ref_237
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5183,8 +5349,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_236
-            schema: *ref_225
+          - !<!Parameter> &ref_238
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5194,8 +5360,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_237
-            schema: *ref_225
+          - !<!Parameter> &ref_239
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5205,8 +5371,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_238
-            schema: *ref_225
+          - !<!Parameter> &ref_240
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5218,6 +5384,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_228
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5228,8 +5409,6 @@ operationGroups:
                 method: get
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_227
-          - *ref_228
           - *ref_229
           - *ref_230
           - *ref_231
@@ -5240,6 +5419,8 @@ operationGroups:
           - *ref_236
           - *ref_237
           - *ref_238
+          - *ref_239
+          - *ref_240
         responses:
           - !<!BinaryResponse> 
             binary: true
@@ -5251,112 +5432,112 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_225
+                    schema: *ref_226
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_239
+                    schema: *ref_241
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_240
+                    schema: *ref_242
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_241
+                    schema: *ref_243
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_242
+                    schema: *ref_244
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_243
+                    schema: *ref_245
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_244
+                    schema: *ref_246
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_245
+                    schema: *ref_247
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_246
+                    schema: *ref_248
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'The MD5 hash of complete file. If the file has an MD5 hash and this read operation is to read the complete file, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_247
+                    schema: *ref_249
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_248
+                    schema: *ref_250
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_249
+                    schema: *ref_251
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_226
+                    schema: *ref_227
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_250
+                    schema: *ref_252
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_251
+                    schema: *ref_253
                     header: x-ms-resource-type
                     language:
                       default:
                         name: x-ms-resource-type
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_252
+                    schema: *ref_254
                     header: x-ms-properties
                     language:
                       default:
@@ -5365,21 +5546,21 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_253
+                    schema: *ref_255
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: x-ms-lease-duration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_254
+                    schema: *ref_256
                     header: x-ms-lease-state
                     language:
                       default:
                         name: x-ms-lease-state
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_255
+                    schema: *ref_257
                     header: x-ms-lease-status
                     language:
                       default:
@@ -5392,7 +5573,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_256
+            schema: *ref_258
             language: !<!Languages> 
               default:
                 name: ''
@@ -5401,112 +5582,112 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_225
+                    schema: *ref_226
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_239
+                    schema: *ref_241
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_240
+                    schema: *ref_242
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_241
+                    schema: *ref_243
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_242
+                    schema: *ref_244
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_243
+                    schema: *ref_245
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_244
+                    schema: *ref_246
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_245
+                    schema: *ref_247
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_246
+                    schema: *ref_248
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'The MD5 hash of complete file. If the file has an MD5 hash and this read operation is to read the complete file, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_247
+                    schema: *ref_249
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_248
+                    schema: *ref_250
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_249
+                    schema: *ref_251
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_226
+                    schema: *ref_227
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_250
+                    schema: *ref_252
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_251
+                    schema: *ref_253
                     header: x-ms-resource-type
                     language:
                       default:
                         name: x-ms-resource-type
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_252
+                    schema: *ref_254
                     header: x-ms-properties
                     language:
                       default:
@@ -5515,21 +5696,21 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_253
+                    schema: *ref_255
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: x-ms-lease-duration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_254
+                    schema: *ref_256
                     header: x-ms-lease-state
                     language:
                       default:
                         name: x-ms-lease-state
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_255
+                    schema: *ref_257
                     header: x-ms-lease-status
                     language:
                       default:
@@ -5550,63 +5731,63 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_257
+                    schema: *ref_259
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_258
+                    schema: *ref_260
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_259
+                    schema: *ref_261
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_260
+                    schema: *ref_262
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_261
+                    schema: *ref_263
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_262
+                    schema: *ref_264
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_263
+                    schema: *ref_265
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_264
+                    schema: *ref_266
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_265
+                    schema: *ref_267
                     header: Content-MD5
                     language:
                       default:
@@ -5615,7 +5796,7 @@ operationGroups:
                           The MD5 hash of read range. If the request is to read a specified range and the "x-ms-range-get-content-md5" is set to true, then the request returns an MD5 hash for the range, as long as the range size is less
                           than or equal to 4 MB.
                   - !<!HttpHeader> 
-                    schema: *ref_266
+                    schema: *ref_268
                     header: x-ms-content-md5
                     language:
                       default:
@@ -5624,49 +5805,49 @@ operationGroups:
                           The MD5 hash of complete file stored in storage. If the file has a MD5 hash, and if request contains range header (Range or x-ms-range), this response header is returned with the value of the complete file's MD5
                           value. This value may or may not be equal to the value returned in Content-MD5 header, with the latter calculated from the requested range.
                   - !<!HttpHeader> 
-                    schema: *ref_267
+                    schema: *ref_269
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_268
+                    schema: *ref_270
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_269
+                    schema: *ref_271
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_270
+                    schema: *ref_272
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_271
+                    schema: *ref_273
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_272
+                    schema: *ref_274
                     header: x-ms-resource-type
                     language:
                       default:
                         name: x-ms-resource-type
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_273
+                    schema: *ref_275
                     header: x-ms-properties
                     language:
                       default:
@@ -5675,21 +5856,21 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_274
+                    schema: *ref_276
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: x-ms-lease-duration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_275
+                    schema: *ref_277
                     header: x-ms-lease-state
                     language:
                       default:
                         name: x-ms-lease-state
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_276
+                    schema: *ref_278
                     header: x-ms-lease-status
                     language:
                       default:
@@ -5702,7 +5883,7 @@ operationGroups:
                 statusCodes:
                   - '206'
           - !<!SchemaResponse> 
-            schema: *ref_277
+            schema: *ref_279
             language: !<!Languages> 
               default:
                 name: ''
@@ -5711,63 +5892,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_257
+                    schema: *ref_259
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_258
+                    schema: *ref_260
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_259
+                    schema: *ref_261
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_260
+                    schema: *ref_262
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_261
+                    schema: *ref_263
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_262
+                    schema: *ref_264
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_263
+                    schema: *ref_265
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_264
+                    schema: *ref_266
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_265
+                    schema: *ref_267
                     header: Content-MD5
                     language:
                       default:
@@ -5776,7 +5957,7 @@ operationGroups:
                           The MD5 hash of read range. If the request is to read a specified range and the "x-ms-range-get-content-md5" is set to true, then the request returns an MD5 hash for the range, as long as the range size is less
                           than or equal to 4 MB.
                   - !<!HttpHeader> 
-                    schema: *ref_266
+                    schema: *ref_268
                     header: x-ms-content-md5
                     language:
                       default:
@@ -5785,49 +5966,49 @@ operationGroups:
                           The MD5 hash of complete file stored in storage. If the file has a MD5 hash, and if request contains range header (Range or x-ms-range), this response header is returned with the value of the complete file's MD5
                           value. This value may or may not be equal to the value returned in Content-MD5 header, with the latter calculated from the requested range.
                   - !<!HttpHeader> 
-                    schema: *ref_267
+                    schema: *ref_269
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_268
+                    schema: *ref_270
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_269
+                    schema: *ref_271
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_270
+                    schema: *ref_272
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_271
+                    schema: *ref_273
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_272
+                    schema: *ref_274
                     header: x-ms-resource-type
                     language:
                       default:
                         name: x-ms-resource-type
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_273
+                    schema: *ref_275
                     header: x-ms-properties
                     language:
                       default:
@@ -5836,21 +6017,21 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_274
+                    schema: *ref_276
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: x-ms-lease-duration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_275
+                    schema: *ref_277
                     header: x-ms-lease-state
                     language:
                       default:
                         name: x-ms-lease-state
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_276
+                    schema: *ref_278
                     header: x-ms-lease-status
                     language:
                       default:
@@ -5863,7 +6044,7 @@ operationGroups:
                   - '206'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -5872,14 +6053,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -5905,8 +6086,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_281
-            schema: *ref_39
+          - !<!Parameter> &ref_283
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -5917,8 +6098,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_282
-            schema: *ref_101
+          - !<!Parameter> &ref_284
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -5929,8 +6110,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_283
-            schema: *ref_102
+          - !<!Parameter> &ref_285
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -5942,7 +6123,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_284
+          - !<!Parameter> &ref_286
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -5953,8 +6134,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_285
-            schema: *ref_101
+          - !<!Parameter> &ref_287
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5965,8 +6146,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_286
-            schema: *ref_278
+          - !<!Parameter> &ref_288
+            schema: *ref_280
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5978,8 +6159,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_287
-            schema: *ref_85
+          - !<!Parameter> &ref_289
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5992,8 +6173,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_288
-            schema: *ref_279
+          - !<!Parameter> &ref_290
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6003,8 +6184,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_289
-            schema: *ref_280
+          - !<!Parameter> &ref_291
+            schema: *ref_282
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6016,8 +6197,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_290
-            schema: *ref_279
+          - !<!Parameter> &ref_292
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6027,8 +6208,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_291
-            schema: *ref_279
+          - !<!Parameter> &ref_293
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6038,8 +6219,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_292
-            schema: *ref_279
+          - !<!Parameter> &ref_294
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6049,8 +6230,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_293
-            schema: *ref_279
+          - !<!Parameter> &ref_295
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6062,6 +6243,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6072,8 +6268,6 @@ operationGroups:
                 method: head
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_281
-          - *ref_282
           - *ref_283
           - *ref_284
           - *ref_285
@@ -6085,6 +6279,8 @@ operationGroups:
           - *ref_291
           - *ref_292
           - *ref_293
+          - *ref_294
+          - *ref_295
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -6095,63 +6291,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_279
+                    schema: *ref_281
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_294
+                    schema: *ref_296
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_295
+                    schema: *ref_297
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_296
+                    schema: *ref_298
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_297
+                    schema: *ref_299
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_298
+                    schema: *ref_300
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_299
+                    schema: *ref_301
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_300
+                    schema: *ref_302
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_301
+                    schema: *ref_303
                     header: Content-MD5
                     language:
                       default:
@@ -6160,49 +6356,49 @@ operationGroups:
                           The MD5 hash of complete file stored in storage. This header is returned only for "GetProperties" operation. If the Content-MD5 header has been set for the file, this response header is returned for GetProperties
                           call so that the client can check for message content integrity.
                   - !<!HttpHeader> 
-                    schema: *ref_302
+                    schema: *ref_304
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_303
+                    schema: *ref_305
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_304
+                    schema: *ref_306
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_280
+                    schema: *ref_282
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_305
+                    schema: *ref_307
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_306
+                    schema: *ref_308
                     header: x-ms-resource-type
                     language:
                       default:
                         name: x-ms-resource-type
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_307
+                    schema: *ref_309
                     header: x-ms-properties
                     language:
                       default:
@@ -6211,49 +6407,49 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_308
+                    schema: *ref_310
                     header: x-ms-owner
                     language:
                       default:
                         name: x-ms-owner
                         description: The owner of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_309
+                    schema: *ref_311
                     header: x-ms-group
                     language:
                       default:
                         name: x-ms-group
                         description: The owning group of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_310
+                    schema: *ref_312
                     header: x-ms-permissions
                     language:
                       default:
                         name: x-ms-permissions
                         description: 'The POSIX access permissions for the file owner, the file owning group, and others. Included in the response if Hierarchical Namespace is enabled for the account.'
                   - !<!HttpHeader> 
-                    schema: *ref_311
+                    schema: *ref_313
                     header: x-ms-acl
                     language:
                       default:
                         name: x-ms-acl
                         description: The POSIX access control list for the file or directory.  Included in the response only if the action is "getAccessControl" and Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_312
+                    schema: *ref_314
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: x-ms-lease-duration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_313
+                    schema: *ref_315
                     header: x-ms-lease-state
                     language:
                       default:
                         name: x-ms-lease-state
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_314
+                    schema: *ref_316
                     header: x-ms-lease-status
                     language:
                       default:
@@ -6263,7 +6459,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -6272,14 +6468,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -6306,8 +6502,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_317
-            schema: *ref_39
+          - !<!Parameter> &ref_319
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -6318,8 +6514,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_318
-            schema: *ref_101
+          - !<!Parameter> &ref_320
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -6330,8 +6526,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_319
-            schema: *ref_102
+          - !<!Parameter> &ref_321
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -6343,7 +6539,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_320
+          - !<!Parameter> &ref_322
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -6354,8 +6550,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_321
-            schema: *ref_101
+          - !<!Parameter> &ref_323
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6366,8 +6562,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_322
-            schema: *ref_85
+          - !<!Parameter> &ref_324
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6377,8 +6573,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_323
-            schema: *ref_315
+          - !<!Parameter> &ref_325
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6390,8 +6586,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_324
-            schema: *ref_316
+          - !<!Parameter> &ref_326
+            schema: *ref_318
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6401,8 +6597,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_325
-            schema: *ref_315
+          - !<!Parameter> &ref_327
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6412,8 +6608,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_326
-            schema: *ref_315
+          - !<!Parameter> &ref_328
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6423,8 +6619,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_327
-            schema: *ref_315
+          - !<!Parameter> &ref_329
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6434,8 +6630,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_328
-            schema: *ref_315
+          - !<!Parameter> &ref_330
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6447,6 +6643,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6457,8 +6668,6 @@ operationGroups:
                 method: delete
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_317
-          - *ref_318
           - *ref_319
           - *ref_320
           - *ref_321
@@ -6469,6 +6678,8 @@ operationGroups:
           - *ref_326
           - *ref_327
           - *ref_328
+          - *ref_329
+          - *ref_330
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -6479,28 +6690,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_315
+                    schema: *ref_317
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_316
+                    schema: *ref_318
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_329
+                    schema: *ref_331
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_330
+                    schema: *ref_332
                     header: x-ms-continuation
                     language:
                       default:
@@ -6512,7 +6723,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -6521,14 +6732,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:

--- a/modelerfour/test/scenarios/datalake-storage/grouped.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: Azure Data Lake Storage REST API
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_85
+    - !<!BooleanSchema> &ref_86
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -43,19 +43,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_140
-      type: integer
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: ''
-          header: Content-Length
-      protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_142
+    - !<!NumberSchema> &ref_141
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -72,6 +60,18 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: '2019-10-31'
+      precision: 64
+      language: !<!Languages> 
+        default:
+          name: integer
+          description: ''
+          header: Content-Length
+      protocol: !<!Protocols> {}
+    - !<!NumberSchema> &ref_144
+      type: integer
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
       minimum: 0
       precision: 64
       language: !<!Languages> 
@@ -79,7 +79,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_193
+    - !<!NumberSchema> &ref_194
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -90,7 +90,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_243
+    - !<!NumberSchema> &ref_245
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -102,7 +102,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_262
+    - !<!NumberSchema> &ref_264
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -114,7 +114,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_298
+    - !<!NumberSchema> &ref_300
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -157,7 +157,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_33
+    - !<!StringSchema> &ref_34
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -168,7 +168,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_34
+    - !<!StringSchema> &ref_35
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -179,7 +179,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-continuation
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_35
+    - !<!StringSchema> &ref_36
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -220,7 +220,7 @@ schemas: !<!Schemas>
           name: Filesystem-eTag
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_37
+    - !<!StringSchema> &ref_38
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -232,7 +232,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_38
+    - !<!StringSchema> &ref_39
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -263,7 +263,7 @@ schemas: !<!Schemas>
           name: DataLakeStorageError-error-message
           description: The service error message.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_39
+    - !<!StringSchema> &ref_40
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -276,7 +276,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_41
+    - !<!StringSchema> &ref_42
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -288,7 +288,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_42
+    - !<!StringSchema> &ref_43
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -298,17 +298,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_48
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_49
       type: string
@@ -319,7 +308,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_50
       type: string
@@ -330,7 +319,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_51
       type: string
@@ -341,7 +330,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-namespace-enabled
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_52
       type: string
@@ -352,9 +341,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Date
+          header: x-ms-namespace-enabled
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_60
+    - !<!StringSchema> &ref_53
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -363,7 +352,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_61
       type: string
@@ -374,9 +363,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_62
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_63
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -388,7 +388,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_63
+    - !<!StringSchema> &ref_64
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -399,7 +399,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_84
+    - !<!StringSchema> &ref_85
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -410,7 +410,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_96
+    - !<!StringSchema> &ref_97
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -421,7 +421,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_97
+    - !<!StringSchema> &ref_98
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -432,7 +432,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_98
+    - !<!StringSchema> &ref_99
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -444,7 +444,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_99
+    - !<!StringSchema> &ref_100
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -455,7 +455,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_100
+    - !<!StringSchema> &ref_101
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -526,17 +526,6 @@ schemas: !<!Schemas>
           name: Path-permissions
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_68
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_69
       type: string
       apiVersions:
@@ -546,7 +535,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_70
       type: string
@@ -557,9 +546,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_71
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_72
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -570,17 +570,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_72
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_73
       type: string
@@ -591,7 +580,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-properties
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_74
       type: string
@@ -602,7 +591,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-namespace-enabled
+          header: x-ms-properties
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_75
       type: string
@@ -613,9 +602,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-namespace-enabled
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_76
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_82
+    - !<!StringSchema> &ref_83
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -627,18 +627,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_83
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_101
+    - !<!StringSchema> &ref_84
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -654,23 +643,23 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_103
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
       pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
       language: !<!Languages> 
         default:
           name: string
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_136
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_137
       type: string
@@ -681,7 +670,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_138
       type: string
@@ -692,7 +681,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_139
       type: string
@@ -703,9 +692,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_140
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-continuation
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_144
+    - !<!StringSchema> &ref_145
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -716,7 +716,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_145
+    - !<!StringSchema> &ref_146
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -727,17 +727,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_176
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_177
       type: string
@@ -748,7 +737,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_178
       type: string
@@ -759,7 +748,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Accept-Ranges
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_179
       type: string
@@ -770,7 +759,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Cache-Control
+          header: Accept-Ranges
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_180
       type: string
@@ -781,7 +770,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Disposition
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_181
       type: string
@@ -792,7 +781,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Encoding
+          header: Content-Disposition
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_182
       type: string
@@ -803,7 +792,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_183
       type: string
@@ -814,7 +803,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Range
+          header: Content-Language
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_184
       type: string
@@ -825,7 +814,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Type
+          header: Content-Range
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_185
       type: string
@@ -836,7 +825,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-MD5
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_186
       type: string
@@ -847,7 +836,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-properties
+          header: Content-MD5
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_187
       type: string
@@ -858,7 +847,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-properties
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_188
       type: string
@@ -869,7 +858,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-MD5
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_189
       type: string
@@ -880,9 +869,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Date
+          header: Content-MD5
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_190
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_191
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -894,7 +894,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_191
+    - !<!StringSchema> &ref_192
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -905,7 +905,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_194
+    - !<!StringSchema> &ref_195
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -917,7 +917,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_195
+    - !<!StringSchema> &ref_196
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -927,17 +927,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_210
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_211
       type: string
@@ -948,7 +937,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_212
       type: string
@@ -959,9 +948,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_213
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_214
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -972,17 +972,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-lease-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_214
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_215
       type: string
@@ -993,7 +982,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_216
       type: string
@@ -1004,9 +993,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_217
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_218
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1018,7 +1018,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_218
+    - !<!StringSchema> &ref_219
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1029,7 +1029,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_219
+    - !<!StringSchema> &ref_220
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1041,7 +1041,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-lease-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_220
+    - !<!StringSchema> &ref_221
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1052,7 +1052,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_221
+    - !<!StringSchema> &ref_222
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1063,7 +1063,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_222
+    - !<!StringSchema> &ref_223
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1074,17 +1074,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_223
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_224
       type: string
@@ -1095,7 +1084,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-lease-time
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_225
       type: string
@@ -1106,9 +1095,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Accept-Ranges
+          header: x-ms-lease-time
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_226
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Accept-Ranges
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_227
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1119,28 +1119,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_239
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Cache-Control
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_240
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Disposition
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_241
       type: string
@@ -1151,7 +1129,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Encoding
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_242
       type: string
@@ -1162,7 +1140,18 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
+          header: Content-Disposition
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_243
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_244
       type: string
@@ -1173,18 +1162,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Range
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_245
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Type
+          header: Content-Language
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_246
       type: string
@@ -1195,7 +1173,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-MD5
+          header: Content-Range
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_247
       type: string
@@ -1206,7 +1184,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Date
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_248
       type: string
@@ -1217,7 +1195,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Content-MD5
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_249
       type: string
@@ -1228,7 +1206,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_250
       type: string
@@ -1239,7 +1217,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_251
       type: string
@@ -1250,7 +1228,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-resource-type
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_252
       type: string
@@ -1261,7 +1239,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-properties
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_253
       type: string
@@ -1272,7 +1250,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-lease-duration
+          header: x-ms-resource-type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_254
       type: string
@@ -1283,7 +1261,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-lease-state
+          header: x-ms-properties
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_255
       type: string
@@ -1294,7 +1272,18 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-lease-status
+          header: x-ms-lease-duration
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_256
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-state
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_257
       type: string
@@ -1305,18 +1294,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Accept-Ranges
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_258
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Cache-Control
+          header: x-ms-lease-status
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_259
       type: string
@@ -1327,7 +1305,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Disposition
+          header: Accept-Ranges
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_260
       type: string
@@ -1338,7 +1316,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Encoding
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_261
       type: string
@@ -1349,209 +1327,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_263
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Range
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_264
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Type
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_265
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-MD5
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_266
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-content-md5
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_267
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_268
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_269
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Last-Modified
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_270
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_271
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_272
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-resource-type
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_273
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-properties
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_274
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-duration
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_275
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-state
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_276
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-status
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_279
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Accept-Ranges
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_280
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_294
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Cache-Control
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_295
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
           header: Content-Disposition
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_296
+    - !<!StringSchema> &ref_262
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1562,7 +1340,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Encoding
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_297
+    - !<!StringSchema> &ref_263
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1573,7 +1351,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Language
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_299
+    - !<!StringSchema> &ref_265
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1584,7 +1362,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Range
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_300
+    - !<!StringSchema> &ref_266
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1595,7 +1373,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_301
+    - !<!StringSchema> &ref_267
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1606,7 +1384,18 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_302
+    - !<!StringSchema> &ref_268
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-content-md5
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_269
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1617,7 +1406,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_303
+    - !<!StringSchema> &ref_270
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1628,7 +1417,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_304
+    - !<!StringSchema> &ref_271
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1639,128 +1428,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_305
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_306
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-resource-type
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_307
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-properties
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_308
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-owner
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_309
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-group
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_310
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-permissions
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_311
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-acl
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_312
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-duration
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_313
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-state
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_314
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-status
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_315
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_316
+    - !<!StringSchema> &ref_272
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1772,7 +1440,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_329
+    - !<!StringSchema> &ref_273
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1783,7 +1451,339 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_330
+    - !<!StringSchema> &ref_274
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-resource-type
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_275
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-properties
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_276
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-duration
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_277
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-state
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_278
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-status
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_281
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Accept-Ranges
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_282
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_296
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Cache-Control
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_297
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Disposition
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_298
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Encoding
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_299
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Language
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_301
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Range
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_302
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Type
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_303
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-MD5
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_304
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_305
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: ETag
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_306
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_307
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_308
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-resource-type
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_309
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-properties
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_310
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-owner
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_311
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-group
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_312
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-permissions
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_313
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-acl
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_314
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-duration
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_315
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-state
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_316
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-status
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_317
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_318
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_331
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_332
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1816,7 +1816,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_103
+    - !<!SealedChoiceSchema> &ref_104
       choices:
         - !<!ChoiceValue> 
           value: directory
@@ -1840,7 +1840,7 @@ schemas: !<!Schemas>
           name: PathResourceType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_104
+    - !<!SealedChoiceSchema> &ref_105
       choices:
         - !<!ChoiceValue> 
           value: legacy
@@ -1864,7 +1864,7 @@ schemas: !<!Schemas>
           name: PathRenameMode
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_141
+    - !<!SealedChoiceSchema> &ref_142
       choices:
         - !<!ChoiceValue> 
           value: append
@@ -1900,7 +1900,7 @@ schemas: !<!Schemas>
           name: PathUpdateAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_192
+    - !<!SealedChoiceSchema> &ref_193
       choices:
         - !<!ChoiceValue> 
           value: acquire
@@ -1942,7 +1942,7 @@ schemas: !<!Schemas>
           name: PathLeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_278
+    - !<!SealedChoiceSchema> &ref_280
       choices:
         - !<!ChoiceValue> 
           value: getAccessControl
@@ -1983,7 +1983,17 @@ schemas: !<!Schemas>
           name: AccountResourceType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_40
+    - !<!ConstantSchema> &ref_26
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_41
       type: constant
       value: !<!ConstantValue> 
         value: filesystem
@@ -1993,8 +2003,18 @@ schemas: !<!Schemas>
           name: FilesystemResourceType
           description: ''
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_228
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'application/octet-stream, application/json, text/plain'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/octet-stream, application/json, text/plain'
+      protocol: !<!Protocols> {}
   binaries:
-    - !<!BinarySchema> &ref_146
+    - !<!BinarySchema> &ref_147
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -2004,7 +2024,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_256
+    - !<!BinarySchema> &ref_258
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -2014,7 +2034,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_277
+    - !<!BinarySchema> &ref_279
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -2025,7 +2045,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_32
+    - !<!ObjectSchema> &ref_33
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2099,7 +2119,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_4
-    - !<!ObjectSchema> &ref_36
+    - !<!ObjectSchema> &ref_37
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2155,7 +2175,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_7
-    - !<!ObjectSchema> &ref_95
+    - !<!ObjectSchema> &ref_96
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2348,7 +2368,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_26
+          - !<!Parameter> &ref_27
             schema: *ref_19
             implementation: Method
             language: !<!Languages> 
@@ -2359,7 +2379,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_27
+          - !<!Parameter> &ref_28
             schema: *ref_19
             implementation: Method
             language: !<!Languages> 
@@ -2372,7 +2392,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -2383,7 +2403,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_29
+          - !<!Parameter> &ref_30
             schema: *ref_24
             implementation: Method
             extensions:
@@ -2396,7 +2416,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_30
+          - !<!Parameter> &ref_31
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -2407,7 +2427,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_31
+          - !<!Parameter> &ref_32
             schema: *ref_19
             implementation: Method
             language: !<!Languages> 
@@ -2421,6 +2441,21 @@ operationGroups:
           - *ref_25
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2431,15 +2466,15 @@ operationGroups:
                 method: get
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_26
           - *ref_27
           - *ref_28
           - *ref_29
           - *ref_30
           - *ref_31
+          - *ref_32
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_32
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -2462,14 +2497,14 @@ operationGroups:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_33
+                    schema: *ref_34
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_34
+                    schema: *ref_35
                     header: x-ms-continuation
                     language:
                       default:
@@ -2478,7 +2513,7 @@ operationGroups:
                           If the number of filesystems to be listed exceeds the maxResults limit, a continuation token is returned in this response header.  When a continuation token is returned in the response, it must be specified in a
                           subsequent invocation of the list operation to continue listing the filesystems.
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Content-Type
                     language:
                       default:
@@ -2491,7 +2526,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -2500,14 +2535,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -2538,8 +2573,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_43
-            schema: *ref_39
+          - !<!Parameter> &ref_44
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2553,7 +2588,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_40
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2564,8 +2599,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_44
-            schema: *ref_41
+          - !<!Parameter> &ref_45
+            schema: *ref_42
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -2577,7 +2612,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_45
+          - !<!Parameter> &ref_46
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -2588,8 +2623,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_46
-            schema: *ref_42
+          - !<!Parameter> &ref_47
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2600,8 +2635,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_47
-            schema: *ref_42
+          - !<!Parameter> &ref_48
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2615,6 +2650,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2625,11 +2675,11 @@ operationGroups:
                 method: put
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_43
           - *ref_44
           - *ref_45
           - *ref_46
           - *ref_47
+          - *ref_48
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2640,42 +2690,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_42
+                    schema: *ref_43
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_48
+                    schema: *ref_49
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the filesystem.
                   - !<!HttpHeader> 
-                    schema: *ref_49
+                    schema: *ref_50
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the filesystem was last modified.  Operations on files and directories do not affect the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_41
+                    schema: *ref_42
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_50
+                    schema: *ref_51
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_51
+                    schema: *ref_52
                     header: x-ms-namespace-enabled
                     language:
                       default:
@@ -2685,7 +2735,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -2694,14 +2744,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -2725,8 +2775,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_53
-            schema: *ref_39
+          - !<!Parameter> &ref_54
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2740,7 +2790,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_40
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2751,8 +2801,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_54
-            schema: *ref_41
+          - !<!Parameter> &ref_55
+            schema: *ref_42
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -2764,7 +2814,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_55
+          - !<!Parameter> &ref_56
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -2775,8 +2825,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_56
-            schema: *ref_42
+          - !<!Parameter> &ref_57
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2787,8 +2837,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_57
-            schema: *ref_52
+          - !<!Parameter> &ref_58
+            schema: *ref_53
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2801,8 +2851,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_58
-            schema: *ref_52
+          - !<!Parameter> &ref_59
+            schema: *ref_53
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2812,8 +2862,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_59
-            schema: *ref_52
+          - !<!Parameter> &ref_60
+            schema: *ref_53
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2825,6 +2875,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2835,13 +2900,13 @@ operationGroups:
                 method: patch
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_53
           - *ref_54
           - *ref_55
           - *ref_56
           - *ref_57
           - *ref_58
           - *ref_59
+          - *ref_60
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2852,35 +2917,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_52
+                    schema: *ref_53
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_60
+                    schema: *ref_61
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'An HTTP entity tag associated with the filesystem.  Changes to filesystem properties affect the entity tag, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_61
+                    schema: *ref_62
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'The data and time the filesystem was last modified.  Changes to filesystem properties update the last modified time, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_62
+                    schema: *ref_63
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_63
+                    schema: *ref_64
                     header: x-ms-version
                     language:
                       default:
@@ -2890,7 +2955,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -2899,14 +2964,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -2932,8 +2997,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_64
-            schema: *ref_39
+          - !<!Parameter> &ref_65
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2947,7 +3012,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_40
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2958,8 +3023,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_65
-            schema: *ref_41
+          - !<!Parameter> &ref_66
+            schema: *ref_42
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -2971,7 +3036,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_66
+          - !<!Parameter> &ref_67
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -2982,8 +3047,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_67
-            schema: *ref_42
+          - !<!Parameter> &ref_68
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2996,6 +3061,21 @@ operationGroups:
           - *ref_25
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3006,10 +3086,10 @@ operationGroups:
                 method: head
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_64
           - *ref_65
           - *ref_66
           - *ref_67
+          - *ref_68
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3020,42 +3100,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_68
+                    schema: *ref_69
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_69
+                    schema: *ref_70
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'An HTTP entity tag associated with the filesystem.  Changes to filesystem properties affect the entity tag, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_70
+                    schema: *ref_71
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'The data and time the filesystem was last modified.  Changes to filesystem properties update the last modified time, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_71
+                    schema: *ref_72
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_72
+                    schema: *ref_73
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_73
+                    schema: *ref_74
                     header: x-ms-properties
                     language:
                       default:
@@ -3064,7 +3144,7 @@ operationGroups:
                           The user-defined properties associated with the filesystem.  A comma-separated list of name and value pairs in the format "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the string may
                           only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_74
+                    schema: *ref_75
                     header: x-ms-namespace-enabled
                     language:
                       default:
@@ -3074,7 +3154,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -3083,14 +3163,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -3114,8 +3194,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_76
-            schema: *ref_39
+          - !<!Parameter> &ref_77
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3129,7 +3209,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_40
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3140,8 +3220,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_77
-            schema: *ref_41
+          - !<!Parameter> &ref_78
+            schema: *ref_42
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -3153,7 +3233,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_78
+          - !<!Parameter> &ref_79
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -3164,8 +3244,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_79
-            schema: *ref_42
+          - !<!Parameter> &ref_80
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3176,8 +3256,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_80
-            schema: *ref_75
+          - !<!Parameter> &ref_81
+            schema: *ref_76
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3187,8 +3267,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_81
-            schema: *ref_75
+          - !<!Parameter> &ref_82
+            schema: *ref_76
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3200,6 +3280,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3210,12 +3305,12 @@ operationGroups:
                 method: delete
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_76
           - *ref_77
           - *ref_78
           - *ref_79
           - *ref_80
           - *ref_81
+          - *ref_82
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3226,21 +3321,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_82
+                    schema: *ref_83
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_75
+                    schema: *ref_76
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_83
+                    schema: *ref_84
                     header: Date
                     language:
                       default:
@@ -3250,7 +3345,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -3259,14 +3354,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -3302,8 +3397,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_86
-            schema: *ref_39
+          - !<!Parameter> &ref_87
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3317,7 +3412,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_40
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3328,8 +3423,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_87
-            schema: *ref_41
+          - !<!Parameter> &ref_88
+            schema: *ref_42
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -3341,7 +3436,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_88
+          - !<!Parameter> &ref_89
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -3352,8 +3447,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_89
-            schema: *ref_42
+          - !<!Parameter> &ref_90
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3364,8 +3459,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_90
-            schema: *ref_84
+          - !<!Parameter> &ref_91
+            schema: *ref_85
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3375,8 +3470,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_91
-            schema: *ref_85
+          - !<!Parameter> &ref_92
+            schema: *ref_86
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3387,8 +3482,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_92
-            schema: *ref_84
+          - !<!Parameter> &ref_93
+            schema: *ref_85
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3400,7 +3495,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_93
+          - !<!Parameter> &ref_94
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -3411,8 +3506,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_94
-            schema: *ref_85
+          - !<!Parameter> &ref_95
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3427,6 +3522,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3437,7 +3547,6 @@ operationGroups:
                 method: get
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_86
           - *ref_87
           - *ref_88
           - *ref_89
@@ -3446,9 +3555,10 @@ operationGroups:
           - *ref_92
           - *ref_93
           - *ref_94
+          - *ref_95
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_95
+            schema: *ref_96
             language: !<!Languages> 
               default:
                 name: ''
@@ -3457,42 +3567,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_84
+                    schema: *ref_85
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_96
+                    schema: *ref_97
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'An HTTP entity tag associated with the filesystem.  Changes to filesystem properties affect the entity tag, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_97
+                    schema: *ref_98
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'The data and time the filesystem was last modified.  Changes to filesystem properties update the last modified time, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_98
+                    schema: *ref_99
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_99
+                    schema: *ref_100
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_100
+                    schema: *ref_101
                     header: x-ms-continuation
                     language:
                       default:
@@ -3507,7 +3617,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -3516,14 +3626,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -3554,8 +3664,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_105
-            schema: *ref_39
+          - !<!Parameter> &ref_106
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3566,8 +3676,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_106
-            schema: *ref_101
+          - !<!Parameter> &ref_107
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3578,8 +3688,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_107
-            schema: *ref_102
+          - !<!Parameter> &ref_108
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -3591,7 +3701,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_108
+          - !<!Parameter> &ref_109
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -3602,8 +3712,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_109
-            schema: *ref_101
+          - !<!Parameter> &ref_110
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3614,8 +3724,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_110
-            schema: *ref_103
+          - !<!Parameter> &ref_111
+            schema: *ref_104
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3625,8 +3735,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_111
-            schema: *ref_101
+          - !<!Parameter> &ref_112
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3638,8 +3748,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_112
-            schema: *ref_104
+          - !<!Parameter> &ref_113
+            schema: *ref_105
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3649,8 +3759,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_113
-            schema: *ref_101
+          - !<!Parameter> &ref_114
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3660,8 +3770,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_114
-            schema: *ref_101
+          - !<!Parameter> &ref_115
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3671,8 +3781,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_115
-            schema: *ref_101
+          - !<!Parameter> &ref_116
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3682,8 +3792,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_116
-            schema: *ref_101
+          - !<!Parameter> &ref_117
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3693,8 +3803,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_117
-            schema: *ref_101
+          - !<!Parameter> &ref_118
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3704,8 +3814,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_118
-            schema: *ref_101
+          - !<!Parameter> &ref_119
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3715,8 +3825,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_119
-            schema: *ref_101
+          - !<!Parameter> &ref_120
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3726,8 +3836,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_120
-            schema: *ref_101
+          - !<!Parameter> &ref_121
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3737,8 +3847,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_121
-            schema: *ref_101
+          - !<!Parameter> &ref_122
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3748,8 +3858,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_122
-            schema: *ref_101
+          - !<!Parameter> &ref_123
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3761,8 +3871,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_123
-            schema: *ref_102
+          - !<!Parameter> &ref_124
+            schema: *ref_103
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3772,8 +3882,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_124
-            schema: *ref_102
+          - !<!Parameter> &ref_125
+            schema: *ref_103
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3783,8 +3893,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_125
-            schema: *ref_101
+          - !<!Parameter> &ref_126
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3796,8 +3906,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_126
-            schema: *ref_101
+          - !<!Parameter> &ref_127
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3809,8 +3919,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_127
-            schema: *ref_101
+          - !<!Parameter> &ref_128
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3823,8 +3933,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_128
-            schema: *ref_101
+          - !<!Parameter> &ref_129
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3834,8 +3944,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_129
-            schema: *ref_101
+          - !<!Parameter> &ref_130
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3845,8 +3955,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_130
-            schema: *ref_101
+          - !<!Parameter> &ref_131
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3856,8 +3966,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_131
-            schema: *ref_101
+          - !<!Parameter> &ref_132
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3867,8 +3977,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_132
-            schema: *ref_101
+          - !<!Parameter> &ref_133
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3878,8 +3988,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_133
-            schema: *ref_101
+          - !<!Parameter> &ref_134
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3889,8 +3999,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_134
-            schema: *ref_101
+          - !<!Parameter> &ref_135
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3900,8 +4010,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_135
-            schema: *ref_101
+          - !<!Parameter> &ref_136
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3913,6 +4023,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3923,7 +4048,6 @@ operationGroups:
                 method: put
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_105
           - *ref_106
           - *ref_107
           - *ref_108
@@ -3954,6 +4078,7 @@ operationGroups:
           - *ref_133
           - *ref_134
           - *ref_135
+          - *ref_136
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3964,42 +4089,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_101
+                    schema: *ref_102
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_136
+                    schema: *ref_137
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_137
+                    schema: *ref_138
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_102
+                    schema: *ref_103
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_138
+                    schema: *ref_139
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_139
+                    schema: *ref_140
                     header: x-ms-continuation
                     language:
                       default:
@@ -4008,7 +4133,7 @@ operationGroups:
                           When renaming a directory, the number of paths that are renamed with each invocation is limited.  If the number of paths to be renamed exceeds this limit, a continuation token is returned in this response header. 
                           When a continuation token is returned in the response, it must be specified in a subsequent invocation of the rename operation to continue renaming the directory.
                   - !<!HttpHeader> 
-                    schema: *ref_140
+                    schema: *ref_141
                     header: Content-Length
                     language:
                       default:
@@ -4018,7 +4143,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -4027,14 +4152,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -4061,8 +4186,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_149
-            schema: *ref_39
+          - !<!Parameter> &ref_150
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4073,8 +4198,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_150
-            schema: *ref_101
+          - !<!Parameter> &ref_151
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4085,8 +4210,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_151
-            schema: *ref_102
+          - !<!Parameter> &ref_152
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -4098,7 +4223,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_152
+          - !<!Parameter> &ref_153
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -4109,8 +4234,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_153
-            schema: *ref_101
+          - !<!Parameter> &ref_154
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4121,8 +4246,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_154
-            schema: *ref_141
+          - !<!Parameter> &ref_155
+            schema: *ref_142
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4136,8 +4261,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_155
-            schema: *ref_142
+          - !<!Parameter> &ref_156
+            schema: *ref_143
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4150,8 +4275,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_156
-            schema: *ref_85
+          - !<!Parameter> &ref_157
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4163,8 +4288,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_157
-            schema: *ref_85
+          - !<!Parameter> &ref_158
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4178,8 +4303,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_158
-            schema: *ref_143
+          - !<!Parameter> &ref_159
+            schema: *ref_144
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4189,8 +4314,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_159
-            schema: *ref_144
+          - !<!Parameter> &ref_160
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4203,8 +4328,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_160
-            schema: *ref_145
+          - !<!Parameter> &ref_161
+            schema: *ref_146
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4214,8 +4339,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_161
-            schema: *ref_144
+          - !<!Parameter> &ref_162
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4225,8 +4350,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_162
-            schema: *ref_144
+          - !<!Parameter> &ref_163
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4236,8 +4361,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_163
-            schema: *ref_144
+          - !<!Parameter> &ref_164
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4247,8 +4372,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_164
-            schema: *ref_144
+          - !<!Parameter> &ref_165
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4258,8 +4383,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_165
-            schema: *ref_144
+          - !<!Parameter> &ref_166
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4269,8 +4394,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_166
-            schema: *ref_144
+          - !<!Parameter> &ref_167
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4282,8 +4407,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_167
-            schema: *ref_144
+          - !<!Parameter> &ref_168
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4297,8 +4422,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_168
-            schema: *ref_144
+          - !<!Parameter> &ref_169
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4308,8 +4433,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_169
-            schema: *ref_144
+          - !<!Parameter> &ref_170
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4319,8 +4444,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_170
-            schema: *ref_144
+          - !<!Parameter> &ref_171
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4332,8 +4457,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_171
-            schema: *ref_144
+          - !<!Parameter> &ref_172
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4351,8 +4476,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_172
-            schema: *ref_144
+          - !<!Parameter> &ref_173
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4364,8 +4489,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_173
-            schema: *ref_144
+          - !<!Parameter> &ref_174
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4377,8 +4502,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_174
-            schema: *ref_144
+          - !<!Parameter> &ref_175
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4388,8 +4513,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_175
-            schema: *ref_144
+          - !<!Parameter> &ref_176
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4402,8 +4527,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_147
-                schema: *ref_146
+              - !<!Parameter> &ref_148
+                schema: *ref_147
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -4414,8 +4539,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_147
+              - *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -4431,7 +4569,7 @@ operationGroups:
                 uri: 'https://{accountName}.{dnsSuffix}'
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_148
+              - !<!Parameter> &ref_149
                 schema: *ref_0
                 implementation: Method
                 required: true
@@ -4443,8 +4581,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_148
+              - *ref_149
             language: !<!Languages> 
               default:
                 name: ''
@@ -4459,7 +4610,6 @@ operationGroups:
                   - text/plain
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_149
           - *ref_150
           - *ref_151
           - *ref_152
@@ -4486,6 +4636,7 @@ operationGroups:
           - *ref_173
           - *ref_174
           - *ref_175
+          - *ref_176
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4496,84 +4647,84 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_144
+                    schema: *ref_145
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_176
+                    schema: *ref_177
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_177
+                    schema: *ref_178
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_178
+                    schema: *ref_179
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_179
+                    schema: *ref_180
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_180
+                    schema: *ref_181
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_181
+                    schema: *ref_182
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_182
+                    schema: *ref_183
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_142
+                    schema: *ref_143
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_183
+                    schema: *ref_184
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_184
+                    schema: *ref_185
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_185
+                    schema: *ref_186
                     header: Content-MD5
                     language:
                       default:
@@ -4582,7 +4733,7 @@ operationGroups:
                           An MD5 hash of the request content. This header is only returned for "Flush" operation. This header is returned so that the client can check for message content integrity. This header refers to the content of the
                           request, not actual file content.
                   - !<!HttpHeader> 
-                    schema: *ref_186
+                    schema: *ref_187
                     header: x-ms-properties
                     language:
                       default:
@@ -4591,14 +4742,14 @@ operationGroups:
                           User-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the string
                           may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_145
+                    schema: *ref_146
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_187
+                    schema: *ref_188
                     header: x-ms-version
                     language:
                       default:
@@ -4615,7 +4766,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_188
+                    schema: *ref_189
                     header: Content-MD5
                     language:
                       default:
@@ -4624,21 +4775,21 @@ operationGroups:
                           An MD5 hash of the request content. This header is only returned for "Append" operation. This header is returned so that the client can check for message content integrity. The value of this header is computed by
                           the service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_189
+                    schema: *ref_190
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_190
+                    schema: *ref_191
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_191
+                    schema: *ref_192
                     header: x-ms-version
                     language:
                       default:
@@ -4648,7 +4799,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -4657,14 +4808,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -4691,8 +4842,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_196
-            schema: *ref_39
+          - !<!Parameter> &ref_197
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4703,8 +4854,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_197
-            schema: *ref_101
+          - !<!Parameter> &ref_198
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4715,8 +4866,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_198
-            schema: *ref_102
+          - !<!Parameter> &ref_199
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -4728,7 +4879,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_199
+          - !<!Parameter> &ref_200
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -4739,8 +4890,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_200
-            schema: *ref_101
+          - !<!Parameter> &ref_201
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4751,8 +4902,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_201
-            schema: *ref_192
+          - !<!Parameter> &ref_202
+            schema: *ref_193
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4767,8 +4918,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_202
-            schema: *ref_193
+          - !<!Parameter> &ref_203
+            schema: *ref_194
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4778,8 +4929,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_203
-            schema: *ref_193
+          - !<!Parameter> &ref_204
+            schema: *ref_194
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4789,8 +4940,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_204
-            schema: *ref_194
+          - !<!Parameter> &ref_205
+            schema: *ref_195
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4800,8 +4951,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_205
-            schema: *ref_194
+          - !<!Parameter> &ref_206
+            schema: *ref_195
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4811,8 +4962,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_206
-            schema: *ref_195
+          - !<!Parameter> &ref_207
+            schema: *ref_196
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4822,8 +4973,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_207
-            schema: *ref_195
+          - !<!Parameter> &ref_208
+            schema: *ref_196
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4833,8 +4984,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_208
-            schema: *ref_195
+          - !<!Parameter> &ref_209
+            schema: *ref_196
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4844,8 +4995,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_209
-            schema: *ref_195
+          - !<!Parameter> &ref_210
+            schema: *ref_196
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4857,6 +5008,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4867,7 +5033,6 @@ operationGroups:
                 method: post
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_196
           - *ref_197
           - *ref_198
           - *ref_199
@@ -4881,6 +5046,7 @@ operationGroups:
           - *ref_207
           - *ref_208
           - *ref_209
+          - *ref_210
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4891,42 +5057,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_195
+                    schema: *ref_196
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_210
+                    schema: *ref_211
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file.
                   - !<!HttpHeader> 
-                    schema: *ref_211
+                    schema: *ref_212
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file was last modified.  Write operations on the file update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_194
+                    schema: *ref_195
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_212
+                    schema: *ref_213
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_213
+                    schema: *ref_214
                     header: x-ms-lease-id
                     language:
                       default:
@@ -4943,42 +5109,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_214
+                    schema: *ref_215
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_215
+                    schema: *ref_216
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_216
+                    schema: *ref_217
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_217
+                    schema: *ref_218
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_218
+                    schema: *ref_219
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_219
+                    schema: *ref_220
                     header: x-ms-lease-id
                     language:
                       default:
@@ -4995,35 +5161,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_220
+                    schema: *ref_221
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_221
+                    schema: *ref_222
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_222
+                    schema: *ref_223
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_223
+                    schema: *ref_224
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_224
+                    schema: *ref_225
                     header: x-ms-lease-time
                     language:
                       default:
@@ -5033,7 +5199,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -5042,14 +5208,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -5075,8 +5241,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_227
-            schema: *ref_39
+          - !<!Parameter> &ref_229
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -5087,8 +5253,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_228
-            schema: *ref_101
+          - !<!Parameter> &ref_230
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -5099,8 +5265,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_229
-            schema: *ref_102
+          - !<!Parameter> &ref_231
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -5112,7 +5278,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_230
+          - !<!Parameter> &ref_232
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -5123,8 +5289,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_231
-            schema: *ref_101
+          - !<!Parameter> &ref_233
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5135,8 +5301,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_232
-            schema: *ref_225
+          - !<!Parameter> &ref_234
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5146,8 +5312,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_233
-            schema: *ref_226
+          - !<!Parameter> &ref_235
+            schema: *ref_227
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5159,8 +5325,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_234
-            schema: *ref_85
+          - !<!Parameter> &ref_236
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5172,8 +5338,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_235
-            schema: *ref_225
+          - !<!Parameter> &ref_237
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5183,8 +5349,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_236
-            schema: *ref_225
+          - !<!Parameter> &ref_238
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5194,8 +5360,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_237
-            schema: *ref_225
+          - !<!Parameter> &ref_239
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5205,8 +5371,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_238
-            schema: *ref_225
+          - !<!Parameter> &ref_240
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5218,6 +5384,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_228
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5228,8 +5409,6 @@ operationGroups:
                 method: get
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_227
-          - *ref_228
           - *ref_229
           - *ref_230
           - *ref_231
@@ -5240,6 +5419,8 @@ operationGroups:
           - *ref_236
           - *ref_237
           - *ref_238
+          - *ref_239
+          - *ref_240
         responses:
           - !<!BinaryResponse> 
             binary: true
@@ -5251,112 +5432,112 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_225
+                    schema: *ref_226
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_239
+                    schema: *ref_241
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_240
+                    schema: *ref_242
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_241
+                    schema: *ref_243
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_242
+                    schema: *ref_244
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_243
+                    schema: *ref_245
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_244
+                    schema: *ref_246
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_245
+                    schema: *ref_247
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_246
+                    schema: *ref_248
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'The MD5 hash of complete file. If the file has an MD5 hash and this read operation is to read the complete file, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_247
+                    schema: *ref_249
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_248
+                    schema: *ref_250
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_249
+                    schema: *ref_251
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_226
+                    schema: *ref_227
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_250
+                    schema: *ref_252
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_251
+                    schema: *ref_253
                     header: x-ms-resource-type
                     language:
                       default:
                         name: x-ms-resource-type
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_252
+                    schema: *ref_254
                     header: x-ms-properties
                     language:
                       default:
@@ -5365,21 +5546,21 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_253
+                    schema: *ref_255
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: x-ms-lease-duration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_254
+                    schema: *ref_256
                     header: x-ms-lease-state
                     language:
                       default:
                         name: x-ms-lease-state
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_255
+                    schema: *ref_257
                     header: x-ms-lease-status
                     language:
                       default:
@@ -5392,7 +5573,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_256
+            schema: *ref_258
             language: !<!Languages> 
               default:
                 name: ''
@@ -5401,112 +5582,112 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_225
+                    schema: *ref_226
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_239
+                    schema: *ref_241
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_240
+                    schema: *ref_242
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_241
+                    schema: *ref_243
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_242
+                    schema: *ref_244
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_243
+                    schema: *ref_245
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_244
+                    schema: *ref_246
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_245
+                    schema: *ref_247
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_246
+                    schema: *ref_248
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'The MD5 hash of complete file. If the file has an MD5 hash and this read operation is to read the complete file, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_247
+                    schema: *ref_249
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_248
+                    schema: *ref_250
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_249
+                    schema: *ref_251
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_226
+                    schema: *ref_227
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_250
+                    schema: *ref_252
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_251
+                    schema: *ref_253
                     header: x-ms-resource-type
                     language:
                       default:
                         name: x-ms-resource-type
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_252
+                    schema: *ref_254
                     header: x-ms-properties
                     language:
                       default:
@@ -5515,21 +5696,21 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_253
+                    schema: *ref_255
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: x-ms-lease-duration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_254
+                    schema: *ref_256
                     header: x-ms-lease-state
                     language:
                       default:
                         name: x-ms-lease-state
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_255
+                    schema: *ref_257
                     header: x-ms-lease-status
                     language:
                       default:
@@ -5550,63 +5731,63 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_257
+                    schema: *ref_259
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_258
+                    schema: *ref_260
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_259
+                    schema: *ref_261
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_260
+                    schema: *ref_262
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_261
+                    schema: *ref_263
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_262
+                    schema: *ref_264
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_263
+                    schema: *ref_265
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_264
+                    schema: *ref_266
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_265
+                    schema: *ref_267
                     header: Content-MD5
                     language:
                       default:
@@ -5615,7 +5796,7 @@ operationGroups:
                           The MD5 hash of read range. If the request is to read a specified range and the "x-ms-range-get-content-md5" is set to true, then the request returns an MD5 hash for the range, as long as the range size is less
                           than or equal to 4 MB.
                   - !<!HttpHeader> 
-                    schema: *ref_266
+                    schema: *ref_268
                     header: x-ms-content-md5
                     language:
                       default:
@@ -5624,49 +5805,49 @@ operationGroups:
                           The MD5 hash of complete file stored in storage. If the file has a MD5 hash, and if request contains range header (Range or x-ms-range), this response header is returned with the value of the complete file's MD5
                           value. This value may or may not be equal to the value returned in Content-MD5 header, with the latter calculated from the requested range.
                   - !<!HttpHeader> 
-                    schema: *ref_267
+                    schema: *ref_269
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_268
+                    schema: *ref_270
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_269
+                    schema: *ref_271
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_270
+                    schema: *ref_272
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_271
+                    schema: *ref_273
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_272
+                    schema: *ref_274
                     header: x-ms-resource-type
                     language:
                       default:
                         name: x-ms-resource-type
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_273
+                    schema: *ref_275
                     header: x-ms-properties
                     language:
                       default:
@@ -5675,21 +5856,21 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_274
+                    schema: *ref_276
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: x-ms-lease-duration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_275
+                    schema: *ref_277
                     header: x-ms-lease-state
                     language:
                       default:
                         name: x-ms-lease-state
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_276
+                    schema: *ref_278
                     header: x-ms-lease-status
                     language:
                       default:
@@ -5702,7 +5883,7 @@ operationGroups:
                 statusCodes:
                   - '206'
           - !<!SchemaResponse> 
-            schema: *ref_277
+            schema: *ref_279
             language: !<!Languages> 
               default:
                 name: ''
@@ -5711,63 +5892,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_257
+                    schema: *ref_259
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_258
+                    schema: *ref_260
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_259
+                    schema: *ref_261
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_260
+                    schema: *ref_262
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_261
+                    schema: *ref_263
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_262
+                    schema: *ref_264
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_263
+                    schema: *ref_265
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_264
+                    schema: *ref_266
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_265
+                    schema: *ref_267
                     header: Content-MD5
                     language:
                       default:
@@ -5776,7 +5957,7 @@ operationGroups:
                           The MD5 hash of read range. If the request is to read a specified range and the "x-ms-range-get-content-md5" is set to true, then the request returns an MD5 hash for the range, as long as the range size is less
                           than or equal to 4 MB.
                   - !<!HttpHeader> 
-                    schema: *ref_266
+                    schema: *ref_268
                     header: x-ms-content-md5
                     language:
                       default:
@@ -5785,49 +5966,49 @@ operationGroups:
                           The MD5 hash of complete file stored in storage. If the file has a MD5 hash, and if request contains range header (Range or x-ms-range), this response header is returned with the value of the complete file's MD5
                           value. This value may or may not be equal to the value returned in Content-MD5 header, with the latter calculated from the requested range.
                   - !<!HttpHeader> 
-                    schema: *ref_267
+                    schema: *ref_269
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_268
+                    schema: *ref_270
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_269
+                    schema: *ref_271
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_270
+                    schema: *ref_272
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_271
+                    schema: *ref_273
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_272
+                    schema: *ref_274
                     header: x-ms-resource-type
                     language:
                       default:
                         name: x-ms-resource-type
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_273
+                    schema: *ref_275
                     header: x-ms-properties
                     language:
                       default:
@@ -5836,21 +6017,21 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_274
+                    schema: *ref_276
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: x-ms-lease-duration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_275
+                    schema: *ref_277
                     header: x-ms-lease-state
                     language:
                       default:
                         name: x-ms-lease-state
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_276
+                    schema: *ref_278
                     header: x-ms-lease-status
                     language:
                       default:
@@ -5863,7 +6044,7 @@ operationGroups:
                   - '206'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -5872,14 +6053,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -5905,8 +6086,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_281
-            schema: *ref_39
+          - !<!Parameter> &ref_283
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -5917,8 +6098,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_282
-            schema: *ref_101
+          - !<!Parameter> &ref_284
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -5929,8 +6110,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_283
-            schema: *ref_102
+          - !<!Parameter> &ref_285
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -5942,7 +6123,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_284
+          - !<!Parameter> &ref_286
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -5953,8 +6134,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_285
-            schema: *ref_101
+          - !<!Parameter> &ref_287
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5965,8 +6146,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_286
-            schema: *ref_278
+          - !<!Parameter> &ref_288
+            schema: *ref_280
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5978,8 +6159,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_287
-            schema: *ref_85
+          - !<!Parameter> &ref_289
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5992,8 +6173,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_288
-            schema: *ref_279
+          - !<!Parameter> &ref_290
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6003,8 +6184,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_289
-            schema: *ref_280
+          - !<!Parameter> &ref_291
+            schema: *ref_282
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6016,8 +6197,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_290
-            schema: *ref_279
+          - !<!Parameter> &ref_292
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6027,8 +6208,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_291
-            schema: *ref_279
+          - !<!Parameter> &ref_293
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6038,8 +6219,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_292
-            schema: *ref_279
+          - !<!Parameter> &ref_294
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6049,8 +6230,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_293
-            schema: *ref_279
+          - !<!Parameter> &ref_295
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6062,6 +6243,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6072,8 +6268,6 @@ operationGroups:
                 method: head
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_281
-          - *ref_282
           - *ref_283
           - *ref_284
           - *ref_285
@@ -6085,6 +6279,8 @@ operationGroups:
           - *ref_291
           - *ref_292
           - *ref_293
+          - *ref_294
+          - *ref_295
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -6095,63 +6291,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_279
+                    schema: *ref_281
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_294
+                    schema: *ref_296
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_295
+                    schema: *ref_297
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_296
+                    schema: *ref_298
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_297
+                    schema: *ref_299
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_298
+                    schema: *ref_300
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_299
+                    schema: *ref_301
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_300
+                    schema: *ref_302
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_301
+                    schema: *ref_303
                     header: Content-MD5
                     language:
                       default:
@@ -6160,49 +6356,49 @@ operationGroups:
                           The MD5 hash of complete file stored in storage. This header is returned only for "GetProperties" operation. If the Content-MD5 header has been set for the file, this response header is returned for GetProperties
                           call so that the client can check for message content integrity.
                   - !<!HttpHeader> 
-                    schema: *ref_302
+                    schema: *ref_304
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_303
+                    schema: *ref_305
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_304
+                    schema: *ref_306
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_280
+                    schema: *ref_282
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_305
+                    schema: *ref_307
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_306
+                    schema: *ref_308
                     header: x-ms-resource-type
                     language:
                       default:
                         name: x-ms-resource-type
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_307
+                    schema: *ref_309
                     header: x-ms-properties
                     language:
                       default:
@@ -6211,49 +6407,49 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_308
+                    schema: *ref_310
                     header: x-ms-owner
                     language:
                       default:
                         name: x-ms-owner
                         description: The owner of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_309
+                    schema: *ref_311
                     header: x-ms-group
                     language:
                       default:
                         name: x-ms-group
                         description: The owning group of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_310
+                    schema: *ref_312
                     header: x-ms-permissions
                     language:
                       default:
                         name: x-ms-permissions
                         description: 'The POSIX access permissions for the file owner, the file owning group, and others. Included in the response if Hierarchical Namespace is enabled for the account.'
                   - !<!HttpHeader> 
-                    schema: *ref_311
+                    schema: *ref_313
                     header: x-ms-acl
                     language:
                       default:
                         name: x-ms-acl
                         description: The POSIX access control list for the file or directory.  Included in the response only if the action is "getAccessControl" and Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_312
+                    schema: *ref_314
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: x-ms-lease-duration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_313
+                    schema: *ref_315
                     header: x-ms-lease-state
                     language:
                       default:
                         name: x-ms-lease-state
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_314
+                    schema: *ref_316
                     header: x-ms-lease-status
                     language:
                       default:
@@ -6263,7 +6459,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -6272,14 +6468,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -6306,8 +6502,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_317
-            schema: *ref_39
+          - !<!Parameter> &ref_319
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -6318,8 +6514,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_318
-            schema: *ref_101
+          - !<!Parameter> &ref_320
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -6330,8 +6526,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_319
-            schema: *ref_102
+          - !<!Parameter> &ref_321
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -6343,7 +6539,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_320
+          - !<!Parameter> &ref_322
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -6354,8 +6550,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_321
-            schema: *ref_101
+          - !<!Parameter> &ref_323
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6366,8 +6562,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_322
-            schema: *ref_85
+          - !<!Parameter> &ref_324
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6377,8 +6573,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_323
-            schema: *ref_315
+          - !<!Parameter> &ref_325
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6390,8 +6586,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_324
-            schema: *ref_316
+          - !<!Parameter> &ref_326
+            schema: *ref_318
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6401,8 +6597,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_325
-            schema: *ref_315
+          - !<!Parameter> &ref_327
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6412,8 +6608,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_326
-            schema: *ref_315
+          - !<!Parameter> &ref_328
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6423,8 +6619,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_327
-            schema: *ref_315
+          - !<!Parameter> &ref_329
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6434,8 +6630,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_328
-            schema: *ref_315
+          - !<!Parameter> &ref_330
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6447,6 +6643,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6457,8 +6668,6 @@ operationGroups:
                 method: delete
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_317
-          - *ref_318
           - *ref_319
           - *ref_320
           - *ref_321
@@ -6469,6 +6678,8 @@ operationGroups:
           - *ref_326
           - *ref_327
           - *ref_328
+          - *ref_329
+          - *ref_330
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -6479,28 +6690,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_315
+                    schema: *ref_317
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_316
+                    schema: *ref_318
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_329
+                    schema: *ref_331
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_330
+                    schema: *ref_332
                     header: x-ms-continuation
                     language:
                       default:
@@ -6512,7 +6723,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -6521,14 +6732,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:

--- a/modelerfour/test/scenarios/datalake-storage/modeler.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/modeler.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: Azure Data Lake Storage REST API
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_85
+    - !<!BooleanSchema> &ref_86
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -43,19 +43,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_140
-      type: integer
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: ''
-          header: Content-Length
-      protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_142
+    - !<!NumberSchema> &ref_141
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -72,6 +60,18 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: '2019-10-31'
+      precision: 64
+      language: !<!Languages> 
+        default:
+          name: integer
+          description: ''
+          header: Content-Length
+      protocol: !<!Protocols> {}
+    - !<!NumberSchema> &ref_144
+      type: integer
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
       minimum: 0
       precision: 64
       language: !<!Languages> 
@@ -79,7 +79,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_193
+    - !<!NumberSchema> &ref_194
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -90,7 +90,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_243
+    - !<!NumberSchema> &ref_245
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -102,7 +102,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_262
+    - !<!NumberSchema> &ref_264
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -114,7 +114,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_298
+    - !<!NumberSchema> &ref_300
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -157,7 +157,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_29
+    - !<!StringSchema> &ref_30
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -168,7 +168,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_30
+    - !<!StringSchema> &ref_31
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -179,7 +179,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-continuation
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_31
+    - !<!StringSchema> &ref_32
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -220,7 +220,7 @@ schemas: !<!Schemas>
           name: Filesystem-eTag
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_33
+    - !<!StringSchema> &ref_34
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -232,7 +232,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_34
+    - !<!StringSchema> &ref_35
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -263,7 +263,7 @@ schemas: !<!Schemas>
           name: DataLakeStorageError-error-message
           description: The service error message.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_38
+    - !<!StringSchema> &ref_39
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -276,7 +276,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_40
+    - !<!StringSchema> &ref_41
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -288,7 +288,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_41
+    - !<!StringSchema> &ref_42
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -298,17 +298,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_48
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_49
       type: string
@@ -319,7 +308,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_50
       type: string
@@ -330,7 +319,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_51
       type: string
@@ -341,7 +330,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-namespace-enabled
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_52
       type: string
@@ -352,9 +341,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Date
+          header: x-ms-namespace-enabled
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_60
+    - !<!StringSchema> &ref_53
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -363,7 +352,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_61
       type: string
@@ -374,9 +363,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_62
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_63
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -388,7 +388,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_63
+    - !<!StringSchema> &ref_64
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -399,7 +399,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_84
+    - !<!StringSchema> &ref_85
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -410,7 +410,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_95
+    - !<!StringSchema> &ref_96
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -421,7 +421,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_96
+    - !<!StringSchema> &ref_97
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -432,7 +432,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_97
+    - !<!StringSchema> &ref_98
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -444,7 +444,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_98
+    - !<!StringSchema> &ref_99
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -455,7 +455,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_99
+    - !<!StringSchema> &ref_100
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -526,17 +526,6 @@ schemas: !<!Schemas>
           name: Path-permissions
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_68
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_69
       type: string
       apiVersions:
@@ -546,7 +535,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_70
       type: string
@@ -557,9 +546,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_71
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_72
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -570,17 +570,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_72
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_73
       type: string
@@ -591,7 +580,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-properties
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_74
       type: string
@@ -602,7 +591,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-namespace-enabled
+          header: x-ms-properties
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_75
       type: string
@@ -613,9 +602,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-namespace-enabled
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_76
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_82
+    - !<!StringSchema> &ref_83
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -627,18 +627,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_83
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_101
+    - !<!StringSchema> &ref_84
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -654,23 +643,23 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_103
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
       pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
       language: !<!Languages> 
         default:
           name: string
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_136
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_137
       type: string
@@ -681,7 +670,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_138
       type: string
@@ -692,7 +681,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_139
       type: string
@@ -703,9 +692,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_140
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
           header: x-ms-continuation
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_144
+    - !<!StringSchema> &ref_145
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -716,7 +716,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_145
+    - !<!StringSchema> &ref_146
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -727,17 +727,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_176
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_177
       type: string
@@ -748,7 +737,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_178
       type: string
@@ -759,7 +748,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Accept-Ranges
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_179
       type: string
@@ -770,7 +759,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Cache-Control
+          header: Accept-Ranges
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_180
       type: string
@@ -781,7 +770,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Disposition
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_181
       type: string
@@ -792,7 +781,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Encoding
+          header: Content-Disposition
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_182
       type: string
@@ -803,7 +792,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_183
       type: string
@@ -814,7 +803,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Range
+          header: Content-Language
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_184
       type: string
@@ -825,7 +814,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Type
+          header: Content-Range
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_185
       type: string
@@ -836,7 +825,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-MD5
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_186
       type: string
@@ -847,7 +836,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-properties
+          header: Content-MD5
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_187
       type: string
@@ -858,7 +847,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: x-ms-properties
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_188
       type: string
@@ -869,7 +858,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-MD5
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_189
       type: string
@@ -880,9 +869,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Date
+          header: Content-MD5
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_190
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_191
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -894,7 +894,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_191
+    - !<!StringSchema> &ref_192
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -905,7 +905,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_194
+    - !<!StringSchema> &ref_195
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -917,7 +917,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_195
+    - !<!StringSchema> &ref_196
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -927,17 +927,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_210
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_211
       type: string
@@ -948,7 +937,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_212
       type: string
@@ -959,9 +948,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_213
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_214
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -972,17 +972,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-lease-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_214
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_215
       type: string
@@ -993,7 +982,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_216
       type: string
@@ -1004,9 +993,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_217
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_218
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1018,7 +1018,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_218
+    - !<!StringSchema> &ref_219
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1029,7 +1029,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_219
+    - !<!StringSchema> &ref_220
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1041,7 +1041,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-lease-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_220
+    - !<!StringSchema> &ref_221
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1052,7 +1052,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_221
+    - !<!StringSchema> &ref_222
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1063,7 +1063,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_222
+    - !<!StringSchema> &ref_223
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1074,17 +1074,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_223
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_224
       type: string
@@ -1095,7 +1084,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-lease-time
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_225
       type: string
@@ -1106,9 +1095,20 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Accept-Ranges
+          header: x-ms-lease-time
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_226
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Accept-Ranges
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_227
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1119,28 +1119,6 @@ schemas: !<!Schemas>
           name: string
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_239
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Cache-Control
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_240
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Disposition
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_241
       type: string
@@ -1151,7 +1129,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Encoding
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_242
       type: string
@@ -1162,7 +1140,18 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
+          header: Content-Disposition
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_243
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_244
       type: string
@@ -1173,18 +1162,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Range
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_245
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Type
+          header: Content-Language
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_246
       type: string
@@ -1195,7 +1173,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-MD5
+          header: Content-Range
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_247
       type: string
@@ -1206,7 +1184,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Date
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_248
       type: string
@@ -1217,7 +1195,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: ETag
+          header: Content-MD5
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_249
       type: string
@@ -1228,7 +1206,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Last-Modified
+          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_250
       type: string
@@ -1239,7 +1217,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-version
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_251
       type: string
@@ -1250,7 +1228,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-resource-type
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_252
       type: string
@@ -1261,7 +1239,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-properties
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_253
       type: string
@@ -1272,7 +1250,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-lease-duration
+          header: x-ms-resource-type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_254
       type: string
@@ -1283,7 +1261,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-lease-state
+          header: x-ms-properties
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_255
       type: string
@@ -1294,7 +1272,18 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: x-ms-lease-status
+          header: x-ms-lease-duration
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_256
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-state
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_257
       type: string
@@ -1305,18 +1294,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Accept-Ranges
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_258
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Cache-Control
+          header: x-ms-lease-status
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_259
       type: string
@@ -1327,7 +1305,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Disposition
+          header: Accept-Ranges
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_260
       type: string
@@ -1338,7 +1316,7 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Encoding
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_261
       type: string
@@ -1349,209 +1327,9 @@ schemas: !<!Schemas>
         default:
           name: string
           description: ''
-          header: Content-Language
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_263
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Range
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_264
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-Type
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_265
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Content-MD5
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_266
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-content-md5
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_267
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_268
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_269
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Last-Modified
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_270
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_271
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_272
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-resource-type
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_273
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-properties
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_274
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-duration
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_275
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-state
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_276
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-status
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_279
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Accept-Ranges
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_280
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_294
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Cache-Control
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_295
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
           header: Content-Disposition
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_296
+    - !<!StringSchema> &ref_262
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1562,7 +1340,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Encoding
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_297
+    - !<!StringSchema> &ref_263
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1573,7 +1351,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Language
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_299
+    - !<!StringSchema> &ref_265
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1584,7 +1362,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Range
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_300
+    - !<!StringSchema> &ref_266
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1595,7 +1373,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_301
+    - !<!StringSchema> &ref_267
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1606,7 +1384,18 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_302
+    - !<!StringSchema> &ref_268
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-content-md5
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_269
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1617,7 +1406,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_303
+    - !<!StringSchema> &ref_270
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1628,7 +1417,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_304
+    - !<!StringSchema> &ref_271
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1639,128 +1428,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_305
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-version
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_306
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-resource-type
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_307
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-properties
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_308
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-owner
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_309
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-group
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_310
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-permissions
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_311
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-acl
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_312
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-duration
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_313
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-state
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_314
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: x-ms-lease-status
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_315
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: string
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_316
+    - !<!StringSchema> &ref_272
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1772,7 +1440,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_329
+    - !<!StringSchema> &ref_273
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1783,7 +1451,339 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_330
+    - !<!StringSchema> &ref_274
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-resource-type
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_275
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-properties
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_276
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-duration
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_277
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-state
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_278
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-status
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_281
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Accept-Ranges
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_282
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_296
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Cache-Control
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_297
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Disposition
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_298
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Encoding
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_299
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Language
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_301
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Range
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_302
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-Type
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_303
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Content-MD5
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_304
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_305
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: ETag
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_306
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_307
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_308
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-resource-type
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_309
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-properties
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_310
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-owner
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_311
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-group
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_312
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-permissions
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_313
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-acl
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_314
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-duration
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_315
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-state
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_316
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-lease-status
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_317
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_318
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_331
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_332
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1816,7 +1816,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_103
+    - !<!SealedChoiceSchema> &ref_104
       choices:
         - !<!ChoiceValue> 
           value: directory
@@ -1840,7 +1840,7 @@ schemas: !<!Schemas>
           name: PathResourceType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_104
+    - !<!SealedChoiceSchema> &ref_105
       choices:
         - !<!ChoiceValue> 
           value: legacy
@@ -1864,7 +1864,7 @@ schemas: !<!Schemas>
           name: PathRenameMode
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_141
+    - !<!SealedChoiceSchema> &ref_142
       choices:
         - !<!ChoiceValue> 
           value: append
@@ -1900,7 +1900,7 @@ schemas: !<!Schemas>
           name: PathUpdateAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_192
+    - !<!SealedChoiceSchema> &ref_193
       choices:
         - !<!ChoiceValue> 
           value: acquire
@@ -1942,7 +1942,7 @@ schemas: !<!Schemas>
           name: PathLeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_278
+    - !<!SealedChoiceSchema> &ref_280
       choices:
         - !<!ChoiceValue> 
           value: getAccessControl
@@ -1983,7 +1983,17 @@ schemas: !<!Schemas>
           name: AccountResourceType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_39
+    - !<!ConstantSchema> &ref_29
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_40
       type: constant
       value: !<!ConstantValue> 
         value: filesystem
@@ -1993,8 +2003,18 @@ schemas: !<!Schemas>
           name: FilesystemResourceType
           description: ''
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_240
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'application/octet-stream, application/json, text/plain'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/octet-stream, application/json, text/plain'
+      protocol: !<!Protocols> {}
   binaries:
-    - !<!BinarySchema> &ref_173
+    - !<!BinarySchema> &ref_174
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -2004,7 +2024,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_256
+    - !<!BinarySchema> &ref_258
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -2014,7 +2034,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_277
+    - !<!BinarySchema> &ref_279
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -2025,7 +2045,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_32
+    - !<!ObjectSchema> &ref_33
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2099,7 +2119,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_4
-    - !<!ObjectSchema> &ref_35
+    - !<!ObjectSchema> &ref_36
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2155,7 +2175,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_7
-    - !<!ObjectSchema> &ref_100
+    - !<!ObjectSchema> &ref_101
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2273,7 +2293,7 @@ schemas: !<!Schemas>
     - *ref_16
     - *ref_17
 globalParameters:
-  - !<!Parameter> &ref_42
+  - !<!Parameter> &ref_43
     schema: *ref_20
     implementation: Client
     extensions:
@@ -2286,7 +2306,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: header
-  - !<!Parameter> &ref_36
+  - !<!Parameter> &ref_37
     schema: *ref_0
     implementation: Client
     required: true
@@ -2305,7 +2325,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_37
+  - !<!Parameter> &ref_38
     schema: *ref_0
     clientDefaultValue: dfs.core.windows.net
     implementation: Client
@@ -2334,8 +2354,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-10-31'
         parameters:
-          - *ref_36
           - *ref_37
+          - *ref_38
           - !<!Parameter> 
             schema: *ref_19
             implementation: Method
@@ -2418,9 +2438,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_42
+          - *ref_43
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_29
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2439,7 +2474,7 @@ operationGroups:
           - *ref_28
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_32
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -2462,14 +2497,14 @@ operationGroups:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_29
+                    schema: *ref_30
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_30
+                    schema: *ref_31
                     header: x-ms-continuation
                     language:
                       default:
@@ -2478,7 +2513,7 @@ operationGroups:
                           If the number of filesystems to be listed exceeds the maxResults limit, a continuation token is returned in this response header.  When a continuation token is returned in the response, it must be specified in a
                           subsequent invocation of the list operation to continue listing the filesystems.
                   - !<!HttpHeader> 
-                    schema: *ref_31
+                    schema: *ref_32
                     header: Content-Type
                     language:
                       default:
@@ -2491,7 +2526,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -2500,14 +2535,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_33
+                    schema: *ref_34
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_34
+                    schema: *ref_35
                     header: x-ms-version
                     language:
                       default:
@@ -2536,10 +2571,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-10-31'
         parameters:
-          - *ref_36
           - *ref_37
-          - !<!Parameter> &ref_43
-            schema: *ref_38
+          - *ref_38
+          - !<!Parameter> &ref_44
+            schema: *ref_39
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2553,7 +2588,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_39
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2564,8 +2599,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_44
-            schema: *ref_40
+          - !<!Parameter> &ref_45
+            schema: *ref_41
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -2577,7 +2612,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_45
+          - !<!Parameter> &ref_46
             schema: *ref_21
             implementation: Method
             language: !<!Languages> 
@@ -2588,8 +2623,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_46
-            schema: *ref_41
+          - !<!Parameter> &ref_47
+            schema: *ref_42
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2599,9 +2634,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_42
-          - !<!Parameter> &ref_47
-            schema: *ref_41
+          - *ref_43
+          - !<!Parameter> &ref_48
+            schema: *ref_42
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2615,6 +2650,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_29
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2625,11 +2675,11 @@ operationGroups:
                 method: put
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_43
           - *ref_44
           - *ref_45
           - *ref_46
           - *ref_47
+          - *ref_48
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2640,42 +2690,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_41
+                    schema: *ref_42
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_48
+                    schema: *ref_49
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the filesystem.
                   - !<!HttpHeader> 
-                    schema: *ref_49
+                    schema: *ref_50
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the filesystem was last modified.  Operations on files and directories do not affect the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_40
+                    schema: *ref_41
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_50
+                    schema: *ref_51
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_51
+                    schema: *ref_52
                     header: x-ms-namespace-enabled
                     language:
                       default:
@@ -2685,7 +2735,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -2694,14 +2744,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_33
+                    schema: *ref_34
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_34
+                    schema: *ref_35
                     header: x-ms-version
                     language:
                       default:
@@ -2723,10 +2773,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-10-31'
         parameters:
-          - *ref_36
           - *ref_37
-          - !<!Parameter> &ref_53
-            schema: *ref_38
+          - *ref_38
+          - !<!Parameter> &ref_54
+            schema: *ref_39
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2740,7 +2790,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_39
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2751,8 +2801,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_54
-            schema: *ref_40
+          - !<!Parameter> &ref_55
+            schema: *ref_41
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -2764,7 +2814,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_55
+          - !<!Parameter> &ref_56
             schema: *ref_21
             implementation: Method
             language: !<!Languages> 
@@ -2775,8 +2825,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_56
-            schema: *ref_41
+          - !<!Parameter> &ref_57
+            schema: *ref_42
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2786,9 +2836,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_42
-          - !<!Parameter> &ref_57
-            schema: *ref_52
+          - *ref_43
+          - !<!Parameter> &ref_58
+            schema: *ref_53
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2801,8 +2851,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_58
-            schema: *ref_52
+          - !<!Parameter> &ref_59
+            schema: *ref_53
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2812,8 +2862,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_59
-            schema: *ref_52
+          - !<!Parameter> &ref_60
+            schema: *ref_53
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2825,6 +2875,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_29
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2835,13 +2900,13 @@ operationGroups:
                 method: patch
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_53
           - *ref_54
           - *ref_55
           - *ref_56
           - *ref_57
           - *ref_58
           - *ref_59
+          - *ref_60
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2852,35 +2917,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_52
+                    schema: *ref_53
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_60
+                    schema: *ref_61
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'An HTTP entity tag associated with the filesystem.  Changes to filesystem properties affect the entity tag, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_61
+                    schema: *ref_62
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'The data and time the filesystem was last modified.  Changes to filesystem properties update the last modified time, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_62
+                    schema: *ref_63
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_63
+                    schema: *ref_64
                     header: x-ms-version
                     language:
                       default:
@@ -2890,7 +2955,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -2899,14 +2964,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_33
+                    schema: *ref_34
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_34
+                    schema: *ref_35
                     header: x-ms-version
                     language:
                       default:
@@ -2930,10 +2995,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-10-31'
         parameters:
-          - *ref_36
           - *ref_37
-          - !<!Parameter> &ref_64
-            schema: *ref_38
+          - *ref_38
+          - !<!Parameter> &ref_65
+            schema: *ref_39
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2947,7 +3012,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_39
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2958,8 +3023,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_65
-            schema: *ref_40
+          - !<!Parameter> &ref_66
+            schema: *ref_41
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -2971,7 +3036,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_66
+          - !<!Parameter> &ref_67
             schema: *ref_21
             implementation: Method
             language: !<!Languages> 
@@ -2982,8 +3047,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_67
-            schema: *ref_41
+          - !<!Parameter> &ref_68
+            schema: *ref_42
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2993,9 +3058,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_42
+          - *ref_43
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_29
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3006,10 +3086,10 @@ operationGroups:
                 method: head
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_64
           - *ref_65
           - *ref_66
           - *ref_67
+          - *ref_68
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3020,42 +3100,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_68
+                    schema: *ref_69
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_69
+                    schema: *ref_70
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'An HTTP entity tag associated with the filesystem.  Changes to filesystem properties affect the entity tag, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_70
+                    schema: *ref_71
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'The data and time the filesystem was last modified.  Changes to filesystem properties update the last modified time, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_71
+                    schema: *ref_72
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_72
+                    schema: *ref_73
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_73
+                    schema: *ref_74
                     header: x-ms-properties
                     language:
                       default:
@@ -3064,7 +3144,7 @@ operationGroups:
                           The user-defined properties associated with the filesystem.  A comma-separated list of name and value pairs in the format "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the string may
                           only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_74
+                    schema: *ref_75
                     header: x-ms-namespace-enabled
                     language:
                       default:
@@ -3074,7 +3154,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -3083,14 +3163,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_33
+                    schema: *ref_34
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_34
+                    schema: *ref_35
                     header: x-ms-version
                     language:
                       default:
@@ -3112,10 +3192,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-10-31'
         parameters:
-          - *ref_36
           - *ref_37
-          - !<!Parameter> &ref_76
-            schema: *ref_38
+          - *ref_38
+          - !<!Parameter> &ref_77
+            schema: *ref_39
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3129,7 +3209,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_39
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3140,8 +3220,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_77
-            schema: *ref_40
+          - !<!Parameter> &ref_78
+            schema: *ref_41
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -3153,7 +3233,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_78
+          - !<!Parameter> &ref_79
             schema: *ref_21
             implementation: Method
             language: !<!Languages> 
@@ -3164,8 +3244,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_79
-            schema: *ref_41
+          - !<!Parameter> &ref_80
+            schema: *ref_42
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3175,9 +3255,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_42
-          - !<!Parameter> &ref_80
-            schema: *ref_75
+          - *ref_43
+          - !<!Parameter> &ref_81
+            schema: *ref_76
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3187,8 +3267,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_81
-            schema: *ref_75
+          - !<!Parameter> &ref_82
+            schema: *ref_76
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3200,6 +3280,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_29
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3210,12 +3305,12 @@ operationGroups:
                 method: delete
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_76
           - *ref_77
           - *ref_78
           - *ref_79
           - *ref_80
           - *ref_81
+          - *ref_82
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3226,21 +3321,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_82
+                    schema: *ref_83
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_75
+                    schema: *ref_76
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_83
+                    schema: *ref_84
                     header: Date
                     language:
                       default:
@@ -3250,7 +3345,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -3259,14 +3354,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_33
+                    schema: *ref_34
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_34
+                    schema: *ref_35
                     header: x-ms-version
                     language:
                       default:
@@ -3300,10 +3395,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-10-31'
         parameters:
-          - *ref_36
           - *ref_37
-          - !<!Parameter> &ref_86
-            schema: *ref_38
+          - *ref_38
+          - !<!Parameter> &ref_87
+            schema: *ref_39
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3317,7 +3412,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_39
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3328,8 +3423,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_87
-            schema: *ref_40
+          - !<!Parameter> &ref_88
+            schema: *ref_41
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -3341,7 +3436,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_88
+          - !<!Parameter> &ref_89
             schema: *ref_21
             implementation: Method
             language: !<!Languages> 
@@ -3352,8 +3447,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_89
-            schema: *ref_41
+          - !<!Parameter> &ref_90
+            schema: *ref_42
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3363,9 +3458,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_42
-          - !<!Parameter> &ref_90
-            schema: *ref_84
+          - *ref_43
+          - !<!Parameter> &ref_91
+            schema: *ref_85
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3375,8 +3470,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_91
-            schema: *ref_85
+          - !<!Parameter> &ref_92
+            schema: *ref_86
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3387,8 +3482,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_92
-            schema: *ref_84
+          - !<!Parameter> &ref_93
+            schema: *ref_85
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3400,7 +3495,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_93
+          - !<!Parameter> &ref_94
             schema: *ref_21
             implementation: Method
             language: !<!Languages> 
@@ -3411,8 +3506,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_94
-            schema: *ref_85
+          - !<!Parameter> &ref_95
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3427,6 +3522,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_29
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3437,7 +3547,6 @@ operationGroups:
                 method: get
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_86
           - *ref_87
           - *ref_88
           - *ref_89
@@ -3446,9 +3555,10 @@ operationGroups:
           - *ref_92
           - *ref_93
           - *ref_94
+          - *ref_95
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_100
+            schema: *ref_101
             language: !<!Languages> 
               default:
                 name: ''
@@ -3457,42 +3567,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_84
+                    schema: *ref_85
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_95
+                    schema: *ref_96
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'An HTTP entity tag associated with the filesystem.  Changes to filesystem properties affect the entity tag, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_96
+                    schema: *ref_97
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: 'The data and time the filesystem was last modified.  Changes to filesystem properties update the last modified time, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_97
+                    schema: *ref_98
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_98
+                    schema: *ref_99
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_99
+                    schema: *ref_100
                     header: x-ms-continuation
                     language:
                       default:
@@ -3507,7 +3617,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -3516,14 +3626,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_33
+                    schema: *ref_34
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_34
+                    schema: *ref_35
                     header: x-ms-version
                     language:
                       default:
@@ -3552,10 +3662,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-10-31'
         parameters:
-          - *ref_36
           - *ref_37
-          - !<!Parameter> &ref_105
-            schema: *ref_38
+          - *ref_38
+          - !<!Parameter> &ref_106
+            schema: *ref_39
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3566,8 +3676,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_106
-            schema: *ref_101
+          - !<!Parameter> &ref_107
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3578,8 +3688,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_107
-            schema: *ref_102
+          - !<!Parameter> &ref_108
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -3591,7 +3701,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_108
+          - !<!Parameter> &ref_109
             schema: *ref_21
             implementation: Method
             language: !<!Languages> 
@@ -3602,8 +3712,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_109
-            schema: *ref_101
+          - !<!Parameter> &ref_110
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3613,9 +3723,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_42
-          - !<!Parameter> &ref_110
-            schema: *ref_103
+          - *ref_43
+          - !<!Parameter> &ref_111
+            schema: *ref_104
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3625,8 +3735,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_111
-            schema: *ref_101
+          - !<!Parameter> &ref_112
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3638,8 +3748,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_112
-            schema: *ref_104
+          - !<!Parameter> &ref_113
+            schema: *ref_105
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3649,8 +3759,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_113
-            schema: *ref_101
+          - !<!Parameter> &ref_114
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3660,8 +3770,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_114
-            schema: *ref_101
+          - !<!Parameter> &ref_115
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3671,8 +3781,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_115
-            schema: *ref_101
+          - !<!Parameter> &ref_116
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3682,8 +3792,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_116
-            schema: *ref_101
+          - !<!Parameter> &ref_117
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3693,8 +3803,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_117
-            schema: *ref_101
+          - !<!Parameter> &ref_118
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3704,8 +3814,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_118
-            schema: *ref_101
+          - !<!Parameter> &ref_119
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3715,8 +3825,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_119
-            schema: *ref_101
+          - !<!Parameter> &ref_120
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3726,8 +3836,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_120
-            schema: *ref_101
+          - !<!Parameter> &ref_121
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3737,8 +3847,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_121
-            schema: *ref_101
+          - !<!Parameter> &ref_122
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3748,8 +3858,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_122
-            schema: *ref_101
+          - !<!Parameter> &ref_123
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3761,8 +3871,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_123
-            schema: *ref_102
+          - !<!Parameter> &ref_124
+            schema: *ref_103
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3772,8 +3882,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_124
-            schema: *ref_102
+          - !<!Parameter> &ref_125
+            schema: *ref_103
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3783,8 +3893,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_125
-            schema: *ref_101
+          - !<!Parameter> &ref_126
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3796,8 +3906,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_126
-            schema: *ref_101
+          - !<!Parameter> &ref_127
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3809,8 +3919,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_127
-            schema: *ref_101
+          - !<!Parameter> &ref_128
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3823,8 +3933,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_128
-            schema: *ref_101
+          - !<!Parameter> &ref_129
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3834,8 +3944,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_129
-            schema: *ref_101
+          - !<!Parameter> &ref_130
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3845,8 +3955,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_130
-            schema: *ref_101
+          - !<!Parameter> &ref_131
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3856,8 +3966,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_131
-            schema: *ref_101
+          - !<!Parameter> &ref_132
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3867,8 +3977,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_132
-            schema: *ref_101
+          - !<!Parameter> &ref_133
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3878,8 +3988,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_133
-            schema: *ref_101
+          - !<!Parameter> &ref_134
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3889,8 +3999,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_134
-            schema: *ref_101
+          - !<!Parameter> &ref_135
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3900,8 +4010,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_135
-            schema: *ref_101
+          - !<!Parameter> &ref_136
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3913,6 +4023,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_29
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3923,7 +4048,6 @@ operationGroups:
                 method: put
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_105
           - *ref_106
           - *ref_107
           - *ref_108
@@ -3954,6 +4078,7 @@ operationGroups:
           - *ref_133
           - *ref_134
           - *ref_135
+          - *ref_136
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3964,42 +4089,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_101
+                    schema: *ref_102
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_136
+                    schema: *ref_137
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_137
+                    schema: *ref_138
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_102
+                    schema: *ref_103
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_138
+                    schema: *ref_139
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_139
+                    schema: *ref_140
                     header: x-ms-continuation
                     language:
                       default:
@@ -4008,7 +4133,7 @@ operationGroups:
                           When renaming a directory, the number of paths that are renamed with each invocation is limited.  If the number of paths to be renamed exceeds this limit, a continuation token is returned in this response header. 
                           When a continuation token is returned in the response, it must be specified in a subsequent invocation of the rename operation to continue renaming the directory.
                   - !<!HttpHeader> 
-                    schema: *ref_140
+                    schema: *ref_141
                     header: Content-Length
                     language:
                       default:
@@ -4018,7 +4143,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -4027,14 +4152,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_33
+                    schema: *ref_34
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_34
+                    schema: *ref_35
                     header: x-ms-version
                     language:
                       default:
@@ -4059,10 +4184,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-10-31'
         parameters:
-          - *ref_36
           - *ref_37
-          - !<!Parameter> &ref_146
-            schema: *ref_38
+          - *ref_38
+          - !<!Parameter> &ref_147
+            schema: *ref_39
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4073,8 +4198,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_147
-            schema: *ref_101
+          - !<!Parameter> &ref_148
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4085,8 +4210,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_148
-            schema: *ref_102
+          - !<!Parameter> &ref_149
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -4098,7 +4223,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_149
+          - !<!Parameter> &ref_150
             schema: *ref_21
             implementation: Method
             language: !<!Languages> 
@@ -4109,8 +4234,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_150
-            schema: *ref_101
+          - !<!Parameter> &ref_151
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4120,9 +4245,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_42
-          - !<!Parameter> &ref_151
-            schema: *ref_141
+          - *ref_43
+          - !<!Parameter> &ref_152
+            schema: *ref_142
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4136,8 +4261,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_152
-            schema: *ref_142
+          - !<!Parameter> &ref_153
+            schema: *ref_143
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4150,8 +4275,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_153
-            schema: *ref_85
+          - !<!Parameter> &ref_154
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4163,8 +4288,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_154
-            schema: *ref_85
+          - !<!Parameter> &ref_155
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4178,8 +4303,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_155
-            schema: *ref_143
+          - !<!Parameter> &ref_156
+            schema: *ref_144
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4189,8 +4314,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_156
-            schema: *ref_144
+          - !<!Parameter> &ref_157
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4203,8 +4328,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_157
-            schema: *ref_145
+          - !<!Parameter> &ref_158
+            schema: *ref_146
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4214,8 +4339,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_158
-            schema: *ref_144
+          - !<!Parameter> &ref_159
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4225,8 +4350,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_159
-            schema: *ref_144
+          - !<!Parameter> &ref_160
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4236,8 +4361,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_160
-            schema: *ref_144
+          - !<!Parameter> &ref_161
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4247,8 +4372,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_161
-            schema: *ref_144
+          - !<!Parameter> &ref_162
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4258,8 +4383,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_162
-            schema: *ref_144
+          - !<!Parameter> &ref_163
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4269,8 +4394,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_163
-            schema: *ref_144
+          - !<!Parameter> &ref_164
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4282,8 +4407,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_164
-            schema: *ref_144
+          - !<!Parameter> &ref_165
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4297,8 +4422,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_165
-            schema: *ref_144
+          - !<!Parameter> &ref_166
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4308,8 +4433,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_166
-            schema: *ref_144
+          - !<!Parameter> &ref_167
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4319,8 +4444,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_167
-            schema: *ref_144
+          - !<!Parameter> &ref_168
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4332,8 +4457,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_168
-            schema: *ref_144
+          - !<!Parameter> &ref_169
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4351,8 +4476,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_169
-            schema: *ref_144
+          - !<!Parameter> &ref_170
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4364,8 +4489,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_170
-            schema: *ref_144
+          - !<!Parameter> &ref_171
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4377,8 +4502,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_171
-            schema: *ref_144
+          - !<!Parameter> &ref_172
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4388,8 +4513,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_172
-            schema: *ref_144
+          - !<!Parameter> &ref_173
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4402,8 +4527,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_174
-                schema: *ref_173
+              - !<!Parameter> &ref_175
+                schema: *ref_174
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -4414,8 +4539,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_29
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_174
+              - *ref_175
             language: !<!Languages> 
               default:
                 name: ''
@@ -4431,7 +4569,7 @@ operationGroups:
                 uri: 'https://{accountName}.{dnsSuffix}'
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_175
+              - !<!Parameter> &ref_176
                 schema: *ref_0
                 implementation: Method
                 required: true
@@ -4443,8 +4581,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_29
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_175
+              - *ref_176
             language: !<!Languages> 
               default:
                 name: ''
@@ -4459,7 +4610,6 @@ operationGroups:
                   - text/plain
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_146
           - *ref_147
           - *ref_148
           - *ref_149
@@ -4486,6 +4636,7 @@ operationGroups:
           - *ref_170
           - *ref_171
           - *ref_172
+          - *ref_173
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4496,84 +4647,84 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_144
+                    schema: *ref_145
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_176
+                    schema: *ref_177
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_177
+                    schema: *ref_178
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_178
+                    schema: *ref_179
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_179
+                    schema: *ref_180
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_180
+                    schema: *ref_181
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_181
+                    schema: *ref_182
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_182
+                    schema: *ref_183
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_142
+                    schema: *ref_143
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_183
+                    schema: *ref_184
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_184
+                    schema: *ref_185
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_185
+                    schema: *ref_186
                     header: Content-MD5
                     language:
                       default:
@@ -4582,7 +4733,7 @@ operationGroups:
                           An MD5 hash of the request content. This header is only returned for "Flush" operation. This header is returned so that the client can check for message content integrity. This header refers to the content of the
                           request, not actual file content.
                   - !<!HttpHeader> 
-                    schema: *ref_186
+                    schema: *ref_187
                     header: x-ms-properties
                     language:
                       default:
@@ -4591,14 +4742,14 @@ operationGroups:
                           User-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the string
                           may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_145
+                    schema: *ref_146
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_187
+                    schema: *ref_188
                     header: x-ms-version
                     language:
                       default:
@@ -4615,7 +4766,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_188
+                    schema: *ref_189
                     header: Content-MD5
                     language:
                       default:
@@ -4624,21 +4775,21 @@ operationGroups:
                           An MD5 hash of the request content. This header is only returned for "Append" operation. This header is returned so that the client can check for message content integrity. The value of this header is computed by
                           the service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_189
+                    schema: *ref_190
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_190
+                    schema: *ref_191
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_191
+                    schema: *ref_192
                     header: x-ms-version
                     language:
                       default:
@@ -4648,7 +4799,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -4657,14 +4808,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_33
+                    schema: *ref_34
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_34
+                    schema: *ref_35
                     header: x-ms-version
                     language:
                       default:
@@ -4689,10 +4840,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-10-31'
         parameters:
-          - *ref_36
           - *ref_37
-          - !<!Parameter> &ref_196
-            schema: *ref_38
+          - *ref_38
+          - !<!Parameter> &ref_197
+            schema: *ref_39
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4703,8 +4854,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_197
-            schema: *ref_101
+          - !<!Parameter> &ref_198
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4715,8 +4866,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_198
-            schema: *ref_102
+          - !<!Parameter> &ref_199
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -4728,7 +4879,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_199
+          - !<!Parameter> &ref_200
             schema: *ref_21
             implementation: Method
             language: !<!Languages> 
@@ -4739,8 +4890,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_200
-            schema: *ref_101
+          - !<!Parameter> &ref_201
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4750,9 +4901,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_42
-          - !<!Parameter> &ref_201
-            schema: *ref_192
+          - *ref_43
+          - !<!Parameter> &ref_202
+            schema: *ref_193
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4767,8 +4918,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_202
-            schema: *ref_193
+          - !<!Parameter> &ref_203
+            schema: *ref_194
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4778,8 +4929,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_203
-            schema: *ref_193
+          - !<!Parameter> &ref_204
+            schema: *ref_194
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4789,8 +4940,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_204
-            schema: *ref_194
+          - !<!Parameter> &ref_205
+            schema: *ref_195
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4800,8 +4951,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_205
-            schema: *ref_194
+          - !<!Parameter> &ref_206
+            schema: *ref_195
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4811,8 +4962,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_206
-            schema: *ref_195
+          - !<!Parameter> &ref_207
+            schema: *ref_196
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4822,8 +4973,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_207
-            schema: *ref_195
+          - !<!Parameter> &ref_208
+            schema: *ref_196
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4833,8 +4984,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_208
-            schema: *ref_195
+          - !<!Parameter> &ref_209
+            schema: *ref_196
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4844,8 +4995,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_209
-            schema: *ref_195
+          - !<!Parameter> &ref_210
+            schema: *ref_196
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4857,6 +5008,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_29
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4867,7 +5033,6 @@ operationGroups:
                 method: post
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_196
           - *ref_197
           - *ref_198
           - *ref_199
@@ -4881,6 +5046,7 @@ operationGroups:
           - *ref_207
           - *ref_208
           - *ref_209
+          - *ref_210
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4891,42 +5057,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_195
+                    schema: *ref_196
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_210
+                    schema: *ref_211
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file.
                   - !<!HttpHeader> 
-                    schema: *ref_211
+                    schema: *ref_212
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file was last modified.  Write operations on the file update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_194
+                    schema: *ref_195
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_212
+                    schema: *ref_213
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_213
+                    schema: *ref_214
                     header: x-ms-lease-id
                     language:
                       default:
@@ -4943,42 +5109,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_214
+                    schema: *ref_215
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_215
+                    schema: *ref_216
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_216
+                    schema: *ref_217
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_217
+                    schema: *ref_218
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_218
+                    schema: *ref_219
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_219
+                    schema: *ref_220
                     header: x-ms-lease-id
                     language:
                       default:
@@ -4995,35 +5161,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_220
+                    schema: *ref_221
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_221
+                    schema: *ref_222
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_222
+                    schema: *ref_223
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_223
+                    schema: *ref_224
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_224
+                    schema: *ref_225
                     header: x-ms-lease-time
                     language:
                       default:
@@ -5033,7 +5199,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -5042,14 +5208,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_33
+                    schema: *ref_34
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_34
+                    schema: *ref_35
                     header: x-ms-version
                     language:
                       default:
@@ -5073,10 +5239,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-10-31'
         parameters:
-          - *ref_36
           - *ref_37
-          - !<!Parameter> &ref_227
-            schema: *ref_38
+          - *ref_38
+          - !<!Parameter> &ref_228
+            schema: *ref_39
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -5087,8 +5253,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_228
-            schema: *ref_101
+          - !<!Parameter> &ref_229
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -5099,8 +5265,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_229
-            schema: *ref_102
+          - !<!Parameter> &ref_230
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -5112,7 +5278,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_230
+          - !<!Parameter> &ref_231
             schema: *ref_21
             implementation: Method
             language: !<!Languages> 
@@ -5123,8 +5289,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_231
-            schema: *ref_101
+          - !<!Parameter> &ref_232
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5134,9 +5300,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_42
-          - !<!Parameter> &ref_232
-            schema: *ref_225
+          - *ref_43
+          - !<!Parameter> &ref_233
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5146,8 +5312,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_233
-            schema: *ref_226
+          - !<!Parameter> &ref_234
+            schema: *ref_227
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5159,8 +5325,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_234
-            schema: *ref_85
+          - !<!Parameter> &ref_235
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5172,8 +5338,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_235
-            schema: *ref_225
+          - !<!Parameter> &ref_236
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5183,8 +5349,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_236
-            schema: *ref_225
+          - !<!Parameter> &ref_237
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5194,8 +5360,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_237
-            schema: *ref_225
+          - !<!Parameter> &ref_238
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5205,8 +5371,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_238
-            schema: *ref_225
+          - !<!Parameter> &ref_239
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5218,6 +5384,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_240
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5228,7 +5409,6 @@ operationGroups:
                 method: get
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_227
           - *ref_228
           - *ref_229
           - *ref_230
@@ -5240,6 +5420,7 @@ operationGroups:
           - *ref_236
           - *ref_237
           - *ref_238
+          - *ref_239
         responses:
           - !<!BinaryResponse> 
             binary: true
@@ -5251,112 +5432,112 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_225
+                    schema: *ref_226
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_239
+                    schema: *ref_241
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_240
+                    schema: *ref_242
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_241
+                    schema: *ref_243
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_242
+                    schema: *ref_244
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_243
+                    schema: *ref_245
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_244
+                    schema: *ref_246
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_245
+                    schema: *ref_247
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_246
+                    schema: *ref_248
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'The MD5 hash of complete file. If the file has an MD5 hash and this read operation is to read the complete file, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_247
+                    schema: *ref_249
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_248
+                    schema: *ref_250
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_249
+                    schema: *ref_251
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_226
+                    schema: *ref_227
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_250
+                    schema: *ref_252
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_251
+                    schema: *ref_253
                     header: x-ms-resource-type
                     language:
                       default:
                         name: x-ms-resource-type
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_252
+                    schema: *ref_254
                     header: x-ms-properties
                     language:
                       default:
@@ -5365,21 +5546,21 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_253
+                    schema: *ref_255
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: x-ms-lease-duration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_254
+                    schema: *ref_256
                     header: x-ms-lease-state
                     language:
                       default:
                         name: x-ms-lease-state
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_255
+                    schema: *ref_257
                     header: x-ms-lease-status
                     language:
                       default:
@@ -5392,7 +5573,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_256
+            schema: *ref_258
             language: !<!Languages> 
               default:
                 name: ''
@@ -5401,112 +5582,112 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_225
+                    schema: *ref_226
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_239
+                    schema: *ref_241
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_240
+                    schema: *ref_242
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_241
+                    schema: *ref_243
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_242
+                    schema: *ref_244
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_243
+                    schema: *ref_245
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_244
+                    schema: *ref_246
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_245
+                    schema: *ref_247
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_246
+                    schema: *ref_248
                     header: Content-MD5
                     language:
                       default:
                         name: Content-MD5
                         description: 'The MD5 hash of complete file. If the file has an MD5 hash and this read operation is to read the complete file, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_247
+                    schema: *ref_249
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_248
+                    schema: *ref_250
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_249
+                    schema: *ref_251
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_226
+                    schema: *ref_227
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_250
+                    schema: *ref_252
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_251
+                    schema: *ref_253
                     header: x-ms-resource-type
                     language:
                       default:
                         name: x-ms-resource-type
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_252
+                    schema: *ref_254
                     header: x-ms-properties
                     language:
                       default:
@@ -5515,21 +5696,21 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_253
+                    schema: *ref_255
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: x-ms-lease-duration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_254
+                    schema: *ref_256
                     header: x-ms-lease-state
                     language:
                       default:
                         name: x-ms-lease-state
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_255
+                    schema: *ref_257
                     header: x-ms-lease-status
                     language:
                       default:
@@ -5550,63 +5731,63 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_257
+                    schema: *ref_259
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_258
+                    schema: *ref_260
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_259
+                    schema: *ref_261
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_260
+                    schema: *ref_262
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_261
+                    schema: *ref_263
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_262
+                    schema: *ref_264
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_263
+                    schema: *ref_265
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_264
+                    schema: *ref_266
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_265
+                    schema: *ref_267
                     header: Content-MD5
                     language:
                       default:
@@ -5615,7 +5796,7 @@ operationGroups:
                           The MD5 hash of read range. If the request is to read a specified range and the "x-ms-range-get-content-md5" is set to true, then the request returns an MD5 hash for the range, as long as the range size is less
                           than or equal to 4 MB.
                   - !<!HttpHeader> 
-                    schema: *ref_266
+                    schema: *ref_268
                     header: x-ms-content-md5
                     language:
                       default:
@@ -5624,49 +5805,49 @@ operationGroups:
                           The MD5 hash of complete file stored in storage. If the file has a MD5 hash, and if request contains range header (Range or x-ms-range), this response header is returned with the value of the complete file's MD5
                           value. This value may or may not be equal to the value returned in Content-MD5 header, with the latter calculated from the requested range.
                   - !<!HttpHeader> 
-                    schema: *ref_267
+                    schema: *ref_269
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_268
+                    schema: *ref_270
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_269
+                    schema: *ref_271
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_270
+                    schema: *ref_272
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_271
+                    schema: *ref_273
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_272
+                    schema: *ref_274
                     header: x-ms-resource-type
                     language:
                       default:
                         name: x-ms-resource-type
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_273
+                    schema: *ref_275
                     header: x-ms-properties
                     language:
                       default:
@@ -5675,21 +5856,21 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_274
+                    schema: *ref_276
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: x-ms-lease-duration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_275
+                    schema: *ref_277
                     header: x-ms-lease-state
                     language:
                       default:
                         name: x-ms-lease-state
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_276
+                    schema: *ref_278
                     header: x-ms-lease-status
                     language:
                       default:
@@ -5702,7 +5883,7 @@ operationGroups:
                 statusCodes:
                   - '206'
           - !<!SchemaResponse> 
-            schema: *ref_277
+            schema: *ref_279
             language: !<!Languages> 
               default:
                 name: ''
@@ -5711,63 +5892,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_257
+                    schema: *ref_259
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_258
+                    schema: *ref_260
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_259
+                    schema: *ref_261
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_260
+                    schema: *ref_262
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_261
+                    schema: *ref_263
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_262
+                    schema: *ref_264
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_263
+                    schema: *ref_265
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_264
+                    schema: *ref_266
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_265
+                    schema: *ref_267
                     header: Content-MD5
                     language:
                       default:
@@ -5776,7 +5957,7 @@ operationGroups:
                           The MD5 hash of read range. If the request is to read a specified range and the "x-ms-range-get-content-md5" is set to true, then the request returns an MD5 hash for the range, as long as the range size is less
                           than or equal to 4 MB.
                   - !<!HttpHeader> 
-                    schema: *ref_266
+                    schema: *ref_268
                     header: x-ms-content-md5
                     language:
                       default:
@@ -5785,49 +5966,49 @@ operationGroups:
                           The MD5 hash of complete file stored in storage. If the file has a MD5 hash, and if request contains range header (Range or x-ms-range), this response header is returned with the value of the complete file's MD5
                           value. This value may or may not be equal to the value returned in Content-MD5 header, with the latter calculated from the requested range.
                   - !<!HttpHeader> 
-                    schema: *ref_267
+                    schema: *ref_269
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_268
+                    schema: *ref_270
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_269
+                    schema: *ref_271
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_270
+                    schema: *ref_272
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_271
+                    schema: *ref_273
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_272
+                    schema: *ref_274
                     header: x-ms-resource-type
                     language:
                       default:
                         name: x-ms-resource-type
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_273
+                    schema: *ref_275
                     header: x-ms-properties
                     language:
                       default:
@@ -5836,21 +6017,21 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_274
+                    schema: *ref_276
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: x-ms-lease-duration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_275
+                    schema: *ref_277
                     header: x-ms-lease-state
                     language:
                       default:
                         name: x-ms-lease-state
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_276
+                    schema: *ref_278
                     header: x-ms-lease-status
                     language:
                       default:
@@ -5863,7 +6044,7 @@ operationGroups:
                   - '206'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -5872,14 +6053,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_33
+                    schema: *ref_34
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_34
+                    schema: *ref_35
                     header: x-ms-version
                     language:
                       default:
@@ -5903,10 +6084,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-10-31'
         parameters:
-          - *ref_36
           - *ref_37
-          - !<!Parameter> &ref_281
-            schema: *ref_38
+          - *ref_38
+          - !<!Parameter> &ref_283
+            schema: *ref_39
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -5917,8 +6098,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_282
-            schema: *ref_101
+          - !<!Parameter> &ref_284
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -5929,8 +6110,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_283
-            schema: *ref_102
+          - !<!Parameter> &ref_285
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -5942,7 +6123,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_284
+          - !<!Parameter> &ref_286
             schema: *ref_21
             implementation: Method
             language: !<!Languages> 
@@ -5953,8 +6134,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_285
-            schema: *ref_101
+          - !<!Parameter> &ref_287
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5964,9 +6145,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_42
-          - !<!Parameter> &ref_286
-            schema: *ref_278
+          - *ref_43
+          - !<!Parameter> &ref_288
+            schema: *ref_280
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5978,8 +6159,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_287
-            schema: *ref_85
+          - !<!Parameter> &ref_289
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5992,8 +6173,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_288
-            schema: *ref_279
+          - !<!Parameter> &ref_290
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6003,8 +6184,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_289
-            schema: *ref_280
+          - !<!Parameter> &ref_291
+            schema: *ref_282
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6016,8 +6197,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_290
-            schema: *ref_279
+          - !<!Parameter> &ref_292
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6027,8 +6208,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_291
-            schema: *ref_279
+          - !<!Parameter> &ref_293
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6038,8 +6219,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_292
-            schema: *ref_279
+          - !<!Parameter> &ref_294
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6049,8 +6230,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_293
-            schema: *ref_279
+          - !<!Parameter> &ref_295
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6062,6 +6243,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_29
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6072,8 +6268,6 @@ operationGroups:
                 method: head
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_281
-          - *ref_282
           - *ref_283
           - *ref_284
           - *ref_285
@@ -6085,6 +6279,8 @@ operationGroups:
           - *ref_291
           - *ref_292
           - *ref_293
+          - *ref_294
+          - *ref_295
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -6095,63 +6291,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_279
+                    schema: *ref_281
                     header: Accept-Ranges
                     language:
                       default:
                         name: Accept-Ranges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_294
+                    schema: *ref_296
                     header: Cache-Control
                     language:
                       default:
                         name: Cache-Control
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_295
+                    schema: *ref_297
                     header: Content-Disposition
                     language:
                       default:
                         name: Content-Disposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_296
+                    schema: *ref_298
                     header: Content-Encoding
                     language:
                       default:
                         name: Content-Encoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_297
+                    schema: *ref_299
                     header: Content-Language
                     language:
                       default:
                         name: Content-Language
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_298
+                    schema: *ref_300
                     header: Content-Length
                     language:
                       default:
                         name: Content-Length
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_299
+                    schema: *ref_301
                     header: Content-Range
                     language:
                       default:
                         name: Content-Range
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_300
+                    schema: *ref_302
                     header: Content-Type
                     language:
                       default:
                         name: Content-Type
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_301
+                    schema: *ref_303
                     header: Content-MD5
                     language:
                       default:
@@ -6160,49 +6356,49 @@ operationGroups:
                           The MD5 hash of complete file stored in storage. This header is returned only for "GetProperties" operation. If the Content-MD5 header has been set for the file, this response header is returned for GetProperties
                           call so that the client can check for message content integrity.
                   - !<!HttpHeader> 
-                    schema: *ref_302
+                    schema: *ref_304
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_303
+                    schema: *ref_305
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_304
+                    schema: *ref_306
                     header: Last-Modified
                     language:
                       default:
                         name: Last-Modified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_280
+                    schema: *ref_282
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_305
+                    schema: *ref_307
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_306
+                    schema: *ref_308
                     header: x-ms-resource-type
                     language:
                       default:
                         name: x-ms-resource-type
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_307
+                    schema: *ref_309
                     header: x-ms-properties
                     language:
                       default:
@@ -6211,49 +6407,49 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_308
+                    schema: *ref_310
                     header: x-ms-owner
                     language:
                       default:
                         name: x-ms-owner
                         description: The owner of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_309
+                    schema: *ref_311
                     header: x-ms-group
                     language:
                       default:
                         name: x-ms-group
                         description: The owning group of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_310
+                    schema: *ref_312
                     header: x-ms-permissions
                     language:
                       default:
                         name: x-ms-permissions
                         description: 'The POSIX access permissions for the file owner, the file owning group, and others. Included in the response if Hierarchical Namespace is enabled for the account.'
                   - !<!HttpHeader> 
-                    schema: *ref_311
+                    schema: *ref_313
                     header: x-ms-acl
                     language:
                       default:
                         name: x-ms-acl
                         description: The POSIX access control list for the file or directory.  Included in the response only if the action is "getAccessControl" and Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_312
+                    schema: *ref_314
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: x-ms-lease-duration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_313
+                    schema: *ref_315
                     header: x-ms-lease-state
                     language:
                       default:
                         name: x-ms-lease-state
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_314
+                    schema: *ref_316
                     header: x-ms-lease-status
                     language:
                       default:
@@ -6263,7 +6459,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -6272,14 +6468,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_33
+                    schema: *ref_34
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_34
+                    schema: *ref_35
                     header: x-ms-version
                     language:
                       default:
@@ -6304,10 +6500,10 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2019-10-31'
         parameters:
-          - *ref_36
           - *ref_37
-          - !<!Parameter> &ref_317
-            schema: *ref_38
+          - *ref_38
+          - !<!Parameter> &ref_319
+            schema: *ref_39
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -6318,8 +6514,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_318
-            schema: *ref_101
+          - !<!Parameter> &ref_320
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -6330,8 +6526,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_319
-            schema: *ref_102
+          - !<!Parameter> &ref_321
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -6343,7 +6539,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_320
+          - !<!Parameter> &ref_322
             schema: *ref_21
             implementation: Method
             language: !<!Languages> 
@@ -6354,8 +6550,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_321
-            schema: *ref_101
+          - !<!Parameter> &ref_323
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6365,9 +6561,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_42
-          - !<!Parameter> &ref_322
-            schema: *ref_85
+          - *ref_43
+          - !<!Parameter> &ref_324
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6377,8 +6573,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_323
-            schema: *ref_315
+          - !<!Parameter> &ref_325
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6390,8 +6586,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_324
-            schema: *ref_316
+          - !<!Parameter> &ref_326
+            schema: *ref_318
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6401,8 +6597,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_325
-            schema: *ref_315
+          - !<!Parameter> &ref_327
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6412,8 +6608,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_326
-            schema: *ref_315
+          - !<!Parameter> &ref_328
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6423,8 +6619,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_327
-            schema: *ref_315
+          - !<!Parameter> &ref_329
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6434,8 +6630,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_328
-            schema: *ref_315
+          - !<!Parameter> &ref_330
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6447,6 +6643,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_29
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6457,8 +6668,6 @@ operationGroups:
                 method: delete
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_317
-          - *ref_318
           - *ref_319
           - *ref_320
           - *ref_321
@@ -6469,6 +6678,8 @@ operationGroups:
           - *ref_326
           - *ref_327
           - *ref_328
+          - *ref_329
+          - *ref_330
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -6479,28 +6690,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_315
+                    schema: *ref_317
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_316
+                    schema: *ref_318
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_329
+                    schema: *ref_331
                     header: x-ms-version
                     language:
                       default:
                         name: x-ms-version
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_330
+                    schema: *ref_332
                     header: x-ms-continuation
                     language:
                       default:
@@ -6512,7 +6723,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -6521,14 +6732,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_33
+                    schema: *ref_34
                     header: x-ms-request-id
                     language:
                       default:
                         name: x-ms-request-id
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_34
+                    schema: *ref_35
                     header: x-ms-version
                     language:
                       default:

--- a/modelerfour/test/scenarios/datalake-storage/namer.yaml
+++ b/modelerfour/test/scenarios/datalake-storage/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: Azure Data Lake Storage REST API
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_85
+    - !<!BooleanSchema> &ref_86
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -43,19 +43,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_140
-      type: integer
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      precision: 64
-      language: !<!Languages> 
-        default:
-          name: Integer
-          description: ''
-          header: Content-Length
-      protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_142
+    - !<!NumberSchema> &ref_141
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -72,6 +60,18 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: '2019-10-31'
+      precision: 64
+      language: !<!Languages> 
+        default:
+          name: Integer
+          description: ''
+          header: Content-Length
+      protocol: !<!Protocols> {}
+    - !<!NumberSchema> &ref_144
+      type: integer
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
       minimum: 0
       precision: 64
       language: !<!Languages> 
@@ -79,7 +79,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_193
+    - !<!NumberSchema> &ref_194
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -90,7 +90,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_243
+    - !<!NumberSchema> &ref_245
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -102,7 +102,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_262
+    - !<!NumberSchema> &ref_264
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -114,7 +114,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Length
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_298
+    - !<!NumberSchema> &ref_300
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -157,7 +157,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_33
+    - !<!StringSchema> &ref_34
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -168,7 +168,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_34
+    - !<!StringSchema> &ref_35
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -179,7 +179,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-continuation
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_35
+    - !<!StringSchema> &ref_36
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -220,7 +220,7 @@ schemas: !<!Schemas>
           name: FilesystemETag
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_37
+    - !<!StringSchema> &ref_38
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -232,7 +232,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_38
+    - !<!StringSchema> &ref_39
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -263,7 +263,7 @@ schemas: !<!Schemas>
           name: DataLakeStorageErrorMessage
           description: The service error message.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_39
+    - !<!StringSchema> &ref_40
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -276,7 +276,7 @@ schemas: !<!Schemas>
           name: String
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_41
+    - !<!StringSchema> &ref_42
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -288,7 +288,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_42
+    - !<!StringSchema> &ref_43
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -298,17 +298,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_48
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_49
       type: string
@@ -319,7 +308,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_50
       type: string
@@ -330,7 +319,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_51
       type: string
@@ -341,7 +330,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-namespace-enabled
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_52
       type: string
@@ -352,9 +341,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Date
+          header: x-ms-namespace-enabled
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_60
+    - !<!StringSchema> &ref_53
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -363,7 +352,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: ETag
+          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_61
       type: string
@@ -374,9 +363,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_62
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_63
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -388,7 +388,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_63
+    - !<!StringSchema> &ref_64
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -399,7 +399,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_84
+    - !<!StringSchema> &ref_85
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -410,7 +410,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_96
+    - !<!StringSchema> &ref_97
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -421,7 +421,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_97
+    - !<!StringSchema> &ref_98
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -432,7 +432,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_98
+    - !<!StringSchema> &ref_99
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -444,7 +444,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_99
+    - !<!StringSchema> &ref_100
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -455,7 +455,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_100
+    - !<!StringSchema> &ref_101
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -526,17 +526,6 @@ schemas: !<!Schemas>
           name: PathPermissions
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_68
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_69
       type: string
       apiVersions:
@@ -546,7 +535,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: ETag
+          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_70
       type: string
@@ -557,9 +546,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_71
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_72
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -570,17 +570,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_72
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_73
       type: string
@@ -591,7 +580,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-properties
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_74
       type: string
@@ -602,7 +591,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-namespace-enabled
+          header: x-ms-properties
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_75
       type: string
@@ -613,9 +602,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-namespace-enabled
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_76
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_82
+    - !<!StringSchema> &ref_83
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -627,18 +627,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_83
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_101
+    - !<!StringSchema> &ref_84
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -654,23 +643,23 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_103
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
       pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
       language: !<!Languages> 
         default:
           name: String
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_136
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_137
       type: string
@@ -681,7 +670,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_138
       type: string
@@ -692,7 +681,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_139
       type: string
@@ -703,9 +692,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_140
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
           header: x-ms-continuation
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_144
+    - !<!StringSchema> &ref_145
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -716,7 +716,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_145
+    - !<!StringSchema> &ref_146
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -727,17 +727,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_176
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_177
       type: string
@@ -748,7 +737,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_178
       type: string
@@ -759,7 +748,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Accept-Ranges
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_179
       type: string
@@ -770,7 +759,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Cache-Control
+          header: Accept-Ranges
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_180
       type: string
@@ -781,7 +770,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Disposition
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_181
       type: string
@@ -792,7 +781,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Encoding
+          header: Content-Disposition
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_182
       type: string
@@ -803,7 +792,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Language
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_183
       type: string
@@ -814,7 +803,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Range
+          header: Content-Language
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_184
       type: string
@@ -825,7 +814,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Type
+          header: Content-Range
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_185
       type: string
@@ -836,7 +825,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-MD5
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_186
       type: string
@@ -847,7 +836,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-properties
+          header: Content-MD5
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_187
       type: string
@@ -858,7 +847,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: x-ms-properties
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_188
       type: string
@@ -869,7 +858,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-MD5
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_189
       type: string
@@ -880,9 +869,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Date
+          header: Content-MD5
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_190
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_191
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -894,7 +894,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_191
+    - !<!StringSchema> &ref_192
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -905,7 +905,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_194
+    - !<!StringSchema> &ref_195
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -917,7 +917,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_195
+    - !<!StringSchema> &ref_196
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -927,17 +927,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_210
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_211
       type: string
@@ -948,7 +937,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_212
       type: string
@@ -959,9 +948,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_213
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_214
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -972,17 +972,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: x-ms-lease-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_214
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_215
       type: string
@@ -993,7 +982,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: ETag
+          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_216
       type: string
@@ -1004,9 +993,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Last-Modified
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_217
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_218
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1018,7 +1018,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_218
+    - !<!StringSchema> &ref_219
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1029,7 +1029,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_219
+    - !<!StringSchema> &ref_220
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1041,7 +1041,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-lease-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_220
+    - !<!StringSchema> &ref_221
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1052,7 +1052,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_221
+    - !<!StringSchema> &ref_222
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1063,7 +1063,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_222
+    - !<!StringSchema> &ref_223
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1074,17 +1074,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_223
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_224
       type: string
@@ -1095,7 +1084,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-lease-time
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_225
       type: string
@@ -1106,9 +1095,20 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Accept-Ranges
+          header: x-ms-lease-time
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_226
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Accept-Ranges
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_227
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1119,28 +1119,6 @@ schemas: !<!Schemas>
           name: String
           description: ''
           header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_239
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Cache-Control
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_240
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Content-Disposition
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_241
       type: string
@@ -1151,7 +1129,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Encoding
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_242
       type: string
@@ -1162,7 +1140,18 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Language
+          header: Content-Disposition
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_243
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Content-Encoding
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_244
       type: string
@@ -1173,18 +1162,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Range
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_245
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Content-Type
+          header: Content-Language
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_246
       type: string
@@ -1195,7 +1173,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-MD5
+          header: Content-Range
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_247
       type: string
@@ -1206,7 +1184,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Date
+          header: Content-Type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_248
       type: string
@@ -1217,7 +1195,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: ETag
+          header: Content-MD5
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_249
       type: string
@@ -1228,7 +1206,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Last-Modified
+          header: Date
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_250
       type: string
@@ -1239,7 +1217,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-version
+          header: ETag
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_251
       type: string
@@ -1250,7 +1228,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-resource-type
+          header: Last-Modified
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_252
       type: string
@@ -1261,7 +1239,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-properties
+          header: x-ms-version
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_253
       type: string
@@ -1272,7 +1250,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-lease-duration
+          header: x-ms-resource-type
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_254
       type: string
@@ -1283,7 +1261,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-lease-state
+          header: x-ms-properties
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_255
       type: string
@@ -1294,7 +1272,18 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: x-ms-lease-status
+          header: x-ms-lease-duration
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_256
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-lease-state
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_257
       type: string
@@ -1305,18 +1294,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Accept-Ranges
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_258
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Cache-Control
+          header: x-ms-lease-status
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_259
       type: string
@@ -1327,7 +1305,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Disposition
+          header: Accept-Ranges
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_260
       type: string
@@ -1338,7 +1316,7 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Encoding
+          header: Cache-Control
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_261
       type: string
@@ -1349,209 +1327,9 @@ schemas: !<!Schemas>
         default:
           name: String
           description: ''
-          header: Content-Language
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_263
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Content-Range
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_264
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Content-Type
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_265
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Content-MD5
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_266
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-content-md5
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_267
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_268
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: ETag
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_269
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Last-Modified
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_270
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_271
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-version
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_272
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-resource-type
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_273
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-properties
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_274
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-lease-duration
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_275
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-lease-state
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_276
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-lease-status
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_279
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Accept-Ranges
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_280
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-request-id
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_294
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Cache-Control
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_295
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
           header: Content-Disposition
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_296
+    - !<!StringSchema> &ref_262
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1562,7 +1340,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Encoding
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_297
+    - !<!StringSchema> &ref_263
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1573,7 +1351,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Language
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_299
+    - !<!StringSchema> &ref_265
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1584,7 +1362,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Range
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_300
+    - !<!StringSchema> &ref_266
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1595,7 +1373,7 @@ schemas: !<!Schemas>
           description: ''
           header: Content-Type
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_301
+    - !<!StringSchema> &ref_267
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1606,7 +1384,18 @@ schemas: !<!Schemas>
           description: ''
           header: Content-MD5
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_302
+    - !<!StringSchema> &ref_268
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-content-md5
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_269
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1617,7 +1406,7 @@ schemas: !<!Schemas>
           description: ''
           header: Date
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_303
+    - !<!StringSchema> &ref_270
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1628,7 +1417,7 @@ schemas: !<!Schemas>
           description: ''
           header: ETag
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_304
+    - !<!StringSchema> &ref_271
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1639,128 +1428,7 @@ schemas: !<!Schemas>
           description: ''
           header: Last-Modified
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_305
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-version
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_306
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-resource-type
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_307
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-properties
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_308
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-owner
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_309
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-group
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_310
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-permissions
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_311
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-acl
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_312
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-lease-duration
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_313
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-lease-state
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_314
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: x-ms-lease-status
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_315
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: '2019-10-31'
-      language: !<!Languages> 
-        default:
-          name: String
-          description: ''
-          header: Date
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_316
+    - !<!StringSchema> &ref_272
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1772,7 +1440,7 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-request-id
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_329
+    - !<!StringSchema> &ref_273
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1783,7 +1451,339 @@ schemas: !<!Schemas>
           description: ''
           header: x-ms-version
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_330
+    - !<!StringSchema> &ref_274
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-resource-type
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_275
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-properties
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_276
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-lease-duration
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_277
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-lease-state
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_278
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-lease-status
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_281
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Accept-Ranges
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_282
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_296
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Cache-Control
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_297
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Content-Disposition
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_298
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Content-Encoding
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_299
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Content-Language
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_301
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Content-Range
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_302
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Content-Type
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_303
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Content-MD5
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_304
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_305
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: ETag
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_306
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Last-Modified
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_307
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_308
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-resource-type
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_309
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-properties
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_310
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-owner
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_311
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-group
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_312
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-permissions
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_313
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-acl
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_314
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-lease-duration
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_315
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-lease-state
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_316
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-lease-status
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_317
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: Date
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_318
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      pattern: '^[{(]?[0-9a-f]{8}[-]?([0-9a-f]{4}[-]?){3}[0-9a-f]{12}[)}]?$'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-request-id
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_331
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: '2019-10-31'
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+          header: x-ms-version
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_332
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1816,7 +1816,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_103
+    - !<!SealedChoiceSchema> &ref_104
       choices:
         - !<!ChoiceValue> 
           value: directory
@@ -1840,7 +1840,7 @@ schemas: !<!Schemas>
           name: PathResourceType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_104
+    - !<!SealedChoiceSchema> &ref_105
       choices:
         - !<!ChoiceValue> 
           value: legacy
@@ -1864,7 +1864,7 @@ schemas: !<!Schemas>
           name: PathRenameMode
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_141
+    - !<!SealedChoiceSchema> &ref_142
       choices:
         - !<!ChoiceValue> 
           value: append
@@ -1900,7 +1900,7 @@ schemas: !<!Schemas>
           name: PathUpdateAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_192
+    - !<!SealedChoiceSchema> &ref_193
       choices:
         - !<!ChoiceValue> 
           value: acquire
@@ -1942,7 +1942,7 @@ schemas: !<!Schemas>
           name: PathLeaseAction
           description: ''
       protocol: !<!Protocols> {}
-    - !<!SealedChoiceSchema> &ref_278
+    - !<!SealedChoiceSchema> &ref_280
       choices:
         - !<!ChoiceValue> 
           value: getAccessControl
@@ -1983,7 +1983,17 @@ schemas: !<!Schemas>
           name: AccountResourceType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_40
+    - !<!ConstantSchema> &ref_26
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_41
       type: constant
       value: !<!ConstantValue> 
         value: filesystem
@@ -1993,8 +2003,18 @@ schemas: !<!Schemas>
           name: FilesystemResourceType
           description: ''
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_228
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'application/octet-stream, application/json, text/plain'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/octet-stream, application/json, text/plain'
+      protocol: !<!Protocols> {}
   binaries:
-    - !<!BinarySchema> &ref_146
+    - !<!BinarySchema> &ref_147
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -2004,7 +2024,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_256
+    - !<!BinarySchema> &ref_258
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -2014,7 +2034,7 @@ schemas: !<!Schemas>
           name: binary
           description: ''
       protocol: !<!Protocols> {}
-    - !<!BinarySchema> &ref_277
+    - !<!BinarySchema> &ref_279
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -2025,7 +2045,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_32
+    - !<!ObjectSchema> &ref_33
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2099,7 +2119,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_4
-    - !<!ObjectSchema> &ref_36
+    - !<!ObjectSchema> &ref_37
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2155,7 +2175,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_7
-    - !<!ObjectSchema> &ref_95
+    - !<!ObjectSchema> &ref_96
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2348,7 +2368,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_26
+          - !<!Parameter> &ref_27
             schema: *ref_19
             implementation: Method
             language: !<!Languages> 
@@ -2359,7 +2379,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_27
+          - !<!Parameter> &ref_28
             schema: *ref_19
             implementation: Method
             language: !<!Languages> 
@@ -2372,7 +2392,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -2383,7 +2403,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_29
+          - !<!Parameter> &ref_30
             schema: *ref_24
             implementation: Method
             extensions:
@@ -2396,7 +2416,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_30
+          - !<!Parameter> &ref_31
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -2407,7 +2427,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_31
+          - !<!Parameter> &ref_32
             schema: *ref_19
             implementation: Method
             language: !<!Languages> 
@@ -2421,6 +2441,21 @@ operationGroups:
           - *ref_25
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2431,15 +2466,15 @@ operationGroups:
                 method: get
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_26
           - *ref_27
           - *ref_28
           - *ref_29
           - *ref_30
           - *ref_31
+          - *ref_32
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_32
+            schema: *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -2462,14 +2497,14 @@ operationGroups:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_33
+                    schema: *ref_34
                     header: x-ms-version
                     language:
                       default:
                         name: XMsVersion
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_34
+                    schema: *ref_35
                     header: x-ms-continuation
                     language:
                       default:
@@ -2478,7 +2513,7 @@ operationGroups:
                           If the number of filesystems to be listed exceeds the maxResults limit, a continuation token is returned in this response header.  When a continuation token is returned in the response, it must be specified in a
                           subsequent invocation of the list operation to continue listing the filesystems.
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Content-Type
                     language:
                       default:
@@ -2491,7 +2526,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -2500,14 +2535,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -2538,8 +2573,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_43
-            schema: *ref_39
+          - !<!Parameter> &ref_44
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2553,7 +2588,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_40
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2564,8 +2599,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_44
-            schema: *ref_41
+          - !<!Parameter> &ref_45
+            schema: *ref_42
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -2577,7 +2612,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_45
+          - !<!Parameter> &ref_46
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -2588,8 +2623,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_46
-            schema: *ref_42
+          - !<!Parameter> &ref_47
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2600,8 +2635,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_47
-            schema: *ref_42
+          - !<!Parameter> &ref_48
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2615,6 +2650,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2625,11 +2675,11 @@ operationGroups:
                 method: put
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_43
           - *ref_44
           - *ref_45
           - *ref_46
           - *ref_47
+          - *ref_48
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2640,42 +2690,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_42
+                    schema: *ref_43
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_48
+                    schema: *ref_49
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the filesystem.
                   - !<!HttpHeader> 
-                    schema: *ref_49
+                    schema: *ref_50
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the filesystem was last modified.  Operations on files and directories do not affect the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_41
+                    schema: *ref_42
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_50
+                    schema: *ref_51
                     header: x-ms-version
                     language:
                       default:
                         name: XMsVersion
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_51
+                    schema: *ref_52
                     header: x-ms-namespace-enabled
                     language:
                       default:
@@ -2685,7 +2735,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -2694,14 +2744,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -2725,8 +2775,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_53
-            schema: *ref_39
+          - !<!Parameter> &ref_54
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2740,7 +2790,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_40
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2751,8 +2801,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_54
-            schema: *ref_41
+          - !<!Parameter> &ref_55
+            schema: *ref_42
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -2764,7 +2814,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_55
+          - !<!Parameter> &ref_56
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -2775,8 +2825,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_56
-            schema: *ref_42
+          - !<!Parameter> &ref_57
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2787,8 +2837,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_57
-            schema: *ref_52
+          - !<!Parameter> &ref_58
+            schema: *ref_53
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2801,8 +2851,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_58
-            schema: *ref_52
+          - !<!Parameter> &ref_59
+            schema: *ref_53
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2812,8 +2862,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_59
-            schema: *ref_52
+          - !<!Parameter> &ref_60
+            schema: *ref_53
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2825,6 +2875,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2835,13 +2900,13 @@ operationGroups:
                 method: patch
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_53
           - *ref_54
           - *ref_55
           - *ref_56
           - *ref_57
           - *ref_58
           - *ref_59
+          - *ref_60
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2852,35 +2917,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_52
+                    schema: *ref_53
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_60
+                    schema: *ref_61
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'An HTTP entity tag associated with the filesystem.  Changes to filesystem properties affect the entity tag, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_61
+                    schema: *ref_62
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'The data and time the filesystem was last modified.  Changes to filesystem properties update the last modified time, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_62
+                    schema: *ref_63
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_63
+                    schema: *ref_64
                     header: x-ms-version
                     language:
                       default:
@@ -2890,7 +2955,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -2899,14 +2964,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -2932,8 +2997,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_64
-            schema: *ref_39
+          - !<!Parameter> &ref_65
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2947,7 +3012,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_40
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2958,8 +3023,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_65
-            schema: *ref_41
+          - !<!Parameter> &ref_66
+            schema: *ref_42
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -2971,7 +3036,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_66
+          - !<!Parameter> &ref_67
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -2982,8 +3047,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_67
-            schema: *ref_42
+          - !<!Parameter> &ref_68
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2996,6 +3061,21 @@ operationGroups:
           - *ref_25
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3006,10 +3086,10 @@ operationGroups:
                 method: head
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_64
           - *ref_65
           - *ref_66
           - *ref_67
+          - *ref_68
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3020,42 +3100,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_68
+                    schema: *ref_69
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_69
+                    schema: *ref_70
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'An HTTP entity tag associated with the filesystem.  Changes to filesystem properties affect the entity tag, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_70
+                    schema: *ref_71
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'The data and time the filesystem was last modified.  Changes to filesystem properties update the last modified time, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_71
+                    schema: *ref_72
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_72
+                    schema: *ref_73
                     header: x-ms-version
                     language:
                       default:
                         name: XMsVersion
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_73
+                    schema: *ref_74
                     header: x-ms-properties
                     language:
                       default:
@@ -3064,7 +3144,7 @@ operationGroups:
                           The user-defined properties associated with the filesystem.  A comma-separated list of name and value pairs in the format "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the string may
                           only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_74
+                    schema: *ref_75
                     header: x-ms-namespace-enabled
                     language:
                       default:
@@ -3074,7 +3154,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -3083,14 +3163,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -3114,8 +3194,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_76
-            schema: *ref_39
+          - !<!Parameter> &ref_77
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3129,7 +3209,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_40
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3140,8 +3220,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_77
-            schema: *ref_41
+          - !<!Parameter> &ref_78
+            schema: *ref_42
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -3153,7 +3233,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_78
+          - !<!Parameter> &ref_79
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -3164,8 +3244,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_79
-            schema: *ref_42
+          - !<!Parameter> &ref_80
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3176,8 +3256,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_80
-            schema: *ref_75
+          - !<!Parameter> &ref_81
+            schema: *ref_76
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3187,8 +3267,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_81
-            schema: *ref_75
+          - !<!Parameter> &ref_82
+            schema: *ref_76
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3200,6 +3280,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3210,12 +3305,12 @@ operationGroups:
                 method: delete
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_76
           - *ref_77
           - *ref_78
           - *ref_79
           - *ref_80
           - *ref_81
+          - *ref_82
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3226,21 +3321,21 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_82
+                    schema: *ref_83
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_75
+                    schema: *ref_76
                     header: x-ms-version
                     language:
                       default:
                         name: XMsVersion
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_83
+                    schema: *ref_84
                     header: Date
                     language:
                       default:
@@ -3250,7 +3345,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -3259,14 +3354,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -3302,8 +3397,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_86
-            schema: *ref_39
+          - !<!Parameter> &ref_87
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3317,7 +3412,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: path
           - !<!Parameter> 
-            schema: *ref_40
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3328,8 +3423,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_87
-            schema: *ref_41
+          - !<!Parameter> &ref_88
+            schema: *ref_42
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -3341,7 +3436,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_88
+          - !<!Parameter> &ref_89
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -3352,8 +3447,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_89
-            schema: *ref_42
+          - !<!Parameter> &ref_90
+            schema: *ref_43
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3364,8 +3459,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_90
-            schema: *ref_84
+          - !<!Parameter> &ref_91
+            schema: *ref_85
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3375,8 +3470,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_91
-            schema: *ref_85
+          - !<!Parameter> &ref_92
+            schema: *ref_86
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3387,8 +3482,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_92
-            schema: *ref_84
+          - !<!Parameter> &ref_93
+            schema: *ref_85
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3400,7 +3495,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_93
+          - !<!Parameter> &ref_94
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -3411,8 +3506,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_94
-            schema: *ref_85
+          - !<!Parameter> &ref_95
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3427,6 +3522,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3437,7 +3547,6 @@ operationGroups:
                 method: get
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_86
           - *ref_87
           - *ref_88
           - *ref_89
@@ -3446,9 +3555,10 @@ operationGroups:
           - *ref_92
           - *ref_93
           - *ref_94
+          - *ref_95
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_95
+            schema: *ref_96
             language: !<!Languages> 
               default:
                 name: ''
@@ -3457,42 +3567,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_84
+                    schema: *ref_85
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_96
+                    schema: *ref_97
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: 'An HTTP entity tag associated with the filesystem.  Changes to filesystem properties affect the entity tag, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_97
+                    schema: *ref_98
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: 'The data and time the filesystem was last modified.  Changes to filesystem properties update the last modified time, but operations on files and directories do not.'
                   - !<!HttpHeader> 
-                    schema: *ref_98
+                    schema: *ref_99
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_99
+                    schema: *ref_100
                     header: x-ms-version
                     language:
                       default:
                         name: XMsVersion
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_100
+                    schema: *ref_101
                     header: x-ms-continuation
                     language:
                       default:
@@ -3507,7 +3617,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -3516,14 +3626,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -3554,8 +3664,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_105
-            schema: *ref_39
+          - !<!Parameter> &ref_106
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3566,8 +3676,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_106
-            schema: *ref_101
+          - !<!Parameter> &ref_107
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3578,8 +3688,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_107
-            schema: *ref_102
+          - !<!Parameter> &ref_108
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -3591,7 +3701,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_108
+          - !<!Parameter> &ref_109
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -3602,8 +3712,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_109
-            schema: *ref_101
+          - !<!Parameter> &ref_110
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3614,8 +3724,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_110
-            schema: *ref_103
+          - !<!Parameter> &ref_111
+            schema: *ref_104
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3625,8 +3735,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_111
-            schema: *ref_101
+          - !<!Parameter> &ref_112
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3638,8 +3748,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_112
-            schema: *ref_104
+          - !<!Parameter> &ref_113
+            schema: *ref_105
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3649,8 +3759,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_113
-            schema: *ref_101
+          - !<!Parameter> &ref_114
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3660,8 +3770,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_114
-            schema: *ref_101
+          - !<!Parameter> &ref_115
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3671,8 +3781,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_115
-            schema: *ref_101
+          - !<!Parameter> &ref_116
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3682,8 +3792,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_116
-            schema: *ref_101
+          - !<!Parameter> &ref_117
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3693,8 +3803,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_117
-            schema: *ref_101
+          - !<!Parameter> &ref_118
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3704,8 +3814,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_118
-            schema: *ref_101
+          - !<!Parameter> &ref_119
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3715,8 +3825,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_119
-            schema: *ref_101
+          - !<!Parameter> &ref_120
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3726,8 +3836,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_120
-            schema: *ref_101
+          - !<!Parameter> &ref_121
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3737,8 +3847,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_121
-            schema: *ref_101
+          - !<!Parameter> &ref_122
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3748,8 +3858,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_122
-            schema: *ref_101
+          - !<!Parameter> &ref_123
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3761,8 +3871,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_123
-            schema: *ref_102
+          - !<!Parameter> &ref_124
+            schema: *ref_103
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3772,8 +3882,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_124
-            schema: *ref_102
+          - !<!Parameter> &ref_125
+            schema: *ref_103
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3783,8 +3893,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_125
-            schema: *ref_101
+          - !<!Parameter> &ref_126
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3796,8 +3906,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_126
-            schema: *ref_101
+          - !<!Parameter> &ref_127
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3809,8 +3919,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_127
-            schema: *ref_101
+          - !<!Parameter> &ref_128
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3823,8 +3933,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_128
-            schema: *ref_101
+          - !<!Parameter> &ref_129
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3834,8 +3944,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_129
-            schema: *ref_101
+          - !<!Parameter> &ref_130
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3845,8 +3955,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_130
-            schema: *ref_101
+          - !<!Parameter> &ref_131
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3856,8 +3966,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_131
-            schema: *ref_101
+          - !<!Parameter> &ref_132
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3867,8 +3977,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_132
-            schema: *ref_101
+          - !<!Parameter> &ref_133
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3878,8 +3988,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_133
-            schema: *ref_101
+          - !<!Parameter> &ref_134
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3889,8 +3999,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_134
-            schema: *ref_101
+          - !<!Parameter> &ref_135
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3900,8 +4010,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_135
-            schema: *ref_101
+          - !<!Parameter> &ref_136
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3913,6 +4023,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3923,7 +4048,6 @@ operationGroups:
                 method: put
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_105
           - *ref_106
           - *ref_107
           - *ref_108
@@ -3954,6 +4078,7 @@ operationGroups:
           - *ref_133
           - *ref_134
           - *ref_135
+          - *ref_136
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3964,42 +4089,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_101
+                    schema: *ref_102
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_136
+                    schema: *ref_137
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_137
+                    schema: *ref_138
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_102
+                    schema: *ref_103
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_138
+                    schema: *ref_139
                     header: x-ms-version
                     language:
                       default:
                         name: XMsVersion
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_139
+                    schema: *ref_140
                     header: x-ms-continuation
                     language:
                       default:
@@ -4008,7 +4133,7 @@ operationGroups:
                           When renaming a directory, the number of paths that are renamed with each invocation is limited.  If the number of paths to be renamed exceeds this limit, a continuation token is returned in this response header. 
                           When a continuation token is returned in the response, it must be specified in a subsequent invocation of the rename operation to continue renaming the directory.
                   - !<!HttpHeader> 
-                    schema: *ref_140
+                    schema: *ref_141
                     header: Content-Length
                     language:
                       default:
@@ -4018,7 +4143,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -4027,14 +4152,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -4061,8 +4186,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_149
-            schema: *ref_39
+          - !<!Parameter> &ref_150
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4073,8 +4198,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_150
-            schema: *ref_101
+          - !<!Parameter> &ref_151
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4085,8 +4210,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_151
-            schema: *ref_102
+          - !<!Parameter> &ref_152
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -4098,7 +4223,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_152
+          - !<!Parameter> &ref_153
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -4109,8 +4234,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_153
-            schema: *ref_101
+          - !<!Parameter> &ref_154
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4121,8 +4246,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_154
-            schema: *ref_141
+          - !<!Parameter> &ref_155
+            schema: *ref_142
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4136,8 +4261,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_155
-            schema: *ref_142
+          - !<!Parameter> &ref_156
+            schema: *ref_143
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4150,8 +4275,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_156
-            schema: *ref_85
+          - !<!Parameter> &ref_157
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4163,8 +4288,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_157
-            schema: *ref_85
+          - !<!Parameter> &ref_158
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4178,8 +4303,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_158
-            schema: *ref_143
+          - !<!Parameter> &ref_159
+            schema: *ref_144
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4189,8 +4314,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_159
-            schema: *ref_144
+          - !<!Parameter> &ref_160
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4203,8 +4328,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_160
-            schema: *ref_145
+          - !<!Parameter> &ref_161
+            schema: *ref_146
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4214,8 +4339,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_161
-            schema: *ref_144
+          - !<!Parameter> &ref_162
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4225,8 +4350,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_162
-            schema: *ref_144
+          - !<!Parameter> &ref_163
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4236,8 +4361,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_163
-            schema: *ref_144
+          - !<!Parameter> &ref_164
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4247,8 +4372,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_164
-            schema: *ref_144
+          - !<!Parameter> &ref_165
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4258,8 +4383,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_165
-            schema: *ref_144
+          - !<!Parameter> &ref_166
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4269,8 +4394,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_166
-            schema: *ref_144
+          - !<!Parameter> &ref_167
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4282,8 +4407,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_167
-            schema: *ref_144
+          - !<!Parameter> &ref_168
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4297,8 +4422,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_168
-            schema: *ref_144
+          - !<!Parameter> &ref_169
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4308,8 +4433,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_169
-            schema: *ref_144
+          - !<!Parameter> &ref_170
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4319,8 +4444,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_170
-            schema: *ref_144
+          - !<!Parameter> &ref_171
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4332,8 +4457,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_171
-            schema: *ref_144
+          - !<!Parameter> &ref_172
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4351,8 +4476,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_172
-            schema: *ref_144
+          - !<!Parameter> &ref_173
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4364,8 +4489,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_173
-            schema: *ref_144
+          - !<!Parameter> &ref_174
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4377,8 +4502,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_174
-            schema: *ref_144
+          - !<!Parameter> &ref_175
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4388,8 +4513,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_175
-            schema: *ref_144
+          - !<!Parameter> &ref_176
+            schema: *ref_145
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4402,8 +4527,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_147
-                schema: *ref_146
+              - !<!Parameter> &ref_148
+                schema: *ref_147
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -4414,8 +4539,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_147
+              - *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -4431,7 +4569,7 @@ operationGroups:
                 uri: 'https://{accountName}.{dnsSuffix}'
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_148
+              - !<!Parameter> &ref_149
                 schema: *ref_0
                 implementation: Method
                 required: true
@@ -4443,8 +4581,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_148
+              - *ref_149
             language: !<!Languages> 
               default:
                 name: ''
@@ -4459,7 +4610,6 @@ operationGroups:
                   - text/plain
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_149
           - *ref_150
           - *ref_151
           - *ref_152
@@ -4486,6 +4636,7 @@ operationGroups:
           - *ref_173
           - *ref_174
           - *ref_175
+          - *ref_176
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4496,84 +4647,84 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_144
+                    schema: *ref_145
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_176
+                    schema: *ref_177
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_177
+                    schema: *ref_178
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_178
+                    schema: *ref_179
                     header: Accept-Ranges
                     language:
                       default:
                         name: AcceptRanges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_179
+                    schema: *ref_180
                     header: Cache-Control
                     language:
                       default:
                         name: CacheControl
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_180
+                    schema: *ref_181
                     header: Content-Disposition
                     language:
                       default:
                         name: ContentDisposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_181
+                    schema: *ref_182
                     header: Content-Encoding
                     language:
                       default:
                         name: ContentEncoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_182
+                    schema: *ref_183
                     header: Content-Language
                     language:
                       default:
                         name: ContentLanguage
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_142
+                    schema: *ref_143
                     header: Content-Length
                     language:
                       default:
                         name: ContentLength
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_183
+                    schema: *ref_184
                     header: Content-Range
                     language:
                       default:
                         name: ContentRange
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_184
+                    schema: *ref_185
                     header: Content-Type
                     language:
                       default:
                         name: ContentType
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_185
+                    schema: *ref_186
                     header: Content-MD5
                     language:
                       default:
@@ -4582,7 +4733,7 @@ operationGroups:
                           An MD5 hash of the request content. This header is only returned for "Flush" operation. This header is returned so that the client can check for message content integrity. This header refers to the content of the
                           request, not actual file content.
                   - !<!HttpHeader> 
-                    schema: *ref_186
+                    schema: *ref_187
                     header: x-ms-properties
                     language:
                       default:
@@ -4591,14 +4742,14 @@ operationGroups:
                           User-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the string
                           may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_145
+                    schema: *ref_146
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_187
+                    schema: *ref_188
                     header: x-ms-version
                     language:
                       default:
@@ -4615,7 +4766,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_188
+                    schema: *ref_189
                     header: Content-MD5
                     language:
                       default:
@@ -4624,21 +4775,21 @@ operationGroups:
                           An MD5 hash of the request content. This header is only returned for "Append" operation. This header is returned so that the client can check for message content integrity. The value of this header is computed by
                           the service; it is not necessarily the same value specified in the request headers.
                   - !<!HttpHeader> 
-                    schema: *ref_189
+                    schema: *ref_190
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_190
+                    schema: *ref_191
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_191
+                    schema: *ref_192
                     header: x-ms-version
                     language:
                       default:
@@ -4648,7 +4799,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -4657,14 +4808,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -4691,8 +4842,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_196
-            schema: *ref_39
+          - !<!Parameter> &ref_197
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4703,8 +4854,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_197
-            schema: *ref_101
+          - !<!Parameter> &ref_198
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4715,8 +4866,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_198
-            schema: *ref_102
+          - !<!Parameter> &ref_199
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -4728,7 +4879,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_199
+          - !<!Parameter> &ref_200
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -4739,8 +4890,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_200
-            schema: *ref_101
+          - !<!Parameter> &ref_201
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4751,8 +4902,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_201
-            schema: *ref_192
+          - !<!Parameter> &ref_202
+            schema: *ref_193
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4767,8 +4918,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_202
-            schema: *ref_193
+          - !<!Parameter> &ref_203
+            schema: *ref_194
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4778,8 +4929,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_203
-            schema: *ref_193
+          - !<!Parameter> &ref_204
+            schema: *ref_194
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4789,8 +4940,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_204
-            schema: *ref_194
+          - !<!Parameter> &ref_205
+            schema: *ref_195
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4800,8 +4951,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_205
-            schema: *ref_194
+          - !<!Parameter> &ref_206
+            schema: *ref_195
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4811,8 +4962,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_206
-            schema: *ref_195
+          - !<!Parameter> &ref_207
+            schema: *ref_196
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4822,8 +4973,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_207
-            schema: *ref_195
+          - !<!Parameter> &ref_208
+            schema: *ref_196
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4833,8 +4984,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_208
-            schema: *ref_195
+          - !<!Parameter> &ref_209
+            schema: *ref_196
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4844,8 +4995,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_209
-            schema: *ref_195
+          - !<!Parameter> &ref_210
+            schema: *ref_196
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4857,6 +5008,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4867,7 +5033,6 @@ operationGroups:
                 method: post
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_196
           - *ref_197
           - *ref_198
           - *ref_199
@@ -4881,6 +5046,7 @@ operationGroups:
           - *ref_207
           - *ref_208
           - *ref_209
+          - *ref_210
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4891,42 +5057,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_195
+                    schema: *ref_196
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_210
+                    schema: *ref_211
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file.
                   - !<!HttpHeader> 
-                    schema: *ref_211
+                    schema: *ref_212
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the file was last modified.  Write operations on the file update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_194
+                    schema: *ref_195
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_212
+                    schema: *ref_213
                     header: x-ms-version
                     language:
                       default:
                         name: XMsVersion
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_213
+                    schema: *ref_214
                     header: x-ms-lease-id
                     language:
                       default:
@@ -4943,42 +5109,42 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_214
+                    schema: *ref_215
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_215
+                    schema: *ref_216
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_216
+                    schema: *ref_217
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_217
+                    schema: *ref_218
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_218
+                    schema: *ref_219
                     header: x-ms-version
                     language:
                       default:
                         name: XMsVersion
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_219
+                    schema: *ref_220
                     header: x-ms-lease-id
                     language:
                       default:
@@ -4995,35 +5161,35 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_220
+                    schema: *ref_221
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_221
+                    schema: *ref_222
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_222
+                    schema: *ref_223
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_223
+                    schema: *ref_224
                     header: x-ms-version
                     language:
                       default:
                         name: XMsVersion
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_224
+                    schema: *ref_225
                     header: x-ms-lease-time
                     language:
                       default:
@@ -5033,7 +5199,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -5042,14 +5208,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -5075,8 +5241,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_227
-            schema: *ref_39
+          - !<!Parameter> &ref_229
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -5087,8 +5253,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_228
-            schema: *ref_101
+          - !<!Parameter> &ref_230
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -5099,8 +5265,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_229
-            schema: *ref_102
+          - !<!Parameter> &ref_231
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -5112,7 +5278,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_230
+          - !<!Parameter> &ref_232
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -5123,8 +5289,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_231
-            schema: *ref_101
+          - !<!Parameter> &ref_233
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5135,8 +5301,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_232
-            schema: *ref_225
+          - !<!Parameter> &ref_234
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5146,8 +5312,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_233
-            schema: *ref_226
+          - !<!Parameter> &ref_235
+            schema: *ref_227
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5159,8 +5325,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_234
-            schema: *ref_85
+          - !<!Parameter> &ref_236
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5172,8 +5338,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_235
-            schema: *ref_225
+          - !<!Parameter> &ref_237
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5183,8 +5349,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_236
-            schema: *ref_225
+          - !<!Parameter> &ref_238
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5194,8 +5360,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_237
-            schema: *ref_225
+          - !<!Parameter> &ref_239
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5205,8 +5371,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_238
-            schema: *ref_225
+          - !<!Parameter> &ref_240
+            schema: *ref_226
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5218,6 +5384,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_228
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5228,8 +5409,6 @@ operationGroups:
                 method: get
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_227
-          - *ref_228
           - *ref_229
           - *ref_230
           - *ref_231
@@ -5240,6 +5419,8 @@ operationGroups:
           - *ref_236
           - *ref_237
           - *ref_238
+          - *ref_239
+          - *ref_240
         responses:
           - !<!BinaryResponse> 
             binary: true
@@ -5251,112 +5432,112 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_225
+                    schema: *ref_226
                     header: Accept-Ranges
                     language:
                       default:
                         name: AcceptRanges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_239
+                    schema: *ref_241
                     header: Cache-Control
                     language:
                       default:
                         name: CacheControl
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_240
+                    schema: *ref_242
                     header: Content-Disposition
                     language:
                       default:
                         name: ContentDisposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_241
+                    schema: *ref_243
                     header: Content-Encoding
                     language:
                       default:
                         name: ContentEncoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_242
+                    schema: *ref_244
                     header: Content-Language
                     language:
                       default:
                         name: ContentLanguage
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_243
+                    schema: *ref_245
                     header: Content-Length
                     language:
                       default:
                         name: ContentLength
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_244
+                    schema: *ref_246
                     header: Content-Range
                     language:
                       default:
                         name: ContentRange
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_245
+                    schema: *ref_247
                     header: Content-Type
                     language:
                       default:
                         name: ContentType
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_246
+                    schema: *ref_248
                     header: Content-MD5
                     language:
                       default:
                         name: ContentMD5
                         description: 'The MD5 hash of complete file. If the file has an MD5 hash and this read operation is to read the complete file, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_247
+                    schema: *ref_249
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_248
+                    schema: *ref_250
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_249
+                    schema: *ref_251
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_226
+                    schema: *ref_227
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_250
+                    schema: *ref_252
                     header: x-ms-version
                     language:
                       default:
                         name: XMsVersion
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_251
+                    schema: *ref_253
                     header: x-ms-resource-type
                     language:
                       default:
                         name: XMsResourceType
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_252
+                    schema: *ref_254
                     header: x-ms-properties
                     language:
                       default:
@@ -5365,21 +5546,21 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_253
+                    schema: *ref_255
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: XMsLeaseDuration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_254
+                    schema: *ref_256
                     header: x-ms-lease-state
                     language:
                       default:
                         name: XMsLeaseState
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_255
+                    schema: *ref_257
                     header: x-ms-lease-status
                     language:
                       default:
@@ -5392,7 +5573,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_256
+            schema: *ref_258
             language: !<!Languages> 
               default:
                 name: ''
@@ -5401,112 +5582,112 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_225
+                    schema: *ref_226
                     header: Accept-Ranges
                     language:
                       default:
                         name: AcceptRanges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_239
+                    schema: *ref_241
                     header: Cache-Control
                     language:
                       default:
                         name: CacheControl
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_240
+                    schema: *ref_242
                     header: Content-Disposition
                     language:
                       default:
                         name: ContentDisposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_241
+                    schema: *ref_243
                     header: Content-Encoding
                     language:
                       default:
                         name: ContentEncoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_242
+                    schema: *ref_244
                     header: Content-Language
                     language:
                       default:
                         name: ContentLanguage
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_243
+                    schema: *ref_245
                     header: Content-Length
                     language:
                       default:
                         name: ContentLength
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_244
+                    schema: *ref_246
                     header: Content-Range
                     language:
                       default:
                         name: ContentRange
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_245
+                    schema: *ref_247
                     header: Content-Type
                     language:
                       default:
                         name: ContentType
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_246
+                    schema: *ref_248
                     header: Content-MD5
                     language:
                       default:
                         name: ContentMD5
                         description: 'The MD5 hash of complete file. If the file has an MD5 hash and this read operation is to read the complete file, this response header is returned so that the client can check for message content integrity.'
                   - !<!HttpHeader> 
-                    schema: *ref_247
+                    schema: *ref_249
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_248
+                    schema: *ref_250
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_249
+                    schema: *ref_251
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_226
+                    schema: *ref_227
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_250
+                    schema: *ref_252
                     header: x-ms-version
                     language:
                       default:
                         name: XMsVersion
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_251
+                    schema: *ref_253
                     header: x-ms-resource-type
                     language:
                       default:
                         name: XMsResourceType
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_252
+                    schema: *ref_254
                     header: x-ms-properties
                     language:
                       default:
@@ -5515,21 +5696,21 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_253
+                    schema: *ref_255
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: XMsLeaseDuration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_254
+                    schema: *ref_256
                     header: x-ms-lease-state
                     language:
                       default:
                         name: XMsLeaseState
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_255
+                    schema: *ref_257
                     header: x-ms-lease-status
                     language:
                       default:
@@ -5550,63 +5731,63 @@ operationGroups:
               http: !<!HttpBinaryResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_257
+                    schema: *ref_259
                     header: Accept-Ranges
                     language:
                       default:
                         name: AcceptRanges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_258
+                    schema: *ref_260
                     header: Cache-Control
                     language:
                       default:
                         name: CacheControl
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_259
+                    schema: *ref_261
                     header: Content-Disposition
                     language:
                       default:
                         name: ContentDisposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_260
+                    schema: *ref_262
                     header: Content-Encoding
                     language:
                       default:
                         name: ContentEncoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_261
+                    schema: *ref_263
                     header: Content-Language
                     language:
                       default:
                         name: ContentLanguage
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_262
+                    schema: *ref_264
                     header: Content-Length
                     language:
                       default:
                         name: ContentLength
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_263
+                    schema: *ref_265
                     header: Content-Range
                     language:
                       default:
                         name: ContentRange
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_264
+                    schema: *ref_266
                     header: Content-Type
                     language:
                       default:
                         name: ContentType
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_265
+                    schema: *ref_267
                     header: Content-MD5
                     language:
                       default:
@@ -5615,7 +5796,7 @@ operationGroups:
                           The MD5 hash of read range. If the request is to read a specified range and the "x-ms-range-get-content-md5" is set to true, then the request returns an MD5 hash for the range, as long as the range size is less
                           than or equal to 4 MB.
                   - !<!HttpHeader> 
-                    schema: *ref_266
+                    schema: *ref_268
                     header: x-ms-content-md5
                     language:
                       default:
@@ -5624,49 +5805,49 @@ operationGroups:
                           The MD5 hash of complete file stored in storage. If the file has a MD5 hash, and if request contains range header (Range or x-ms-range), this response header is returned with the value of the complete file's MD5
                           value. This value may or may not be equal to the value returned in Content-MD5 header, with the latter calculated from the requested range.
                   - !<!HttpHeader> 
-                    schema: *ref_267
+                    schema: *ref_269
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_268
+                    schema: *ref_270
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_269
+                    schema: *ref_271
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_270
+                    schema: *ref_272
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_271
+                    schema: *ref_273
                     header: x-ms-version
                     language:
                       default:
                         name: XMsVersion
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_272
+                    schema: *ref_274
                     header: x-ms-resource-type
                     language:
                       default:
                         name: XMsResourceType
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_273
+                    schema: *ref_275
                     header: x-ms-properties
                     language:
                       default:
@@ -5675,21 +5856,21 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_274
+                    schema: *ref_276
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: XMsLeaseDuration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_275
+                    schema: *ref_277
                     header: x-ms-lease-state
                     language:
                       default:
                         name: XMsLeaseState
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_276
+                    schema: *ref_278
                     header: x-ms-lease-status
                     language:
                       default:
@@ -5702,7 +5883,7 @@ operationGroups:
                 statusCodes:
                   - '206'
           - !<!SchemaResponse> 
-            schema: *ref_277
+            schema: *ref_279
             language: !<!Languages> 
               default:
                 name: ''
@@ -5711,63 +5892,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_257
+                    schema: *ref_259
                     header: Accept-Ranges
                     language:
                       default:
                         name: AcceptRanges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_258
+                    schema: *ref_260
                     header: Cache-Control
                     language:
                       default:
                         name: CacheControl
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_259
+                    schema: *ref_261
                     header: Content-Disposition
                     language:
                       default:
                         name: ContentDisposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_260
+                    schema: *ref_262
                     header: Content-Encoding
                     language:
                       default:
                         name: ContentEncoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_261
+                    schema: *ref_263
                     header: Content-Language
                     language:
                       default:
                         name: ContentLanguage
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_262
+                    schema: *ref_264
                     header: Content-Length
                     language:
                       default:
                         name: ContentLength
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_263
+                    schema: *ref_265
                     header: Content-Range
                     language:
                       default:
                         name: ContentRange
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_264
+                    schema: *ref_266
                     header: Content-Type
                     language:
                       default:
                         name: ContentType
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_265
+                    schema: *ref_267
                     header: Content-MD5
                     language:
                       default:
@@ -5776,7 +5957,7 @@ operationGroups:
                           The MD5 hash of read range. If the request is to read a specified range and the "x-ms-range-get-content-md5" is set to true, then the request returns an MD5 hash for the range, as long as the range size is less
                           than or equal to 4 MB.
                   - !<!HttpHeader> 
-                    schema: *ref_266
+                    schema: *ref_268
                     header: x-ms-content-md5
                     language:
                       default:
@@ -5785,49 +5966,49 @@ operationGroups:
                           The MD5 hash of complete file stored in storage. If the file has a MD5 hash, and if request contains range header (Range or x-ms-range), this response header is returned with the value of the complete file's MD5
                           value. This value may or may not be equal to the value returned in Content-MD5 header, with the latter calculated from the requested range.
                   - !<!HttpHeader> 
-                    schema: *ref_267
+                    schema: *ref_269
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_268
+                    schema: *ref_270
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_269
+                    schema: *ref_271
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_270
+                    schema: *ref_272
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_271
+                    schema: *ref_273
                     header: x-ms-version
                     language:
                       default:
                         name: XMsVersion
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_272
+                    schema: *ref_274
                     header: x-ms-resource-type
                     language:
                       default:
                         name: XMsResourceType
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_273
+                    schema: *ref_275
                     header: x-ms-properties
                     language:
                       default:
@@ -5836,21 +6017,21 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_274
+                    schema: *ref_276
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: XMsLeaseDuration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_275
+                    schema: *ref_277
                     header: x-ms-lease-state
                     language:
                       default:
                         name: XMsLeaseState
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_276
+                    schema: *ref_278
                     header: x-ms-lease-status
                     language:
                       default:
@@ -5863,7 +6044,7 @@ operationGroups:
                   - '206'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -5872,14 +6053,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -5905,8 +6086,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_281
-            schema: *ref_39
+          - !<!Parameter> &ref_283
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -5917,8 +6098,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_282
-            schema: *ref_101
+          - !<!Parameter> &ref_284
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -5929,8 +6110,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_283
-            schema: *ref_102
+          - !<!Parameter> &ref_285
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -5942,7 +6123,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_284
+          - !<!Parameter> &ref_286
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -5953,8 +6134,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_285
-            schema: *ref_101
+          - !<!Parameter> &ref_287
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5965,8 +6146,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_286
-            schema: *ref_278
+          - !<!Parameter> &ref_288
+            schema: *ref_280
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5978,8 +6159,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_287
-            schema: *ref_85
+          - !<!Parameter> &ref_289
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -5992,8 +6173,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_288
-            schema: *ref_279
+          - !<!Parameter> &ref_290
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6003,8 +6184,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_289
-            schema: *ref_280
+          - !<!Parameter> &ref_291
+            schema: *ref_282
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6016,8 +6197,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_290
-            schema: *ref_279
+          - !<!Parameter> &ref_292
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6027,8 +6208,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_291
-            schema: *ref_279
+          - !<!Parameter> &ref_293
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6038,8 +6219,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_292
-            schema: *ref_279
+          - !<!Parameter> &ref_294
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6049,8 +6230,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_293
-            schema: *ref_279
+          - !<!Parameter> &ref_295
+            schema: *ref_281
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6062,6 +6243,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6072,8 +6268,6 @@ operationGroups:
                 method: head
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_281
-          - *ref_282
           - *ref_283
           - *ref_284
           - *ref_285
@@ -6085,6 +6279,8 @@ operationGroups:
           - *ref_291
           - *ref_292
           - *ref_293
+          - *ref_294
+          - *ref_295
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -6095,63 +6291,63 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_279
+                    schema: *ref_281
                     header: Accept-Ranges
                     language:
                       default:
                         name: AcceptRanges
                         description: Indicates that the service supports requests for partial file content.
                   - !<!HttpHeader> 
-                    schema: *ref_294
+                    schema: *ref_296
                     header: Cache-Control
                     language:
                       default:
                         name: CacheControl
                         description: 'If the Cache-Control request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_295
+                    schema: *ref_297
                     header: Content-Disposition
                     language:
                       default:
                         name: ContentDisposition
                         description: 'If the Content-Disposition request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_296
+                    schema: *ref_298
                     header: Content-Encoding
                     language:
                       default:
                         name: ContentEncoding
                         description: 'If the Content-Encoding request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_297
+                    schema: *ref_299
                     header: Content-Language
                     language:
                       default:
                         name: ContentLanguage
                         description: 'If the Content-Language request header has previously been set for the resource, that value is returned in this header.'
                   - !<!HttpHeader> 
-                    schema: *ref_298
+                    schema: *ref_300
                     header: Content-Length
                     language:
                       default:
                         name: ContentLength
                         description: The size of the resource in bytes.
                   - !<!HttpHeader> 
-                    schema: *ref_299
+                    schema: *ref_301
                     header: Content-Range
                     language:
                       default:
                         name: ContentRange
                         description: Indicates the range of bytes returned in the event that the client requested a subset of the file by setting the Range request header.
                   - !<!HttpHeader> 
-                    schema: *ref_300
+                    schema: *ref_302
                     header: Content-Type
                     language:
                       default:
                         name: ContentType
                         description: 'The content type specified for the resource. If no content type was specified, the default content type is application/octet-stream.'
                   - !<!HttpHeader> 
-                    schema: *ref_301
+                    schema: *ref_303
                     header: Content-MD5
                     language:
                       default:
@@ -6160,49 +6356,49 @@ operationGroups:
                           The MD5 hash of complete file stored in storage. This header is returned only for "GetProperties" operation. If the Content-MD5 header has been set for the file, this response header is returned for GetProperties
                           call so that the client can check for message content integrity.
                   - !<!HttpHeader> 
-                    schema: *ref_302
+                    schema: *ref_304
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_303
+                    schema: *ref_305
                     header: ETag
                     language:
                       default:
                         name: ETag
                         description: An HTTP entity tag associated with the file or directory.
                   - !<!HttpHeader> 
-                    schema: *ref_304
+                    schema: *ref_306
                     header: Last-Modified
                     language:
                       default:
                         name: LastModified
                         description: The data and time the file or directory was last modified.  Write operations on the file or directory update the last modified time.
                   - !<!HttpHeader> 
-                    schema: *ref_280
+                    schema: *ref_282
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_305
+                    schema: *ref_307
                     header: x-ms-version
                     language:
                       default:
                         name: XMsVersion
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_306
+                    schema: *ref_308
                     header: x-ms-resource-type
                     language:
                       default:
                         name: XMsResourceType
                         description: 'The type of the resource.  The value may be "file" or "directory".  If not set, the value is "file".'
                   - !<!HttpHeader> 
-                    schema: *ref_307
+                    schema: *ref_309
                     header: x-ms-properties
                     language:
                       default:
@@ -6211,49 +6407,49 @@ operationGroups:
                           The user-defined properties associated with the file or directory, in the format of a comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is a base64 encoded string. Note that the
                           string may only contain ASCII characters in the ISO-8859-1 character set.
                   - !<!HttpHeader> 
-                    schema: *ref_308
+                    schema: *ref_310
                     header: x-ms-owner
                     language:
                       default:
                         name: XMsOwner
                         description: The owner of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_309
+                    schema: *ref_311
                     header: x-ms-group
                     language:
                       default:
                         name: XMsGroup
                         description: The owning group of the file or directory. Included in the response if Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_310
+                    schema: *ref_312
                     header: x-ms-permissions
                     language:
                       default:
                         name: XMsPermissions
                         description: 'The POSIX access permissions for the file owner, the file owning group, and others. Included in the response if Hierarchical Namespace is enabled for the account.'
                   - !<!HttpHeader> 
-                    schema: *ref_311
+                    schema: *ref_313
                     header: x-ms-acl
                     language:
                       default:
                         name: XMsAcl
                         description: The POSIX access control list for the file or directory.  Included in the response only if the action is "getAccessControl" and Hierarchical Namespace is enabled for the account.
                   - !<!HttpHeader> 
-                    schema: *ref_312
+                    schema: *ref_314
                     header: x-ms-lease-duration
                     language:
                       default:
                         name: XMsLeaseDuration
                         description: 'When a resource is leased, specifies whether the lease is of infinite or fixed duration.'
                   - !<!HttpHeader> 
-                    schema: *ref_313
+                    schema: *ref_315
                     header: x-ms-lease-state
                     language:
                       default:
                         name: XMsLeaseState
                         description: 'Lease state of the resource. '
                   - !<!HttpHeader> 
-                    schema: *ref_314
+                    schema: *ref_316
                     header: x-ms-lease-status
                     language:
                       default:
@@ -6263,7 +6459,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -6272,14 +6468,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:
@@ -6306,8 +6502,8 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_317
-            schema: *ref_39
+          - !<!Parameter> &ref_319
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -6318,8 +6514,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_318
-            schema: *ref_101
+          - !<!Parameter> &ref_320
+            schema: *ref_102
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -6330,8 +6526,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_319
-            schema: *ref_102
+          - !<!Parameter> &ref_321
+            schema: *ref_103
             implementation: Method
             extensions:
               x-ms-client-request-id: true
@@ -6343,7 +6539,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_320
+          - !<!Parameter> &ref_322
             schema: *ref_23
             implementation: Method
             language: !<!Languages> 
@@ -6354,8 +6550,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_321
-            schema: *ref_101
+          - !<!Parameter> &ref_323
+            schema: *ref_102
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6366,8 +6562,8 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: header
           - *ref_25
-          - !<!Parameter> &ref_322
-            schema: *ref_85
+          - !<!Parameter> &ref_324
+            schema: *ref_86
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6377,8 +6573,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_323
-            schema: *ref_315
+          - !<!Parameter> &ref_325
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6390,8 +6586,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_324
-            schema: *ref_316
+          - !<!Parameter> &ref_326
+            schema: *ref_318
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6401,8 +6597,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_325
-            schema: *ref_315
+          - !<!Parameter> &ref_327
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6412,8 +6608,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_326
-            schema: *ref_315
+          - !<!Parameter> &ref_328
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6423,8 +6619,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_327
-            schema: *ref_315
+          - !<!Parameter> &ref_329
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6434,8 +6630,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_328
-            schema: *ref_315
+          - !<!Parameter> &ref_330
+            schema: *ref_317
             implementation: Method
             language: !<!Languages> 
               default:
@@ -6447,6 +6643,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6457,8 +6668,6 @@ operationGroups:
                 method: delete
                 uri: 'https://{accountName}.{dnsSuffix}'
         signatureParameters:
-          - *ref_317
-          - *ref_318
           - *ref_319
           - *ref_320
           - *ref_321
@@ -6469,6 +6678,8 @@ operationGroups:
           - *ref_326
           - *ref_327
           - *ref_328
+          - *ref_329
+          - *ref_330
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -6479,28 +6690,28 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_315
+                    schema: *ref_317
                     header: Date
                     language:
                       default:
                         name: Date
                         description: A UTC date/time value generated by the service that indicates the time at which the response was initiated.
                   - !<!HttpHeader> 
-                    schema: *ref_316
+                    schema: *ref_318
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_329
+                    schema: *ref_331
                     header: x-ms-version
                     language:
                       default:
                         name: XMsVersion
                         description: The version of the REST protocol used to process the request.
                   - !<!HttpHeader> 
-                    schema: *ref_330
+                    schema: *ref_332
                     header: x-ms-continuation
                     language:
                       default:
@@ -6512,7 +6723,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -6521,14 +6732,14 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: x-ms-request-id
                     language:
                       default:
                         name: XMsRequestId
                         description: A server-generated UUID recorded in the analytics logs for troubleshooting and correlation.
                   - !<!HttpHeader> 
-                    schema: *ref_38
+                    schema: *ref_39
                     header: x-ms-version
                     language:
                       default:

--- a/modelerfour/test/scenarios/extensible-enums-swagger/flattened.yaml
+++ b/modelerfour/test/scenarios/extensible-enums-swagger/flattened.yaml
@@ -117,8 +117,19 @@ schemas: !<!Schemas>
           name: IntEnum
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -189,7 +200,7 @@ operationGroups:
             version: '2016-07-07'
         parameters:
           - *ref_4
-          - !<!Parameter> &ref_6
+          - !<!Parameter> &ref_7
             schema: *ref_5
             implementation: Method
             required: true
@@ -203,6 +214,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -213,10 +239,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_6
+          - *ref_7
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -242,8 +268,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_7
+              - !<!Parameter> &ref_9
+                schema: *ref_8
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -254,8 +280,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -271,7 +310,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/extensible-enums-swagger/grouped.yaml
+++ b/modelerfour/test/scenarios/extensible-enums-swagger/grouped.yaml
@@ -117,8 +117,19 @@ schemas: !<!Schemas>
           name: IntEnum
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -189,7 +200,7 @@ operationGroups:
             version: '2016-07-07'
         parameters:
           - *ref_4
-          - !<!Parameter> &ref_6
+          - !<!Parameter> &ref_7
             schema: *ref_5
             implementation: Method
             required: true
@@ -203,6 +214,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -213,10 +239,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_6
+          - *ref_7
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -242,8 +268,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_7
+              - !<!Parameter> &ref_9
+                schema: *ref_8
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -254,8 +280,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -271,7 +310,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/extensible-enums-swagger/modeler.yaml
+++ b/modelerfour/test/scenarios/extensible-enums-swagger/modeler.yaml
@@ -117,8 +117,19 @@ schemas: !<!Schemas>
           name: IntEnum
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_6
+    - !<!ObjectSchema> &ref_7
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -163,7 +174,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_7
+  - !<!Parameter> &ref_8
     schema: *ref_1
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -188,7 +199,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-07-07'
         parameters:
-          - *ref_7
+          - *ref_8
           - !<!Parameter> &ref_5
             schema: *ref_4
             implementation: Method
@@ -203,6 +214,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -216,7 +242,7 @@ operationGroups:
           - *ref_5
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -238,12 +264,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: '2016-07-07'
         parameters:
-          - *ref_7
+          - *ref_8
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_6
+              - !<!Parameter> &ref_9
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -254,8 +280,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -271,7 +310,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/extensible-enums-swagger/namer.yaml
+++ b/modelerfour/test/scenarios/extensible-enums-swagger/namer.yaml
@@ -117,8 +117,19 @@ schemas: !<!Schemas>
           name: IntEnum
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -189,7 +200,7 @@ operationGroups:
             version: '2016-07-07'
         parameters:
           - *ref_4
-          - !<!Parameter> &ref_6
+          - !<!Parameter> &ref_7
             schema: *ref_5
             implementation: Method
             required: true
@@ -203,6 +214,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -213,10 +239,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_6
+          - *ref_7
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -242,8 +268,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_7
+              - !<!Parameter> &ref_9
+                schema: *ref_8
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -254,8 +280,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_8
+              - *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -271,7 +310,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/header/flattened.yaml
+++ b/modelerfour/test/scenarios/header/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: header
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_24
+    - !<!BooleanSchema> &ref_25
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -24,7 +24,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_8
+    - !<!NumberSchema> &ref_9
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -36,7 +36,7 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_12
+    - !<!NumberSchema> &ref_13
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -48,7 +48,7 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_16
+    - !<!NumberSchema> &ref_17
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -60,7 +60,7 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_20
+    - !<!NumberSchema> &ref_21
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -102,7 +102,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_51
+    - !<!SealedChoiceSchema> &ref_52
       choices:
         - !<!ChoiceValue> 
           value: White
@@ -133,8 +133,19 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_47
+    - !<!ByteArraySchema> &ref_48
       type: byte-array
       format: byte
       apiVersions:
@@ -147,7 +158,7 @@ schemas: !<!Schemas>
           header: value
       protocol: !<!Protocols> {}
   dateTimes:
-    - !<!DateTimeSchema> &ref_35
+    - !<!DateTimeSchema> &ref_36
       type: date-time
       format: date-time
       apiVersions:
@@ -159,7 +170,7 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_39
+    - !<!DateTimeSchema> &ref_40
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -172,7 +183,7 @@ schemas: !<!Schemas>
           header: value
       protocol: !<!Protocols> {}
   dates:
-    - !<!DateSchema> &ref_31
+    - !<!DateSchema> &ref_32
       type: date
       apiVersions:
         - !<!ApiVersion> 
@@ -184,7 +195,7 @@ schemas: !<!Schemas>
           header: value
       protocol: !<!Protocols> {}
   durations:
-    - !<!DurationSchema> &ref_43
+    - !<!DurationSchema> &ref_44
       type: duration
       apiVersions:
         - !<!ApiVersion> 
@@ -196,7 +207,7 @@ schemas: !<!Schemas>
           header: value
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_6
+    - !<!ObjectSchema> &ref_7
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -255,7 +266,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_5
+          - !<!Parameter> &ref_6
             schema: *ref_4
             implementation: Method
             required: true
@@ -269,6 +280,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -279,7 +305,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_5
+          - *ref_6
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -292,7 +318,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -317,6 +343,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -347,7 +388,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -370,7 +411,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_7
+          - !<!Parameter> &ref_8
             schema: *ref_4
             implementation: Method
             required: true
@@ -384,6 +425,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -394,7 +450,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_7
+          - *ref_8
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -407,7 +463,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -432,6 +488,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -462,7 +533,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -485,7 +556,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_9
+          - !<!Parameter> &ref_10
             schema: *ref_4
             implementation: Method
             required: true
@@ -497,8 +568,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_10
-            schema: *ref_8
+          - !<!Parameter> &ref_11
+            schema: *ref_9
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -511,6 +582,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -521,8 +607,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_9
           - *ref_10
+          - *ref_11
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -535,7 +621,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -558,7 +644,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_11
+          - !<!Parameter> &ref_12
             schema: *ref_4
             implementation: Method
             required: true
@@ -572,6 +658,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -582,7 +683,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_11
+          - *ref_12
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -593,7 +694,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_8
+                    schema: *ref_9
                     header: value
                     language:
                       default:
@@ -603,7 +704,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -626,7 +727,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_13
+          - !<!Parameter> &ref_14
             schema: *ref_4
             implementation: Method
             required: true
@@ -638,8 +739,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_14
-            schema: *ref_12
+          - !<!Parameter> &ref_15
+            schema: *ref_13
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -652,6 +753,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -662,8 +778,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_13
           - *ref_14
+          - *ref_15
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -676,7 +792,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -699,7 +815,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_15
+          - !<!Parameter> &ref_16
             schema: *ref_4
             implementation: Method
             required: true
@@ -713,6 +829,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -723,7 +854,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_15
+          - *ref_16
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -734,7 +865,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_12
+                    schema: *ref_13
                     header: value
                     language:
                       default:
@@ -744,7 +875,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -767,7 +898,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_17
+          - !<!Parameter> &ref_18
             schema: *ref_4
             implementation: Method
             required: true
@@ -779,8 +910,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_18
-            schema: *ref_16
+          - !<!Parameter> &ref_19
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -793,6 +924,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -803,8 +949,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_17
           - *ref_18
+          - *ref_19
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -817,7 +963,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -840,7 +986,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_19
+          - !<!Parameter> &ref_20
             schema: *ref_4
             implementation: Method
             required: true
@@ -854,6 +1000,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -864,7 +1025,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_19
+          - *ref_20
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -875,7 +1036,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: value
                     language:
                       default:
@@ -885,7 +1046,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -908,7 +1069,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_21
+          - !<!Parameter> &ref_22
             schema: *ref_4
             implementation: Method
             required: true
@@ -920,8 +1081,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_22
-            schema: *ref_20
+          - !<!Parameter> &ref_23
+            schema: *ref_21
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -934,6 +1095,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -944,8 +1120,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_21
           - *ref_22
+          - *ref_23
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -958,7 +1134,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -981,7 +1157,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_23
+          - !<!Parameter> &ref_24
             schema: *ref_4
             implementation: Method
             required: true
@@ -995,6 +1171,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1005,7 +1196,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_23
+          - *ref_24
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1016,7 +1207,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_20
+                    schema: *ref_21
                     header: value
                     language:
                       default:
@@ -1026,7 +1217,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1049,7 +1240,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_25
+          - !<!Parameter> &ref_26
             schema: *ref_4
             implementation: Method
             required: true
@@ -1061,8 +1252,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_26
-            schema: *ref_24
+          - !<!Parameter> &ref_27
+            schema: *ref_25
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1075,6 +1266,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1085,8 +1291,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_25
           - *ref_26
+          - *ref_27
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1099,7 +1305,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1122,7 +1328,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_27
+          - !<!Parameter> &ref_28
             schema: *ref_4
             implementation: Method
             required: true
@@ -1136,6 +1342,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1146,7 +1367,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_27
+          - *ref_28
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1157,7 +1378,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_24
+                    schema: *ref_25
                     header: value
                     language:
                       default:
@@ -1167,7 +1388,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1190,7 +1411,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_4
             implementation: Method
             required: true
@@ -1202,7 +1423,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_29
+          - !<!Parameter> &ref_30
             schema: *ref_4
             implementation: Method
             language: !<!Languages> 
@@ -1215,6 +1436,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1225,8 +1461,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
           - *ref_29
+          - *ref_30
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1239,7 +1475,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1262,7 +1498,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_30
+          - !<!Parameter> &ref_31
             schema: *ref_4
             implementation: Method
             required: true
@@ -1276,6 +1512,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1286,7 +1537,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_30
+          - *ref_31
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1307,7 +1558,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1330,7 +1581,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_32
+          - !<!Parameter> &ref_33
             schema: *ref_4
             implementation: Method
             required: true
@@ -1342,8 +1593,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_33
-            schema: *ref_31
+          - !<!Parameter> &ref_34
+            schema: *ref_32
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1356,6 +1607,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1366,8 +1632,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_32
           - *ref_33
+          - *ref_34
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1380,7 +1646,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1403,7 +1669,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_34
+          - !<!Parameter> &ref_35
             schema: *ref_4
             implementation: Method
             required: true
@@ -1417,6 +1683,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1427,7 +1708,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_34
+          - *ref_35
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1438,7 +1719,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_31
+                    schema: *ref_32
                     header: value
                     language:
                       default:
@@ -1448,7 +1729,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1471,7 +1752,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_36
+          - !<!Parameter> &ref_37
             schema: *ref_4
             implementation: Method
             required: true
@@ -1483,8 +1764,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_37
-            schema: *ref_35
+          - !<!Parameter> &ref_38
+            schema: *ref_36
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1497,6 +1778,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1507,8 +1803,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_36
           - *ref_37
+          - *ref_38
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1521,7 +1817,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1544,7 +1840,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_38
+          - !<!Parameter> &ref_39
             schema: *ref_4
             implementation: Method
             required: true
@@ -1558,6 +1854,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1568,7 +1879,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_38
+          - *ref_39
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1579,7 +1890,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: value
                     language:
                       default:
@@ -1589,7 +1900,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1612,7 +1923,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_40
+          - !<!Parameter> &ref_41
             schema: *ref_4
             implementation: Method
             required: true
@@ -1624,8 +1935,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_41
-            schema: *ref_39
+          - !<!Parameter> &ref_42
+            schema: *ref_40
             implementation: Method
             language: !<!Languages> 
               default:
@@ -1637,6 +1948,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1647,8 +1973,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_40
           - *ref_41
+          - *ref_42
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1661,7 +1987,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1684,7 +2010,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_42
+          - !<!Parameter> &ref_43
             schema: *ref_4
             implementation: Method
             required: true
@@ -1698,6 +2024,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1708,7 +2049,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_42
+          - *ref_43
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1719,7 +2060,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_39
+                    schema: *ref_40
                     header: value
                     language:
                       default:
@@ -1729,7 +2070,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1752,7 +2093,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_44
+          - !<!Parameter> &ref_45
             schema: *ref_4
             implementation: Method
             required: true
@@ -1764,8 +2105,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_45
-            schema: *ref_43
+          - !<!Parameter> &ref_46
+            schema: *ref_44
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1778,6 +2119,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1788,8 +2144,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_44
           - *ref_45
+          - *ref_46
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1802,7 +2158,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1825,7 +2181,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_46
+          - !<!Parameter> &ref_47
             schema: *ref_4
             implementation: Method
             required: true
@@ -1839,6 +2195,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1849,7 +2220,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_46
+          - *ref_47
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1860,7 +2231,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_43
+                    schema: *ref_44
                     header: value
                     language:
                       default:
@@ -1870,7 +2241,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1893,7 +2264,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_48
+          - !<!Parameter> &ref_49
             schema: *ref_4
             implementation: Method
             required: true
@@ -1905,8 +2276,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_49
-            schema: *ref_47
+          - !<!Parameter> &ref_50
+            schema: *ref_48
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1919,6 +2290,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1929,8 +2315,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_48
           - *ref_49
+          - *ref_50
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1943,7 +2329,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1966,7 +2352,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_50
+          - !<!Parameter> &ref_51
             schema: *ref_4
             implementation: Method
             required: true
@@ -1980,6 +2366,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1990,7 +2391,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_50
+          - *ref_51
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2001,7 +2402,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_47
+                    schema: *ref_48
                     header: value
                     language:
                       default:
@@ -2011,7 +2412,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2034,7 +2435,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_52
+          - !<!Parameter> &ref_53
             schema: *ref_4
             implementation: Method
             required: true
@@ -2046,8 +2447,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_53
-            schema: *ref_51
+          - !<!Parameter> &ref_54
+            schema: *ref_52
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2059,6 +2460,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2069,8 +2485,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_52
           - *ref_53
+          - *ref_54
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2083,7 +2499,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2106,7 +2522,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_54
+          - !<!Parameter> &ref_55
             schema: *ref_4
             implementation: Method
             required: true
@@ -2120,6 +2536,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2130,7 +2561,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_54
+          - *ref_55
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2141,7 +2572,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_51
+                    schema: *ref_52
                     header: value
                     language:
                       default:
@@ -2151,7 +2582,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2176,6 +2607,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2198,7 +2644,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/header/grouped.yaml
+++ b/modelerfour/test/scenarios/header/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: header
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_24
+    - !<!BooleanSchema> &ref_25
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -24,7 +24,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_8
+    - !<!NumberSchema> &ref_9
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -36,7 +36,7 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_12
+    - !<!NumberSchema> &ref_13
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -48,7 +48,7 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_16
+    - !<!NumberSchema> &ref_17
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -60,7 +60,7 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_20
+    - !<!NumberSchema> &ref_21
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -102,7 +102,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_51
+    - !<!SealedChoiceSchema> &ref_52
       choices:
         - !<!ChoiceValue> 
           value: White
@@ -133,8 +133,19 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_47
+    - !<!ByteArraySchema> &ref_48
       type: byte-array
       format: byte
       apiVersions:
@@ -147,7 +158,7 @@ schemas: !<!Schemas>
           header: value
       protocol: !<!Protocols> {}
   dateTimes:
-    - !<!DateTimeSchema> &ref_35
+    - !<!DateTimeSchema> &ref_36
       type: date-time
       format: date-time
       apiVersions:
@@ -159,7 +170,7 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_39
+    - !<!DateTimeSchema> &ref_40
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -172,7 +183,7 @@ schemas: !<!Schemas>
           header: value
       protocol: !<!Protocols> {}
   dates:
-    - !<!DateSchema> &ref_31
+    - !<!DateSchema> &ref_32
       type: date
       apiVersions:
         - !<!ApiVersion> 
@@ -184,7 +195,7 @@ schemas: !<!Schemas>
           header: value
       protocol: !<!Protocols> {}
   durations:
-    - !<!DurationSchema> &ref_43
+    - !<!DurationSchema> &ref_44
       type: duration
       apiVersions:
         - !<!ApiVersion> 
@@ -196,7 +207,7 @@ schemas: !<!Schemas>
           header: value
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_6
+    - !<!ObjectSchema> &ref_7
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -255,7 +266,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_5
+          - !<!Parameter> &ref_6
             schema: *ref_4
             implementation: Method
             required: true
@@ -269,6 +280,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -279,7 +305,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_5
+          - *ref_6
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -292,7 +318,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -317,6 +343,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -347,7 +388,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -370,7 +411,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_7
+          - !<!Parameter> &ref_8
             schema: *ref_4
             implementation: Method
             required: true
@@ -384,6 +425,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -394,7 +450,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_7
+          - *ref_8
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -407,7 +463,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -432,6 +488,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -462,7 +533,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -485,7 +556,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_9
+          - !<!Parameter> &ref_10
             schema: *ref_4
             implementation: Method
             required: true
@@ -497,8 +568,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_10
-            schema: *ref_8
+          - !<!Parameter> &ref_11
+            schema: *ref_9
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -511,6 +582,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -521,8 +607,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_9
           - *ref_10
+          - *ref_11
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -535,7 +621,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -558,7 +644,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_11
+          - !<!Parameter> &ref_12
             schema: *ref_4
             implementation: Method
             required: true
@@ -572,6 +658,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -582,7 +683,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_11
+          - *ref_12
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -593,7 +694,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_8
+                    schema: *ref_9
                     header: value
                     language:
                       default:
@@ -603,7 +704,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -626,7 +727,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_13
+          - !<!Parameter> &ref_14
             schema: *ref_4
             implementation: Method
             required: true
@@ -638,8 +739,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_14
-            schema: *ref_12
+          - !<!Parameter> &ref_15
+            schema: *ref_13
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -652,6 +753,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -662,8 +778,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_13
           - *ref_14
+          - *ref_15
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -676,7 +792,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -699,7 +815,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_15
+          - !<!Parameter> &ref_16
             schema: *ref_4
             implementation: Method
             required: true
@@ -713,6 +829,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -723,7 +854,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_15
+          - *ref_16
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -734,7 +865,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_12
+                    schema: *ref_13
                     header: value
                     language:
                       default:
@@ -744,7 +875,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -767,7 +898,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_17
+          - !<!Parameter> &ref_18
             schema: *ref_4
             implementation: Method
             required: true
@@ -779,8 +910,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_18
-            schema: *ref_16
+          - !<!Parameter> &ref_19
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -793,6 +924,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -803,8 +949,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_17
           - *ref_18
+          - *ref_19
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -817,7 +963,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -840,7 +986,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_19
+          - !<!Parameter> &ref_20
             schema: *ref_4
             implementation: Method
             required: true
@@ -854,6 +1000,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -864,7 +1025,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_19
+          - *ref_20
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -875,7 +1036,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: value
                     language:
                       default:
@@ -885,7 +1046,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -908,7 +1069,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_21
+          - !<!Parameter> &ref_22
             schema: *ref_4
             implementation: Method
             required: true
@@ -920,8 +1081,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_22
-            schema: *ref_20
+          - !<!Parameter> &ref_23
+            schema: *ref_21
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -934,6 +1095,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -944,8 +1120,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_21
           - *ref_22
+          - *ref_23
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -958,7 +1134,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -981,7 +1157,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_23
+          - !<!Parameter> &ref_24
             schema: *ref_4
             implementation: Method
             required: true
@@ -995,6 +1171,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1005,7 +1196,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_23
+          - *ref_24
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1016,7 +1207,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_20
+                    schema: *ref_21
                     header: value
                     language:
                       default:
@@ -1026,7 +1217,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1049,7 +1240,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_25
+          - !<!Parameter> &ref_26
             schema: *ref_4
             implementation: Method
             required: true
@@ -1061,8 +1252,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_26
-            schema: *ref_24
+          - !<!Parameter> &ref_27
+            schema: *ref_25
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1075,6 +1266,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1085,8 +1291,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_25
           - *ref_26
+          - *ref_27
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1099,7 +1305,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1122,7 +1328,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_27
+          - !<!Parameter> &ref_28
             schema: *ref_4
             implementation: Method
             required: true
@@ -1136,6 +1342,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1146,7 +1367,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_27
+          - *ref_28
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1157,7 +1378,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_24
+                    schema: *ref_25
                     header: value
                     language:
                       default:
@@ -1167,7 +1388,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1190,7 +1411,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_4
             implementation: Method
             required: true
@@ -1202,7 +1423,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_29
+          - !<!Parameter> &ref_30
             schema: *ref_4
             implementation: Method
             language: !<!Languages> 
@@ -1215,6 +1436,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1225,8 +1461,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
           - *ref_29
+          - *ref_30
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1239,7 +1475,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1262,7 +1498,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_30
+          - !<!Parameter> &ref_31
             schema: *ref_4
             implementation: Method
             required: true
@@ -1276,6 +1512,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1286,7 +1537,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_30
+          - *ref_31
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1307,7 +1558,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1330,7 +1581,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_32
+          - !<!Parameter> &ref_33
             schema: *ref_4
             implementation: Method
             required: true
@@ -1342,8 +1593,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_33
-            schema: *ref_31
+          - !<!Parameter> &ref_34
+            schema: *ref_32
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1356,6 +1607,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1366,8 +1632,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_32
           - *ref_33
+          - *ref_34
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1380,7 +1646,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1403,7 +1669,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_34
+          - !<!Parameter> &ref_35
             schema: *ref_4
             implementation: Method
             required: true
@@ -1417,6 +1683,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1427,7 +1708,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_34
+          - *ref_35
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1438,7 +1719,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_31
+                    schema: *ref_32
                     header: value
                     language:
                       default:
@@ -1448,7 +1729,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1471,7 +1752,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_36
+          - !<!Parameter> &ref_37
             schema: *ref_4
             implementation: Method
             required: true
@@ -1483,8 +1764,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_37
-            schema: *ref_35
+          - !<!Parameter> &ref_38
+            schema: *ref_36
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1497,6 +1778,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1507,8 +1803,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_36
           - *ref_37
+          - *ref_38
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1521,7 +1817,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1544,7 +1840,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_38
+          - !<!Parameter> &ref_39
             schema: *ref_4
             implementation: Method
             required: true
@@ -1558,6 +1854,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1568,7 +1879,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_38
+          - *ref_39
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1579,7 +1890,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: value
                     language:
                       default:
@@ -1589,7 +1900,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1612,7 +1923,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_40
+          - !<!Parameter> &ref_41
             schema: *ref_4
             implementation: Method
             required: true
@@ -1624,8 +1935,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_41
-            schema: *ref_39
+          - !<!Parameter> &ref_42
+            schema: *ref_40
             implementation: Method
             language: !<!Languages> 
               default:
@@ -1637,6 +1948,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1647,8 +1973,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_40
           - *ref_41
+          - *ref_42
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1661,7 +1987,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1684,7 +2010,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_42
+          - !<!Parameter> &ref_43
             schema: *ref_4
             implementation: Method
             required: true
@@ -1698,6 +2024,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1708,7 +2049,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_42
+          - *ref_43
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1719,7 +2060,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_39
+                    schema: *ref_40
                     header: value
                     language:
                       default:
@@ -1729,7 +2070,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1752,7 +2093,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_44
+          - !<!Parameter> &ref_45
             schema: *ref_4
             implementation: Method
             required: true
@@ -1764,8 +2105,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_45
-            schema: *ref_43
+          - !<!Parameter> &ref_46
+            schema: *ref_44
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1778,6 +2119,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1788,8 +2144,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_44
           - *ref_45
+          - *ref_46
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1802,7 +2158,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1825,7 +2181,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_46
+          - !<!Parameter> &ref_47
             schema: *ref_4
             implementation: Method
             required: true
@@ -1839,6 +2195,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1849,7 +2220,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_46
+          - *ref_47
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1860,7 +2231,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_43
+                    schema: *ref_44
                     header: value
                     language:
                       default:
@@ -1870,7 +2241,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1893,7 +2264,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_48
+          - !<!Parameter> &ref_49
             schema: *ref_4
             implementation: Method
             required: true
@@ -1905,8 +2276,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_49
-            schema: *ref_47
+          - !<!Parameter> &ref_50
+            schema: *ref_48
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1919,6 +2290,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1929,8 +2315,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_48
           - *ref_49
+          - *ref_50
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1943,7 +2329,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1966,7 +2352,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_50
+          - !<!Parameter> &ref_51
             schema: *ref_4
             implementation: Method
             required: true
@@ -1980,6 +2366,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1990,7 +2391,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_50
+          - *ref_51
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2001,7 +2402,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_47
+                    schema: *ref_48
                     header: value
                     language:
                       default:
@@ -2011,7 +2412,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2034,7 +2435,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_52
+          - !<!Parameter> &ref_53
             schema: *ref_4
             implementation: Method
             required: true
@@ -2046,8 +2447,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_53
-            schema: *ref_51
+          - !<!Parameter> &ref_54
+            schema: *ref_52
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2059,6 +2460,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2069,8 +2485,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_52
           - *ref_53
+          - *ref_54
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2083,7 +2499,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2106,7 +2522,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_54
+          - !<!Parameter> &ref_55
             schema: *ref_4
             implementation: Method
             required: true
@@ -2120,6 +2536,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2130,7 +2561,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_54
+          - *ref_55
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2141,7 +2572,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_51
+                    schema: *ref_52
                     header: value
                     language:
                       default:
@@ -2151,7 +2582,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2176,6 +2607,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2198,7 +2644,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/header/modeler.yaml
+++ b/modelerfour/test/scenarios/header/modeler.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: header
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_24
+    - !<!BooleanSchema> &ref_25
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -24,7 +24,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_8
+    - !<!NumberSchema> &ref_9
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -36,7 +36,7 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_12
+    - !<!NumberSchema> &ref_13
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -48,7 +48,7 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_16
+    - !<!NumberSchema> &ref_17
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -60,7 +60,7 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_20
+    - !<!NumberSchema> &ref_21
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -102,7 +102,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_51
+    - !<!SealedChoiceSchema> &ref_52
       choices:
         - !<!ChoiceValue> 
           value: White
@@ -133,8 +133,19 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_2
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_47
+    - !<!ByteArraySchema> &ref_48
       type: byte-array
       format: byte
       apiVersions:
@@ -147,7 +158,7 @@ schemas: !<!Schemas>
           header: value
       protocol: !<!Protocols> {}
   dateTimes:
-    - !<!DateTimeSchema> &ref_35
+    - !<!DateTimeSchema> &ref_36
       type: date-time
       format: date-time
       apiVersions:
@@ -159,7 +170,7 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_39
+    - !<!DateTimeSchema> &ref_40
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -172,7 +183,7 @@ schemas: !<!Schemas>
           header: value
       protocol: !<!Protocols> {}
   dates:
-    - !<!DateSchema> &ref_31
+    - !<!DateSchema> &ref_32
       type: date
       apiVersions:
         - !<!ApiVersion> 
@@ -184,7 +195,7 @@ schemas: !<!Schemas>
           header: value
       protocol: !<!Protocols> {}
   durations:
-    - !<!DurationSchema> &ref_43
+    - !<!DurationSchema> &ref_44
       type: duration
       apiVersions:
         - !<!ApiVersion> 
@@ -196,7 +207,7 @@ schemas: !<!Schemas>
           header: value
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -229,7 +240,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_6
+  - !<!Parameter> &ref_7
     schema: *ref_2
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -254,7 +265,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
           - !<!Parameter> &ref_4
             schema: *ref_3
             implementation: Method
@@ -269,6 +280,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -292,7 +318,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -314,9 +340,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -347,7 +388,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -369,8 +410,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_7
+          - *ref_7
+          - !<!Parameter> &ref_8
             schema: *ref_3
             implementation: Method
             required: true
@@ -384,6 +425,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -394,7 +450,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_7
+          - *ref_8
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -407,7 +463,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -429,9 +485,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -462,7 +533,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -484,8 +555,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_9
+          - *ref_7
+          - !<!Parameter> &ref_10
             schema: *ref_3
             implementation: Method
             required: true
@@ -497,8 +568,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_10
-            schema: *ref_8
+          - !<!Parameter> &ref_11
+            schema: *ref_9
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -511,6 +582,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -521,8 +607,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_9
           - *ref_10
+          - *ref_11
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -535,7 +621,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -557,8 +643,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_11
+          - *ref_7
+          - !<!Parameter> &ref_12
             schema: *ref_3
             implementation: Method
             required: true
@@ -572,6 +658,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -582,7 +683,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_11
+          - *ref_12
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -593,7 +694,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_8
+                    schema: *ref_9
                     header: value
                     language:
                       default:
@@ -603,7 +704,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -625,8 +726,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_13
+          - *ref_7
+          - !<!Parameter> &ref_14
             schema: *ref_3
             implementation: Method
             required: true
@@ -638,8 +739,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_14
-            schema: *ref_12
+          - !<!Parameter> &ref_15
+            schema: *ref_13
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -652,6 +753,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -662,8 +778,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_13
           - *ref_14
+          - *ref_15
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -676,7 +792,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -698,8 +814,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_15
+          - *ref_7
+          - !<!Parameter> &ref_16
             schema: *ref_3
             implementation: Method
             required: true
@@ -713,6 +829,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -723,7 +854,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_15
+          - *ref_16
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -734,7 +865,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_12
+                    schema: *ref_13
                     header: value
                     language:
                       default:
@@ -744,7 +875,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -766,8 +897,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_17
+          - *ref_7
+          - !<!Parameter> &ref_18
             schema: *ref_3
             implementation: Method
             required: true
@@ -779,8 +910,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_18
-            schema: *ref_16
+          - !<!Parameter> &ref_19
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -793,6 +924,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -803,8 +949,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_17
           - *ref_18
+          - *ref_19
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -817,7 +963,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -839,8 +985,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_19
+          - *ref_7
+          - !<!Parameter> &ref_20
             schema: *ref_3
             implementation: Method
             required: true
@@ -854,6 +1000,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -864,7 +1025,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_19
+          - *ref_20
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -875,7 +1036,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: value
                     language:
                       default:
@@ -885,7 +1046,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -907,8 +1068,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_21
+          - *ref_7
+          - !<!Parameter> &ref_22
             schema: *ref_3
             implementation: Method
             required: true
@@ -920,8 +1081,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_22
-            schema: *ref_20
+          - !<!Parameter> &ref_23
+            schema: *ref_21
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -934,6 +1095,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -944,8 +1120,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_21
           - *ref_22
+          - *ref_23
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -958,7 +1134,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -980,8 +1156,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_23
+          - *ref_7
+          - !<!Parameter> &ref_24
             schema: *ref_3
             implementation: Method
             required: true
@@ -995,6 +1171,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1005,7 +1196,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_23
+          - *ref_24
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1016,7 +1207,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_20
+                    schema: *ref_21
                     header: value
                     language:
                       default:
@@ -1026,7 +1217,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1048,8 +1239,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_25
+          - *ref_7
+          - !<!Parameter> &ref_26
             schema: *ref_3
             implementation: Method
             required: true
@@ -1061,8 +1252,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_26
-            schema: *ref_24
+          - !<!Parameter> &ref_27
+            schema: *ref_25
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1075,6 +1266,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1085,8 +1291,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_25
           - *ref_26
+          - *ref_27
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1099,7 +1305,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1121,8 +1327,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_27
+          - *ref_7
+          - !<!Parameter> &ref_28
             schema: *ref_3
             implementation: Method
             required: true
@@ -1136,6 +1342,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1146,7 +1367,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_27
+          - *ref_28
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1157,7 +1378,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_24
+                    schema: *ref_25
                     header: value
                     language:
                       default:
@@ -1167,7 +1388,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1189,8 +1410,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_28
+          - *ref_7
+          - !<!Parameter> &ref_29
             schema: *ref_3
             implementation: Method
             required: true
@@ -1202,7 +1423,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_29
+          - !<!Parameter> &ref_30
             schema: *ref_3
             implementation: Method
             language: !<!Languages> 
@@ -1215,6 +1436,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1225,8 +1461,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
           - *ref_29
+          - *ref_30
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1239,7 +1475,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1261,8 +1497,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_30
+          - *ref_7
+          - !<!Parameter> &ref_31
             schema: *ref_3
             implementation: Method
             required: true
@@ -1276,6 +1512,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1286,7 +1537,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_30
+          - *ref_31
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1307,7 +1558,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1329,8 +1580,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_32
+          - *ref_7
+          - !<!Parameter> &ref_33
             schema: *ref_3
             implementation: Method
             required: true
@@ -1342,8 +1593,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_33
-            schema: *ref_31
+          - !<!Parameter> &ref_34
+            schema: *ref_32
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1356,6 +1607,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1366,8 +1632,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_32
           - *ref_33
+          - *ref_34
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1380,7 +1646,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1402,8 +1668,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_34
+          - *ref_7
+          - !<!Parameter> &ref_35
             schema: *ref_3
             implementation: Method
             required: true
@@ -1417,6 +1683,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1427,7 +1708,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_34
+          - *ref_35
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1438,7 +1719,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_31
+                    schema: *ref_32
                     header: value
                     language:
                       default:
@@ -1448,7 +1729,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1470,8 +1751,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_36
+          - *ref_7
+          - !<!Parameter> &ref_37
             schema: *ref_3
             implementation: Method
             required: true
@@ -1483,8 +1764,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_37
-            schema: *ref_35
+          - !<!Parameter> &ref_38
+            schema: *ref_36
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1497,6 +1778,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1507,8 +1803,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_36
           - *ref_37
+          - *ref_38
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1521,7 +1817,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1543,8 +1839,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_38
+          - *ref_7
+          - !<!Parameter> &ref_39
             schema: *ref_3
             implementation: Method
             required: true
@@ -1558,6 +1854,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1568,7 +1879,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_38
+          - *ref_39
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1579,7 +1890,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: value
                     language:
                       default:
@@ -1589,7 +1900,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1611,8 +1922,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_40
+          - *ref_7
+          - !<!Parameter> &ref_41
             schema: *ref_3
             implementation: Method
             required: true
@@ -1624,8 +1935,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_41
-            schema: *ref_39
+          - !<!Parameter> &ref_42
+            schema: *ref_40
             implementation: Method
             language: !<!Languages> 
               default:
@@ -1637,6 +1948,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1647,8 +1973,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_40
           - *ref_41
+          - *ref_42
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1661,7 +1987,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1683,8 +2009,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_42
+          - *ref_7
+          - !<!Parameter> &ref_43
             schema: *ref_3
             implementation: Method
             required: true
@@ -1698,6 +2024,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1708,7 +2049,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_42
+          - *ref_43
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1719,7 +2060,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_39
+                    schema: *ref_40
                     header: value
                     language:
                       default:
@@ -1729,7 +2070,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1751,8 +2092,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_44
+          - *ref_7
+          - !<!Parameter> &ref_45
             schema: *ref_3
             implementation: Method
             required: true
@@ -1764,8 +2105,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_45
-            schema: *ref_43
+          - !<!Parameter> &ref_46
+            schema: *ref_44
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1778,6 +2119,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1788,8 +2144,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_44
           - *ref_45
+          - *ref_46
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1802,7 +2158,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1824,8 +2180,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_46
+          - *ref_7
+          - !<!Parameter> &ref_47
             schema: *ref_3
             implementation: Method
             required: true
@@ -1839,6 +2195,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1849,7 +2220,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_46
+          - *ref_47
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1860,7 +2231,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_43
+                    schema: *ref_44
                     header: value
                     language:
                       default:
@@ -1870,7 +2241,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1892,8 +2263,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_48
+          - *ref_7
+          - !<!Parameter> &ref_49
             schema: *ref_3
             implementation: Method
             required: true
@@ -1905,8 +2276,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_49
-            schema: *ref_47
+          - !<!Parameter> &ref_50
+            schema: *ref_48
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1919,6 +2290,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1929,8 +2315,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_48
           - *ref_49
+          - *ref_50
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1943,7 +2329,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -1965,8 +2351,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_50
+          - *ref_7
+          - !<!Parameter> &ref_51
             schema: *ref_3
             implementation: Method
             required: true
@@ -1980,6 +2366,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1990,7 +2391,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_50
+          - *ref_51
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2001,7 +2402,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_47
+                    schema: *ref_48
                     header: value
                     language:
                       default:
@@ -2011,7 +2412,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -2033,8 +2434,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_52
+          - *ref_7
+          - !<!Parameter> &ref_53
             schema: *ref_3
             implementation: Method
             required: true
@@ -2046,8 +2447,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_53
-            schema: *ref_51
+          - !<!Parameter> &ref_54
+            schema: *ref_52
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2059,6 +2460,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2069,8 +2485,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_52
           - *ref_53
+          - *ref_54
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2083,7 +2499,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -2105,8 +2521,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
-          - !<!Parameter> &ref_54
+          - *ref_7
+          - !<!Parameter> &ref_55
             schema: *ref_3
             implementation: Method
             required: true
@@ -2120,6 +2536,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2130,7 +2561,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_54
+          - *ref_55
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2141,7 +2572,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_51
+                    schema: *ref_52
                     header: value
                     language:
                       default:
@@ -2151,7 +2582,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -2173,9 +2604,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_6
+          - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2198,7 +2644,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_5
+            schema: *ref_6
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/header/namer.yaml
+++ b/modelerfour/test/scenarios/header/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: header
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_24
+    - !<!BooleanSchema> &ref_25
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -24,7 +24,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_8
+    - !<!NumberSchema> &ref_9
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -36,7 +36,7 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_12
+    - !<!NumberSchema> &ref_13
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -48,7 +48,7 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_16
+    - !<!NumberSchema> &ref_17
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -60,7 +60,7 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_20
+    - !<!NumberSchema> &ref_21
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -102,7 +102,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_51
+    - !<!SealedChoiceSchema> &ref_52
       choices:
         - !<!ChoiceValue> 
           value: White
@@ -133,8 +133,19 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_47
+    - !<!ByteArraySchema> &ref_48
       type: byte-array
       format: byte
       apiVersions:
@@ -147,7 +158,7 @@ schemas: !<!Schemas>
           header: value
       protocol: !<!Protocols> {}
   dateTimes:
-    - !<!DateTimeSchema> &ref_35
+    - !<!DateTimeSchema> &ref_36
       type: date-time
       format: date-time
       apiVersions:
@@ -159,7 +170,7 @@ schemas: !<!Schemas>
           description: ''
           header: value
       protocol: !<!Protocols> {}
-    - !<!DateTimeSchema> &ref_39
+    - !<!DateTimeSchema> &ref_40
       type: date-time
       format: date-time-rfc1123
       apiVersions:
@@ -172,7 +183,7 @@ schemas: !<!Schemas>
           header: value
       protocol: !<!Protocols> {}
   dates:
-    - !<!DateSchema> &ref_31
+    - !<!DateSchema> &ref_32
       type: date
       apiVersions:
         - !<!ApiVersion> 
@@ -184,7 +195,7 @@ schemas: !<!Schemas>
           header: value
       protocol: !<!Protocols> {}
   durations:
-    - !<!DurationSchema> &ref_43
+    - !<!DurationSchema> &ref_44
       type: duration
       apiVersions:
         - !<!ApiVersion> 
@@ -196,7 +207,7 @@ schemas: !<!Schemas>
           header: value
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_6
+    - !<!ObjectSchema> &ref_7
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -255,7 +266,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_5
+          - !<!Parameter> &ref_6
             schema: *ref_4
             implementation: Method
             required: true
@@ -269,6 +280,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -279,7 +305,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_5
+          - *ref_6
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -292,7 +318,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -317,6 +343,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -347,7 +388,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -370,7 +411,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_7
+          - !<!Parameter> &ref_8
             schema: *ref_4
             implementation: Method
             required: true
@@ -384,6 +425,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -394,7 +450,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_7
+          - *ref_8
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -407,7 +463,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -432,6 +488,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -462,7 +533,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -485,7 +556,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_9
+          - !<!Parameter> &ref_10
             schema: *ref_4
             implementation: Method
             required: true
@@ -497,8 +568,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_10
-            schema: *ref_8
+          - !<!Parameter> &ref_11
+            schema: *ref_9
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -511,6 +582,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -521,8 +607,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_9
           - *ref_10
+          - *ref_11
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -535,7 +621,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -558,7 +644,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_11
+          - !<!Parameter> &ref_12
             schema: *ref_4
             implementation: Method
             required: true
@@ -572,6 +658,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -582,7 +683,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_11
+          - *ref_12
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -593,7 +694,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_8
+                    schema: *ref_9
                     header: value
                     language:
                       default:
@@ -603,7 +704,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -626,7 +727,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_13
+          - !<!Parameter> &ref_14
             schema: *ref_4
             implementation: Method
             required: true
@@ -638,8 +739,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_14
-            schema: *ref_12
+          - !<!Parameter> &ref_15
+            schema: *ref_13
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -652,6 +753,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -662,8 +778,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_13
           - *ref_14
+          - *ref_15
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -676,7 +792,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -699,7 +815,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_15
+          - !<!Parameter> &ref_16
             schema: *ref_4
             implementation: Method
             required: true
@@ -713,6 +829,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -723,7 +854,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_15
+          - *ref_16
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -734,7 +865,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_12
+                    schema: *ref_13
                     header: value
                     language:
                       default:
@@ -744,7 +875,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -767,7 +898,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_17
+          - !<!Parameter> &ref_18
             schema: *ref_4
             implementation: Method
             required: true
@@ -779,8 +910,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_18
-            schema: *ref_16
+          - !<!Parameter> &ref_19
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -793,6 +924,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -803,8 +949,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_17
           - *ref_18
+          - *ref_19
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -817,7 +963,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -840,7 +986,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_19
+          - !<!Parameter> &ref_20
             schema: *ref_4
             implementation: Method
             required: true
@@ -854,6 +1000,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -864,7 +1025,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_19
+          - *ref_20
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -875,7 +1036,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: value
                     language:
                       default:
@@ -885,7 +1046,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -908,7 +1069,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_21
+          - !<!Parameter> &ref_22
             schema: *ref_4
             implementation: Method
             required: true
@@ -920,8 +1081,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_22
-            schema: *ref_20
+          - !<!Parameter> &ref_23
+            schema: *ref_21
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -934,6 +1095,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -944,8 +1120,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_21
           - *ref_22
+          - *ref_23
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -958,7 +1134,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -981,7 +1157,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_23
+          - !<!Parameter> &ref_24
             schema: *ref_4
             implementation: Method
             required: true
@@ -995,6 +1171,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1005,7 +1196,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_23
+          - *ref_24
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1016,7 +1207,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_20
+                    schema: *ref_21
                     header: value
                     language:
                       default:
@@ -1026,7 +1217,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1049,7 +1240,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_25
+          - !<!Parameter> &ref_26
             schema: *ref_4
             implementation: Method
             required: true
@@ -1061,8 +1252,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_26
-            schema: *ref_24
+          - !<!Parameter> &ref_27
+            schema: *ref_25
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1075,6 +1266,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1085,8 +1291,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_25
           - *ref_26
+          - *ref_27
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1099,7 +1305,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1122,7 +1328,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_27
+          - !<!Parameter> &ref_28
             schema: *ref_4
             implementation: Method
             required: true
@@ -1136,6 +1342,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1146,7 +1367,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_27
+          - *ref_28
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1157,7 +1378,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_24
+                    schema: *ref_25
                     header: value
                     language:
                       default:
@@ -1167,7 +1388,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1190,7 +1411,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_4
             implementation: Method
             required: true
@@ -1202,7 +1423,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_29
+          - !<!Parameter> &ref_30
             schema: *ref_4
             implementation: Method
             language: !<!Languages> 
@@ -1215,6 +1436,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1225,8 +1461,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
           - *ref_29
+          - *ref_30
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1239,7 +1475,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1262,7 +1498,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_30
+          - !<!Parameter> &ref_31
             schema: *ref_4
             implementation: Method
             required: true
@@ -1276,6 +1512,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1286,7 +1537,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_30
+          - *ref_31
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1307,7 +1558,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1330,7 +1581,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_32
+          - !<!Parameter> &ref_33
             schema: *ref_4
             implementation: Method
             required: true
@@ -1342,8 +1593,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_33
-            schema: *ref_31
+          - !<!Parameter> &ref_34
+            schema: *ref_32
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1356,6 +1607,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1366,8 +1632,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_32
           - *ref_33
+          - *ref_34
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1380,7 +1646,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1403,7 +1669,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_34
+          - !<!Parameter> &ref_35
             schema: *ref_4
             implementation: Method
             required: true
@@ -1417,6 +1683,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1427,7 +1708,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_34
+          - *ref_35
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1438,7 +1719,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_31
+                    schema: *ref_32
                     header: value
                     language:
                       default:
@@ -1448,7 +1729,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1471,7 +1752,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_36
+          - !<!Parameter> &ref_37
             schema: *ref_4
             implementation: Method
             required: true
@@ -1483,8 +1764,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_37
-            schema: *ref_35
+          - !<!Parameter> &ref_38
+            schema: *ref_36
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1497,6 +1778,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1507,8 +1803,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_36
           - *ref_37
+          - *ref_38
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1521,7 +1817,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1544,7 +1840,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_38
+          - !<!Parameter> &ref_39
             schema: *ref_4
             implementation: Method
             required: true
@@ -1558,6 +1854,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1568,7 +1879,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_38
+          - *ref_39
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1579,7 +1890,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: value
                     language:
                       default:
@@ -1589,7 +1900,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1612,7 +1923,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_40
+          - !<!Parameter> &ref_41
             schema: *ref_4
             implementation: Method
             required: true
@@ -1624,8 +1935,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_41
-            schema: *ref_39
+          - !<!Parameter> &ref_42
+            schema: *ref_40
             implementation: Method
             language: !<!Languages> 
               default:
@@ -1637,6 +1948,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1647,8 +1973,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_40
           - *ref_41
+          - *ref_42
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1661,7 +1987,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1684,7 +2010,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_42
+          - !<!Parameter> &ref_43
             schema: *ref_4
             implementation: Method
             required: true
@@ -1698,6 +2024,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1708,7 +2049,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_42
+          - *ref_43
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1719,7 +2060,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_39
+                    schema: *ref_40
                     header: value
                     language:
                       default:
@@ -1729,7 +2070,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1752,7 +2093,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_44
+          - !<!Parameter> &ref_45
             schema: *ref_4
             implementation: Method
             required: true
@@ -1764,8 +2105,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_45
-            schema: *ref_43
+          - !<!Parameter> &ref_46
+            schema: *ref_44
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1778,6 +2119,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1788,8 +2144,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_44
           - *ref_45
+          - *ref_46
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1802,7 +2158,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1825,7 +2181,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_46
+          - !<!Parameter> &ref_47
             schema: *ref_4
             implementation: Method
             required: true
@@ -1839,6 +2195,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1849,7 +2220,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_46
+          - *ref_47
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1860,7 +2231,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_43
+                    schema: *ref_44
                     header: value
                     language:
                       default:
@@ -1870,7 +2241,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1893,7 +2264,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_48
+          - !<!Parameter> &ref_49
             schema: *ref_4
             implementation: Method
             required: true
@@ -1905,8 +2276,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_49
-            schema: *ref_47
+          - !<!Parameter> &ref_50
+            schema: *ref_48
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1919,6 +2290,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1929,8 +2315,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_48
           - *ref_49
+          - *ref_50
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1943,7 +2329,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -1966,7 +2352,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_50
+          - !<!Parameter> &ref_51
             schema: *ref_4
             implementation: Method
             required: true
@@ -1980,6 +2366,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1990,7 +2391,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_50
+          - *ref_51
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2001,7 +2402,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_47
+                    schema: *ref_48
                     header: value
                     language:
                       default:
@@ -2011,7 +2412,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2034,7 +2435,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_52
+          - !<!Parameter> &ref_53
             schema: *ref_4
             implementation: Method
             required: true
@@ -2046,8 +2447,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_53
-            schema: *ref_51
+          - !<!Parameter> &ref_54
+            schema: *ref_52
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2059,6 +2460,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2069,8 +2485,8 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_52
           - *ref_53
+          - *ref_54
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2083,7 +2499,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2106,7 +2522,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !<!Parameter> &ref_54
+          - !<!Parameter> &ref_55
             schema: *ref_4
             implementation: Method
             required: true
@@ -2120,6 +2536,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2130,7 +2561,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_54
+          - *ref_55
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2141,7 +2572,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_51
+                    schema: *ref_52
                     header: value
                     language:
                       default:
@@ -2151,7 +2582,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -2176,6 +2607,21 @@ operationGroups:
           - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2198,7 +2644,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/flattened.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/flattened.yaml
@@ -11,7 +11,7 @@ schemas: !<!Schemas>
           name: bool
           description: simple boolean
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_13
+    - !<!BooleanSchema> &ref_14
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -112,7 +112,17 @@ schemas: !<!Schemas>
           name: paths·hhuu7h·http-failure-emptybody-error·get·responses·200·content·application-json·schema
           description: Simple boolean value true
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_28
+    - !<!ConstantSchema> &ref_12
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_29
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -126,7 +136,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_30
+    - !<!ConstantSchema> &ref_31
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -140,7 +150,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_32
+    - !<!ConstantSchema> &ref_33
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -154,7 +164,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_35
+    - !<!ConstantSchema> &ref_36
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -168,7 +178,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_37
+    - !<!ConstantSchema> &ref_38
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -182,7 +192,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_39
+    - !<!ConstantSchema> &ref_40
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -196,7 +206,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_41
+    - !<!ConstantSchema> &ref_42
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -210,7 +220,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_43
+    - !<!ConstantSchema> &ref_44
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -225,7 +235,7 @@ schemas: !<!Schemas>
           header: Location
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_12
+    - !<!ObjectSchema> &ref_13
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -317,7 +327,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_6
-    - !<!ObjectSchema> &ref_65
+    - !<!ObjectSchema> &ref_66
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -341,7 +351,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_66
+    - !<!ObjectSchema> &ref_67
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -366,7 +376,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_29
+    - !<!ArraySchema> &ref_30
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -406,6 +416,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -432,7 +457,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -457,6 +482,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -494,6 +534,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -539,6 +594,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -561,7 +631,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -586,6 +656,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -612,7 +697,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -637,6 +722,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -663,7 +763,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -689,8 +789,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_14
-                schema: *ref_13
+              - !<!Parameter> &ref_15
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -701,8 +801,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_14
+              - *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -728,7 +841,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -754,8 +867,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_13
+              - !<!Parameter> &ref_16
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -766,8 +879,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -793,7 +919,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -819,8 +945,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_13
+              - !<!Parameter> &ref_17
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -831,8 +957,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -858,7 +997,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -884,8 +1023,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
-                schema: *ref_13
+              - !<!Parameter> &ref_18
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -896,8 +1035,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -923,7 +1075,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -949,8 +1101,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_18
-                schema: *ref_13
+              - !<!Parameter> &ref_19
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -961,8 +1113,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_18
+              - *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -988,7 +1153,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1014,8 +1179,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_19
-                schema: *ref_13
+              - !<!Parameter> &ref_20
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1026,8 +1191,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_19
+              - *ref_20
             language: !<!Languages> 
               default:
                 name: ''
@@ -1053,7 +1231,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1079,8 +1257,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_20
-                schema: *ref_13
+              - !<!Parameter> &ref_21
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1091,8 +1269,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_20
+              - *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -1118,7 +1309,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1144,8 +1335,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_21
-                schema: *ref_13
+              - !<!Parameter> &ref_22
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1156,8 +1347,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -1183,7 +1387,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1209,8 +1413,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_22
-                schema: *ref_13
+              - !<!Parameter> &ref_23
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1221,8 +1425,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_22
+              - *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -1248,7 +1465,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1274,8 +1491,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_23
-                schema: *ref_13
+              - !<!Parameter> &ref_24
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1286,8 +1503,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_23
+              - *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -1313,7 +1543,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1338,6 +1568,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1360,7 +1605,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1386,8 +1631,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_24
-                schema: *ref_13
+              - !<!Parameter> &ref_25
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1398,8 +1643,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_24
+              - *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1425,7 +1683,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1451,8 +1709,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_25
-                schema: *ref_13
+              - !<!Parameter> &ref_26
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1463,8 +1721,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_25
+              - *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1490,7 +1761,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1516,8 +1787,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_26
-                schema: *ref_13
+              - !<!Parameter> &ref_27
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1528,8 +1799,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_26
+              - *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1555,7 +1839,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1581,8 +1865,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_27
-                schema: *ref_13
+              - !<!Parameter> &ref_28
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1593,8 +1877,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_27
+              - *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1620,7 +1917,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1645,6 +1942,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1676,7 +1988,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1709,6 +2021,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1738,7 +2065,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_28
+                    schema: *ref_29
                     header: Location
                     language:
                       default:
@@ -1748,7 +2075,7 @@ operationGroups:
                   - '300'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1773,6 +2100,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1794,7 +2136,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1803,7 +2145,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_30
+                    schema: *ref_31
                     header: Location
                     language:
                       default:
@@ -1816,7 +2158,7 @@ operationGroups:
                   - '300'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1841,6 +2183,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1870,7 +2227,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_28
+                    schema: *ref_29
                     header: Location
                     language:
                       default:
@@ -1880,7 +2237,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1905,6 +2262,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1934,7 +2306,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_30
+                    schema: *ref_31
                     header: Location
                     language:
                       default:
@@ -1944,7 +2316,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1970,8 +2342,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
-                schema: *ref_13
+              - !<!Parameter> &ref_32
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1982,8 +2354,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_31
+              - *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -2007,7 +2392,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_32
+                    schema: *ref_33
                     header: Location
                     language:
                       default:
@@ -2017,7 +2402,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2042,6 +2427,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2071,7 +2471,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_28
+                    schema: *ref_29
                     header: Location
                     language:
                       default:
@@ -2081,7 +2481,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2106,6 +2506,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2135,7 +2550,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_30
+                    schema: *ref_31
                     header: Location
                     language:
                       default:
@@ -2145,7 +2560,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2171,8 +2586,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
-                schema: *ref_13
+              - !<!Parameter> &ref_34
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2183,8 +2598,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -2208,7 +2636,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_32
+                    schema: *ref_33
                     header: Location
                     language:
                       default:
@@ -2218,7 +2646,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2244,8 +2672,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
-                schema: *ref_13
+              - !<!Parameter> &ref_35
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2256,8 +2684,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -2290,7 +2731,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_30
+                    schema: *ref_31
                     header: Location
                     language:
                       default:
@@ -2300,7 +2741,7 @@ operationGroups:
                   - '303'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2325,6 +2766,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2354,7 +2810,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_28
+                    schema: *ref_29
                     header: Location
                     language:
                       default:
@@ -2364,7 +2820,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2389,6 +2845,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2418,7 +2889,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_30
+                    schema: *ref_31
                     header: Location
                     language:
                       default:
@@ -2428,7 +2899,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2453,6 +2924,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2482,7 +2968,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Location
                     language:
                       default:
@@ -2492,7 +2978,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2518,8 +3004,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_13
+              - !<!Parameter> &ref_37
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2530,8 +3016,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -2564,7 +3063,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Location
                     language:
                       default:
@@ -2574,7 +3073,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2600,8 +3099,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_38
-                schema: *ref_13
+              - !<!Parameter> &ref_39
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2612,8 +3111,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_38
+              - *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -2646,7 +3158,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_39
+                    schema: *ref_40
                     header: Location
                     language:
                       default:
@@ -2656,7 +3168,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2682,8 +3194,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_40
-                schema: *ref_13
+              - !<!Parameter> &ref_41
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2694,8 +3206,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_40
+              - *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -2728,7 +3253,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_41
+                    schema: *ref_42
                     header: Location
                     language:
                       default:
@@ -2738,7 +3263,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2764,8 +3289,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_42
-                schema: *ref_13
+              - !<!Parameter> &ref_43
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2776,8 +3301,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_42
+              - *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -2810,7 +3348,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_43
+                    schema: *ref_44
                     header: Location
                     language:
                       default:
@@ -2820,7 +3358,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2853,6 +3391,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2865,7 +3418,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2890,6 +3443,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2902,7 +3470,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2927,6 +3495,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2939,7 +3522,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2965,8 +3548,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_44
-                schema: *ref_13
+              - !<!Parameter> &ref_45
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2977,8 +3560,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_44
+              - *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -2994,7 +3590,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3020,8 +3616,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_45
-                schema: *ref_13
+              - !<!Parameter> &ref_46
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3032,8 +3628,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -3049,7 +3658,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3075,8 +3684,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_46
-                schema: *ref_13
+              - !<!Parameter> &ref_47
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3087,8 +3696,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_46
+              - *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -3104,7 +3726,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3130,8 +3752,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_47
-                schema: *ref_13
+              - !<!Parameter> &ref_48
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3142,8 +3764,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_47
+              - *ref_48
             language: !<!Languages> 
               default:
                 name: ''
@@ -3159,7 +3794,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3184,6 +3819,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3196,7 +3846,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3221,6 +3871,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3233,7 +3898,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3258,6 +3923,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3270,7 +3950,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3295,6 +3975,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3307,7 +4002,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3333,8 +4028,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_48
-                schema: *ref_13
+              - !<!Parameter> &ref_49
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3345,8 +4040,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_48
+              - *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -3362,7 +4070,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3388,8 +4096,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_49
-                schema: *ref_13
+              - !<!Parameter> &ref_50
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3400,8 +4108,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_49
+              - *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3417,7 +4138,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3443,8 +4164,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_50
-                schema: *ref_13
+              - !<!Parameter> &ref_51
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3455,8 +4176,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_50
+              - *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -3472,7 +4206,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3498,8 +4232,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_51
-                schema: *ref_13
+              - !<!Parameter> &ref_52
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3510,8 +4244,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_51
+              - *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -3527,7 +4274,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3553,8 +4300,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_52
-                schema: *ref_13
+              - !<!Parameter> &ref_53
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3565,8 +4312,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_52
+              - *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3582,7 +4342,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3607,6 +4367,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3619,7 +4394,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3644,6 +4419,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3656,7 +4446,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3681,6 +4471,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3693,7 +4498,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3718,6 +4523,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3730,7 +4550,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3756,8 +4576,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_53
-                schema: *ref_13
+              - !<!Parameter> &ref_54
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3768,8 +4588,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_53
+              - *ref_54
             language: !<!Languages> 
               default:
                 name: ''
@@ -3785,7 +4618,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3811,8 +4644,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_54
-                schema: *ref_13
+              - !<!Parameter> &ref_55
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3823,8 +4656,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_54
+              - *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -3840,7 +4686,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3866,8 +4712,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_55
-                schema: *ref_13
+              - !<!Parameter> &ref_56
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3878,8 +4724,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_55
+              - *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3895,7 +4754,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3920,6 +4779,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3932,7 +4806,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3958,8 +4832,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_56
-                schema: *ref_13
+              - !<!Parameter> &ref_57
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3970,8 +4844,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_56
+              - *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3987,7 +4874,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4012,6 +4899,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4024,7 +4926,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4057,6 +4959,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4069,7 +4986,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4094,6 +5011,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4106,7 +5038,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4132,8 +5064,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_57
-                schema: *ref_13
+              - !<!Parameter> &ref_58
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4144,8 +5076,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_57
+              - *ref_58
             language: !<!Languages> 
               default:
                 name: ''
@@ -4161,7 +5106,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4187,8 +5132,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_58
-                schema: *ref_13
+              - !<!Parameter> &ref_59
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4199,8 +5144,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_58
+              - *ref_59
             language: !<!Languages> 
               default:
                 name: ''
@@ -4216,7 +5174,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4249,6 +5207,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4271,7 +5244,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4297,8 +5270,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_59
-                schema: *ref_13
+              - !<!Parameter> &ref_60
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4309,8 +5282,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_59
+              - *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -4336,7 +5322,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4362,8 +5348,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_60
-                schema: *ref_13
+              - !<!Parameter> &ref_61
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4374,8 +5360,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_60
+              - *ref_61
             language: !<!Languages> 
               default:
                 name: ''
@@ -4401,7 +5400,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4426,6 +5425,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4448,7 +5462,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4473,6 +5487,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4499,7 +5528,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4525,8 +5554,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_61
-                schema: *ref_13
+              - !<!Parameter> &ref_62
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4537,8 +5566,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_61
+              - *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -4564,7 +5606,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4590,8 +5632,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_62
-                schema: *ref_13
+              - !<!Parameter> &ref_63
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4602,8 +5644,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_62
+              - *ref_63
             language: !<!Languages> 
               default:
                 name: ''
@@ -4629,7 +5684,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4655,8 +5710,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_63
-                schema: *ref_13
+              - !<!Parameter> &ref_64
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4667,8 +5722,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -4694,7 +5762,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4720,8 +5788,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_64
-                schema: *ref_13
+              - !<!Parameter> &ref_65
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4732,8 +5800,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_64
+              - *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4759,7 +5840,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4792,6 +5873,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4827,7 +5923,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4852,6 +5948,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4887,7 +5998,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4912,6 +6023,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4947,7 +6073,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4972,6 +6098,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5007,7 +6148,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5032,6 +6173,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5067,7 +6223,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5092,6 +6248,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5131,7 +6302,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5156,6 +6327,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5195,7 +6381,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5220,6 +6406,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5259,7 +6460,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5284,6 +6485,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5309,7 +6525,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_65
+            schema: *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5322,7 +6538,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_66
+            schema: *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5336,7 +6552,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5361,6 +6577,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5386,7 +6617,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_65
+            schema: *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5399,7 +6630,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_66
+            schema: *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5413,7 +6644,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5438,6 +6669,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5463,7 +6709,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_65
+            schema: *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5476,7 +6722,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_66
+            schema: *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5490,7 +6736,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5515,6 +6761,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5540,7 +6801,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_65
+            schema: *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5553,7 +6814,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_66
+            schema: *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5567,7 +6828,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5592,6 +6853,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5623,7 +6899,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5648,6 +6924,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5679,7 +6970,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5704,6 +6995,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5735,7 +7041,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5968,6 +7274,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6005,6 +7326,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6042,6 +7378,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6079,6 +7430,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6248,6 +7614,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6285,6 +7666,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6322,6 +7718,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6359,6 +7770,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6396,6 +7822,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6433,6 +7874,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6470,6 +7926,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/grouped.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/grouped.yaml
@@ -11,7 +11,7 @@ schemas: !<!Schemas>
           name: bool
           description: simple boolean
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_13
+    - !<!BooleanSchema> &ref_14
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -112,7 +112,17 @@ schemas: !<!Schemas>
           name: paths·hhuu7h·http-failure-emptybody-error·get·responses·200·content·application-json·schema
           description: Simple boolean value true
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_28
+    - !<!ConstantSchema> &ref_12
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_29
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -126,7 +136,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_30
+    - !<!ConstantSchema> &ref_31
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -140,7 +150,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_32
+    - !<!ConstantSchema> &ref_33
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -154,7 +164,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_35
+    - !<!ConstantSchema> &ref_36
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -168,7 +178,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_37
+    - !<!ConstantSchema> &ref_38
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -182,7 +192,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_39
+    - !<!ConstantSchema> &ref_40
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -196,7 +206,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_41
+    - !<!ConstantSchema> &ref_42
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -210,7 +220,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_43
+    - !<!ConstantSchema> &ref_44
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -225,7 +235,7 @@ schemas: !<!Schemas>
           header: Location
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_12
+    - !<!ObjectSchema> &ref_13
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -317,7 +327,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_6
-    - !<!ObjectSchema> &ref_65
+    - !<!ObjectSchema> &ref_66
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -341,7 +351,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_66
+    - !<!ObjectSchema> &ref_67
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -366,7 +376,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_29
+    - !<!ArraySchema> &ref_30
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -406,6 +416,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -432,7 +457,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -457,6 +482,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -494,6 +534,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -539,6 +594,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -561,7 +631,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -586,6 +656,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -612,7 +697,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -637,6 +722,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -663,7 +763,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -689,8 +789,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_14
-                schema: *ref_13
+              - !<!Parameter> &ref_15
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -701,8 +801,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_14
+              - *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -728,7 +841,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -754,8 +867,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_13
+              - !<!Parameter> &ref_16
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -766,8 +879,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -793,7 +919,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -819,8 +945,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_13
+              - !<!Parameter> &ref_17
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -831,8 +957,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -858,7 +997,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -884,8 +1023,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
-                schema: *ref_13
+              - !<!Parameter> &ref_18
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -896,8 +1035,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -923,7 +1075,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -949,8 +1101,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_18
-                schema: *ref_13
+              - !<!Parameter> &ref_19
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -961,8 +1113,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_18
+              - *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -988,7 +1153,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1014,8 +1179,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_19
-                schema: *ref_13
+              - !<!Parameter> &ref_20
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1026,8 +1191,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_19
+              - *ref_20
             language: !<!Languages> 
               default:
                 name: ''
@@ -1053,7 +1231,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1079,8 +1257,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_20
-                schema: *ref_13
+              - !<!Parameter> &ref_21
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1091,8 +1269,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_20
+              - *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -1118,7 +1309,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1144,8 +1335,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_21
-                schema: *ref_13
+              - !<!Parameter> &ref_22
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1156,8 +1347,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -1183,7 +1387,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1209,8 +1413,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_22
-                schema: *ref_13
+              - !<!Parameter> &ref_23
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1221,8 +1425,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_22
+              - *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -1248,7 +1465,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1274,8 +1491,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_23
-                schema: *ref_13
+              - !<!Parameter> &ref_24
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1286,8 +1503,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_23
+              - *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -1313,7 +1543,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1338,6 +1568,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1360,7 +1605,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1386,8 +1631,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_24
-                schema: *ref_13
+              - !<!Parameter> &ref_25
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1398,8 +1643,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_24
+              - *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1425,7 +1683,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1451,8 +1709,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_25
-                schema: *ref_13
+              - !<!Parameter> &ref_26
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1463,8 +1721,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_25
+              - *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1490,7 +1761,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1516,8 +1787,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_26
-                schema: *ref_13
+              - !<!Parameter> &ref_27
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1528,8 +1799,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_26
+              - *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1555,7 +1839,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1581,8 +1865,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_27
-                schema: *ref_13
+              - !<!Parameter> &ref_28
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1593,8 +1877,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_27
+              - *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1620,7 +1917,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1645,6 +1942,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1676,7 +1988,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1709,6 +2021,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1738,7 +2065,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_28
+                    schema: *ref_29
                     header: Location
                     language:
                       default:
@@ -1748,7 +2075,7 @@ operationGroups:
                   - '300'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1773,6 +2100,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1794,7 +2136,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1803,7 +2145,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_30
+                    schema: *ref_31
                     header: Location
                     language:
                       default:
@@ -1816,7 +2158,7 @@ operationGroups:
                   - '300'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1841,6 +2183,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1870,7 +2227,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_28
+                    schema: *ref_29
                     header: Location
                     language:
                       default:
@@ -1880,7 +2237,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1905,6 +2262,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1934,7 +2306,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_30
+                    schema: *ref_31
                     header: Location
                     language:
                       default:
@@ -1944,7 +2316,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1970,8 +2342,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
-                schema: *ref_13
+              - !<!Parameter> &ref_32
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1982,8 +2354,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_31
+              - *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -2007,7 +2392,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_32
+                    schema: *ref_33
                     header: Location
                     language:
                       default:
@@ -2017,7 +2402,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2042,6 +2427,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2071,7 +2471,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_28
+                    schema: *ref_29
                     header: Location
                     language:
                       default:
@@ -2081,7 +2481,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2106,6 +2506,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2135,7 +2550,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_30
+                    schema: *ref_31
                     header: Location
                     language:
                       default:
@@ -2145,7 +2560,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2171,8 +2586,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
-                schema: *ref_13
+              - !<!Parameter> &ref_34
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2183,8 +2598,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -2208,7 +2636,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_32
+                    schema: *ref_33
                     header: Location
                     language:
                       default:
@@ -2218,7 +2646,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2244,8 +2672,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
-                schema: *ref_13
+              - !<!Parameter> &ref_35
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2256,8 +2684,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -2290,7 +2731,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_30
+                    schema: *ref_31
                     header: Location
                     language:
                       default:
@@ -2300,7 +2741,7 @@ operationGroups:
                   - '303'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2325,6 +2766,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2354,7 +2810,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_28
+                    schema: *ref_29
                     header: Location
                     language:
                       default:
@@ -2364,7 +2820,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2389,6 +2845,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2418,7 +2889,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_30
+                    schema: *ref_31
                     header: Location
                     language:
                       default:
@@ -2428,7 +2899,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2453,6 +2924,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2482,7 +2968,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Location
                     language:
                       default:
@@ -2492,7 +2978,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2518,8 +3004,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_13
+              - !<!Parameter> &ref_37
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2530,8 +3016,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -2564,7 +3063,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Location
                     language:
                       default:
@@ -2574,7 +3073,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2600,8 +3099,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_38
-                schema: *ref_13
+              - !<!Parameter> &ref_39
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2612,8 +3111,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_38
+              - *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -2646,7 +3158,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_39
+                    schema: *ref_40
                     header: Location
                     language:
                       default:
@@ -2656,7 +3168,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2682,8 +3194,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_40
-                schema: *ref_13
+              - !<!Parameter> &ref_41
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2694,8 +3206,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_40
+              - *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -2728,7 +3253,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_41
+                    schema: *ref_42
                     header: Location
                     language:
                       default:
@@ -2738,7 +3263,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2764,8 +3289,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_42
-                schema: *ref_13
+              - !<!Parameter> &ref_43
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2776,8 +3301,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_42
+              - *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -2810,7 +3348,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_43
+                    schema: *ref_44
                     header: Location
                     language:
                       default:
@@ -2820,7 +3358,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2853,6 +3391,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2865,7 +3418,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2890,6 +3443,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2902,7 +3470,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2927,6 +3495,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2939,7 +3522,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2965,8 +3548,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_44
-                schema: *ref_13
+              - !<!Parameter> &ref_45
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2977,8 +3560,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_44
+              - *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -2994,7 +3590,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3020,8 +3616,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_45
-                schema: *ref_13
+              - !<!Parameter> &ref_46
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3032,8 +3628,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -3049,7 +3658,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3075,8 +3684,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_46
-                schema: *ref_13
+              - !<!Parameter> &ref_47
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3087,8 +3696,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_46
+              - *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -3104,7 +3726,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3130,8 +3752,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_47
-                schema: *ref_13
+              - !<!Parameter> &ref_48
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3142,8 +3764,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_47
+              - *ref_48
             language: !<!Languages> 
               default:
                 name: ''
@@ -3159,7 +3794,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3184,6 +3819,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3196,7 +3846,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3221,6 +3871,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3233,7 +3898,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3258,6 +3923,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3270,7 +3950,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3295,6 +3975,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3307,7 +4002,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3333,8 +4028,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_48
-                schema: *ref_13
+              - !<!Parameter> &ref_49
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3345,8 +4040,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_48
+              - *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -3362,7 +4070,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3388,8 +4096,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_49
-                schema: *ref_13
+              - !<!Parameter> &ref_50
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3400,8 +4108,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_49
+              - *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3417,7 +4138,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3443,8 +4164,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_50
-                schema: *ref_13
+              - !<!Parameter> &ref_51
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3455,8 +4176,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_50
+              - *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -3472,7 +4206,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3498,8 +4232,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_51
-                schema: *ref_13
+              - !<!Parameter> &ref_52
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3510,8 +4244,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_51
+              - *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -3527,7 +4274,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3553,8 +4300,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_52
-                schema: *ref_13
+              - !<!Parameter> &ref_53
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3565,8 +4312,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_52
+              - *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3582,7 +4342,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3607,6 +4367,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3619,7 +4394,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3644,6 +4419,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3656,7 +4446,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3681,6 +4471,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3693,7 +4498,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3718,6 +4523,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3730,7 +4550,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3756,8 +4576,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_53
-                schema: *ref_13
+              - !<!Parameter> &ref_54
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3768,8 +4588,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_53
+              - *ref_54
             language: !<!Languages> 
               default:
                 name: ''
@@ -3785,7 +4618,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3811,8 +4644,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_54
-                schema: *ref_13
+              - !<!Parameter> &ref_55
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3823,8 +4656,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_54
+              - *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -3840,7 +4686,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3866,8 +4712,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_55
-                schema: *ref_13
+              - !<!Parameter> &ref_56
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3878,8 +4724,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_55
+              - *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3895,7 +4754,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3920,6 +4779,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3932,7 +4806,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3958,8 +4832,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_56
-                schema: *ref_13
+              - !<!Parameter> &ref_57
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3970,8 +4844,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_56
+              - *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3987,7 +4874,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4012,6 +4899,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4024,7 +4926,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4057,6 +4959,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4069,7 +4986,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4094,6 +5011,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4106,7 +5038,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4132,8 +5064,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_57
-                schema: *ref_13
+              - !<!Parameter> &ref_58
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4144,8 +5076,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_57
+              - *ref_58
             language: !<!Languages> 
               default:
                 name: ''
@@ -4161,7 +5106,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4187,8 +5132,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_58
-                schema: *ref_13
+              - !<!Parameter> &ref_59
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4199,8 +5144,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_58
+              - *ref_59
             language: !<!Languages> 
               default:
                 name: ''
@@ -4216,7 +5174,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4249,6 +5207,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4271,7 +5244,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4297,8 +5270,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_59
-                schema: *ref_13
+              - !<!Parameter> &ref_60
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4309,8 +5282,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_59
+              - *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -4336,7 +5322,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4362,8 +5348,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_60
-                schema: *ref_13
+              - !<!Parameter> &ref_61
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4374,8 +5360,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_60
+              - *ref_61
             language: !<!Languages> 
               default:
                 name: ''
@@ -4401,7 +5400,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4426,6 +5425,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4448,7 +5462,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4473,6 +5487,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4499,7 +5528,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4525,8 +5554,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_61
-                schema: *ref_13
+              - !<!Parameter> &ref_62
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4537,8 +5566,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_61
+              - *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -4564,7 +5606,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4590,8 +5632,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_62
-                schema: *ref_13
+              - !<!Parameter> &ref_63
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4602,8 +5644,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_62
+              - *ref_63
             language: !<!Languages> 
               default:
                 name: ''
@@ -4629,7 +5684,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4655,8 +5710,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_63
-                schema: *ref_13
+              - !<!Parameter> &ref_64
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4667,8 +5722,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -4694,7 +5762,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4720,8 +5788,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_64
-                schema: *ref_13
+              - !<!Parameter> &ref_65
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4732,8 +5800,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_64
+              - *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4759,7 +5840,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4792,6 +5873,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4827,7 +5923,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4852,6 +5948,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4887,7 +5998,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4912,6 +6023,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4947,7 +6073,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4972,6 +6098,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5007,7 +6148,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5032,6 +6173,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5067,7 +6223,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5092,6 +6248,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5131,7 +6302,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5156,6 +6327,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5195,7 +6381,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5220,6 +6406,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5259,7 +6460,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5284,6 +6485,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5309,7 +6525,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_65
+            schema: *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5322,7 +6538,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_66
+            schema: *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5336,7 +6552,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5361,6 +6577,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5386,7 +6617,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_65
+            schema: *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5399,7 +6630,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_66
+            schema: *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5413,7 +6644,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5438,6 +6669,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5463,7 +6709,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_65
+            schema: *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5476,7 +6722,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_66
+            schema: *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5490,7 +6736,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5515,6 +6761,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5540,7 +6801,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_65
+            schema: *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5553,7 +6814,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_66
+            schema: *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5567,7 +6828,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5592,6 +6853,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5623,7 +6899,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5648,6 +6924,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5679,7 +6970,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5704,6 +6995,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5735,7 +7041,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5968,6 +7274,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6005,6 +7326,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6042,6 +7378,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6079,6 +7430,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6248,6 +7614,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6285,6 +7666,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6322,6 +7718,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6359,6 +7770,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6396,6 +7822,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6433,6 +7874,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6470,6 +7926,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/modeler.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/modeler.yaml
@@ -11,7 +11,7 @@ schemas: !<!Schemas>
           name: bool
           description: simple boolean
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_13
+    - !<!BooleanSchema> &ref_14
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -112,7 +112,17 @@ schemas: !<!Schemas>
           name: paths·hhuu7h·http-failure-emptybody-error·get·responses·200·content·application-json·schema
           description: Simple boolean value true
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_28
+    - !<!ConstantSchema> &ref_11
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_29
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -126,7 +136,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_29
+    - !<!ConstantSchema> &ref_30
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -140,7 +150,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_32
+    - !<!ConstantSchema> &ref_33
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -154,7 +164,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_35
+    - !<!ConstantSchema> &ref_36
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -168,7 +178,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_37
+    - !<!ConstantSchema> &ref_38
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -182,7 +192,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_39
+    - !<!ConstantSchema> &ref_40
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -196,7 +206,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_41
+    - !<!ConstantSchema> &ref_42
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -210,7 +220,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_43
+    - !<!ConstantSchema> &ref_44
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -225,7 +235,7 @@ schemas: !<!Schemas>
           header: Location
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_11
+    - !<!ObjectSchema> &ref_12
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -317,7 +327,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_6
-    - !<!ObjectSchema> &ref_65
+    - !<!ObjectSchema> &ref_66
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -341,7 +351,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_66
+    - !<!ObjectSchema> &ref_67
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -366,7 +376,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_30
+    - !<!ArraySchema> &ref_31
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -378,7 +388,7 @@ schemas: !<!Schemas>
           description: 'A list of location options for the request [''/http/success/get/200'']'
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_12
+  - !<!Parameter> &ref_13
     schema: *ref_1
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -403,9 +413,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -432,7 +457,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -454,9 +479,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -491,9 +531,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -536,9 +591,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -561,7 +631,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -583,9 +653,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -612,7 +697,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -634,9 +719,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -663,7 +763,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -685,12 +785,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_14
-                schema: *ref_13
+              - !<!Parameter> &ref_15
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -701,8 +801,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_14
+              - *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -728,7 +841,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -750,12 +863,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_13
+              - !<!Parameter> &ref_16
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -766,8 +879,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -793,7 +919,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -815,12 +941,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_13
+              - !<!Parameter> &ref_17
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -831,8 +957,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -858,7 +997,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -880,12 +1019,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
-                schema: *ref_13
+              - !<!Parameter> &ref_18
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -896,8 +1035,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -923,7 +1075,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -945,12 +1097,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_18
-                schema: *ref_13
+              - !<!Parameter> &ref_19
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -961,8 +1113,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_18
+              - *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -988,7 +1153,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1010,12 +1175,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_19
-                schema: *ref_13
+              - !<!Parameter> &ref_20
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1026,8 +1191,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_19
+              - *ref_20
             language: !<!Languages> 
               default:
                 name: ''
@@ -1053,7 +1231,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1075,12 +1253,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_20
-                schema: *ref_13
+              - !<!Parameter> &ref_21
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1091,8 +1269,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_20
+              - *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -1118,7 +1309,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1140,12 +1331,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_21
-                schema: *ref_13
+              - !<!Parameter> &ref_22
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1156,8 +1347,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -1183,7 +1387,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1205,12 +1409,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_22
-                schema: *ref_13
+              - !<!Parameter> &ref_23
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1221,8 +1425,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_22
+              - *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -1248,7 +1465,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1270,12 +1487,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_23
-                schema: *ref_13
+              - !<!Parameter> &ref_24
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1286,8 +1503,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_23
+              - *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -1313,7 +1543,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1335,9 +1565,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1360,7 +1605,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1382,12 +1627,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_24
-                schema: *ref_13
+              - !<!Parameter> &ref_25
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1398,8 +1643,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_24
+              - *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1425,7 +1683,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1447,12 +1705,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_25
-                schema: *ref_13
+              - !<!Parameter> &ref_26
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1463,8 +1721,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_25
+              - *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1490,7 +1761,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1512,12 +1783,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_26
-                schema: *ref_13
+              - !<!Parameter> &ref_27
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1528,8 +1799,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_26
+              - *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1555,7 +1839,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1577,12 +1861,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_27
-                schema: *ref_13
+              - !<!Parameter> &ref_28
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1593,8 +1877,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_27
+              - *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1620,7 +1917,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1642,9 +1939,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1676,7 +1988,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1706,9 +2018,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1738,7 +2065,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_28
+                    schema: *ref_29
                     header: Location
                     language:
                       default:
@@ -1748,7 +2075,7 @@ operationGroups:
                   - '300'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1770,9 +2097,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1794,7 +2136,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_30
+            schema: *ref_31
             language: !<!Languages> 
               default:
                 name: ''
@@ -1803,7 +2145,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_29
+                    schema: *ref_30
                     header: Location
                     language:
                       default:
@@ -1816,7 +2158,7 @@ operationGroups:
                   - '300'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1838,9 +2180,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1870,7 +2227,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_28
+                    schema: *ref_29
                     header: Location
                     language:
                       default:
@@ -1880,7 +2237,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1902,9 +2259,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1934,7 +2306,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_29
+                    schema: *ref_30
                     header: Location
                     language:
                       default:
@@ -1944,7 +2316,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1966,12 +2338,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
-                schema: *ref_13
+              - !<!Parameter> &ref_32
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1982,8 +2354,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_31
+              - *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -2007,7 +2392,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_32
+                    schema: *ref_33
                     header: Location
                     language:
                       default:
@@ -2017,7 +2402,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2039,9 +2424,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2050,70 +2450,6 @@ operationGroups:
               http: !<!HttpRequest> 
                 path: /http/redirect/302
                 method: head
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                statusCodes:
-                  - '200'
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                headers:
-                  - !<!HttpHeader> 
-                    schema: *ref_28
-                    header: Location
-                    language:
-                      default:
-                        name: Location
-                        description: The redirect location for this request
-                statusCodes:
-                  - '302'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_11
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: head302
-            description: Return 302 status code and redirect to /http/success/200
-        protocol: !<!Protocols> {}
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: 1.0.0
-        parameters:
-          - *ref_12
-        requests:
-          - !<!Request> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpRequest> 
-                path: /http/redirect/302
-                method: get
                 uri: '{$host}'
         signatureParameters: []
         responses:
@@ -2145,7 +2481,86 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: head302
+            description: Return 302 status code and redirect to /http/success/200
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_13
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpRequest> 
+                path: /http/redirect/302
+                method: get
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                headers:
+                  - !<!HttpHeader> 
+                    schema: *ref_30
+                    header: Location
+                    language:
+                      default:
+                        name: Location
+                        description: The redirect location for this request
+                statusCodes:
+                  - '302'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2167,12 +2582,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
-                schema: *ref_13
+              - !<!Parameter> &ref_34
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2183,8 +2598,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -2208,7 +2636,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_32
+                    schema: *ref_33
                     header: Location
                     language:
                       default:
@@ -2218,7 +2646,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2240,12 +2668,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
-                schema: *ref_13
+              - !<!Parameter> &ref_35
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2256,8 +2684,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -2290,7 +2731,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_29
+                    schema: *ref_30
                     header: Location
                     language:
                       default:
@@ -2300,7 +2741,7 @@ operationGroups:
                   - '303'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2322,9 +2763,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2354,7 +2810,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_28
+                    schema: *ref_29
                     header: Location
                     language:
                       default:
@@ -2364,7 +2820,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2386,9 +2842,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2418,7 +2889,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_29
+                    schema: *ref_30
                     header: Location
                     language:
                       default:
@@ -2428,7 +2899,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2450,9 +2921,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2482,7 +2968,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Location
                     language:
                       default:
@@ -2492,7 +2978,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2514,12 +3000,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_13
+              - !<!Parameter> &ref_37
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2530,8 +3016,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -2564,7 +3063,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Location
                     language:
                       default:
@@ -2574,7 +3073,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2596,12 +3095,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_38
-                schema: *ref_13
+              - !<!Parameter> &ref_39
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2612,8 +3111,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_38
+              - *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -2646,7 +3158,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_39
+                    schema: *ref_40
                     header: Location
                     language:
                       default:
@@ -2656,7 +3168,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2678,12 +3190,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_40
-                schema: *ref_13
+              - !<!Parameter> &ref_41
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2694,8 +3206,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_40
+              - *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -2728,7 +3253,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_41
+                    schema: *ref_42
                     header: Location
                     language:
                       default:
@@ -2738,7 +3263,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2760,12 +3285,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_42
-                schema: *ref_13
+              - !<!Parameter> &ref_43
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2776,8 +3301,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_42
+              - *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -2810,7 +3348,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_43
+                    schema: *ref_44
                     header: Location
                     language:
                       default:
@@ -2820,7 +3358,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2850,9 +3388,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2865,7 +3418,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2887,9 +3440,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2902,7 +3470,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2924,9 +3492,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2939,7 +3522,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2961,12 +3544,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_44
-                schema: *ref_13
+              - !<!Parameter> &ref_45
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2977,8 +3560,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_44
+              - *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -2994,7 +3590,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3016,12 +3612,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_45
-                schema: *ref_13
+              - !<!Parameter> &ref_46
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3032,8 +3628,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -3049,7 +3658,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3071,12 +3680,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_46
-                schema: *ref_13
+              - !<!Parameter> &ref_47
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3087,8 +3696,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_46
+              - *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -3104,7 +3726,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3126,12 +3748,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_47
-                schema: *ref_13
+              - !<!Parameter> &ref_48
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3142,8 +3764,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_47
+              - *ref_48
             language: !<!Languages> 
               default:
                 name: ''
@@ -3159,7 +3794,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3181,9 +3816,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3196,7 +3846,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3218,9 +3868,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3233,7 +3898,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3255,9 +3920,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3270,7 +3950,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3292,9 +3972,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3307,7 +4002,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3329,12 +4024,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_48
-                schema: *ref_13
+              - !<!Parameter> &ref_49
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3345,8 +4040,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_48
+              - *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -3362,7 +4070,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3384,12 +4092,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_49
-                schema: *ref_13
+              - !<!Parameter> &ref_50
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3400,8 +4108,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_49
+              - *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3417,7 +4138,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3439,12 +4160,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_50
-                schema: *ref_13
+              - !<!Parameter> &ref_51
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3455,8 +4176,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_50
+              - *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -3472,7 +4206,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3494,12 +4228,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_51
-                schema: *ref_13
+              - !<!Parameter> &ref_52
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3510,8 +4244,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_51
+              - *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -3527,7 +4274,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3549,12 +4296,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_52
-                schema: *ref_13
+              - !<!Parameter> &ref_53
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3565,8 +4312,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_52
+              - *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3582,7 +4342,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3604,9 +4364,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3619,7 +4394,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3641,9 +4416,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3656,7 +4446,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3678,9 +4468,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3693,7 +4498,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3715,9 +4520,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3730,7 +4550,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3752,12 +4572,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_53
-                schema: *ref_13
+              - !<!Parameter> &ref_54
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3768,8 +4588,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_53
+              - *ref_54
             language: !<!Languages> 
               default:
                 name: ''
@@ -3785,7 +4618,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3807,12 +4640,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_54
-                schema: *ref_13
+              - !<!Parameter> &ref_55
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3823,8 +4656,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_54
+              - *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -3840,7 +4686,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3862,12 +4708,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_55
-                schema: *ref_13
+              - !<!Parameter> &ref_56
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3878,8 +4724,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_55
+              - *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3895,7 +4754,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3917,9 +4776,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3932,7 +4806,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3954,12 +4828,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_56
-                schema: *ref_13
+              - !<!Parameter> &ref_57
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3970,8 +4844,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_56
+              - *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3987,7 +4874,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4009,9 +4896,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4024,7 +4926,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4054,9 +4956,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4069,7 +4986,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4091,9 +5008,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4106,7 +5038,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4128,12 +5060,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_57
-                schema: *ref_13
+              - !<!Parameter> &ref_58
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4144,8 +5076,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_57
+              - *ref_58
             language: !<!Languages> 
               default:
                 name: ''
@@ -4161,7 +5106,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4183,12 +5128,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_58
-                schema: *ref_13
+              - !<!Parameter> &ref_59
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4199,8 +5144,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_58
+              - *ref_59
             language: !<!Languages> 
               default:
                 name: ''
@@ -4216,7 +5174,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4246,9 +5204,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4271,7 +5244,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4293,12 +5266,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_59
-                schema: *ref_13
+              - !<!Parameter> &ref_60
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4309,8 +5282,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_59
+              - *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -4336,7 +5322,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4358,12 +5344,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_60
-                schema: *ref_13
+              - !<!Parameter> &ref_61
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4374,8 +5360,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_60
+              - *ref_61
             language: !<!Languages> 
               default:
                 name: ''
@@ -4401,7 +5400,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4423,9 +5422,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4448,7 +5462,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4470,9 +5484,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4499,7 +5528,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4521,12 +5550,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_61
-                schema: *ref_13
+              - !<!Parameter> &ref_62
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4537,8 +5566,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_61
+              - *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -4564,7 +5606,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4586,12 +5628,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_62
-                schema: *ref_13
+              - !<!Parameter> &ref_63
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4602,8 +5644,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_62
+              - *ref_63
             language: !<!Languages> 
               default:
                 name: ''
@@ -4629,7 +5684,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4651,12 +5706,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_63
-                schema: *ref_13
+              - !<!Parameter> &ref_64
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4667,8 +5722,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -4694,7 +5762,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4716,12 +5784,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_64
-                schema: *ref_13
+              - !<!Parameter> &ref_65
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4732,8 +5800,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_64
+              - *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4759,7 +5840,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4789,9 +5870,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4827,7 +5923,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4849,9 +5945,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4887,7 +5998,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4909,9 +6020,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4947,7 +6073,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4969,9 +6095,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5007,7 +6148,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5029,9 +6170,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5067,7 +6223,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5089,9 +6245,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5131,7 +6302,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5153,9 +6324,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5195,7 +6381,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5217,9 +6403,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5259,7 +6460,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5281,9 +6482,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5309,7 +6525,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_65
+            schema: *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5322,7 +6538,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_66
+            schema: *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5336,7 +6552,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5358,9 +6574,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5386,7 +6617,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_65
+            schema: *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5399,7 +6630,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_66
+            schema: *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5413,7 +6644,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5435,9 +6666,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5463,7 +6709,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_65
+            schema: *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5476,7 +6722,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_66
+            schema: *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5490,7 +6736,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5512,9 +6758,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5540,7 +6801,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_65
+            schema: *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5553,7 +6814,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_66
+            schema: *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5567,7 +6828,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5589,9 +6850,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5623,7 +6899,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5645,9 +6921,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5679,7 +6970,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5701,9 +6992,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5735,7 +7041,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5757,7 +7063,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -5809,7 +7115,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -5861,7 +7167,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -5913,7 +7219,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -5965,9 +7271,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6002,9 +7323,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6039,9 +7375,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6076,9 +7427,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6113,7 +7479,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -6146,7 +7512,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -6179,7 +7545,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -6212,7 +7578,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -6245,9 +7611,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6282,9 +7663,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6319,9 +7715,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6356,9 +7767,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6393,9 +7819,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6430,9 +7871,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6467,9 +7923,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/httpInfrastructure.quirks/namer.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure.quirks/namer.yaml
@@ -11,7 +11,7 @@ schemas: !<!Schemas>
           name: Bool
           description: simple boolean
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_13
+    - !<!BooleanSchema> &ref_14
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -112,7 +112,17 @@ schemas: !<!Schemas>
           name: Constant0
           description: Simple boolean value true
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_28
+    - !<!ConstantSchema> &ref_12
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_29
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -122,11 +132,11 @@ schemas: !<!Schemas>
       valueType: *ref_1
       language: !<!Languages> 
         default:
-          name: Constant1
+          name: Constant2
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_30
+    - !<!ConstantSchema> &ref_31
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -136,11 +146,11 @@ schemas: !<!Schemas>
       valueType: *ref_1
       language: !<!Languages> 
         default:
-          name: Constant2
+          name: Constant3
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_32
+    - !<!ConstantSchema> &ref_33
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -150,11 +160,11 @@ schemas: !<!Schemas>
       valueType: *ref_1
       language: !<!Languages> 
         default:
-          name: Constant3
+          name: Constant4
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_35
+    - !<!ConstantSchema> &ref_36
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -164,11 +174,11 @@ schemas: !<!Schemas>
       valueType: *ref_1
       language: !<!Languages> 
         default:
-          name: Constant4
+          name: Constant5
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_37
+    - !<!ConstantSchema> &ref_38
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -178,11 +188,11 @@ schemas: !<!Schemas>
       valueType: *ref_1
       language: !<!Languages> 
         default:
-          name: Constant5
+          name: Constant6
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_39
+    - !<!ConstantSchema> &ref_40
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -192,11 +202,11 @@ schemas: !<!Schemas>
       valueType: *ref_1
       language: !<!Languages> 
         default:
-          name: Constant6
+          name: Constant7
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_41
+    - !<!ConstantSchema> &ref_42
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -206,11 +216,11 @@ schemas: !<!Schemas>
       valueType: *ref_1
       language: !<!Languages> 
         default:
-          name: Constant7
+          name: Constant8
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_43
+    - !<!ConstantSchema> &ref_44
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -220,12 +230,12 @@ schemas: !<!Schemas>
       valueType: *ref_1
       language: !<!Languages> 
         default:
-          name: Constant8
+          name: Constant9
           description: ''
           header: Location
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_12
+    - !<!ObjectSchema> &ref_13
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -317,7 +327,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_6
-    - !<!ObjectSchema> &ref_65
+    - !<!ObjectSchema> &ref_66
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -341,7 +351,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_66
+    - !<!ObjectSchema> &ref_67
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -366,7 +376,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_29
+    - !<!ArraySchema> &ref_30
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -406,6 +416,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -432,7 +457,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -457,6 +482,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -494,6 +534,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -539,6 +594,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -561,7 +631,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -586,6 +656,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -612,7 +697,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -637,6 +722,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -663,7 +763,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -689,8 +789,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_14
-                schema: *ref_13
+              - !<!Parameter> &ref_15
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -701,8 +801,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_14
+              - *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -728,7 +841,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -754,8 +867,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_13
+              - !<!Parameter> &ref_16
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -766,8 +879,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
+              - *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -793,7 +919,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -819,8 +945,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_13
+              - !<!Parameter> &ref_17
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -831,8 +957,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -858,7 +997,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -884,8 +1023,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_17
-                schema: *ref_13
+              - !<!Parameter> &ref_18
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -896,8 +1035,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -923,7 +1075,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -949,8 +1101,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_18
-                schema: *ref_13
+              - !<!Parameter> &ref_19
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -961,8 +1113,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_18
+              - *ref_19
             language: !<!Languages> 
               default:
                 name: ''
@@ -988,7 +1153,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1014,8 +1179,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_19
-                schema: *ref_13
+              - !<!Parameter> &ref_20
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1026,8 +1191,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_19
+              - *ref_20
             language: !<!Languages> 
               default:
                 name: ''
@@ -1053,7 +1231,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1079,8 +1257,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_20
-                schema: *ref_13
+              - !<!Parameter> &ref_21
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1091,8 +1269,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_20
+              - *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -1118,7 +1309,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1144,8 +1335,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_21
-                schema: *ref_13
+              - !<!Parameter> &ref_22
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1156,8 +1347,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -1183,7 +1387,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1209,8 +1413,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_22
-                schema: *ref_13
+              - !<!Parameter> &ref_23
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1221,8 +1425,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_22
+              - *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -1248,7 +1465,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1274,8 +1491,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_23
-                schema: *ref_13
+              - !<!Parameter> &ref_24
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1286,8 +1503,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_23
+              - *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -1313,7 +1543,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1338,6 +1568,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1360,7 +1605,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1386,8 +1631,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_24
-                schema: *ref_13
+              - !<!Parameter> &ref_25
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1398,8 +1643,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_24
+              - *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1425,7 +1683,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1451,8 +1709,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_25
-                schema: *ref_13
+              - !<!Parameter> &ref_26
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1463,8 +1721,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_25
+              - *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1490,7 +1761,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1516,8 +1787,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_26
-                schema: *ref_13
+              - !<!Parameter> &ref_27
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1528,8 +1799,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_26
+              - *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1555,7 +1839,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1581,8 +1865,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_27
-                schema: *ref_13
+              - !<!Parameter> &ref_28
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1593,8 +1877,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_27
+              - *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1620,7 +1917,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1645,6 +1942,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1676,7 +1988,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1709,6 +2021,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1738,7 +2065,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_28
+                    schema: *ref_29
                     header: Location
                     language:
                       default:
@@ -1748,7 +2075,7 @@ operationGroups:
                   - '300'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1773,6 +2100,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1794,7 +2136,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1803,7 +2145,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_30
+                    schema: *ref_31
                     header: Location
                     language:
                       default:
@@ -1816,7 +2158,7 @@ operationGroups:
                   - '300'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1841,6 +2183,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1870,7 +2227,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_28
+                    schema: *ref_29
                     header: Location
                     language:
                       default:
@@ -1880,7 +2237,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1905,6 +2262,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1934,7 +2306,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_30
+                    schema: *ref_31
                     header: Location
                     language:
                       default:
@@ -1944,7 +2316,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1970,8 +2342,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
-                schema: *ref_13
+              - !<!Parameter> &ref_32
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1982,8 +2354,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_31
+              - *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -2007,7 +2392,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_32
+                    schema: *ref_33
                     header: Location
                     language:
                       default:
@@ -2017,7 +2402,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2042,6 +2427,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2071,7 +2471,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_28
+                    schema: *ref_29
                     header: Location
                     language:
                       default:
@@ -2081,7 +2481,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2106,6 +2506,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2135,7 +2550,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_30
+                    schema: *ref_31
                     header: Location
                     language:
                       default:
@@ -2145,7 +2560,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2171,8 +2586,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
-                schema: *ref_13
+              - !<!Parameter> &ref_34
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2183,8 +2598,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -2208,7 +2636,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_32
+                    schema: *ref_33
                     header: Location
                     language:
                       default:
@@ -2218,7 +2646,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2244,8 +2672,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
-                schema: *ref_13
+              - !<!Parameter> &ref_35
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2256,8 +2684,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -2290,7 +2731,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_30
+                    schema: *ref_31
                     header: Location
                     language:
                       default:
@@ -2300,7 +2741,7 @@ operationGroups:
                   - '303'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2325,6 +2766,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2354,7 +2810,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_28
+                    schema: *ref_29
                     header: Location
                     language:
                       default:
@@ -2364,7 +2820,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2389,6 +2845,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2418,7 +2889,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_30
+                    schema: *ref_31
                     header: Location
                     language:
                       default:
@@ -2428,7 +2899,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2453,6 +2924,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2482,7 +2968,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Location
                     language:
                       default:
@@ -2492,7 +2978,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2518,8 +3004,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_13
+              - !<!Parameter> &ref_37
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2530,8 +3016,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -2564,7 +3063,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Location
                     language:
                       default:
@@ -2574,7 +3073,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2600,8 +3099,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_38
-                schema: *ref_13
+              - !<!Parameter> &ref_39
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2612,8 +3111,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_38
+              - *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -2646,7 +3158,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_39
+                    schema: *ref_40
                     header: Location
                     language:
                       default:
@@ -2656,7 +3168,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2682,8 +3194,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_40
-                schema: *ref_13
+              - !<!Parameter> &ref_41
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2694,8 +3206,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_40
+              - *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -2728,7 +3253,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_41
+                    schema: *ref_42
                     header: Location
                     language:
                       default:
@@ -2738,7 +3263,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2764,8 +3289,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_42
-                schema: *ref_13
+              - !<!Parameter> &ref_43
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2776,8 +3301,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_42
+              - *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -2810,7 +3348,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_43
+                    schema: *ref_44
                     header: Location
                     language:
                       default:
@@ -2820,7 +3358,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2853,6 +3391,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2865,7 +3418,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2890,6 +3443,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2902,7 +3470,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2927,6 +3495,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2939,7 +3522,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2965,8 +3548,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_44
-                schema: *ref_13
+              - !<!Parameter> &ref_45
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2977,8 +3560,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_44
+              - *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -2994,7 +3590,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3020,8 +3616,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_45
-                schema: *ref_13
+              - !<!Parameter> &ref_46
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3032,8 +3628,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -3049,7 +3658,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3075,8 +3684,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_46
-                schema: *ref_13
+              - !<!Parameter> &ref_47
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3087,8 +3696,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_46
+              - *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -3104,7 +3726,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3130,8 +3752,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_47
-                schema: *ref_13
+              - !<!Parameter> &ref_48
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3142,8 +3764,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_47
+              - *ref_48
             language: !<!Languages> 
               default:
                 name: ''
@@ -3159,7 +3794,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3184,6 +3819,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3196,7 +3846,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3221,6 +3871,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3233,7 +3898,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3258,6 +3923,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3270,7 +3950,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3295,6 +3975,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3307,7 +4002,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3333,8 +4028,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_48
-                schema: *ref_13
+              - !<!Parameter> &ref_49
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3345,8 +4040,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_48
+              - *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -3362,7 +4070,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3388,8 +4096,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_49
-                schema: *ref_13
+              - !<!Parameter> &ref_50
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3400,8 +4108,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_49
+              - *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3417,7 +4138,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3443,8 +4164,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_50
-                schema: *ref_13
+              - !<!Parameter> &ref_51
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3455,8 +4176,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_50
+              - *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -3472,7 +4206,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3498,8 +4232,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_51
-                schema: *ref_13
+              - !<!Parameter> &ref_52
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3510,8 +4244,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_51
+              - *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -3527,7 +4274,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3553,8 +4300,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_52
-                schema: *ref_13
+              - !<!Parameter> &ref_53
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3565,8 +4312,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_52
+              - *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3582,7 +4342,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3607,6 +4367,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3619,7 +4394,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3644,6 +4419,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3656,7 +4446,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3681,6 +4471,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3693,7 +4498,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3718,6 +4523,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3730,7 +4550,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3756,8 +4576,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_53
-                schema: *ref_13
+              - !<!Parameter> &ref_54
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3768,8 +4588,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_53
+              - *ref_54
             language: !<!Languages> 
               default:
                 name: ''
@@ -3785,7 +4618,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3811,8 +4644,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_54
-                schema: *ref_13
+              - !<!Parameter> &ref_55
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3823,8 +4656,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_54
+              - *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -3840,7 +4686,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3866,8 +4712,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_55
-                schema: *ref_13
+              - !<!Parameter> &ref_56
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3878,8 +4724,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_55
+              - *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3895,7 +4754,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3920,6 +4779,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3932,7 +4806,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3958,8 +4832,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_56
-                schema: *ref_13
+              - !<!Parameter> &ref_57
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3970,8 +4844,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_56
+              - *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3987,7 +4874,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4012,6 +4899,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4024,7 +4926,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4057,6 +4959,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4069,7 +4986,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4094,6 +5011,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4106,7 +5038,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4132,8 +5064,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_57
-                schema: *ref_13
+              - !<!Parameter> &ref_58
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4144,8 +5076,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_57
+              - *ref_58
             language: !<!Languages> 
               default:
                 name: ''
@@ -4161,7 +5106,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4187,8 +5132,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_58
-                schema: *ref_13
+              - !<!Parameter> &ref_59
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4199,8 +5144,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_58
+              - *ref_59
             language: !<!Languages> 
               default:
                 name: ''
@@ -4216,7 +5174,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4249,6 +5207,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4271,7 +5244,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4297,8 +5270,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_59
-                schema: *ref_13
+              - !<!Parameter> &ref_60
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4309,8 +5282,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_59
+              - *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -4336,7 +5322,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4362,8 +5348,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_60
-                schema: *ref_13
+              - !<!Parameter> &ref_61
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4374,8 +5360,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_60
+              - *ref_61
             language: !<!Languages> 
               default:
                 name: ''
@@ -4401,7 +5400,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4426,6 +5425,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4448,7 +5462,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4473,6 +5487,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4499,7 +5528,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4525,8 +5554,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_61
-                schema: *ref_13
+              - !<!Parameter> &ref_62
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4537,8 +5566,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_61
+              - *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -4564,7 +5606,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4590,8 +5632,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_62
-                schema: *ref_13
+              - !<!Parameter> &ref_63
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4602,8 +5644,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_62
+              - *ref_63
             language: !<!Languages> 
               default:
                 name: ''
@@ -4629,7 +5684,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4655,8 +5710,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_63
-                schema: *ref_13
+              - !<!Parameter> &ref_64
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4667,8 +5722,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -4694,7 +5762,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4720,8 +5788,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_64
-                schema: *ref_13
+              - !<!Parameter> &ref_65
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4732,8 +5800,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_64
+              - *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4759,7 +5840,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4792,6 +5873,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4827,7 +5923,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4852,6 +5948,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4887,7 +5998,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4912,6 +6023,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4947,7 +6073,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4972,6 +6098,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5007,7 +6148,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5032,6 +6173,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5067,7 +6223,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5092,6 +6248,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5131,7 +6302,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5156,6 +6327,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5195,7 +6381,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5220,6 +6406,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5259,7 +6460,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5284,6 +6485,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5309,7 +6525,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_65
+            schema: *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5322,7 +6538,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_66
+            schema: *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5336,7 +6552,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5361,6 +6577,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5386,7 +6617,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_65
+            schema: *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5399,7 +6630,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_66
+            schema: *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5413,7 +6644,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5438,6 +6669,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5463,7 +6709,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_65
+            schema: *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5476,7 +6722,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_66
+            schema: *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5490,7 +6736,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5515,6 +6761,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5540,7 +6801,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_65
+            schema: *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5553,7 +6814,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_66
+            schema: *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5567,7 +6828,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5592,6 +6853,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5623,7 +6899,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5648,6 +6924,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5679,7 +6970,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5704,6 +6995,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5735,7 +7041,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5968,6 +7274,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6005,6 +7326,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6042,6 +7378,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6079,6 +7430,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6248,6 +7614,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6285,6 +7666,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6322,6 +7718,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6359,6 +7770,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6396,6 +7822,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6433,6 +7874,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6470,6 +7926,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/httpInfrastructure/flattened.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/flattened.yaml
@@ -89,7 +89,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_13
+    - !<!ConstantSchema> &ref_14
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -102,7 +102,17 @@ schemas: !<!Schemas>
           name: paths·hhuu7h·http-failure-emptybody-error·get·responses·200·content·application-json·schema
           description: Simple boolean value true
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_14
+    - !<!ConstantSchema> &ref_12
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_15
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -116,7 +126,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_16
+    - !<!ConstantSchema> &ref_17
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -130,7 +140,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_17
+    - !<!ConstantSchema> &ref_18
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -144,7 +154,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_18
+    - !<!ConstantSchema> &ref_19
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -158,7 +168,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_19
+    - !<!ConstantSchema> &ref_20
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -172,7 +182,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_20
+    - !<!ConstantSchema> &ref_21
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -186,7 +196,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_21
+    - !<!ConstantSchema> &ref_22
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -200,7 +210,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_22
+    - !<!ConstantSchema> &ref_23
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -215,7 +225,7 @@ schemas: !<!Schemas>
           header: Location
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_12
+    - !<!ObjectSchema> &ref_13
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -307,7 +317,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_6
-    - !<!ObjectSchema> &ref_23
+    - !<!ObjectSchema> &ref_24
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -331,7 +341,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_24
+    - !<!ObjectSchema> &ref_25
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -356,7 +366,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_15
+    - !<!ArraySchema> &ref_16
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -396,6 +406,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -422,7 +447,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -447,6 +472,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -484,6 +524,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -529,6 +584,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -551,7 +621,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -576,6 +646,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -602,7 +687,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -627,6 +712,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -653,7 +753,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -680,7 +780,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -691,6 +791,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -717,7 +830,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -744,7 +857,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -755,6 +868,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -781,7 +907,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -808,7 +934,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -819,6 +945,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -845,7 +984,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -872,7 +1011,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -883,6 +1022,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -909,7 +1061,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -936,7 +1088,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -947,6 +1099,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -973,7 +1138,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1000,7 +1165,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1011,6 +1176,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1037,7 +1215,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1064,7 +1242,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1075,6 +1253,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1101,7 +1292,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1128,7 +1319,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1139,6 +1330,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1165,7 +1369,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1192,7 +1396,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1203,6 +1407,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1229,7 +1446,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1256,7 +1473,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1267,6 +1484,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1293,7 +1523,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1318,6 +1548,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1340,7 +1585,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1367,7 +1612,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1378,6 +1623,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1404,7 +1662,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1431,7 +1689,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1442,6 +1700,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1468,7 +1739,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1495,7 +1766,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1506,6 +1777,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1532,7 +1816,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1559,7 +1843,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1570,6 +1854,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1596,7 +1893,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1621,6 +1918,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1652,7 +1964,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1685,6 +1997,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1714,7 +2041,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_14
+                    schema: *ref_15
                     header: Location
                     language:
                       default:
@@ -1724,7 +2051,7 @@ operationGroups:
                   - '300'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1749,6 +2076,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1770,7 +2112,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1779,7 +2121,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: Location
                     language:
                       default:
@@ -1792,7 +2134,7 @@ operationGroups:
                   - '300'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1817,6 +2159,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1846,7 +2203,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_14
+                    schema: *ref_15
                     header: Location
                     language:
                       default:
@@ -1856,7 +2213,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1881,6 +2238,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1910,7 +2282,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: Location
                     language:
                       default:
@@ -1920,7 +2292,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1947,7 +2319,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1958,6 +2330,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1982,7 +2367,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_17
+                    schema: *ref_18
                     header: Location
                     language:
                       default:
@@ -1992,7 +2377,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2017,6 +2402,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2046,7 +2446,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_14
+                    schema: *ref_15
                     header: Location
                     language:
                       default:
@@ -2056,7 +2456,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2081,6 +2481,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2110,7 +2525,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: Location
                     language:
                       default:
@@ -2120,7 +2535,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2147,7 +2562,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2158,6 +2573,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2182,7 +2610,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_17
+                    schema: *ref_18
                     header: Location
                     language:
                       default:
@@ -2192,7 +2620,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2219,7 +2647,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2230,6 +2658,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2263,7 +2704,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: Location
                     language:
                       default:
@@ -2273,7 +2714,7 @@ operationGroups:
                   - '303'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2298,6 +2739,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2327,7 +2783,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_14
+                    schema: *ref_15
                     header: Location
                     language:
                       default:
@@ -2337,7 +2793,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2362,6 +2818,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2391,7 +2862,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: Location
                     language:
                       default:
@@ -2401,7 +2872,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2426,6 +2897,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2434,87 +2920,6 @@ operationGroups:
               http: !<!HttpRequest> 
                 path: /http/redirect/307
                 method: options
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                statusCodes:
-                  - '200'
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                headers:
-                  - !<!HttpHeader> 
-                    schema: *ref_18
-                    header: Location
-                    language:
-                      default:
-                        name: Location
-                        description: The redirect location for this request
-                statusCodes:
-                  - '307'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_12
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: options307
-            description: 'options redirected with 307, resulting in a 200 after redirect'
-        protocol: !<!Protocols> {}
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: 1.0.0
-        parameters:
-          - *ref_11
-        requests:
-          - !<!Request> 
-            parameters:
-              - !<!Parameter> 
-                schema: *ref_13
-                implementation: Method
-                required: false
-                language: !<!Languages> 
-                  default:
-                    name: booleanValue
-                    description: Simple boolean value true
-                protocol: !<!Protocols> 
-                  http: !<!HttpParameter> 
-                    in: body
-                    style: json
-            signatureParameters: []
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpWithBodyRequest> 
-                path: /http/redirect/307
-                method: put
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
                 uri: '{$host}'
         signatureParameters: []
         responses:
@@ -2546,7 +2951,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2560,8 +2965,8 @@ operationGroups:
                   - default
         language: !<!Languages> 
           default:
-            name: put307
-            description: 'Put redirected with 307, resulting in a 200 after redirect'
+            name: options307
+            description: 'options redirected with 307, resulting in a 200 after redirect'
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
@@ -2573,7 +2978,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2584,6 +2989,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2592,7 +3010,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpWithBodyRequest> 
                 path: /http/redirect/307
-                method: patch
+                method: put
                 knownMediaType: json
                 mediaTypes:
                   - application/json
@@ -2627,7 +3045,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2641,8 +3059,8 @@ operationGroups:
                   - default
         language: !<!Languages> 
           default:
-            name: patch307
-            description: 'Patch redirected with 307, resulting in a 200 after redirect'
+            name: put307
+            description: 'Put redirected with 307, resulting in a 200 after redirect'
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
@@ -2654,7 +3072,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2665,6 +3083,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2673,7 +3104,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpWithBodyRequest> 
                 path: /http/redirect/307
-                method: post
+                method: patch
                 knownMediaType: json
                 mediaTypes:
                   - application/json
@@ -2708,7 +3139,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2722,8 +3153,8 @@ operationGroups:
                   - default
         language: !<!Languages> 
           default:
-            name: post307
-            description: 'Post redirected with 307, resulting in a 200 after redirect'
+            name: patch307
+            description: 'Patch redirected with 307, resulting in a 200 after redirect'
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
@@ -2735,7 +3166,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2746,6 +3177,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2754,7 +3198,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpWithBodyRequest> 
                 path: /http/redirect/307
-                method: delete
+                method: post
                 knownMediaType: json
                 mediaTypes:
                   - application/json
@@ -2789,7 +3233,101 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: post307
+            description: 'Post redirected with 307, resulting in a 200 after redirect'
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_11
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                required: false
+                language: !<!Languages> 
+                  default:
+                    name: booleanValue
+                    description: Simple boolean value true
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpWithBodyRequest> 
+                path: /http/redirect/307
+                method: delete
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                headers:
+                  - !<!HttpHeader> 
+                    schema: *ref_23
+                    header: Location
+                    language:
+                      default:
+                        name: Location
+                        description: The redirect location for this request
+                statusCodes:
+                  - '307'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2822,6 +3360,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2834,7 +3387,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2859,6 +3412,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2871,7 +3439,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2896,6 +3464,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2908,7 +3491,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2935,7 +3518,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2946,6 +3529,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2962,7 +3558,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2989,7 +3585,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3000,6 +3596,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3016,7 +3625,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3043,7 +3652,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3054,6 +3663,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3070,7 +3692,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3097,7 +3719,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3108,6 +3730,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3124,7 +3759,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3149,6 +3784,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3161,7 +3811,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3186,6 +3836,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3198,7 +3863,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3223,6 +3888,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3235,7 +3915,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3260,6 +3940,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3272,7 +3967,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3299,7 +3994,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3310,6 +4005,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3326,7 +4034,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3353,7 +4061,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3364,6 +4072,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3380,7 +4101,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3407,7 +4128,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3418,6 +4139,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3434,7 +4168,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3461,7 +4195,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3472,6 +4206,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3488,7 +4235,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3515,7 +4262,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3526,6 +4273,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3542,7 +4302,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3567,6 +4327,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3579,7 +4354,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3604,6 +4379,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3616,7 +4406,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3641,6 +4431,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3653,7 +4458,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3678,6 +4483,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3690,7 +4510,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3717,7 +4537,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3728,6 +4548,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3744,7 +4577,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3771,7 +4604,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3782,6 +4615,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3798,7 +4644,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3825,7 +4671,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3836,6 +4682,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3852,7 +4711,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3877,6 +4736,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3889,7 +4763,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3916,7 +4790,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3927,6 +4801,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3943,7 +4830,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3968,6 +4855,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3980,7 +4882,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4013,6 +4915,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4025,7 +4942,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4050,6 +4967,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4062,7 +4994,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4089,7 +5021,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4100,6 +5032,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4116,7 +5061,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4143,7 +5088,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4154,6 +5099,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4170,7 +5128,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4203,6 +5161,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4225,7 +5198,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4252,7 +5225,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4263,6 +5236,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4289,7 +5275,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4316,7 +5302,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4327,6 +5313,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4353,7 +5352,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4378,6 +5377,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4400,7 +5414,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4425,6 +5439,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4451,7 +5480,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4478,7 +5507,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4489,6 +5518,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4515,7 +5557,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4542,7 +5584,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4553,6 +5595,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4579,7 +5634,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4606,7 +5661,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4617,6 +5672,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4643,7 +5711,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4670,7 +5738,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4681,6 +5749,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4707,7 +5788,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4740,6 +5821,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4775,7 +5871,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4800,6 +5896,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4835,7 +5946,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4860,6 +5971,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4895,7 +6021,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4920,6 +6046,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4955,7 +6096,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4980,6 +6121,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5015,7 +6171,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5040,6 +6196,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5079,7 +6250,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5104,6 +6275,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5143,7 +6329,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5168,6 +6354,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5207,7 +6408,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5232,6 +6433,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5257,7 +6473,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -5270,7 +6486,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -5284,7 +6500,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5309,6 +6525,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5334,7 +6565,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -5347,7 +6578,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -5361,7 +6592,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5386,6 +6617,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5411,7 +6657,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -5424,7 +6670,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -5438,7 +6684,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5463,6 +6709,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5488,7 +6749,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -5501,7 +6762,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -5515,7 +6776,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5540,6 +6801,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5571,7 +6847,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5596,6 +6872,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5627,7 +6918,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5652,6 +6943,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5683,7 +6989,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5916,6 +7222,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5953,6 +7274,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5990,6 +7326,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6037,6 +7388,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6236,6 +7602,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6273,6 +7654,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6310,6 +7706,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6347,6 +7758,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6384,6 +7810,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6421,6 +7862,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6458,6 +7914,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/httpInfrastructure/grouped.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/grouped.yaml
@@ -89,7 +89,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_13
+    - !<!ConstantSchema> &ref_14
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -102,7 +102,17 @@ schemas: !<!Schemas>
           name: paths·hhuu7h·http-failure-emptybody-error·get·responses·200·content·application-json·schema
           description: Simple boolean value true
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_14
+    - !<!ConstantSchema> &ref_12
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_15
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -116,7 +126,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_16
+    - !<!ConstantSchema> &ref_17
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -130,7 +140,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_17
+    - !<!ConstantSchema> &ref_18
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -144,7 +154,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_18
+    - !<!ConstantSchema> &ref_19
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -158,7 +168,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_19
+    - !<!ConstantSchema> &ref_20
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -172,7 +182,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_20
+    - !<!ConstantSchema> &ref_21
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -186,7 +196,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_21
+    - !<!ConstantSchema> &ref_22
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -200,7 +210,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_22
+    - !<!ConstantSchema> &ref_23
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -215,7 +225,7 @@ schemas: !<!Schemas>
           header: Location
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_12
+    - !<!ObjectSchema> &ref_13
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -307,7 +317,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_6
-    - !<!ObjectSchema> &ref_23
+    - !<!ObjectSchema> &ref_24
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -331,7 +341,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_24
+    - !<!ObjectSchema> &ref_25
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -356,7 +366,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_15
+    - !<!ArraySchema> &ref_16
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -396,6 +406,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -422,7 +447,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -447,6 +472,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -484,6 +524,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -529,6 +584,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -551,7 +621,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -576,6 +646,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -602,7 +687,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -627,6 +712,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -653,7 +753,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -680,7 +780,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -691,6 +791,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -717,7 +830,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -744,7 +857,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -755,6 +868,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -781,7 +907,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -808,7 +934,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -819,6 +945,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -845,7 +984,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -872,7 +1011,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -883,6 +1022,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -909,7 +1061,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -936,7 +1088,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -947,6 +1099,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -973,7 +1138,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1000,7 +1165,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1011,6 +1176,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1037,7 +1215,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1064,7 +1242,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1075,6 +1253,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1101,7 +1292,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1128,7 +1319,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1139,6 +1330,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1165,7 +1369,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1192,7 +1396,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1203,6 +1407,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1229,7 +1446,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1256,7 +1473,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1267,6 +1484,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1293,7 +1523,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1318,6 +1548,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1340,7 +1585,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1367,7 +1612,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1378,6 +1623,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1404,7 +1662,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1431,7 +1689,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1442,6 +1700,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1468,7 +1739,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1495,7 +1766,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1506,6 +1777,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1532,7 +1816,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1559,7 +1843,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1570,6 +1854,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1596,7 +1893,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1621,6 +1918,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1652,7 +1964,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1685,6 +1997,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1714,7 +2041,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_14
+                    schema: *ref_15
                     header: Location
                     language:
                       default:
@@ -1724,7 +2051,7 @@ operationGroups:
                   - '300'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1749,6 +2076,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1770,7 +2112,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1779,7 +2121,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: Location
                     language:
                       default:
@@ -1792,7 +2134,7 @@ operationGroups:
                   - '300'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1817,6 +2159,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1846,7 +2203,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_14
+                    schema: *ref_15
                     header: Location
                     language:
                       default:
@@ -1856,7 +2213,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1881,6 +2238,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1910,7 +2282,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: Location
                     language:
                       default:
@@ -1920,7 +2292,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1947,7 +2319,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1958,6 +2330,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1982,7 +2367,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_17
+                    schema: *ref_18
                     header: Location
                     language:
                       default:
@@ -1992,7 +2377,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2017,6 +2402,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2046,7 +2446,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_14
+                    schema: *ref_15
                     header: Location
                     language:
                       default:
@@ -2056,7 +2456,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2081,6 +2481,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2110,7 +2525,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: Location
                     language:
                       default:
@@ -2120,7 +2535,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2147,7 +2562,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2158,6 +2573,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2182,7 +2610,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_17
+                    schema: *ref_18
                     header: Location
                     language:
                       default:
@@ -2192,7 +2620,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2219,7 +2647,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2230,6 +2658,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2263,7 +2704,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: Location
                     language:
                       default:
@@ -2273,7 +2714,7 @@ operationGroups:
                   - '303'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2298,6 +2739,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2327,7 +2783,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_14
+                    schema: *ref_15
                     header: Location
                     language:
                       default:
@@ -2337,7 +2793,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2362,6 +2818,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2391,7 +2862,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: Location
                     language:
                       default:
@@ -2401,7 +2872,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2426,6 +2897,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2434,87 +2920,6 @@ operationGroups:
               http: !<!HttpRequest> 
                 path: /http/redirect/307
                 method: options
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                statusCodes:
-                  - '200'
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                headers:
-                  - !<!HttpHeader> 
-                    schema: *ref_18
-                    header: Location
-                    language:
-                      default:
-                        name: Location
-                        description: The redirect location for this request
-                statusCodes:
-                  - '307'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_12
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: options307
-            description: 'options redirected with 307, resulting in a 200 after redirect'
-        protocol: !<!Protocols> {}
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: 1.0.0
-        parameters:
-          - *ref_11
-        requests:
-          - !<!Request> 
-            parameters:
-              - !<!Parameter> 
-                schema: *ref_13
-                implementation: Method
-                required: false
-                language: !<!Languages> 
-                  default:
-                    name: booleanValue
-                    description: Simple boolean value true
-                protocol: !<!Protocols> 
-                  http: !<!HttpParameter> 
-                    in: body
-                    style: json
-            signatureParameters: []
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpWithBodyRequest> 
-                path: /http/redirect/307
-                method: put
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
                 uri: '{$host}'
         signatureParameters: []
         responses:
@@ -2546,7 +2951,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2560,8 +2965,8 @@ operationGroups:
                   - default
         language: !<!Languages> 
           default:
-            name: put307
-            description: 'Put redirected with 307, resulting in a 200 after redirect'
+            name: options307
+            description: 'options redirected with 307, resulting in a 200 after redirect'
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
@@ -2573,7 +2978,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2584,6 +2989,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2592,7 +3010,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpWithBodyRequest> 
                 path: /http/redirect/307
-                method: patch
+                method: put
                 knownMediaType: json
                 mediaTypes:
                   - application/json
@@ -2627,7 +3045,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2641,8 +3059,8 @@ operationGroups:
                   - default
         language: !<!Languages> 
           default:
-            name: patch307
-            description: 'Patch redirected with 307, resulting in a 200 after redirect'
+            name: put307
+            description: 'Put redirected with 307, resulting in a 200 after redirect'
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
@@ -2654,7 +3072,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2665,6 +3083,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2673,7 +3104,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpWithBodyRequest> 
                 path: /http/redirect/307
-                method: post
+                method: patch
                 knownMediaType: json
                 mediaTypes:
                   - application/json
@@ -2708,7 +3139,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2722,8 +3153,8 @@ operationGroups:
                   - default
         language: !<!Languages> 
           default:
-            name: post307
-            description: 'Post redirected with 307, resulting in a 200 after redirect'
+            name: patch307
+            description: 'Patch redirected with 307, resulting in a 200 after redirect'
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
@@ -2735,7 +3166,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2746,6 +3177,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2754,7 +3198,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpWithBodyRequest> 
                 path: /http/redirect/307
-                method: delete
+                method: post
                 knownMediaType: json
                 mediaTypes:
                   - application/json
@@ -2789,7 +3233,101 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: post307
+            description: 'Post redirected with 307, resulting in a 200 after redirect'
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_11
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                required: false
+                language: !<!Languages> 
+                  default:
+                    name: booleanValue
+                    description: Simple boolean value true
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpWithBodyRequest> 
+                path: /http/redirect/307
+                method: delete
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                headers:
+                  - !<!HttpHeader> 
+                    schema: *ref_23
+                    header: Location
+                    language:
+                      default:
+                        name: Location
+                        description: The redirect location for this request
+                statusCodes:
+                  - '307'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2822,6 +3360,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2834,7 +3387,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2859,6 +3412,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2871,7 +3439,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2896,6 +3464,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2908,7 +3491,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2935,7 +3518,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2946,6 +3529,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2962,7 +3558,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2989,7 +3585,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3000,6 +3596,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3016,7 +3625,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3043,7 +3652,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3054,6 +3663,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3070,7 +3692,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3097,7 +3719,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3108,6 +3730,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3124,7 +3759,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3149,6 +3784,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3161,7 +3811,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3186,6 +3836,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3198,7 +3863,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3223,6 +3888,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3235,7 +3915,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3260,6 +3940,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3272,7 +3967,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3299,7 +3994,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3310,6 +4005,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3326,7 +4034,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3353,7 +4061,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3364,6 +4072,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3380,7 +4101,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3407,7 +4128,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3418,6 +4139,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3434,7 +4168,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3461,7 +4195,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3472,6 +4206,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3488,7 +4235,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3515,7 +4262,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3526,6 +4273,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3542,7 +4302,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3567,6 +4327,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3579,7 +4354,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3604,6 +4379,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3616,7 +4406,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3641,6 +4431,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3653,7 +4458,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3678,6 +4483,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3690,7 +4510,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3717,7 +4537,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3728,6 +4548,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3744,7 +4577,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3771,7 +4604,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3782,6 +4615,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3798,7 +4644,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3825,7 +4671,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3836,6 +4682,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3852,7 +4711,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3877,6 +4736,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3889,7 +4763,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3916,7 +4790,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3927,6 +4801,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3943,7 +4830,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3968,6 +4855,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3980,7 +4882,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4013,6 +4915,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4025,7 +4942,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4050,6 +4967,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4062,7 +4994,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4089,7 +5021,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4100,6 +5032,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4116,7 +5061,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4143,7 +5088,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4154,6 +5099,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4170,7 +5128,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4203,6 +5161,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4225,7 +5198,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4252,7 +5225,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4263,6 +5236,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4289,7 +5275,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4316,7 +5302,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4327,6 +5313,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4353,7 +5352,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4378,6 +5377,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4400,7 +5414,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4425,6 +5439,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4451,7 +5480,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4478,7 +5507,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4489,6 +5518,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4515,7 +5557,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4542,7 +5584,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4553,6 +5595,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4579,7 +5634,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4606,7 +5661,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4617,6 +5672,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4643,7 +5711,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4670,7 +5738,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4681,6 +5749,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4707,7 +5788,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4740,6 +5821,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4775,7 +5871,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4800,6 +5896,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4835,7 +5946,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4860,6 +5971,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4895,7 +6021,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4920,6 +6046,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4955,7 +6096,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4980,6 +6121,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5015,7 +6171,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5040,6 +6196,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5079,7 +6250,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5104,6 +6275,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5143,7 +6329,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5168,6 +6354,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5207,7 +6408,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5232,6 +6433,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5257,7 +6473,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -5270,7 +6486,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -5284,7 +6500,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5309,6 +6525,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5334,7 +6565,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -5347,7 +6578,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -5361,7 +6592,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5386,6 +6617,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5411,7 +6657,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -5424,7 +6670,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -5438,7 +6684,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5463,6 +6709,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5488,7 +6749,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -5501,7 +6762,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -5515,7 +6776,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5540,6 +6801,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5571,7 +6847,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5596,6 +6872,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5627,7 +6918,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5652,6 +6943,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5683,7 +6989,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5916,6 +7222,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5953,6 +7274,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5990,6 +7326,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6037,6 +7388,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6236,6 +7602,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6273,6 +7654,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6310,6 +7706,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6347,6 +7758,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6384,6 +7810,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6421,6 +7862,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6458,6 +7914,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/httpInfrastructure/modeler.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/modeler.yaml
@@ -89,7 +89,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_13
+    - !<!ConstantSchema> &ref_14
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -102,7 +102,17 @@ schemas: !<!Schemas>
           name: paths·hhuu7h·http-failure-emptybody-error·get·responses·200·content·application-json·schema
           description: Simple boolean value true
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_14
+    - !<!ConstantSchema> &ref_11
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_15
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -116,7 +126,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_15
+    - !<!ConstantSchema> &ref_16
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -130,7 +140,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_17
+    - !<!ConstantSchema> &ref_18
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -144,7 +154,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_18
+    - !<!ConstantSchema> &ref_19
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -158,7 +168,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_19
+    - !<!ConstantSchema> &ref_20
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -172,7 +182,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_20
+    - !<!ConstantSchema> &ref_21
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -186,7 +196,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_21
+    - !<!ConstantSchema> &ref_22
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -200,7 +210,7 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_22
+    - !<!ConstantSchema> &ref_23
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -215,7 +225,7 @@ schemas: !<!Schemas>
           header: Location
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_11
+    - !<!ObjectSchema> &ref_12
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -307,7 +317,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_6
-    - !<!ObjectSchema> &ref_23
+    - !<!ObjectSchema> &ref_24
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -331,7 +341,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_24
+    - !<!ObjectSchema> &ref_25
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -356,7 +366,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_16
+    - !<!ArraySchema> &ref_17
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -368,7 +378,7 @@ schemas: !<!Schemas>
           description: 'A list of location options for the request [''/http/success/get/200'']'
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_12
+  - !<!Parameter> &ref_13
     schema: *ref_1
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -393,9 +403,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -422,7 +447,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -444,9 +469,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -481,9 +521,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -526,9 +581,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -551,7 +621,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -573,9 +643,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -602,7 +687,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -624,9 +709,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -653,7 +753,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -675,12 +775,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -691,6 +791,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -717,7 +830,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -739,12 +852,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -755,6 +868,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -781,7 +907,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -803,12 +929,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -819,6 +945,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -845,7 +984,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -867,12 +1006,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -883,6 +1022,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -909,7 +1061,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -931,12 +1083,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -947,6 +1099,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -973,7 +1138,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -995,12 +1160,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1011,6 +1176,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1037,7 +1215,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1059,12 +1237,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1075,6 +1253,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1101,7 +1292,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1123,12 +1314,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1139,6 +1330,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1165,7 +1369,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1187,12 +1391,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1203,6 +1407,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1229,7 +1446,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1251,12 +1468,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1267,6 +1484,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1293,7 +1523,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1315,9 +1545,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1340,7 +1585,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1362,12 +1607,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1378,6 +1623,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1404,7 +1662,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1426,12 +1684,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1442,6 +1700,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1468,7 +1739,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1490,12 +1761,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1506,6 +1777,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1532,7 +1816,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1554,12 +1838,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1570,6 +1854,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1596,7 +1893,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1618,9 +1915,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1652,7 +1964,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1682,9 +1994,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1714,7 +2041,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_14
+                    schema: *ref_15
                     header: Location
                     language:
                       default:
@@ -1724,7 +2051,7 @@ operationGroups:
                   - '300'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1746,9 +2073,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1770,7 +2112,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_16
+            schema: *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -1779,7 +2121,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_15
+                    schema: *ref_16
                     header: Location
                     language:
                       default:
@@ -1792,7 +2134,7 @@ operationGroups:
                   - '300'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1814,9 +2156,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1846,7 +2203,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_14
+                    schema: *ref_15
                     header: Location
                     language:
                       default:
@@ -1856,7 +2213,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1878,9 +2235,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1910,7 +2282,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_15
+                    schema: *ref_16
                     header: Location
                     language:
                       default:
@@ -1920,7 +2292,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -1942,12 +2314,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1958,6 +2330,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1982,7 +2367,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_17
+                    schema: *ref_18
                     header: Location
                     language:
                       default:
@@ -1992,7 +2377,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2014,9 +2399,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2025,70 +2425,6 @@ operationGroups:
               http: !<!HttpRequest> 
                 path: /http/redirect/302
                 method: head
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                statusCodes:
-                  - '200'
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                headers:
-                  - !<!HttpHeader> 
-                    schema: *ref_14
-                    header: Location
-                    language:
-                      default:
-                        name: Location
-                        description: The redirect location for this request
-                statusCodes:
-                  - '302'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_11
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: head302
-            description: Return 302 status code and redirect to /http/success/200
-        protocol: !<!Protocols> {}
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: 1.0.0
-        parameters:
-          - *ref_12
-        requests:
-          - !<!Request> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpRequest> 
-                path: /http/redirect/302
-                method: get
                 uri: '{$host}'
         signatureParameters: []
         responses:
@@ -2120,7 +2456,86 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: head302
+            description: Return 302 status code and redirect to /http/success/200
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_13
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpRequest> 
+                path: /http/redirect/302
+                method: get
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                headers:
+                  - !<!HttpHeader> 
+                    schema: *ref_16
+                    header: Location
+                    language:
+                      default:
+                        name: Location
+                        description: The redirect location for this request
+                statusCodes:
+                  - '302'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2142,12 +2557,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2158,6 +2573,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2182,7 +2610,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_17
+                    schema: *ref_18
                     header: Location
                     language:
                       default:
@@ -2192,7 +2620,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2214,12 +2642,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2230,6 +2658,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2263,7 +2704,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_15
+                    schema: *ref_16
                     header: Location
                     language:
                       default:
@@ -2273,7 +2714,7 @@ operationGroups:
                   - '303'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2295,9 +2736,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2327,7 +2783,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_14
+                    schema: *ref_15
                     header: Location
                     language:
                       default:
@@ -2337,7 +2793,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2359,9 +2815,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2391,7 +2862,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_15
+                    schema: *ref_16
                     header: Location
                     language:
                       default:
@@ -2401,7 +2872,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2423,9 +2894,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2434,87 +2920,6 @@ operationGroups:
               http: !<!HttpRequest> 
                 path: /http/redirect/307
                 method: options
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                statusCodes:
-                  - '200'
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                headers:
-                  - !<!HttpHeader> 
-                    schema: *ref_18
-                    header: Location
-                    language:
-                      default:
-                        name: Location
-                        description: The redirect location for this request
-                statusCodes:
-                  - '307'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_11
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: options307
-            description: 'options redirected with 307, resulting in a 200 after redirect'
-        protocol: !<!Protocols> {}
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: 1.0.0
-        parameters:
-          - *ref_12
-        requests:
-          - !<!Request> 
-            parameters:
-              - !<!Parameter> 
-                schema: *ref_13
-                implementation: Method
-                required: false
-                language: !<!Languages> 
-                  default:
-                    name: booleanValue
-                    description: Simple boolean value true
-                protocol: !<!Protocols> 
-                  http: !<!HttpParameter> 
-                    in: body
-                    style: json
-            signatureParameters: []
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpWithBodyRequest> 
-                path: /http/redirect/307
-                method: put
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
                 uri: '{$host}'
         signatureParameters: []
         responses:
@@ -2546,7 +2951,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2560,20 +2965,20 @@ operationGroups:
                   - default
         language: !<!Languages> 
           default:
-            name: put307
-            description: 'Put redirected with 307, resulting in a 200 after redirect'
+            name: options307
+            description: 'options redirected with 307, resulting in a 200 after redirect'
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2584,6 +2989,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2592,7 +3010,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpWithBodyRequest> 
                 path: /http/redirect/307
-                method: patch
+                method: put
                 knownMediaType: json
                 mediaTypes:
                   - application/json
@@ -2627,7 +3045,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2641,20 +3059,20 @@ operationGroups:
                   - default
         language: !<!Languages> 
           default:
-            name: patch307
-            description: 'Patch redirected with 307, resulting in a 200 after redirect'
+            name: put307
+            description: 'Put redirected with 307, resulting in a 200 after redirect'
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2665,6 +3083,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2673,7 +3104,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpWithBodyRequest> 
                 path: /http/redirect/307
-                method: post
+                method: patch
                 knownMediaType: json
                 mediaTypes:
                   - application/json
@@ -2708,7 +3139,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2722,20 +3153,20 @@ operationGroups:
                   - default
         language: !<!Languages> 
           default:
-            name: post307
-            description: 'Post redirected with 307, resulting in a 200 after redirect'
+            name: patch307
+            description: 'Patch redirected with 307, resulting in a 200 after redirect'
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2746,6 +3177,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2754,7 +3198,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpWithBodyRequest> 
                 path: /http/redirect/307
-                method: delete
+                method: post
                 knownMediaType: json
                 mediaTypes:
                   - application/json
@@ -2789,7 +3233,101 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: post307
+            description: 'Post redirected with 307, resulting in a 200 after redirect'
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_13
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                required: false
+                language: !<!Languages> 
+                  default:
+                    name: booleanValue
+                    description: Simple boolean value true
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpWithBodyRequest> 
+                path: /http/redirect/307
+                method: delete
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                headers:
+                  - !<!HttpHeader> 
+                    schema: *ref_23
+                    header: Location
+                    language:
+                      default:
+                        name: Location
+                        description: The redirect location for this request
+                statusCodes:
+                  - '307'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2819,9 +3357,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2834,7 +3387,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2856,9 +3409,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2871,7 +3439,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2893,9 +3461,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2908,7 +3491,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2930,12 +3513,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2946,6 +3529,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2962,7 +3558,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -2984,12 +3580,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3000,6 +3596,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3016,7 +3625,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3038,12 +3647,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3054,6 +3663,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3070,7 +3692,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3092,12 +3714,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3108,6 +3730,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3124,7 +3759,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3146,9 +3781,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3161,7 +3811,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3183,9 +3833,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3198,7 +3863,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3220,9 +3885,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3235,7 +3915,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3257,9 +3937,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3272,7 +3967,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3294,12 +3989,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3310,6 +4005,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3326,7 +4034,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3348,12 +4056,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3364,6 +4072,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3380,7 +4101,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3402,12 +4123,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3418,6 +4139,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3434,7 +4168,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3456,12 +4190,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3472,6 +4206,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3488,7 +4235,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3510,12 +4257,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3526,6 +4273,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3542,7 +4302,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3564,9 +4324,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3579,7 +4354,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3601,9 +4376,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3616,7 +4406,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3638,9 +4428,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3653,7 +4458,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3675,9 +4480,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3690,7 +4510,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3712,12 +4532,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3728,6 +4548,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3744,7 +4577,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3766,12 +4599,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3782,6 +4615,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3798,7 +4644,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3820,12 +4666,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3836,6 +4682,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3852,7 +4711,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3874,9 +4733,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3889,7 +4763,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3911,12 +4785,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3927,6 +4801,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3943,7 +4830,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -3965,9 +4852,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3980,7 +4882,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4010,9 +4912,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4025,7 +4942,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4047,9 +4964,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4062,7 +4994,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4084,12 +5016,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4100,6 +5032,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4116,7 +5061,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4138,12 +5083,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4154,6 +5099,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4170,7 +5128,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4200,9 +5158,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4225,7 +5198,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4247,12 +5220,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4263,6 +5236,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4289,7 +5275,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4311,12 +5297,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4327,6 +5313,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4353,7 +5352,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4375,9 +5374,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4400,7 +5414,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4422,9 +5436,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4451,7 +5480,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4473,12 +5502,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4489,6 +5518,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4515,7 +5557,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4537,12 +5579,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4553,6 +5595,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4579,7 +5634,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4601,12 +5656,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4617,6 +5672,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4643,7 +5711,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4665,12 +5733,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4681,6 +5749,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4707,7 +5788,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4737,9 +5818,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4775,7 +5871,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4797,9 +5893,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4835,7 +5946,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4857,9 +5968,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4895,7 +6021,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4917,9 +6043,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4955,7 +6096,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -4977,9 +6118,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5015,7 +6171,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5037,9 +6193,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5079,7 +6250,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5101,9 +6272,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5143,7 +6329,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5165,9 +6351,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5207,7 +6408,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5229,9 +6430,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5257,7 +6473,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -5270,7 +6486,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -5284,7 +6500,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5306,9 +6522,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5334,7 +6565,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -5347,7 +6578,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -5361,7 +6592,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5383,9 +6614,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5411,7 +6657,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -5424,7 +6670,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -5438,7 +6684,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5460,9 +6706,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5488,7 +6749,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -5501,7 +6762,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -5515,7 +6776,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5537,9 +6798,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5571,7 +6847,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5593,9 +6869,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5627,7 +6918,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5649,9 +6940,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5683,7 +6989,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -5705,7 +7011,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -5757,7 +7063,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -5809,7 +7115,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -5861,7 +7167,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -5913,9 +7219,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5950,9 +7271,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5987,9 +7323,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6034,9 +7385,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6081,7 +7447,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -6114,7 +7480,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -6147,7 +7513,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -6190,7 +7556,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -6233,9 +7599,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6270,9 +7651,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6307,9 +7703,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6344,9 +7755,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6381,9 +7807,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6418,9 +7859,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6455,9 +7911,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_11
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/httpInfrastructure/namer.yaml
+++ b/modelerfour/test/scenarios/httpInfrastructure/namer.yaml
@@ -89,7 +89,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_13
+    - !<!ConstantSchema> &ref_14
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -102,27 +102,23 @@ schemas: !<!Schemas>
           name: Constant0
           description: Simple boolean value true
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_14
+    - !<!ConstantSchema> &ref_12
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_15
       type: constant
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
         value: /http/success/head/200
-      valueType: *ref_1
-      language: !<!Languages> 
-        default:
-          name: Constant1
-          description: ''
-          header: Location
-      protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_16
-      type: constant
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      value: !<!ConstantValue> 
-        value: /http/success/get/200
       valueType: *ref_1
       language: !<!Languages> 
         default:
@@ -136,7 +132,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: /http/failure/500
+        value: /http/success/get/200
       valueType: *ref_1
       language: !<!Languages> 
         default:
@@ -150,7 +146,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: /http/success/options/200
+        value: /http/failure/500
       valueType: *ref_1
       language: !<!Languages> 
         default:
@@ -164,7 +160,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: /http/success/put/200
+        value: /http/success/options/200
       valueType: *ref_1
       language: !<!Languages> 
         default:
@@ -178,7 +174,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: /http/success/patch/200
+        value: /http/success/put/200
       valueType: *ref_1
       language: !<!Languages> 
         default:
@@ -192,7 +188,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: /http/success/post/200
+        value: /http/success/patch/200
       valueType: *ref_1
       language: !<!Languages> 
         default:
@@ -206,7 +202,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 1.0.0
       value: !<!ConstantValue> 
-        value: /http/success/delete/200
+        value: /http/success/post/200
       valueType: *ref_1
       language: !<!Languages> 
         default:
@@ -214,8 +210,22 @@ schemas: !<!Schemas>
           description: ''
           header: Location
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_23
+      type: constant
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      value: !<!ConstantValue> 
+        value: /http/success/delete/200
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Constant9
+          description: ''
+          header: Location
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_12
+    - !<!ObjectSchema> &ref_13
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -307,7 +317,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_6
-    - !<!ObjectSchema> &ref_23
+    - !<!ObjectSchema> &ref_24
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -331,7 +341,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_24
+    - !<!ObjectSchema> &ref_25
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -356,7 +366,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_15
+    - !<!ArraySchema> &ref_16
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -396,6 +406,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -422,7 +447,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -447,6 +472,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -484,6 +524,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -529,6 +584,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -551,7 +621,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -576,6 +646,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -602,7 +687,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -627,6 +712,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -653,7 +753,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -680,7 +780,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -691,6 +791,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -717,7 +830,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -744,7 +857,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -755,6 +868,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -781,7 +907,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -808,7 +934,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -819,6 +945,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -845,7 +984,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -872,7 +1011,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -883,6 +1022,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -909,7 +1061,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -936,7 +1088,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -947,6 +1099,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -973,7 +1138,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1000,7 +1165,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1011,6 +1176,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1037,7 +1215,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1064,7 +1242,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1075,6 +1253,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1101,7 +1292,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1128,7 +1319,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1139,6 +1330,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1165,7 +1369,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1192,7 +1396,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1203,6 +1407,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1229,7 +1446,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1256,7 +1473,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1267,6 +1484,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1293,7 +1523,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1318,6 +1548,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1340,7 +1585,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1367,7 +1612,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1378,6 +1623,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1404,7 +1662,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1431,7 +1689,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1442,6 +1700,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1468,7 +1739,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1495,7 +1766,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1506,6 +1777,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1532,7 +1816,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1559,7 +1843,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1570,6 +1854,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1596,7 +1893,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1621,6 +1918,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1652,7 +1964,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1685,6 +1997,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1714,7 +2041,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_14
+                    schema: *ref_15
                     header: Location
                     language:
                       default:
@@ -1724,7 +2051,7 @@ operationGroups:
                   - '300'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1749,6 +2076,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1770,7 +2112,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1779,7 +2121,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: Location
                     language:
                       default:
@@ -1792,7 +2134,7 @@ operationGroups:
                   - '300'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1817,6 +2159,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1846,7 +2203,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_14
+                    schema: *ref_15
                     header: Location
                     language:
                       default:
@@ -1856,7 +2213,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1881,6 +2238,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1910,7 +2282,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: Location
                     language:
                       default:
@@ -1920,7 +2292,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -1947,7 +2319,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1958,6 +2330,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -1982,7 +2367,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_17
+                    schema: *ref_18
                     header: Location
                     language:
                       default:
@@ -1992,7 +2377,7 @@ operationGroups:
                   - '301'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2017,6 +2402,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2046,7 +2446,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_14
+                    schema: *ref_15
                     header: Location
                     language:
                       default:
@@ -2056,7 +2456,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2081,6 +2481,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2110,7 +2525,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: Location
                     language:
                       default:
@@ -2120,7 +2535,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2147,7 +2562,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2158,6 +2573,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2182,7 +2610,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_17
+                    schema: *ref_18
                     header: Location
                     language:
                       default:
@@ -2192,7 +2620,7 @@ operationGroups:
                   - '302'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2219,7 +2647,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2230,6 +2658,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2263,7 +2704,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: Location
                     language:
                       default:
@@ -2273,7 +2714,7 @@ operationGroups:
                   - '303'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2298,6 +2739,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2327,7 +2783,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_14
+                    schema: *ref_15
                     header: Location
                     language:
                       default:
@@ -2337,7 +2793,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2362,6 +2818,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2391,7 +2862,7 @@ operationGroups:
               http: !<!HttpResponse> 
                 headers:
                   - !<!HttpHeader> 
-                    schema: *ref_16
+                    schema: *ref_17
                     header: Location
                     language:
                       default:
@@ -2401,7 +2872,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2426,6 +2897,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2434,87 +2920,6 @@ operationGroups:
               http: !<!HttpRequest> 
                 path: /http/redirect/307
                 method: options
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                statusCodes:
-                  - '200'
-          - !<!Response> 
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                headers:
-                  - !<!HttpHeader> 
-                    schema: *ref_18
-                    header: Location
-                    language:
-                      default:
-                        name: Location
-                        description: The redirect location for this request
-                statusCodes:
-                  - '307'
-        exceptions:
-          - !<!SchemaResponse> 
-            schema: *ref_12
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpResponse> 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        language: !<!Languages> 
-          default:
-            name: Options307
-            description: 'options redirected with 307, resulting in a 200 after redirect'
-        protocol: !<!Protocols> {}
-      - !<!Operation> 
-        apiVersions:
-          - !<!ApiVersion> 
-            version: 1.0.0
-        parameters:
-          - *ref_11
-        requests:
-          - !<!Request> 
-            parameters:
-              - !<!Parameter> 
-                schema: *ref_13
-                implementation: Method
-                required: false
-                language: !<!Languages> 
-                  default:
-                    name: BooleanValue
-                    description: Simple boolean value true
-                protocol: !<!Protocols> 
-                  http: !<!HttpParameter> 
-                    in: body
-                    style: json
-            signatureParameters: []
-            language: !<!Languages> 
-              default:
-                name: ''
-                description: ''
-            protocol: !<!Protocols> 
-              http: !<!HttpWithBodyRequest> 
-                path: /http/redirect/307
-                method: put
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
                 uri: '{$host}'
         signatureParameters: []
         responses:
@@ -2546,7 +2951,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2560,8 +2965,8 @@ operationGroups:
                   - default
         language: !<!Languages> 
           default:
-            name: Put307
-            description: 'Put redirected with 307, resulting in a 200 after redirect'
+            name: Options307
+            description: 'options redirected with 307, resulting in a 200 after redirect'
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
@@ -2573,7 +2978,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2584,6 +2989,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2592,7 +3010,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpWithBodyRequest> 
                 path: /http/redirect/307
-                method: patch
+                method: put
                 knownMediaType: json
                 mediaTypes:
                   - application/json
@@ -2627,7 +3045,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2641,8 +3059,8 @@ operationGroups:
                   - default
         language: !<!Languages> 
           default:
-            name: Patch307
-            description: 'Patch redirected with 307, resulting in a 200 after redirect'
+            name: Put307
+            description: 'Put redirected with 307, resulting in a 200 after redirect'
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
@@ -2654,7 +3072,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2665,6 +3083,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2673,7 +3104,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpWithBodyRequest> 
                 path: /http/redirect/307
-                method: post
+                method: patch
                 knownMediaType: json
                 mediaTypes:
                   - application/json
@@ -2708,7 +3139,7 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2722,8 +3153,8 @@ operationGroups:
                   - default
         language: !<!Languages> 
           default:
-            name: Post307
-            description: 'Post redirected with 307, resulting in a 200 after redirect'
+            name: Patch307
+            description: 'Patch redirected with 307, resulting in a 200 after redirect'
         protocol: !<!Protocols> {}
       - !<!Operation> 
         apiVersions:
@@ -2735,7 +3166,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2746,6 +3177,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2754,7 +3198,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpWithBodyRequest> 
                 path: /http/redirect/307
-                method: delete
+                method: post
                 knownMediaType: json
                 mediaTypes:
                   - application/json
@@ -2789,7 +3233,101 @@ operationGroups:
                   - '307'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: Post307
+            description: 'Post redirected with 307, resulting in a 200 after redirect'
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_11
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                required: false
+                language: !<!Languages> 
+                  default:
+                    name: BooleanValue
+                    description: Simple boolean value true
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpWithBodyRequest> 
+                path: /http/redirect/307
+                method: delete
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                headers:
+                  - !<!HttpHeader> 
+                    schema: *ref_23
+                    header: Location
+                    language:
+                      default:
+                        name: Location
+                        description: The redirect location for this request
+                statusCodes:
+                  - '307'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2822,6 +3360,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2834,7 +3387,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2859,6 +3412,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2871,7 +3439,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2896,6 +3464,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2908,7 +3491,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2935,7 +3518,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2946,6 +3529,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -2962,7 +3558,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -2989,7 +3585,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3000,6 +3596,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3016,7 +3625,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3043,7 +3652,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3054,6 +3663,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3070,7 +3692,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3097,7 +3719,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3108,6 +3730,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3124,7 +3759,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3149,6 +3784,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3161,7 +3811,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3186,6 +3836,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3198,7 +3863,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3223,6 +3888,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3235,7 +3915,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3260,6 +3940,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3272,7 +3967,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3299,7 +3994,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3310,6 +4005,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3326,7 +4034,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3353,7 +4061,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3364,6 +4072,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3380,7 +4101,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3407,7 +4128,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3418,6 +4139,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3434,7 +4168,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3461,7 +4195,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3472,6 +4206,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3488,7 +4235,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3515,7 +4262,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3526,6 +4273,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3542,7 +4302,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3567,6 +4327,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3579,7 +4354,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3604,6 +4379,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3616,7 +4406,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3641,6 +4431,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3653,7 +4458,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3678,6 +4483,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3690,7 +4510,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3717,7 +4537,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3728,6 +4548,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3744,7 +4577,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3771,7 +4604,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3782,6 +4615,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3798,7 +4644,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3825,7 +4671,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3836,6 +4682,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3852,7 +4711,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3877,6 +4736,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3889,7 +4763,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3916,7 +4790,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -3927,6 +4801,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -3943,7 +4830,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -3968,6 +4855,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3980,7 +4882,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4013,6 +4915,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4025,7 +4942,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4050,6 +4967,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4062,7 +4994,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4089,7 +5021,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4100,6 +5032,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4116,7 +5061,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4143,7 +5088,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4154,6 +5099,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4170,7 +5128,7 @@ operationGroups:
         signatureParameters: []
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4203,6 +5161,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4225,7 +5198,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4252,7 +5225,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4263,6 +5236,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4289,7 +5275,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4316,7 +5302,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4327,6 +5313,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4353,7 +5352,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4378,6 +5377,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4400,7 +5414,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4425,6 +5439,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4451,7 +5480,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4478,7 +5507,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4489,6 +5518,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4515,7 +5557,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4542,7 +5584,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4553,6 +5595,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4579,7 +5634,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4606,7 +5661,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4617,6 +5672,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4643,7 +5711,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4670,7 +5738,7 @@ operationGroups:
           - !<!Request> 
             parameters:
               - !<!Parameter> 
-                schema: *ref_13
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -4681,6 +5749,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters: []
             language: !<!Languages> 
               default:
@@ -4707,7 +5788,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4740,6 +5821,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4775,7 +5871,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4800,6 +5896,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4835,7 +5946,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4860,6 +5971,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4895,7 +6021,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4920,6 +6046,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4955,7 +6096,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -4980,6 +6121,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5015,7 +6171,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5040,6 +6196,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5079,7 +6250,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5104,6 +6275,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5143,7 +6329,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5168,6 +6354,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5207,7 +6408,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5232,6 +6433,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5257,7 +6473,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -5270,7 +6486,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -5284,7 +6500,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5309,6 +6525,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5334,7 +6565,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -5347,7 +6578,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -5361,7 +6592,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5386,6 +6617,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5411,7 +6657,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -5424,7 +6670,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -5438,7 +6684,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5463,6 +6709,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5488,7 +6749,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_23
+            schema: *ref_24
             language: !<!Languages> 
               default:
                 name: ''
@@ -5501,7 +6762,7 @@ operationGroups:
                 statusCodes:
                   - '201'
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -5515,7 +6776,7 @@ operationGroups:
                   - '404'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5540,6 +6801,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5571,7 +6847,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5596,6 +6872,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5627,7 +6918,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5652,6 +6943,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5683,7 +6989,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -5916,6 +7222,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5953,6 +7274,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5990,6 +7326,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6037,6 +7388,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6236,6 +7602,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6273,6 +7654,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6310,6 +7706,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6347,6 +7758,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6384,6 +7810,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6421,6 +7862,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6458,6 +7914,21 @@ operationGroups:
           - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/keyvault/flattened.yaml
+++ b/modelerfour/test/scenarios/keyvault/flattened.yaml
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
           name: boolean
           description: 'True if the secret''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_428
+    - !<!BooleanSchema> &ref_429
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -114,7 +114,7 @@ schemas: !<!Schemas>
           name: integer
           description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_304
+    - !<!NumberSchema> &ref_305
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -883,7 +883,7 @@ schemas: !<!Schemas>
           name: DeletedStorageListResult-nextLink
           description: The URL to get the next set of deleted storage accounts.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_565
+    - !<!StringSchema> &ref_566
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1553,6 +1553,16 @@ schemas: !<!Schemas>
           name: ApiVersion-7.0-preview
           description: Api Version (7.0-preview)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_260
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_15
       type: dictionary
@@ -2164,7 +2174,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_261
+        - !<!Property> &ref_262
           schema: *ref_2
           required: true
           serializedName: kty
@@ -2173,7 +2183,7 @@ schemas: !<!Schemas>
               name: kty
               description: 'The type of key to create. For valid values, see JsonWebKeyType.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_262
+        - !<!Property> &ref_263
           schema: *ref_3
           required: false
           serializedName: key_size
@@ -2182,7 +2192,7 @@ schemas: !<!Schemas>
               name: key_size
               description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_263
+        - !<!Property> &ref_264
           schema: !<!ArraySchema> &ref_233
             type: array
             apiVersions:
@@ -2201,7 +2211,7 @@ schemas: !<!Schemas>
               name: key_ops
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_264
+        - !<!Property> &ref_265
           schema: !<!ObjectSchema> &ref_5
             type: object
             apiVersions:
@@ -2376,7 +2386,7 @@ schemas: !<!Schemas>
               name: keyAttributes
               description: The attributes of a key managed by the key vault service.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_265
+        - !<!Property> &ref_266
           schema: *ref_15
           required: false
           serializedName: tags
@@ -2385,7 +2395,7 @@ schemas: !<!Schemas>
               name: tags
               description: Application specific metadata in the form of key-value pairs.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_266
+        - !<!Property> &ref_267
           schema: *ref_16
           required: false
           serializedName: crv
@@ -2661,7 +2671,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_38
-    - !<!ObjectSchema> &ref_275
+    - !<!ObjectSchema> &ref_276
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2730,13 +2740,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_41
-    - !<!ObjectSchema> &ref_276
+    - !<!ObjectSchema> &ref_277
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_278
+        - !<!Property> &ref_279
           schema: *ref_42
           required: false
           serializedName: Hsm
@@ -2745,7 +2755,7 @@ schemas: !<!Schemas>
               name: Hsm
               description: Whether to import as a hardware key (HSM) or software key.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_279
+        - !<!Property> &ref_280
           schema: *ref_38
           required: true
           serializedName: key
@@ -2754,7 +2764,7 @@ schemas: !<!Schemas>
               name: key
               description: The Json web key
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_280
+        - !<!Property> &ref_281
           schema: *ref_5
           required: false
           serializedName: attributes
@@ -2763,7 +2773,7 @@ schemas: !<!Schemas>
               name: keyAttributes
               description: The key management attributes.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_281
+        - !<!Property> &ref_282
           schema: *ref_43
           required: false
           serializedName: tags
@@ -2783,13 +2793,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_21
-    - !<!ObjectSchema> &ref_290
+    - !<!ObjectSchema> &ref_291
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_292
+        - !<!Property> &ref_293
           schema: !<!ArraySchema> &ref_235
             type: array
             apiVersions:
@@ -2807,7 +2817,7 @@ schemas: !<!Schemas>
               name: key_ops
               description: 'Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_293
+        - !<!Property> &ref_294
           schema: *ref_5
           serializedName: attributes
           language: !<!Languages> 
@@ -2815,7 +2825,7 @@ schemas: !<!Schemas>
               name: keyAttributes
               description: The attributes of a key managed by the key vault service.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_294
+        - !<!Property> &ref_295
           schema: *ref_44
           serializedName: tags
           language: !<!Languages> 
@@ -2833,7 +2843,7 @@ schemas: !<!Schemas>
           description: The key update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_308
+    - !<!ObjectSchema> &ref_309
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2977,7 +2987,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_45
-    - !<!ObjectSchema> &ref_313
+    - !<!ObjectSchema> &ref_314
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3002,13 +3012,13 @@ schemas: !<!Schemas>
           description: 'The backup key result, containing the backup blob.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_314
+    - !<!ObjectSchema> &ref_315
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_316
+        - !<!Property> &ref_317
           schema: *ref_52
           required: true
           serializedName: value
@@ -3027,13 +3037,13 @@ schemas: !<!Schemas>
           description: The key restore parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_319
+    - !<!ObjectSchema> &ref_320
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_321
+        - !<!Property> &ref_322
           schema: *ref_53
           required: true
           serializedName: alg
@@ -3042,7 +3052,7 @@ schemas: !<!Schemas>
               name: algorithm
               description: algorithm identifier
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_322
+        - !<!Property> &ref_323
           schema: *ref_54
           required: true
           serializedName: value
@@ -3061,7 +3071,7 @@ schemas: !<!Schemas>
           description: The key operations parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_328
+    - !<!ObjectSchema> &ref_329
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3095,13 +3105,13 @@ schemas: !<!Schemas>
           description: The key operation result.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_335
+    - !<!ObjectSchema> &ref_336
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_337
+        - !<!Property> &ref_338
           schema: *ref_57
           required: true
           serializedName: alg
@@ -3110,7 +3120,7 @@ schemas: !<!Schemas>
               name: algorithm
               description: 'The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_338
+        - !<!Property> &ref_339
           schema: *ref_58
           required: true
           serializedName: value
@@ -3129,13 +3139,13 @@ schemas: !<!Schemas>
           description: The key operations parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_344
+    - !<!ObjectSchema> &ref_345
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_346
+        - !<!Property> &ref_347
           schema: *ref_57
           required: true
           serializedName: alg
@@ -3144,7 +3154,7 @@ schemas: !<!Schemas>
               name: algorithm
               description: 'The signing/verification algorithm. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_347
+        - !<!Property> &ref_348
           schema: *ref_59
           required: true
           serializedName: digest
@@ -3153,7 +3163,7 @@ schemas: !<!Schemas>
               name: digest
               description: The digest used for signing.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_348
+        - !<!Property> &ref_349
           schema: *ref_60
           required: true
           serializedName: value
@@ -3172,7 +3182,7 @@ schemas: !<!Schemas>
           description: The key verify parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_355
+    - !<!ObjectSchema> &ref_356
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3197,7 +3207,7 @@ schemas: !<!Schemas>
           description: The key verify result.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_370
+    - !<!ObjectSchema> &ref_371
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3242,13 +3252,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_47
-    - !<!ObjectSchema> &ref_377
+    - !<!ObjectSchema> &ref_378
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_379
+        - !<!Property> &ref_380
           schema: *ref_63
           required: true
           serializedName: value
@@ -3257,7 +3267,7 @@ schemas: !<!Schemas>
               name: value
               description: The value of the secret.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_380
+        - !<!Property> &ref_381
           schema: *ref_64
           required: false
           serializedName: tags
@@ -3266,7 +3276,7 @@ schemas: !<!Schemas>
               name: tags
               description: Application specific metadata in the form of key-value pairs.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_381
+        - !<!Property> &ref_382
           schema: *ref_65
           required: false
           serializedName: contentType
@@ -3275,7 +3285,7 @@ schemas: !<!Schemas>
               name: contentType
               description: Type of the secret value such as a password.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_382
+        - !<!Property> &ref_383
           schema: *ref_8
           required: false
           serializedName: attributes
@@ -3421,13 +3431,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_70
-    - !<!ObjectSchema> &ref_391
+    - !<!ObjectSchema> &ref_392
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_393
+        - !<!Property> &ref_394
           schema: *ref_77
           serializedName: contentType
           language: !<!Languages> 
@@ -3435,7 +3445,7 @@ schemas: !<!Schemas>
               name: contentType
               description: Type of the secret value such as a password.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_394
+        - !<!Property> &ref_395
           schema: *ref_8
           serializedName: attributes
           language: !<!Languages> 
@@ -3443,7 +3453,7 @@ schemas: !<!Schemas>
               name: secretAttributes
               description: The secret management attributes.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_395
+        - !<!Property> &ref_396
           schema: *ref_78
           serializedName: tags
           language: !<!Languages> 
@@ -3461,7 +3471,7 @@ schemas: !<!Schemas>
           description: The secret update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_407
+    - !<!ObjectSchema> &ref_408
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3613,7 +3623,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_79
-    - !<!ObjectSchema> &ref_413
+    - !<!ObjectSchema> &ref_414
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3658,7 +3668,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_81
-    - !<!ObjectSchema> &ref_422
+    - !<!ObjectSchema> &ref_423
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3683,13 +3693,13 @@ schemas: !<!Schemas>
           description: 'The backup secret result, containing the backup blob.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_423
+    - !<!ObjectSchema> &ref_424
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_425
+        - !<!Property> &ref_426
           schema: *ref_89
           required: true
           serializedName: value
@@ -3708,7 +3718,7 @@ schemas: !<!Schemas>
           description: The secret restore parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_432
+    - !<!ObjectSchema> &ref_433
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4443,7 +4453,7 @@ schemas: !<!Schemas>
     - *ref_131
     - *ref_132
     - *ref_133
-    - !<!ObjectSchema> &ref_435
+    - !<!ObjectSchema> &ref_436
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4458,7 +4468,7 @@ schemas: !<!Schemas>
               name: id
               description: Identifier for the contacts collection.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_437
+        - !<!Property> &ref_438
           schema: !<!ArraySchema> &ref_247
             type: array
             apiVersions:
@@ -4528,7 +4538,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_138
-    - !<!ObjectSchema> &ref_444
+    - !<!ObjectSchema> &ref_445
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4604,13 +4614,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_142
-    - !<!ObjectSchema> &ref_445
+    - !<!ObjectSchema> &ref_446
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_447
+        - !<!Property> &ref_448
           schema: *ref_143
           required: true
           serializedName: provider
@@ -4619,7 +4629,7 @@ schemas: !<!Schemas>
               name: provider
               description: The issuer provider.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_448
+        - !<!Property> &ref_449
           schema: !<!ObjectSchema> &ref_151
             type: object
             apiVersions:
@@ -4660,7 +4670,7 @@ schemas: !<!Schemas>
               name: credentials
               description: The credentials to be used for the issuer.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_449
+        - !<!Property> &ref_450
           schema: !<!ObjectSchema> &ref_152
             type: object
             apiVersions:
@@ -4759,7 +4769,7 @@ schemas: !<!Schemas>
               name: OrganizationDetails
               description: Details of the organization as provided to the issuer.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_450
+        - !<!Property> &ref_451
           schema: !<!ObjectSchema> &ref_154
             type: object
             apiVersions:
@@ -4824,7 +4834,7 @@ schemas: !<!Schemas>
     - *ref_152
     - *ref_153
     - *ref_154
-    - !<!ObjectSchema> &ref_457
+    - !<!ObjectSchema> &ref_458
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4881,13 +4891,13 @@ schemas: !<!Schemas>
           description: The issuer for Key Vault certificate.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_458
+    - !<!ObjectSchema> &ref_459
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_460
+        - !<!Property> &ref_461
           schema: *ref_157
           serializedName: provider
           language: !<!Languages> 
@@ -4895,7 +4905,7 @@ schemas: !<!Schemas>
               name: provider
               description: The issuer provider.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_461
+        - !<!Property> &ref_462
           schema: *ref_151
           serializedName: credentials
           language: !<!Languages> 
@@ -4903,7 +4913,7 @@ schemas: !<!Schemas>
               name: credentials
               description: The credentials to be used for the issuer.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_462
+        - !<!Property> &ref_463
           schema: *ref_152
           serializedName: org_details
           language: !<!Languages> 
@@ -4911,7 +4921,7 @@ schemas: !<!Schemas>
               name: OrganizationDetails
               description: Details of the organization as provided to the issuer.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_463
+        - !<!Property> &ref_464
           schema: *ref_154
           serializedName: attributes
           language: !<!Languages> 
@@ -4929,13 +4939,13 @@ schemas: !<!Schemas>
           description: The certificate issuer update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_474
+    - !<!ObjectSchema> &ref_475
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_476
+        - !<!Property> &ref_477
           schema: *ref_125
           serializedName: policy
           language: !<!Languages> 
@@ -4943,7 +4953,7 @@ schemas: !<!Schemas>
               name: CertificatePolicy
               description: The management policy for the certificate.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_477
+        - !<!Property> &ref_478
           schema: *ref_9
           serializedName: attributes
           language: !<!Languages> 
@@ -4951,7 +4961,7 @@ schemas: !<!Schemas>
               name: CertificateAttributes
               description: The attributes of the certificate (optional).
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_478
+        - !<!Property> &ref_479
           schema: *ref_158
           serializedName: tags
           language: !<!Languages> 
@@ -4969,7 +4979,7 @@ schemas: !<!Schemas>
           description: The certificate create parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_484
+    - !<!ObjectSchema> &ref_485
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5058,13 +5068,13 @@ schemas: !<!Schemas>
           description: A certificate operation is returned in case of asynchronous requests.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_485
+    - !<!ObjectSchema> &ref_486
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_487
+        - !<!Property> &ref_488
           schema: *ref_166
           required: true
           serializedName: value
@@ -5073,7 +5083,7 @@ schemas: !<!Schemas>
               name: base64EncodedCertificate
               description: Base64 encoded representation of the certificate object to import. This certificate needs to contain the private key.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_488
+        - !<!Property> &ref_489
           schema: *ref_167
           required: false
           serializedName: pwd
@@ -5082,7 +5092,7 @@ schemas: !<!Schemas>
               name: password
               description: 'If the private key in base64EncodedCertificate is encrypted, the password used for encryption.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_489
+        - !<!Property> &ref_490
           schema: *ref_125
           required: false
           serializedName: policy
@@ -5091,7 +5101,7 @@ schemas: !<!Schemas>
               name: CertificatePolicy
               description: The management policy for the certificate.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_490
+        - !<!Property> &ref_491
           schema: *ref_9
           required: false
           serializedName: attributes
@@ -5100,7 +5110,7 @@ schemas: !<!Schemas>
               name: CertificateAttributes
               description: The attributes of the certificate (optional).
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_491
+        - !<!Property> &ref_492
           schema: *ref_168
           required: false
           serializedName: tags
@@ -5119,13 +5129,13 @@ schemas: !<!Schemas>
           description: The certificate import parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_507
+    - !<!ObjectSchema> &ref_508
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_509
+        - !<!Property> &ref_510
           schema: *ref_125
           serializedName: policy
           language: !<!Languages> 
@@ -5133,7 +5143,7 @@ schemas: !<!Schemas>
               name: CertificatePolicy
               description: The management policy for the certificate.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_510
+        - !<!Property> &ref_511
           schema: *ref_9
           serializedName: attributes
           language: !<!Languages> 
@@ -5141,7 +5151,7 @@ schemas: !<!Schemas>
               name: CertificateAttributes
               description: The attributes of the certificate (optional).
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_511
+        - !<!Property> &ref_512
           schema: *ref_169
           serializedName: tags
           language: !<!Languages> 
@@ -5159,13 +5169,13 @@ schemas: !<!Schemas>
           description: The certificate update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_521
+    - !<!ObjectSchema> &ref_522
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_523
+        - !<!Property> &ref_524
           schema: *ref_161
           required: true
           serializedName: cancellation_requested
@@ -5184,13 +5194,13 @@ schemas: !<!Schemas>
           description: The certificate operation update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_531
+    - !<!ObjectSchema> &ref_532
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_533
+        - !<!Property> &ref_534
           schema: !<!ArraySchema> &ref_250
             type: array
             apiVersions:
@@ -5209,7 +5219,7 @@ schemas: !<!Schemas>
               name: x509Certificates
               description: The certificate or the certificate chain to merge.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_534
+        - !<!Property> &ref_535
           schema: *ref_9
           required: false
           serializedName: attributes
@@ -5218,7 +5228,7 @@ schemas: !<!Schemas>
               name: CertificateAttributes
               description: The attributes of the certificate (optional).
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_535
+        - !<!Property> &ref_536
           schema: *ref_171
           required: false
           serializedName: tags
@@ -5237,7 +5247,7 @@ schemas: !<!Schemas>
           description: The certificate merge parameters
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_543
+    - !<!ObjectSchema> &ref_544
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5262,13 +5272,13 @@ schemas: !<!Schemas>
           description: 'The backup certificate result, containing the backup blob.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_544
+    - !<!ObjectSchema> &ref_545
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_546
+        - !<!Property> &ref_547
           schema: *ref_173
           required: true
           serializedName: value
@@ -5287,7 +5297,7 @@ schemas: !<!Schemas>
           description: The certificate restore parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_552
+    - !<!ObjectSchema> &ref_553
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5332,7 +5342,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_94
-    - !<!ObjectSchema> &ref_561
+    - !<!ObjectSchema> &ref_562
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5534,7 +5544,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_175
     - *ref_185
-    - !<!ObjectSchema> &ref_564
+    - !<!ObjectSchema> &ref_565
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5710,7 +5720,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_194
-    - !<!ObjectSchema> &ref_574
+    - !<!ObjectSchema> &ref_575
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5735,13 +5745,13 @@ schemas: !<!Schemas>
           description: 'The backup storage result, containing the backup blob.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_575
+    - !<!ObjectSchema> &ref_576
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_577
+        - !<!Property> &ref_578
           schema: *ref_197
           required: true
           serializedName: value
@@ -5760,13 +5770,13 @@ schemas: !<!Schemas>
           description: The secret restore parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_584
+    - !<!ObjectSchema> &ref_585
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_586
+        - !<!Property> &ref_587
           schema: *ref_198
           required: true
           serializedName: resourceId
@@ -5775,7 +5785,7 @@ schemas: !<!Schemas>
               name: resourceId
               description: Storage account resource id.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_587
+        - !<!Property> &ref_588
           schema: *ref_199
           required: true
           serializedName: activeKeyName
@@ -5784,7 +5794,7 @@ schemas: !<!Schemas>
               name: activeKeyName
               description: Current active storage account key name.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_588
+        - !<!Property> &ref_589
           schema: *ref_191
           required: true
           serializedName: autoRegenerateKey
@@ -5793,7 +5803,7 @@ schemas: !<!Schemas>
               name: autoRegenerateKey
               description: whether keyvault should manage the storage account for the user.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_589
+        - !<!Property> &ref_590
           schema: *ref_200
           required: false
           serializedName: regenerationPeriod
@@ -5802,7 +5812,7 @@ schemas: !<!Schemas>
               name: regenerationPeriod
               description: The key regeneration time duration specified in ISO-8601 format.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_590
+        - !<!Property> &ref_591
           schema: *ref_185
           required: false
           serializedName: attributes
@@ -5811,7 +5821,7 @@ schemas: !<!Schemas>
               name: StorageAccountAttributes
               description: The attributes of the storage account.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_591
+        - !<!Property> &ref_592
           schema: *ref_201
           required: false
           serializedName: tags
@@ -5830,13 +5840,13 @@ schemas: !<!Schemas>
           description: The storage account create parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_600
+    - !<!ObjectSchema> &ref_601
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_602
+        - !<!Property> &ref_603
           schema: *ref_202
           serializedName: activeKeyName
           language: !<!Languages> 
@@ -5844,7 +5854,7 @@ schemas: !<!Schemas>
               name: activeKeyName
               description: The current active storage account key name.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_603
+        - !<!Property> &ref_604
           schema: *ref_191
           serializedName: autoRegenerateKey
           language: !<!Languages> 
@@ -5852,7 +5862,7 @@ schemas: !<!Schemas>
               name: autoRegenerateKey
               description: whether keyvault should manage the storage account for the user.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_604
+        - !<!Property> &ref_605
           schema: *ref_203
           serializedName: regenerationPeriod
           language: !<!Languages> 
@@ -5860,7 +5870,7 @@ schemas: !<!Schemas>
               name: regenerationPeriod
               description: The key regeneration time duration specified in ISO-8601 format.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_605
+        - !<!Property> &ref_606
           schema: *ref_185
           serializedName: attributes
           language: !<!Languages> 
@@ -5868,7 +5878,7 @@ schemas: !<!Schemas>
               name: StorageAccountAttributes
               description: The attributes of the storage account.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_606
+        - !<!Property> &ref_607
           schema: *ref_204
           serializedName: tags
           language: !<!Languages> 
@@ -5886,13 +5896,13 @@ schemas: !<!Schemas>
           description: The storage account update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_614
+    - !<!ObjectSchema> &ref_615
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_616
+        - !<!Property> &ref_617
           schema: *ref_205
           required: true
           serializedName: keyName
@@ -5911,7 +5921,7 @@ schemas: !<!Schemas>
           description: The storage account key regenerate parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_623
+    - !<!ObjectSchema> &ref_624
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -6113,7 +6123,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_206
     - *ref_215
-    - !<!ObjectSchema> &ref_627
+    - !<!ObjectSchema> &ref_628
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -6289,13 +6299,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_224
-    - !<!ObjectSchema> &ref_640
+    - !<!ObjectSchema> &ref_641
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_642
+        - !<!Property> &ref_643
           schema: *ref_226
           required: true
           serializedName: templateUri
@@ -6304,7 +6314,7 @@ schemas: !<!Schemas>
               name: templateUri
               description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_643
+        - !<!Property> &ref_644
           schema: *ref_221
           required: true
           serializedName: sasType
@@ -6313,7 +6323,7 @@ schemas: !<!Schemas>
               name: sasType
               description: The type of SAS token the SAS definition will create.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_644
+        - !<!Property> &ref_645
           schema: *ref_227
           required: true
           serializedName: validityPeriod
@@ -6322,7 +6332,7 @@ schemas: !<!Schemas>
               name: validityPeriod
               description: The validity period of SAS tokens created according to the SAS definition.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_645
+        - !<!Property> &ref_646
           schema: *ref_215
           required: false
           serializedName: attributes
@@ -6331,7 +6341,7 @@ schemas: !<!Schemas>
               name: SasDefinitionAttributes
               description: The attributes of the SAS definition.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_646
+        - !<!Property> &ref_647
           schema: *ref_228
           required: false
           serializedName: tags
@@ -6350,13 +6360,13 @@ schemas: !<!Schemas>
           description: The SAS definition create parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_655
+    - !<!ObjectSchema> &ref_656
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_657
+        - !<!Property> &ref_658
           schema: *ref_229
           serializedName: templateUri
           language: !<!Languages> 
@@ -6364,7 +6374,7 @@ schemas: !<!Schemas>
               name: templateUri
               description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_658
+        - !<!Property> &ref_659
           schema: *ref_221
           serializedName: sasType
           language: !<!Languages> 
@@ -6372,7 +6382,7 @@ schemas: !<!Schemas>
               name: sasType
               description: The type of SAS token the SAS definition will create.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_659
+        - !<!Property> &ref_660
           schema: *ref_230
           serializedName: validityPeriod
           language: !<!Languages> 
@@ -6380,7 +6390,7 @@ schemas: !<!Schemas>
               name: validityPeriod
               description: The validity period of SAS tokens created according to the SAS definition.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_660
+        - !<!Property> &ref_661
           schema: *ref_215
           serializedName: attributes
           language: !<!Languages> 
@@ -6388,7 +6398,7 @@ schemas: !<!Schemas>
               name: SasDefinitionAttributes
               description: The attributes of the SAS definition.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_661
+        - !<!Property> &ref_662
           schema: *ref_231
           serializedName: tags
           language: !<!Languages> 
@@ -6474,7 +6484,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_273
+          - !<!Parameter> &ref_274
             schema: *ref_0
             implementation: Method
             required: true
@@ -6492,7 +6502,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_274
+          - !<!Parameter> &ref_275
             schema: *ref_257
             implementation: Method
             required: true
@@ -6508,7 +6518,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_260
+              - !<!Parameter> &ref_261
                 schema: *ref_259
                 flattened: true
                 implementation: Method
@@ -6523,85 +6533,98 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_267
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_268
                 schema: *ref_2
                 implementation: Method
-                originalParameter: *ref_260
+                originalParameter: *ref_261
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_261
+                targetProperty: *ref_262
                 language: !<!Languages> 
                   default:
                     name: kty
                     description: 'The type of key to create. For valid values, see JsonWebKeyType.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_268
+              - !<!VirtualParameter> &ref_269
                 schema: *ref_3
                 implementation: Method
-                originalParameter: *ref_260
-                pathToProperty: []
-                required: false
-                targetProperty: *ref_262
-                language: !<!Languages> 
-                  default:
-                    name: key_size
-                    description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
-                protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_269
-                schema: *ref_233
-                implementation: Method
-                originalParameter: *ref_260
+                originalParameter: *ref_261
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_263
                 language: !<!Languages> 
                   default:
-                    name: key_ops
-                    description: ''
+                    name: key_size
+                    description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_270
-                schema: *ref_5
+                schema: *ref_233
                 implementation: Method
-                originalParameter: *ref_260
+                originalParameter: *ref_261
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_264
                 language: !<!Languages> 
                   default:
-                    name: keyAttributes
-                    description: The attributes of a key managed by the key vault service.
+                    name: key_ops
+                    description: ''
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_271
-                schema: *ref_15
+                schema: *ref_5
                 implementation: Method
-                originalParameter: *ref_260
+                originalParameter: *ref_261
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_265
                 language: !<!Languages> 
                   default:
-                    name: tags
-                    description: Application specific metadata in the form of key-value pairs.
+                    name: keyAttributes
+                    description: The attributes of a key managed by the key vault service.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_272
-                schema: *ref_16
+                schema: *ref_15
                 implementation: Method
-                originalParameter: *ref_260
+                originalParameter: *ref_261
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_266
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_273
+                schema: *ref_16
+                implementation: Method
+                originalParameter: *ref_261
+                pathToProperty: []
+                required: false
+                targetProperty: *ref_267
                 language: !<!Languages> 
                   default:
                     name: curve
                     description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_267
               - *ref_268
               - *ref_269
               - *ref_270
               - *ref_271
               - *ref_272
+              - *ref_273
             language: !<!Languages> 
               default:
                 name: ''
@@ -6615,8 +6638,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_273
           - *ref_274
+          - *ref_275
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -6633,7 +6656,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -6700,7 +6723,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_286
+          - !<!Parameter> &ref_287
             schema: *ref_0
             implementation: Method
             required: true
@@ -6718,7 +6741,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_287
+          - !<!Parameter> &ref_288
             schema: *ref_257
             implementation: Method
             required: true
@@ -6734,8 +6757,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_277
-                schema: *ref_276
+              - !<!Parameter> &ref_278
+                schema: *ref_277
                 flattened: true
                 implementation: Method
                 required: true
@@ -6749,59 +6772,72 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_282
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_283
                 schema: *ref_42
                 implementation: Method
-                originalParameter: *ref_277
+                originalParameter: *ref_278
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_278
+                targetProperty: *ref_279
                 language: !<!Languages> 
                   default:
                     name: Hsm
                     description: Whether to import as a hardware key (HSM) or software key.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_283
+              - !<!VirtualParameter> &ref_284
                 schema: *ref_38
                 implementation: Method
-                originalParameter: *ref_277
+                originalParameter: *ref_278
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_279
+                targetProperty: *ref_280
                 language: !<!Languages> 
                   default:
                     name: key
                     description: The Json web key
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_284
+              - !<!VirtualParameter> &ref_285
                 schema: *ref_5
                 implementation: Method
-                originalParameter: *ref_277
+                originalParameter: *ref_278
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_280
+                targetProperty: *ref_281
                 language: !<!Languages> 
                   default:
                     name: keyAttributes
                     description: The key management attributes.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_285
+              - !<!VirtualParameter> &ref_286
                 schema: *ref_43
                 implementation: Method
-                originalParameter: *ref_277
+                originalParameter: *ref_278
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_281
+                targetProperty: *ref_282
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_282
               - *ref_283
               - *ref_284
               - *ref_285
+              - *ref_286
             language: !<!Languages> 
               default:
                 name: ''
@@ -6815,8 +6851,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_286
           - *ref_287
+          - *ref_288
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -6833,7 +6869,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -6900,7 +6936,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_288
+          - !<!Parameter> &ref_289
             schema: *ref_0
             implementation: Method
             required: true
@@ -6918,7 +6954,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_289
+          - !<!Parameter> &ref_290
             schema: *ref_1
             implementation: Method
             required: true
@@ -6933,6 +6969,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6943,8 +6994,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_288
           - *ref_289
+          - *ref_290
         responses:
           - !<!SchemaResponse> 
             schema: *ref_21
@@ -6961,7 +7012,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7019,7 +7070,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_298
+          - !<!Parameter> &ref_299
             schema: *ref_0
             implementation: Method
             required: true
@@ -7037,7 +7088,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_299
+          - !<!Parameter> &ref_300
             schema: *ref_1
             implementation: Method
             required: true
@@ -7049,7 +7100,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_300
+          - !<!Parameter> &ref_301
             schema: *ref_1
             implementation: Method
             required: true
@@ -7065,8 +7116,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_291
-                schema: *ref_290
+              - !<!Parameter> &ref_292
+                schema: *ref_291
                 flattened: true
                 implementation: Method
                 required: true
@@ -7080,43 +7131,56 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_295
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_296
                 schema: *ref_235
                 implementation: Method
-                originalParameter: *ref_291
+                originalParameter: *ref_292
                 pathToProperty: []
-                targetProperty: *ref_292
+                targetProperty: *ref_293
                 language: !<!Languages> 
                   default:
                     name: key_ops
                     description: 'Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_296
+              - !<!VirtualParameter> &ref_297
                 schema: *ref_5
                 implementation: Method
-                originalParameter: *ref_291
+                originalParameter: *ref_292
                 pathToProperty: []
-                targetProperty: *ref_293
+                targetProperty: *ref_294
                 language: !<!Languages> 
                   default:
                     name: keyAttributes
                     description: The attributes of a key managed by the key vault service.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_297
+              - !<!VirtualParameter> &ref_298
                 schema: *ref_44
                 implementation: Method
-                originalParameter: *ref_291
+                originalParameter: *ref_292
                 pathToProperty: []
-                targetProperty: *ref_294
+                targetProperty: *ref_295
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_295
               - *ref_296
               - *ref_297
+              - *ref_298
             language: !<!Languages> 
               default:
                 name: ''
@@ -7130,9 +7194,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_298
           - *ref_299
           - *ref_300
+          - *ref_301
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -7149,7 +7213,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7206,7 +7270,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_301
+          - !<!Parameter> &ref_302
             schema: *ref_0
             implementation: Method
             required: true
@@ -7224,7 +7288,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_302
+          - !<!Parameter> &ref_303
             schema: *ref_1
             implementation: Method
             required: true
@@ -7236,7 +7300,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_303
+          - !<!Parameter> &ref_304
             schema: *ref_1
             implementation: Method
             required: true
@@ -7251,6 +7315,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -7261,9 +7340,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_301
           - *ref_302
           - *ref_303
+          - *ref_304
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -7280,7 +7359,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7334,7 +7413,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_305
+          - !<!Parameter> &ref_306
             schema: *ref_0
             implementation: Method
             required: true
@@ -7352,7 +7431,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_306
+          - !<!Parameter> &ref_307
             schema: *ref_1
             implementation: Method
             required: true
@@ -7364,8 +7443,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_307
-            schema: *ref_304
+          - !<!Parameter> &ref_308
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -7378,6 +7457,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -7388,12 +7482,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_305
           - *ref_306
           - *ref_307
+          - *ref_308
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_308
+            schema: *ref_309
             language: !<!Languages> 
               default:
                 name: ''
@@ -7407,7 +7501,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7455,7 +7549,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_309
+          - !<!Parameter> &ref_310
             schema: *ref_0
             implementation: Method
             required: true
@@ -7473,8 +7567,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_310
-            schema: *ref_304
+          - !<!Parameter> &ref_311
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -7487,6 +7581,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -7497,11 +7606,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_309
           - *ref_310
+          - *ref_311
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_308
+            schema: *ref_309
             language: !<!Languages> 
               default:
                 name: ''
@@ -7515,7 +7624,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7563,7 +7672,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_311
+          - !<!Parameter> &ref_312
             schema: *ref_0
             implementation: Method
             required: true
@@ -7581,7 +7690,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_312
+          - !<!Parameter> &ref_313
             schema: *ref_1
             implementation: Method
             required: true
@@ -7596,6 +7705,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -7606,11 +7730,11 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_311
           - *ref_312
+          - *ref_313
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_313
+            schema: *ref_314
             language: !<!Languages> 
               default:
                 name: ''
@@ -7624,7 +7748,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7663,7 +7787,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_318
+          - !<!Parameter> &ref_319
             schema: *ref_0
             implementation: Method
             required: true
@@ -7685,8 +7809,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_315
-                schema: *ref_314
+              - !<!Parameter> &ref_316
+                schema: *ref_315
                 flattened: true
                 implementation: Method
                 required: true
@@ -7700,20 +7824,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_317
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_318
                 schema: *ref_52
                 implementation: Method
-                originalParameter: *ref_315
+                originalParameter: *ref_316
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_316
+                targetProperty: *ref_317
                 language: !<!Languages> 
                   default:
                     name: keyBundleBackup
                     description: The backup blob associated with a key bundle.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_317
+              - *ref_318
             language: !<!Languages> 
               default:
                 name: ''
@@ -7727,7 +7864,7 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_318
+          - *ref_319
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -7744,7 +7881,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7803,7 +7940,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_325
+          - !<!Parameter> &ref_326
             schema: *ref_0
             implementation: Method
             required: true
@@ -7821,7 +7958,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_326
+          - !<!Parameter> &ref_327
             schema: *ref_1
             implementation: Method
             required: true
@@ -7833,7 +7970,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_327
+          - !<!Parameter> &ref_328
             schema: *ref_1
             implementation: Method
             required: true
@@ -7849,8 +7986,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_320
-                schema: *ref_319
+              - !<!Parameter> &ref_321
+                schema: *ref_320
                 flattened: true
                 implementation: Method
                 required: true
@@ -7864,33 +8001,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_323
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_324
                 schema: *ref_53
                 implementation: Method
-                originalParameter: *ref_320
+                originalParameter: *ref_321
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_321
+                targetProperty: *ref_322
                 language: !<!Languages> 
                   default:
                     name: algorithm
                     description: algorithm identifier
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_324
+              - !<!VirtualParameter> &ref_325
                 schema: *ref_54
                 implementation: Method
-                originalParameter: *ref_320
+                originalParameter: *ref_321
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_322
+                targetProperty: *ref_323
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_323
               - *ref_324
+              - *ref_325
             language: !<!Languages> 
               default:
                 name: ''
@@ -7904,12 +8054,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_325
           - *ref_326
           - *ref_327
+          - *ref_328
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_328
+            schema: *ref_329
             language: !<!Languages> 
               default:
                 name: ''
@@ -7923,7 +8073,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7965,7 +8115,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_332
+          - !<!Parameter> &ref_333
             schema: *ref_0
             implementation: Method
             required: true
@@ -7983,7 +8133,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_333
+          - !<!Parameter> &ref_334
             schema: *ref_1
             implementation: Method
             required: true
@@ -7995,7 +8145,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_334
+          - !<!Parameter> &ref_335
             schema: *ref_1
             implementation: Method
             required: true
@@ -8011,8 +8161,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_329
-                schema: *ref_319
+              - !<!Parameter> &ref_330
+                schema: *ref_320
                 flattened: true
                 implementation: Method
                 required: true
@@ -8026,33 +8176,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_330
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_331
                 schema: *ref_53
                 implementation: Method
-                originalParameter: *ref_329
+                originalParameter: *ref_330
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_321
+                targetProperty: *ref_322
                 language: !<!Languages> 
                   default:
                     name: algorithm
                     description: algorithm identifier
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_331
+              - !<!VirtualParameter> &ref_332
                 schema: *ref_54
                 implementation: Method
-                originalParameter: *ref_329
+                originalParameter: *ref_330
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_322
+                targetProperty: *ref_323
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_330
               - *ref_331
+              - *ref_332
             language: !<!Languages> 
               default:
                 name: ''
@@ -8066,12 +8229,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_332
           - *ref_333
           - *ref_334
+          - *ref_335
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_328
+            schema: *ref_329
             language: !<!Languages> 
               default:
                 name: ''
@@ -8085,7 +8248,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8127,7 +8290,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_341
+          - !<!Parameter> &ref_342
             schema: *ref_0
             implementation: Method
             required: true
@@ -8145,7 +8308,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_342
+          - !<!Parameter> &ref_343
             schema: *ref_1
             implementation: Method
             required: true
@@ -8157,7 +8320,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_343
+          - !<!Parameter> &ref_344
             schema: *ref_1
             implementation: Method
             required: true
@@ -8173,8 +8336,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_336
-                schema: *ref_335
+              - !<!Parameter> &ref_337
+                schema: *ref_336
                 flattened: true
                 implementation: Method
                 required: true
@@ -8188,33 +8351,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_339
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_340
                 schema: *ref_57
                 implementation: Method
-                originalParameter: *ref_336
+                originalParameter: *ref_337
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_337
+                targetProperty: *ref_338
                 language: !<!Languages> 
                   default:
                     name: algorithm
                     description: 'The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_340
+              - !<!VirtualParameter> &ref_341
                 schema: *ref_58
                 implementation: Method
-                originalParameter: *ref_336
+                originalParameter: *ref_337
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_338
+                targetProperty: *ref_339
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_339
               - *ref_340
+              - *ref_341
             language: !<!Languages> 
               default:
                 name: ''
@@ -8228,12 +8404,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_341
           - *ref_342
           - *ref_343
+          - *ref_344
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_328
+            schema: *ref_329
             language: !<!Languages> 
               default:
                 name: ''
@@ -8247,7 +8423,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8286,7 +8462,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_352
+          - !<!Parameter> &ref_353
             schema: *ref_0
             implementation: Method
             required: true
@@ -8304,7 +8480,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_353
+          - !<!Parameter> &ref_354
             schema: *ref_1
             implementation: Method
             required: true
@@ -8316,7 +8492,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_354
+          - !<!Parameter> &ref_355
             schema: *ref_1
             implementation: Method
             required: true
@@ -8332,8 +8508,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_345
-                schema: *ref_344
+              - !<!Parameter> &ref_346
+                schema: *ref_345
                 flattened: true
                 implementation: Method
                 required: true
@@ -8347,46 +8523,59 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_349
-                schema: *ref_57
+              - !<!Parameter> 
+                schema: *ref_260
                 implementation: Method
-                originalParameter: *ref_345
-                pathToProperty: []
+                origin: 'modelerfour:synthesized/accept'
                 required: true
-                targetProperty: *ref_346
                 language: !<!Languages> 
                   default:
-                    name: algorithm
-                    description: 'The signing/verification algorithm. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
-                protocol: !<!Protocols> {}
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - !<!VirtualParameter> &ref_350
-                schema: *ref_59
+                schema: *ref_57
                 implementation: Method
-                originalParameter: *ref_345
+                originalParameter: *ref_346
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_347
                 language: !<!Languages> 
                   default:
-                    name: digest
-                    description: The digest used for signing.
+                    name: algorithm
+                    description: 'The signing/verification algorithm. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_351
-                schema: *ref_60
+                schema: *ref_59
                 implementation: Method
-                originalParameter: *ref_345
+                originalParameter: *ref_346
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_348
+                language: !<!Languages> 
+                  default:
+                    name: digest
+                    description: The digest used for signing.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_352
+                schema: *ref_60
+                implementation: Method
+                originalParameter: *ref_346
+                pathToProperty: []
+                required: true
+                targetProperty: *ref_349
                 language: !<!Languages> 
                   default:
                     name: signature
                     description: The signature to be verified.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_349
               - *ref_350
               - *ref_351
+              - *ref_352
             language: !<!Languages> 
               default:
                 name: ''
@@ -8400,12 +8589,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_352
           - *ref_353
           - *ref_354
+          - *ref_355
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_355
+            schema: *ref_356
             language: !<!Languages> 
               default:
                 name: ''
@@ -8419,7 +8608,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8458,7 +8647,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_359
+          - !<!Parameter> &ref_360
             schema: *ref_0
             implementation: Method
             required: true
@@ -8476,7 +8665,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_360
+          - !<!Parameter> &ref_361
             schema: *ref_1
             implementation: Method
             required: true
@@ -8488,7 +8677,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_361
+          - !<!Parameter> &ref_362
             schema: *ref_1
             implementation: Method
             required: true
@@ -8504,8 +8693,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_356
-                schema: *ref_319
+              - !<!Parameter> &ref_357
+                schema: *ref_320
                 flattened: true
                 implementation: Method
                 required: true
@@ -8519,33 +8708,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_357
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_358
                 schema: *ref_53
                 implementation: Method
-                originalParameter: *ref_356
+                originalParameter: *ref_357
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_321
+                targetProperty: *ref_322
                 language: !<!Languages> 
                   default:
                     name: algorithm
                     description: algorithm identifier
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_358
+              - !<!VirtualParameter> &ref_359
                 schema: *ref_54
                 implementation: Method
-                originalParameter: *ref_356
+                originalParameter: *ref_357
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_322
+                targetProperty: *ref_323
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_357
               - *ref_358
+              - *ref_359
             language: !<!Languages> 
               default:
                 name: ''
@@ -8559,12 +8761,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_359
           - *ref_360
           - *ref_361
+          - *ref_362
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_328
+            schema: *ref_329
             language: !<!Languages> 
               default:
                 name: ''
@@ -8578,7 +8780,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8620,7 +8822,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_365
+          - !<!Parameter> &ref_366
             schema: *ref_0
             implementation: Method
             required: true
@@ -8638,7 +8840,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_366
+          - !<!Parameter> &ref_367
             schema: *ref_1
             implementation: Method
             required: true
@@ -8650,7 +8852,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_367
+          - !<!Parameter> &ref_368
             schema: *ref_1
             implementation: Method
             required: true
@@ -8666,8 +8868,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_362
-                schema: *ref_319
+              - !<!Parameter> &ref_363
+                schema: *ref_320
                 flattened: true
                 implementation: Method
                 required: true
@@ -8681,33 +8883,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_363
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_364
                 schema: *ref_53
                 implementation: Method
-                originalParameter: *ref_362
+                originalParameter: *ref_363
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_321
+                targetProperty: *ref_322
                 language: !<!Languages> 
                   default:
                     name: algorithm
                     description: algorithm identifier
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_364
+              - !<!VirtualParameter> &ref_365
                 schema: *ref_54
                 implementation: Method
-                originalParameter: *ref_362
+                originalParameter: *ref_363
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_322
+                targetProperty: *ref_323
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_363
               - *ref_364
+              - *ref_365
             language: !<!Languages> 
               default:
                 name: ''
@@ -8721,12 +8936,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_365
           - *ref_366
           - *ref_367
+          - *ref_368
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_328
+            schema: *ref_329
             language: !<!Languages> 
               default:
                 name: ''
@@ -8740,7 +8955,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8781,7 +8996,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_368
+          - !<!Parameter> &ref_369
             schema: *ref_0
             implementation: Method
             required: true
@@ -8799,8 +9014,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_369
-            schema: *ref_304
+          - !<!Parameter> &ref_370
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -8813,6 +9028,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -8823,11 +9053,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_368
           - *ref_369
+          - *ref_370
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_370
+            schema: *ref_371
             language: !<!Languages> 
               default:
                 name: ''
@@ -8841,7 +9071,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8892,7 +9122,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_371
+          - !<!Parameter> &ref_372
             schema: *ref_0
             implementation: Method
             required: true
@@ -8910,7 +9140,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_372
+          - !<!Parameter> &ref_373
             schema: *ref_1
             implementation: Method
             required: true
@@ -8925,6 +9155,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -8935,8 +9180,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_371
           - *ref_372
+          - *ref_373
         responses:
           - !<!SchemaResponse> 
             schema: *ref_21
@@ -8953,7 +9198,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9011,7 +9256,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_373
+          - !<!Parameter> &ref_374
             schema: *ref_0
             implementation: Method
             required: true
@@ -9029,7 +9274,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_374
+          - !<!Parameter> &ref_375
             schema: *ref_1
             implementation: Method
             required: true
@@ -9044,6 +9289,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9054,8 +9314,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_373
           - *ref_374
+          - *ref_375
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -9068,7 +9328,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9102,7 +9362,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_375
+          - !<!Parameter> &ref_376
             schema: *ref_0
             implementation: Method
             required: true
@@ -9120,7 +9380,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_376
+          - !<!Parameter> &ref_377
             schema: *ref_1
             implementation: Method
             required: true
@@ -9135,6 +9395,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9145,8 +9420,8 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_375
           - *ref_376
+          - *ref_377
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -9163,7 +9438,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9218,7 +9493,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_387
+          - !<!Parameter> &ref_388
             schema: *ref_0
             implementation: Method
             required: true
@@ -9236,7 +9511,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_388
+          - !<!Parameter> &ref_389
             schema: *ref_257
             implementation: Method
             required: true
@@ -9252,8 +9527,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_378
-                schema: *ref_377
+              - !<!Parameter> &ref_379
+                schema: *ref_378
                 flattened: true
                 implementation: Method
                 required: true
@@ -9267,59 +9542,72 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_383
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_384
                 schema: *ref_63
                 implementation: Method
-                originalParameter: *ref_378
+                originalParameter: *ref_379
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_379
+                targetProperty: *ref_380
                 language: !<!Languages> 
                   default:
                     name: value
                     description: The value of the secret.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_384
+              - !<!VirtualParameter> &ref_385
                 schema: *ref_64
                 implementation: Method
-                originalParameter: *ref_378
-                pathToProperty: []
-                required: false
-                targetProperty: *ref_380
-                language: !<!Languages> 
-                  default:
-                    name: tags
-                    description: Application specific metadata in the form of key-value pairs.
-                protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_385
-                schema: *ref_65
-                implementation: Method
-                originalParameter: *ref_378
+                originalParameter: *ref_379
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_381
                 language: !<!Languages> 
                   default:
-                    name: contentType
-                    description: Type of the secret value such as a password.
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_386
-                schema: *ref_8
+                schema: *ref_65
                 implementation: Method
-                originalParameter: *ref_378
+                originalParameter: *ref_379
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_382
+                language: !<!Languages> 
+                  default:
+                    name: contentType
+                    description: Type of the secret value such as a password.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_387
+                schema: *ref_8
+                implementation: Method
+                originalParameter: *ref_379
+                pathToProperty: []
+                required: false
+                targetProperty: *ref_383
                 language: !<!Languages> 
                   default:
                     name: secretAttributes
                     description: The secret management attributes.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_383
               - *ref_384
               - *ref_385
               - *ref_386
+              - *ref_387
             language: !<!Languages> 
               default:
                 name: ''
@@ -9333,8 +9621,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_387
           - *ref_388
+          - *ref_389
         responses:
           - !<!SchemaResponse> 
             schema: *ref_66
@@ -9351,7 +9639,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9392,7 +9680,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_389
+          - !<!Parameter> &ref_390
             schema: *ref_0
             implementation: Method
             required: true
@@ -9410,7 +9698,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_390
+          - !<!Parameter> &ref_391
             schema: *ref_1
             implementation: Method
             required: true
@@ -9425,6 +9713,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9435,8 +9738,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_389
           - *ref_390
+          - *ref_391
         responses:
           - !<!SchemaResponse> 
             schema: *ref_70
@@ -9453,7 +9756,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9494,7 +9797,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_399
+          - !<!Parameter> &ref_400
             schema: *ref_0
             implementation: Method
             required: true
@@ -9512,7 +9815,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_400
+          - !<!Parameter> &ref_401
             schema: *ref_1
             implementation: Method
             required: true
@@ -9524,7 +9827,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_401
+          - !<!Parameter> &ref_402
             schema: *ref_1
             implementation: Method
             required: true
@@ -9540,8 +9843,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_392
-                schema: *ref_391
+              - !<!Parameter> &ref_393
+                schema: *ref_392
                 flattened: true
                 implementation: Method
                 required: true
@@ -9555,43 +9858,56 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_396
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_397
                 schema: *ref_77
                 implementation: Method
-                originalParameter: *ref_392
+                originalParameter: *ref_393
                 pathToProperty: []
-                targetProperty: *ref_393
+                targetProperty: *ref_394
                 language: !<!Languages> 
                   default:
                     name: contentType
                     description: Type of the secret value such as a password.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_397
+              - !<!VirtualParameter> &ref_398
                 schema: *ref_8
                 implementation: Method
-                originalParameter: *ref_392
+                originalParameter: *ref_393
                 pathToProperty: []
-                targetProperty: *ref_394
+                targetProperty: *ref_395
                 language: !<!Languages> 
                   default:
                     name: secretAttributes
                     description: The secret management attributes.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_398
+              - !<!VirtualParameter> &ref_399
                 schema: *ref_78
                 implementation: Method
-                originalParameter: *ref_392
+                originalParameter: *ref_393
                 pathToProperty: []
-                targetProperty: *ref_395
+                targetProperty: *ref_396
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_396
               - *ref_397
               - *ref_398
+              - *ref_399
             language: !<!Languages> 
               default:
                 name: ''
@@ -9605,9 +9921,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_399
           - *ref_400
           - *ref_401
+          - *ref_402
         responses:
           - !<!SchemaResponse> 
             schema: *ref_66
@@ -9624,7 +9940,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9674,7 +9990,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_402
+          - !<!Parameter> &ref_403
             schema: *ref_0
             implementation: Method
             required: true
@@ -9692,7 +10008,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_403
+          - !<!Parameter> &ref_404
             schema: *ref_1
             implementation: Method
             required: true
@@ -9704,7 +10020,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_404
+          - !<!Parameter> &ref_405
             schema: *ref_1
             implementation: Method
             required: true
@@ -9719,6 +10035,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9729,9 +10060,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_402
           - *ref_403
           - *ref_404
+          - *ref_405
         responses:
           - !<!SchemaResponse> 
             schema: *ref_66
@@ -9748,7 +10079,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9788,7 +10119,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_405
+          - !<!Parameter> &ref_406
             schema: *ref_0
             implementation: Method
             required: true
@@ -9806,8 +10137,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_406
-            schema: *ref_304
+          - !<!Parameter> &ref_407
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -9820,6 +10151,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9830,11 +10176,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_405
           - *ref_406
+          - *ref_407
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_407
+            schema: *ref_408
             language: !<!Languages> 
               default:
                 name: ''
@@ -9848,7 +10194,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9895,7 +10241,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_408
+          - !<!Parameter> &ref_409
             schema: *ref_0
             implementation: Method
             required: true
@@ -9913,7 +10259,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_409
+          - !<!Parameter> &ref_410
             schema: *ref_1
             implementation: Method
             required: true
@@ -9925,8 +10271,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_410
-            schema: *ref_304
+          - !<!Parameter> &ref_411
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -9939,6 +10285,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9949,12 +10310,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_408
           - *ref_409
           - *ref_410
+          - *ref_411
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_407
+            schema: *ref_408
             language: !<!Languages> 
               default:
                 name: ''
@@ -9968,7 +10329,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10013,7 +10374,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_411
+          - !<!Parameter> &ref_412
             schema: *ref_0
             implementation: Method
             required: true
@@ -10031,8 +10392,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_412
-            schema: *ref_304
+          - !<!Parameter> &ref_413
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -10045,6 +10406,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10055,11 +10431,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_411
           - *ref_412
+          - *ref_413
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_413
+            schema: *ref_414
             language: !<!Languages> 
               default:
                 name: ''
@@ -10073,7 +10449,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10123,7 +10499,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_414
+          - !<!Parameter> &ref_415
             schema: *ref_0
             implementation: Method
             required: true
@@ -10141,7 +10517,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_415
+          - !<!Parameter> &ref_416
             schema: *ref_1
             implementation: Method
             required: true
@@ -10156,6 +10532,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10166,8 +10557,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_414
           - *ref_415
+          - *ref_416
         responses:
           - !<!SchemaResponse> 
             schema: *ref_70
@@ -10184,7 +10575,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10225,7 +10616,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_416
+          - !<!Parameter> &ref_417
             schema: *ref_0
             implementation: Method
             required: true
@@ -10243,7 +10634,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_417
+          - !<!Parameter> &ref_418
             schema: *ref_1
             implementation: Method
             required: true
@@ -10258,6 +10649,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10268,8 +10674,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_416
           - *ref_417
+          - *ref_418
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -10282,7 +10688,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10314,7 +10720,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_418
+          - !<!Parameter> &ref_419
             schema: *ref_0
             implementation: Method
             required: true
@@ -10332,7 +10738,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_419
+          - !<!Parameter> &ref_420
             schema: *ref_1
             implementation: Method
             required: true
@@ -10347,6 +10753,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10357,8 +10778,8 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_418
           - *ref_419
+          - *ref_420
         responses:
           - !<!SchemaResponse> 
             schema: *ref_66
@@ -10375,7 +10796,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10413,7 +10834,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_420
+          - !<!Parameter> &ref_421
             schema: *ref_0
             implementation: Method
             required: true
@@ -10431,7 +10852,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_421
+          - !<!Parameter> &ref_422
             schema: *ref_1
             implementation: Method
             required: true
@@ -10446,6 +10867,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10456,11 +10892,11 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_420
           - *ref_421
+          - *ref_422
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_422
+            schema: *ref_423
             language: !<!Languages> 
               default:
                 name: ''
@@ -10474,7 +10910,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10508,7 +10944,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_427
+          - !<!Parameter> &ref_428
             schema: *ref_0
             implementation: Method
             required: true
@@ -10530,8 +10966,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_424
-                schema: *ref_423
+              - !<!Parameter> &ref_425
+                schema: *ref_424
                 flattened: true
                 implementation: Method
                 required: true
@@ -10545,20 +10981,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_426
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_427
                 schema: *ref_89
                 implementation: Method
-                originalParameter: *ref_424
+                originalParameter: *ref_425
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_425
+                targetProperty: *ref_426
                 language: !<!Languages> 
                   default:
                     name: secretBundleBackup
                     description: The backup blob associated with a secret bundle.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_426
+              - *ref_427
             language: !<!Languages> 
               default:
                 name: ''
@@ -10572,7 +11021,7 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_427
+          - *ref_428
         responses:
           - !<!SchemaResponse> 
             schema: *ref_66
@@ -10589,7 +11038,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10632,7 +11081,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_429
+          - !<!Parameter> &ref_430
             schema: *ref_0
             implementation: Method
             required: true
@@ -10650,8 +11099,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_430
-            schema: *ref_304
+          - !<!Parameter> &ref_431
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -10661,8 +11110,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_431
-            schema: *ref_428
+          - !<!Parameter> &ref_432
+            schema: *ref_429
             implementation: Method
             language: !<!Languages> 
               default:
@@ -10675,6 +11124,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10685,12 +11149,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_429
           - *ref_430
           - *ref_431
+          - *ref_432
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_432
+            schema: *ref_433
             language: !<!Languages> 
               default:
                 name: ''
@@ -10704,7 +11168,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10757,7 +11221,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_433
+          - !<!Parameter> &ref_434
             schema: *ref_0
             implementation: Method
             required: true
@@ -10775,7 +11239,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_434
+          - !<!Parameter> &ref_435
             schema: *ref_1
             implementation: Method
             required: true
@@ -10790,6 +11254,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10800,8 +11279,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_433
           - *ref_434
+          - *ref_435
         responses:
           - !<!SchemaResponse> 
             schema: *ref_99
@@ -10818,7 +11297,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10895,7 +11374,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_439
+          - !<!Parameter> &ref_440
             schema: *ref_0
             implementation: Method
             required: true
@@ -10917,8 +11396,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_436
-                schema: *ref_435
+              - !<!Parameter> &ref_437
+                schema: *ref_436
                 flattened: true
                 implementation: Method
                 required: true
@@ -10930,19 +11409,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_438
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_439
                 schema: *ref_247
                 implementation: Method
-                originalParameter: *ref_436
+                originalParameter: *ref_437
                 pathToProperty: []
-                targetProperty: *ref_437
+                targetProperty: *ref_438
                 language: !<!Languages> 
                   default:
                     name: ContactList
                     description: The contact list for the vault certificates.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_438
+              - *ref_439
             language: !<!Languages> 
               default:
                 name: ''
@@ -10956,10 +11448,10 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_439
+          - *ref_440
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_435
+            schema: *ref_436
             language: !<!Languages> 
               default:
                 name: ''
@@ -10973,7 +11465,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11020,7 +11512,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_440
+          - !<!Parameter> &ref_441
             schema: *ref_0
             implementation: Method
             required: true
@@ -11041,6 +11533,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11051,10 +11558,10 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_440
+          - *ref_441
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_435
+            schema: *ref_436
             language: !<!Languages> 
               default:
                 name: ''
@@ -11068,7 +11575,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11107,7 +11614,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_441
+          - !<!Parameter> &ref_442
             schema: *ref_0
             implementation: Method
             required: true
@@ -11128,6 +11635,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11138,10 +11660,10 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_441
+          - *ref_442
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_435
+            schema: *ref_436
             language: !<!Languages> 
               default:
                 name: ''
@@ -11155,7 +11677,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11194,7 +11716,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_442
+          - !<!Parameter> &ref_443
             schema: *ref_0
             implementation: Method
             required: true
@@ -11212,8 +11734,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_443
-            schema: *ref_304
+          - !<!Parameter> &ref_444
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -11226,6 +11748,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11236,11 +11773,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_442
           - *ref_443
+          - *ref_444
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_444
+            schema: *ref_445
             language: !<!Languages> 
               default:
                 name: ''
@@ -11254,7 +11791,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11297,7 +11834,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_455
+          - !<!Parameter> &ref_456
             schema: *ref_0
             implementation: Method
             required: true
@@ -11315,7 +11852,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_456
+          - !<!Parameter> &ref_457
             schema: *ref_1
             implementation: Method
             required: true
@@ -11331,8 +11868,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_446
-                schema: *ref_445
+              - !<!Parameter> &ref_447
+                schema: *ref_446
                 flattened: true
                 implementation: Method
                 required: true
@@ -11346,59 +11883,72 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_451
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_452
                 schema: *ref_143
                 implementation: Method
-                originalParameter: *ref_446
+                originalParameter: *ref_447
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_447
+                targetProperty: *ref_448
                 language: !<!Languages> 
                   default:
                     name: provider
                     description: The issuer provider.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_452
+              - !<!VirtualParameter> &ref_453
                 schema: *ref_151
                 implementation: Method
-                originalParameter: *ref_446
-                pathToProperty: []
-                required: false
-                targetProperty: *ref_448
-                language: !<!Languages> 
-                  default:
-                    name: credentials
-                    description: The credentials to be used for the issuer.
-                protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_453
-                schema: *ref_152
-                implementation: Method
-                originalParameter: *ref_446
+                originalParameter: *ref_447
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_449
                 language: !<!Languages> 
                   default:
-                    name: OrganizationDetails
-                    description: Details of the organization as provided to the issuer.
+                    name: credentials
+                    description: The credentials to be used for the issuer.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_454
-                schema: *ref_154
+                schema: *ref_152
                 implementation: Method
-                originalParameter: *ref_446
+                originalParameter: *ref_447
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_450
+                language: !<!Languages> 
+                  default:
+                    name: OrganizationDetails
+                    description: Details of the organization as provided to the issuer.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_455
+                schema: *ref_154
+                implementation: Method
+                originalParameter: *ref_447
+                pathToProperty: []
+                required: false
+                targetProperty: *ref_451
                 language: !<!Languages> 
                   default:
                     name: attributes
                     description: Attributes of the issuer object.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_451
               - *ref_452
               - *ref_453
               - *ref_454
+              - *ref_455
             language: !<!Languages> 
               default:
                 name: ''
@@ -11412,11 +11962,11 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_455
           - *ref_456
+          - *ref_457
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_457
+            schema: *ref_458
             language: !<!Languages> 
               default:
                 name: ''
@@ -11430,7 +11980,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11488,7 +12038,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_468
+          - !<!Parameter> &ref_469
             schema: *ref_0
             implementation: Method
             required: true
@@ -11506,7 +12056,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_469
+          - !<!Parameter> &ref_470
             schema: *ref_1
             implementation: Method
             required: true
@@ -11522,8 +12072,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_459
-                schema: *ref_458
+              - !<!Parameter> &ref_460
+                schema: *ref_459
                 flattened: true
                 implementation: Method
                 required: true
@@ -11537,55 +12087,68 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_464
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_465
                 schema: *ref_157
                 implementation: Method
-                originalParameter: *ref_459
+                originalParameter: *ref_460
                 pathToProperty: []
-                targetProperty: *ref_460
+                targetProperty: *ref_461
                 language: !<!Languages> 
                   default:
                     name: provider
                     description: The issuer provider.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_465
+              - !<!VirtualParameter> &ref_466
                 schema: *ref_151
                 implementation: Method
-                originalParameter: *ref_459
+                originalParameter: *ref_460
                 pathToProperty: []
-                targetProperty: *ref_461
+                targetProperty: *ref_462
                 language: !<!Languages> 
                   default:
                     name: credentials
                     description: The credentials to be used for the issuer.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_466
+              - !<!VirtualParameter> &ref_467
                 schema: *ref_152
                 implementation: Method
-                originalParameter: *ref_459
+                originalParameter: *ref_460
                 pathToProperty: []
-                targetProperty: *ref_462
+                targetProperty: *ref_463
                 language: !<!Languages> 
                   default:
                     name: OrganizationDetails
                     description: Details of the organization as provided to the issuer.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_467
+              - !<!VirtualParameter> &ref_468
                 schema: *ref_154
                 implementation: Method
-                originalParameter: *ref_459
+                originalParameter: *ref_460
                 pathToProperty: []
-                targetProperty: *ref_463
+                targetProperty: *ref_464
                 language: !<!Languages> 
                   default:
                     name: attributes
                     description: Attributes of the issuer object.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_464
               - *ref_465
               - *ref_466
               - *ref_467
+              - *ref_468
             language: !<!Languages> 
               default:
                 name: ''
@@ -11599,11 +12162,11 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_468
           - *ref_469
+          - *ref_470
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_457
+            schema: *ref_458
             language: !<!Languages> 
               default:
                 name: ''
@@ -11617,7 +12180,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11669,7 +12232,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_470
+          - !<!Parameter> &ref_471
             schema: *ref_0
             implementation: Method
             required: true
@@ -11687,7 +12250,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_471
+          - !<!Parameter> &ref_472
             schema: *ref_1
             implementation: Method
             required: true
@@ -11702,6 +12265,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11712,11 +12290,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_470
           - *ref_471
+          - *ref_472
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_457
+            schema: *ref_458
             language: !<!Languages> 
               default:
                 name: ''
@@ -11730,7 +12308,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11777,7 +12355,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_472
+          - !<!Parameter> &ref_473
             schema: *ref_0
             implementation: Method
             required: true
@@ -11795,7 +12373,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_473
+          - !<!Parameter> &ref_474
             schema: *ref_1
             implementation: Method
             required: true
@@ -11810,6 +12388,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11820,11 +12413,11 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_472
           - *ref_473
+          - *ref_474
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_457
+            schema: *ref_458
             language: !<!Languages> 
               default:
                 name: ''
@@ -11838,7 +12431,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11885,7 +12478,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_482
+          - !<!Parameter> &ref_483
             schema: *ref_0
             implementation: Method
             required: true
@@ -11903,7 +12496,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_483
+          - !<!Parameter> &ref_484
             schema: *ref_257
             implementation: Method
             required: true
@@ -11919,8 +12512,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_475
-                schema: *ref_474
+              - !<!Parameter> &ref_476
+                schema: *ref_475
                 flattened: true
                 implementation: Method
                 required: true
@@ -11934,43 +12527,56 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_479
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_480
                 schema: *ref_125
                 implementation: Method
-                originalParameter: *ref_475
+                originalParameter: *ref_476
                 pathToProperty: []
-                targetProperty: *ref_476
+                targetProperty: *ref_477
                 language: !<!Languages> 
                   default:
                     name: CertificatePolicy
                     description: The management policy for the certificate.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_480
+              - !<!VirtualParameter> &ref_481
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_475
+                originalParameter: *ref_476
                 pathToProperty: []
-                targetProperty: *ref_477
+                targetProperty: *ref_478
                 language: !<!Languages> 
                   default:
                     name: CertificateAttributes
                     description: The attributes of the certificate (optional).
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_481
+              - !<!VirtualParameter> &ref_482
                 schema: *ref_158
                 implementation: Method
-                originalParameter: *ref_475
+                originalParameter: *ref_476
                 pathToProperty: []
-                targetProperty: *ref_478
+                targetProperty: *ref_479
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_479
               - *ref_480
               - *ref_481
+              - *ref_482
             language: !<!Languages> 
               default:
                 name: ''
@@ -11984,11 +12590,11 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_482
           - *ref_483
+          - *ref_484
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_484
+            schema: *ref_485
             language: !<!Languages> 
               default:
                 name: ''
@@ -12002,7 +12608,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12060,7 +12666,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_497
+          - !<!Parameter> &ref_498
             schema: *ref_0
             implementation: Method
             required: true
@@ -12078,7 +12684,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_498
+          - !<!Parameter> &ref_499
             schema: *ref_257
             implementation: Method
             required: true
@@ -12094,8 +12700,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_486
-                schema: *ref_485
+              - !<!Parameter> &ref_487
+                schema: *ref_486
                 flattened: true
                 implementation: Method
                 required: true
@@ -12109,72 +12715,85 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_492
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_493
                 schema: *ref_166
                 implementation: Method
-                originalParameter: *ref_486
+                originalParameter: *ref_487
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_487
+                targetProperty: *ref_488
                 language: !<!Languages> 
                   default:
                     name: base64EncodedCertificate
                     description: Base64 encoded representation of the certificate object to import. This certificate needs to contain the private key.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_493
+              - !<!VirtualParameter> &ref_494
                 schema: *ref_167
                 implementation: Method
-                originalParameter: *ref_486
-                pathToProperty: []
-                required: false
-                targetProperty: *ref_488
-                language: !<!Languages> 
-                  default:
-                    name: password
-                    description: 'If the private key in base64EncodedCertificate is encrypted, the password used for encryption.'
-                protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_494
-                schema: *ref_125
-                implementation: Method
-                originalParameter: *ref_486
+                originalParameter: *ref_487
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_489
                 language: !<!Languages> 
                   default:
-                    name: CertificatePolicy
-                    description: The management policy for the certificate.
+                    name: password
+                    description: 'If the private key in base64EncodedCertificate is encrypted, the password used for encryption.'
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_495
-                schema: *ref_9
+                schema: *ref_125
                 implementation: Method
-                originalParameter: *ref_486
+                originalParameter: *ref_487
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_490
                 language: !<!Languages> 
                   default:
-                    name: CertificateAttributes
-                    description: The attributes of the certificate (optional).
+                    name: CertificatePolicy
+                    description: The management policy for the certificate.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_496
-                schema: *ref_168
+                schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_486
+                originalParameter: *ref_487
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_491
+                language: !<!Languages> 
+                  default:
+                    name: CertificateAttributes
+                    description: The attributes of the certificate (optional).
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_497
+                schema: *ref_168
+                implementation: Method
+                originalParameter: *ref_487
+                pathToProperty: []
+                required: false
+                targetProperty: *ref_492
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_492
               - *ref_493
               - *ref_494
               - *ref_495
               - *ref_496
+              - *ref_497
             language: !<!Languages> 
               default:
                 name: ''
@@ -12188,8 +12807,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_497
           - *ref_498
+          - *ref_499
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -12206,7 +12825,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12292,7 +12911,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_499
+          - !<!Parameter> &ref_500
             schema: *ref_0
             implementation: Method
             required: true
@@ -12310,7 +12929,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_500
+          - !<!Parameter> &ref_501
             schema: *ref_1
             implementation: Method
             required: true
@@ -12322,8 +12941,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_501
-            schema: *ref_304
+          - !<!Parameter> &ref_502
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -12336,6 +12955,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12346,12 +12980,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_499
           - *ref_500
           - *ref_501
+          - *ref_502
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_432
+            schema: *ref_433
             language: !<!Languages> 
               default:
                 name: ''
@@ -12365,7 +12999,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12419,7 +13053,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_502
+          - !<!Parameter> &ref_503
             schema: *ref_0
             implementation: Method
             required: true
@@ -12437,7 +13071,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_503
+          - !<!Parameter> &ref_504
             schema: *ref_1
             implementation: Method
             required: true
@@ -12452,6 +13086,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12462,8 +13111,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_502
           - *ref_503
+          - *ref_504
         responses:
           - !<!SchemaResponse> 
             schema: *ref_125
@@ -12480,7 +13129,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12538,7 +13187,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_505
+          - !<!Parameter> &ref_506
             schema: *ref_0
             implementation: Method
             required: true
@@ -12556,7 +13205,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_506
+          - !<!Parameter> &ref_507
             schema: *ref_1
             implementation: Method
             required: true
@@ -12572,7 +13221,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_504
+              - !<!Parameter> &ref_505
                 schema: *ref_125
                 implementation: Method
                 required: true
@@ -12584,8 +13233,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_504
+              - *ref_505
             language: !<!Languages> 
               default:
                 name: ''
@@ -12599,8 +13261,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_505
           - *ref_506
+          - *ref_507
         responses:
           - !<!SchemaResponse> 
             schema: *ref_125
@@ -12617,7 +13279,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12697,7 +13359,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_515
+          - !<!Parameter> &ref_516
             schema: *ref_0
             implementation: Method
             required: true
@@ -12715,7 +13377,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_516
+          - !<!Parameter> &ref_517
             schema: *ref_1
             implementation: Method
             required: true
@@ -12727,7 +13389,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_517
+          - !<!Parameter> &ref_518
             schema: *ref_1
             implementation: Method
             required: true
@@ -12743,8 +13405,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_508
-                schema: *ref_507
+              - !<!Parameter> &ref_509
+                schema: *ref_508
                 flattened: true
                 implementation: Method
                 required: true
@@ -12758,43 +13420,56 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_512
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_513
                 schema: *ref_125
                 implementation: Method
-                originalParameter: *ref_508
+                originalParameter: *ref_509
                 pathToProperty: []
-                targetProperty: *ref_509
+                targetProperty: *ref_510
                 language: !<!Languages> 
                   default:
                     name: CertificatePolicy
                     description: The management policy for the certificate.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_513
+              - !<!VirtualParameter> &ref_514
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_508
+                originalParameter: *ref_509
                 pathToProperty: []
-                targetProperty: *ref_510
+                targetProperty: *ref_511
                 language: !<!Languages> 
                   default:
                     name: CertificateAttributes
                     description: The attributes of the certificate (optional).
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_514
+              - !<!VirtualParameter> &ref_515
                 schema: *ref_169
                 implementation: Method
-                originalParameter: *ref_508
+                originalParameter: *ref_509
                 pathToProperty: []
-                targetProperty: *ref_511
+                targetProperty: *ref_512
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_512
               - *ref_513
               - *ref_514
+              - *ref_515
             language: !<!Languages> 
               default:
                 name: ''
@@ -12808,9 +13483,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_515
           - *ref_516
           - *ref_517
+          - *ref_518
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -12827,7 +13502,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12881,7 +13556,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_518
+          - !<!Parameter> &ref_519
             schema: *ref_0
             implementation: Method
             required: true
@@ -12899,7 +13574,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_519
+          - !<!Parameter> &ref_520
             schema: *ref_1
             implementation: Method
             required: true
@@ -12911,7 +13586,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_520
+          - !<!Parameter> &ref_521
             schema: *ref_1
             implementation: Method
             required: true
@@ -12926,6 +13601,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12936,9 +13626,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_518
           - *ref_519
           - *ref_520
+          - *ref_521
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -12955,7 +13645,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12997,7 +13687,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_525
+          - !<!Parameter> &ref_526
             schema: *ref_0
             implementation: Method
             required: true
@@ -13015,7 +13705,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_526
+          - !<!Parameter> &ref_527
             schema: *ref_1
             implementation: Method
             required: true
@@ -13031,8 +13721,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_522
-                schema: *ref_521
+              - !<!Parameter> &ref_523
+                schema: *ref_522
                 flattened: true
                 implementation: Method
                 required: true
@@ -13046,20 +13736,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_524
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_525
                 schema: *ref_161
                 implementation: Method
-                originalParameter: *ref_522
+                originalParameter: *ref_523
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_523
+                targetProperty: *ref_524
                 language: !<!Languages> 
                   default:
                     name: cancellation_requested
                     description: Indicates if cancellation was requested on the certificate operation.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_524
+              - *ref_525
             language: !<!Languages> 
               default:
                 name: ''
@@ -13073,11 +13776,11 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_525
           - *ref_526
+          - *ref_527
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_484
+            schema: *ref_485
             language: !<!Languages> 
               default:
                 name: ''
@@ -13091,7 +13794,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13134,7 +13837,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_527
+          - !<!Parameter> &ref_528
             schema: *ref_0
             implementation: Method
             required: true
@@ -13152,7 +13855,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_528
+          - !<!Parameter> &ref_529
             schema: *ref_1
             implementation: Method
             required: true
@@ -13167,6 +13870,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13177,11 +13895,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_527
           - *ref_528
+          - *ref_529
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_484
+            schema: *ref_485
             language: !<!Languages> 
               default:
                 name: ''
@@ -13195,7 +13913,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13236,7 +13954,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_529
+          - !<!Parameter> &ref_530
             schema: *ref_0
             implementation: Method
             required: true
@@ -13254,7 +13972,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_530
+          - !<!Parameter> &ref_531
             schema: *ref_1
             implementation: Method
             required: true
@@ -13269,6 +13987,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13279,11 +14012,11 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_529
           - *ref_530
+          - *ref_531
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_484
+            schema: *ref_485
             language: !<!Languages> 
               default:
                 name: ''
@@ -13297,7 +14030,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13338,7 +14071,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_539
+          - !<!Parameter> &ref_540
             schema: *ref_0
             implementation: Method
             required: true
@@ -13356,7 +14089,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_540
+          - !<!Parameter> &ref_541
             schema: *ref_1
             implementation: Method
             required: true
@@ -13372,8 +14105,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_532
-                schema: *ref_531
+              - !<!Parameter> &ref_533
+                schema: *ref_532
                 flattened: true
                 implementation: Method
                 required: true
@@ -13387,46 +14120,59 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_536
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_537
                 schema: *ref_250
                 implementation: Method
-                originalParameter: *ref_532
+                originalParameter: *ref_533
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_533
+                targetProperty: *ref_534
                 language: !<!Languages> 
                   default:
                     name: x509Certificates
                     description: The certificate or the certificate chain to merge.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_537
+              - !<!VirtualParameter> &ref_538
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_532
+                originalParameter: *ref_533
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_534
+                targetProperty: *ref_535
                 language: !<!Languages> 
                   default:
                     name: CertificateAttributes
                     description: The attributes of the certificate (optional).
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_538
+              - !<!VirtualParameter> &ref_539
                 schema: *ref_171
                 implementation: Method
-                originalParameter: *ref_532
+                originalParameter: *ref_533
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_535
+                targetProperty: *ref_536
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_536
               - *ref_537
               - *ref_538
+              - *ref_539
             language: !<!Languages> 
               default:
                 name: ''
@@ -13440,8 +14186,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_539
           - *ref_540
+          - *ref_541
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -13458,7 +14204,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13532,7 +14278,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_541
+          - !<!Parameter> &ref_542
             schema: *ref_0
             implementation: Method
             required: true
@@ -13550,7 +14296,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_542
+          - !<!Parameter> &ref_543
             schema: *ref_1
             implementation: Method
             required: true
@@ -13565,6 +14311,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13575,11 +14336,11 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_541
           - *ref_542
+          - *ref_543
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_543
+            schema: *ref_544
             language: !<!Languages> 
               default:
                 name: ''
@@ -13593,7 +14354,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13627,7 +14388,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_548
+          - !<!Parameter> &ref_549
             schema: *ref_0
             implementation: Method
             required: true
@@ -13649,8 +14410,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_545
-                schema: *ref_544
+              - !<!Parameter> &ref_546
+                schema: *ref_545
                 flattened: true
                 implementation: Method
                 required: true
@@ -13664,20 +14425,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_547
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_548
                 schema: *ref_173
                 implementation: Method
-                originalParameter: *ref_545
+                originalParameter: *ref_546
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_546
+                targetProperty: *ref_547
                 language: !<!Languages> 
                   default:
                     name: certificateBundleBackup
                     description: The backup blob associated with a certificate bundle.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_547
+              - *ref_548
             language: !<!Languages> 
               default:
                 name: ''
@@ -13691,7 +14465,7 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_548
+          - *ref_549
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -13708,7 +14482,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13786,7 +14560,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_549
+          - !<!Parameter> &ref_550
             schema: *ref_0
             implementation: Method
             required: true
@@ -13804,8 +14578,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_550
-            schema: *ref_304
+          - !<!Parameter> &ref_551
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -13815,8 +14589,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_551
-            schema: *ref_428
+          - !<!Parameter> &ref_552
+            schema: *ref_429
             implementation: Method
             language: !<!Languages> 
               default:
@@ -13829,6 +14603,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13839,12 +14628,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_549
           - *ref_550
           - *ref_551
+          - *ref_552
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_552
+            schema: *ref_553
             language: !<!Languages> 
               default:
                 name: ''
@@ -13858,7 +14647,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13911,7 +14700,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_553
+          - !<!Parameter> &ref_554
             schema: *ref_0
             implementation: Method
             required: true
@@ -13929,7 +14718,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_554
+          - !<!Parameter> &ref_555
             schema: *ref_1
             implementation: Method
             required: true
@@ -13944,6 +14733,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13954,8 +14758,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_553
           - *ref_554
+          - *ref_555
         responses:
           - !<!SchemaResponse> 
             schema: *ref_99
@@ -13972,7 +14776,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14050,7 +14854,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_555
+          - !<!Parameter> &ref_556
             schema: *ref_0
             implementation: Method
             required: true
@@ -14068,7 +14872,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_556
+          - !<!Parameter> &ref_557
             schema: *ref_1
             implementation: Method
             required: true
@@ -14083,6 +14887,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14093,8 +14912,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_555
           - *ref_556
+          - *ref_557
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -14107,7 +14926,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14141,7 +14960,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_557
+          - !<!Parameter> &ref_558
             schema: *ref_0
             implementation: Method
             required: true
@@ -14159,7 +14978,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_558
+          - !<!Parameter> &ref_559
             schema: *ref_1
             implementation: Method
             required: true
@@ -14174,6 +14993,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14184,8 +15018,8 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_557
           - *ref_558
+          - *ref_559
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -14202,7 +15036,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14276,7 +15110,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_559
+          - !<!Parameter> &ref_560
             schema: *ref_0
             implementation: Method
             required: true
@@ -14294,8 +15128,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_560
-            schema: *ref_304
+          - !<!Parameter> &ref_561
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14308,6 +15142,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14318,11 +15167,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_559
           - *ref_560
+          - *ref_561
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_561
+            schema: *ref_562
             language: !<!Languages> 
               default:
                 name: ''
@@ -14336,7 +15185,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14394,7 +15243,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_562
+          - !<!Parameter> &ref_563
             schema: *ref_0
             implementation: Method
             required: true
@@ -14412,8 +15261,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_563
-            schema: *ref_304
+          - !<!Parameter> &ref_564
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14426,6 +15275,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14436,11 +15300,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_562
           - *ref_563
+          - *ref_564
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_564
+            schema: *ref_565
             language: !<!Languages> 
               default:
                 name: ''
@@ -14454,7 +15318,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14519,7 +15383,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_566
+          - !<!Parameter> &ref_567
             schema: *ref_0
             implementation: Method
             required: true
@@ -14537,8 +15401,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_567
-            schema: *ref_565
+          - !<!Parameter> &ref_568
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14552,6 +15416,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14562,8 +15441,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_566
           - *ref_567
+          - *ref_568
         responses:
           - !<!SchemaResponse> 
             schema: *ref_187
@@ -14580,7 +15459,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14630,7 +15509,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_568
+          - !<!Parameter> &ref_569
             schema: *ref_0
             implementation: Method
             required: true
@@ -14648,8 +15527,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_569
-            schema: *ref_565
+          - !<!Parameter> &ref_570
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14663,6 +15542,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14673,8 +15567,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_568
           - *ref_569
+          - *ref_570
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -14687,7 +15581,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14723,7 +15617,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_570
+          - !<!Parameter> &ref_571
             schema: *ref_0
             implementation: Method
             required: true
@@ -14741,8 +15635,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_571
-            schema: *ref_565
+          - !<!Parameter> &ref_572
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14756,6 +15650,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14766,8 +15675,8 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_570
           - *ref_571
+          - *ref_572
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -14784,7 +15693,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14831,7 +15740,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_572
+          - !<!Parameter> &ref_573
             schema: *ref_0
             implementation: Method
             required: true
@@ -14849,7 +15758,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_573
+          - !<!Parameter> &ref_574
             schema: *ref_1
             implementation: Method
             required: true
@@ -14864,6 +15773,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14874,11 +15798,11 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_572
           - *ref_573
+          - *ref_574
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_574
+            schema: *ref_575
             language: !<!Languages> 
               default:
                 name: ''
@@ -14892,7 +15816,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14928,7 +15852,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_579
+          - !<!Parameter> &ref_580
             schema: *ref_0
             implementation: Method
             required: true
@@ -14950,8 +15874,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_576
-                schema: *ref_575
+              - !<!Parameter> &ref_577
+                schema: *ref_576
                 flattened: true
                 implementation: Method
                 required: true
@@ -14965,20 +15889,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_578
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_579
                 schema: *ref_197
                 implementation: Method
-                originalParameter: *ref_576
+                originalParameter: *ref_577
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_577
+                targetProperty: *ref_578
                 language: !<!Languages> 
                   default:
                     name: storageBundleBackup
                     description: The backup blob associated with a storage account.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_578
+              - *ref_579
             language: !<!Languages> 
               default:
                 name: ''
@@ -14992,7 +15929,7 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_579
+          - *ref_580
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -15009,7 +15946,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15059,7 +15996,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_580
+          - !<!Parameter> &ref_581
             schema: *ref_0
             implementation: Method
             required: true
@@ -15077,8 +16014,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_581
-            schema: *ref_565
+          - !<!Parameter> &ref_582
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15092,6 +16029,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15102,8 +16054,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_580
           - *ref_581
+          - *ref_582
         responses:
           - !<!SchemaResponse> 
             schema: *ref_187
@@ -15120,7 +16072,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15169,7 +16121,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_582
+          - !<!Parameter> &ref_583
             schema: *ref_0
             implementation: Method
             required: true
@@ -15187,8 +16139,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_583
-            schema: *ref_565
+          - !<!Parameter> &ref_584
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15202,6 +16154,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15212,8 +16179,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_582
           - *ref_583
+          - *ref_584
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -15230,7 +16197,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15276,7 +16243,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_598
+          - !<!Parameter> &ref_599
             schema: *ref_0
             implementation: Method
             required: true
@@ -15294,8 +16261,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_599
-            schema: *ref_565
+          - !<!Parameter> &ref_600
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15310,8 +16277,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_585
-                schema: *ref_584
+              - !<!Parameter> &ref_586
+                schema: *ref_585
                 flattened: true
                 implementation: Method
                 required: true
@@ -15325,85 +16292,98 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_592
-                schema: *ref_198
+              - !<!Parameter> 
+                schema: *ref_260
                 implementation: Method
-                originalParameter: *ref_585
-                pathToProperty: []
+                origin: 'modelerfour:synthesized/accept'
                 required: true
-                targetProperty: *ref_586
                 language: !<!Languages> 
                   default:
-                    name: resourceId
-                    description: Storage account resource id.
-                protocol: !<!Protocols> {}
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - !<!VirtualParameter> &ref_593
-                schema: *ref_199
+                schema: *ref_198
                 implementation: Method
-                originalParameter: *ref_585
+                originalParameter: *ref_586
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_587
                 language: !<!Languages> 
                   default:
-                    name: activeKeyName
-                    description: Current active storage account key name.
+                    name: resourceId
+                    description: Storage account resource id.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_594
-                schema: *ref_191
+                schema: *ref_199
                 implementation: Method
-                originalParameter: *ref_585
+                originalParameter: *ref_586
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_588
                 language: !<!Languages> 
                   default:
-                    name: autoRegenerateKey
-                    description: whether keyvault should manage the storage account for the user.
+                    name: activeKeyName
+                    description: Current active storage account key name.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_595
-                schema: *ref_200
+                schema: *ref_191
                 implementation: Method
-                originalParameter: *ref_585
+                originalParameter: *ref_586
                 pathToProperty: []
-                required: false
+                required: true
                 targetProperty: *ref_589
                 language: !<!Languages> 
                   default:
-                    name: regenerationPeriod
-                    description: The key regeneration time duration specified in ISO-8601 format.
+                    name: autoRegenerateKey
+                    description: whether keyvault should manage the storage account for the user.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_596
-                schema: *ref_185
+                schema: *ref_200
                 implementation: Method
-                originalParameter: *ref_585
+                originalParameter: *ref_586
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_590
                 language: !<!Languages> 
                   default:
-                    name: StorageAccountAttributes
-                    description: The attributes of the storage account.
+                    name: regenerationPeriod
+                    description: The key regeneration time duration specified in ISO-8601 format.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_597
-                schema: *ref_201
+                schema: *ref_185
                 implementation: Method
-                originalParameter: *ref_585
+                originalParameter: *ref_586
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_591
+                language: !<!Languages> 
+                  default:
+                    name: StorageAccountAttributes
+                    description: The attributes of the storage account.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_598
+                schema: *ref_201
+                implementation: Method
+                originalParameter: *ref_586
+                pathToProperty: []
+                required: false
+                targetProperty: *ref_592
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_592
               - *ref_593
               - *ref_594
               - *ref_595
               - *ref_596
               - *ref_597
+              - *ref_598
             language: !<!Languages> 
               default:
                 name: ''
@@ -15417,8 +16397,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_598
           - *ref_599
+          - *ref_600
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -15435,7 +16415,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15491,7 +16471,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_612
+          - !<!Parameter> &ref_613
             schema: *ref_0
             implementation: Method
             required: true
@@ -15509,8 +16489,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_613
-            schema: *ref_565
+          - !<!Parameter> &ref_614
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15525,8 +16505,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_601
-                schema: *ref_600
+              - !<!Parameter> &ref_602
+                schema: *ref_601
                 flattened: true
                 implementation: Method
                 required: true
@@ -15540,67 +16520,80 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_607
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_608
                 schema: *ref_202
                 implementation: Method
-                originalParameter: *ref_601
+                originalParameter: *ref_602
                 pathToProperty: []
-                targetProperty: *ref_602
+                targetProperty: *ref_603
                 language: !<!Languages> 
                   default:
                     name: activeKeyName
                     description: The current active storage account key name.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_608
+              - !<!VirtualParameter> &ref_609
                 schema: *ref_191
                 implementation: Method
-                originalParameter: *ref_601
+                originalParameter: *ref_602
                 pathToProperty: []
-                targetProperty: *ref_603
+                targetProperty: *ref_604
                 language: !<!Languages> 
                   default:
                     name: autoRegenerateKey
                     description: whether keyvault should manage the storage account for the user.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_609
+              - !<!VirtualParameter> &ref_610
                 schema: *ref_203
                 implementation: Method
-                originalParameter: *ref_601
+                originalParameter: *ref_602
                 pathToProperty: []
-                targetProperty: *ref_604
+                targetProperty: *ref_605
                 language: !<!Languages> 
                   default:
                     name: regenerationPeriod
                     description: The key regeneration time duration specified in ISO-8601 format.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_610
+              - !<!VirtualParameter> &ref_611
                 schema: *ref_185
                 implementation: Method
-                originalParameter: *ref_601
+                originalParameter: *ref_602
                 pathToProperty: []
-                targetProperty: *ref_605
+                targetProperty: *ref_606
                 language: !<!Languages> 
                   default:
                     name: StorageAccountAttributes
                     description: The attributes of the storage account.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_611
+              - !<!VirtualParameter> &ref_612
                 schema: *ref_204
                 implementation: Method
-                originalParameter: *ref_601
+                originalParameter: *ref_602
                 pathToProperty: []
-                targetProperty: *ref_606
+                targetProperty: *ref_607
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_607
               - *ref_608
               - *ref_609
               - *ref_610
               - *ref_611
+              - *ref_612
             language: !<!Languages> 
               default:
                 name: ''
@@ -15614,8 +16607,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_612
           - *ref_613
+          - *ref_614
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -15632,7 +16625,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15681,7 +16674,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_618
+          - !<!Parameter> &ref_619
             schema: *ref_0
             implementation: Method
             required: true
@@ -15699,8 +16692,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_619
-            schema: *ref_565
+          - !<!Parameter> &ref_620
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15715,8 +16708,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_615
-                schema: *ref_614
+              - !<!Parameter> &ref_616
+                schema: *ref_615
                 flattened: true
                 implementation: Method
                 required: true
@@ -15730,20 +16723,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_617
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_618
                 schema: *ref_205
                 implementation: Method
-                originalParameter: *ref_615
+                originalParameter: *ref_616
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_616
+                targetProperty: *ref_617
                 language: !<!Languages> 
                   default:
                     name: keyName
                     description: The storage account key name.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_617
+              - *ref_618
             language: !<!Languages> 
               default:
                 name: ''
@@ -15757,8 +16763,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_618
           - *ref_619
+          - *ref_620
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -15775,7 +16781,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15823,7 +16829,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_620
+          - !<!Parameter> &ref_621
             schema: *ref_0
             implementation: Method
             required: true
@@ -15841,8 +16847,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_621
-            schema: *ref_565
+          - !<!Parameter> &ref_622
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15853,8 +16859,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_622
-            schema: *ref_304
+          - !<!Parameter> &ref_623
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15867,6 +16873,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15877,12 +16898,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_620
           - *ref_621
           - *ref_622
+          - *ref_623
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_623
+            schema: *ref_624
             language: !<!Languages> 
               default:
                 name: ''
@@ -15896,7 +16917,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15949,7 +16970,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_624
+          - !<!Parameter> &ref_625
             schema: *ref_0
             implementation: Method
             required: true
@@ -15967,8 +16988,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_625
-            schema: *ref_565
+          - !<!Parameter> &ref_626
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15979,8 +17000,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_626
-            schema: *ref_304
+          - !<!Parameter> &ref_627
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15993,6 +17014,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16003,12 +17039,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_624
           - *ref_625
           - *ref_626
+          - *ref_627
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_627
+            schema: *ref_628
             language: !<!Languages> 
               default:
                 name: ''
@@ -16022,7 +17058,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16082,7 +17118,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_628
+          - !<!Parameter> &ref_629
             schema: *ref_0
             implementation: Method
             required: true
@@ -16100,8 +17136,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_629
-            schema: *ref_565
+          - !<!Parameter> &ref_630
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16112,8 +17148,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_630
-            schema: *ref_565
+          - !<!Parameter> &ref_631
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16127,6 +17163,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16137,9 +17188,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_628
           - *ref_629
           - *ref_630
+          - *ref_631
         responses:
           - !<!SchemaResponse> 
             schema: *ref_217
@@ -16156,7 +17207,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16204,7 +17255,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_631
+          - !<!Parameter> &ref_632
             schema: *ref_0
             implementation: Method
             required: true
@@ -16222,8 +17273,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_632
-            schema: *ref_565
+          - !<!Parameter> &ref_633
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16234,8 +17285,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_633
-            schema: *ref_565
+          - !<!Parameter> &ref_634
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16249,6 +17300,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16259,9 +17325,9 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_631
           - *ref_632
           - *ref_633
+          - *ref_634
         responses:
           - !<!SchemaResponse> 
             schema: *ref_224
@@ -16278,7 +17344,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16323,7 +17389,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_634
+          - !<!Parameter> &ref_635
             schema: *ref_0
             implementation: Method
             required: true
@@ -16341,8 +17407,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_635
-            schema: *ref_565
+          - !<!Parameter> &ref_636
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16353,8 +17419,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_636
-            schema: *ref_565
+          - !<!Parameter> &ref_637
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16368,6 +17434,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16378,9 +17459,9 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_634
           - *ref_635
           - *ref_636
+          - *ref_637
         responses:
           - !<!SchemaResponse> 
             schema: *ref_217
@@ -16397,7 +17478,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16444,7 +17525,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_637
+          - !<!Parameter> &ref_638
             schema: *ref_0
             implementation: Method
             required: true
@@ -16462,8 +17543,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_638
-            schema: *ref_565
+          - !<!Parameter> &ref_639
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16474,8 +17555,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_639
-            schema: *ref_565
+          - !<!Parameter> &ref_640
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16489,6 +17570,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16499,9 +17595,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_637
           - *ref_638
           - *ref_639
+          - *ref_640
         responses:
           - !<!SchemaResponse> 
             schema: *ref_224
@@ -16518,7 +17614,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16562,7 +17658,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_652
+          - !<!Parameter> &ref_653
             schema: *ref_0
             implementation: Method
             required: true
@@ -16580,8 +17676,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_653
-            schema: *ref_565
+          - !<!Parameter> &ref_654
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16592,8 +17688,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_654
-            schema: *ref_565
+          - !<!Parameter> &ref_655
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16608,8 +17704,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_641
-                schema: *ref_640
+              - !<!Parameter> &ref_642
+                schema: *ref_641
                 flattened: true
                 implementation: Method
                 required: true
@@ -16623,72 +17719,85 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_647
-                schema: *ref_226
+              - !<!Parameter> 
+                schema: *ref_260
                 implementation: Method
-                originalParameter: *ref_641
-                pathToProperty: []
+                origin: 'modelerfour:synthesized/accept'
                 required: true
-                targetProperty: *ref_642
                 language: !<!Languages> 
                   default:
-                    name: templateUri
-                    description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
-                protocol: !<!Protocols> {}
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - !<!VirtualParameter> &ref_648
-                schema: *ref_221
+                schema: *ref_226
                 implementation: Method
-                originalParameter: *ref_641
+                originalParameter: *ref_642
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_643
                 language: !<!Languages> 
                   default:
-                    name: sasType
-                    description: The type of SAS token the SAS definition will create.
+                    name: templateUri
+                    description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_649
-                schema: *ref_227
+                schema: *ref_221
                 implementation: Method
-                originalParameter: *ref_641
+                originalParameter: *ref_642
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_644
                 language: !<!Languages> 
                   default:
+                    name: sasType
+                    description: The type of SAS token the SAS definition will create.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_650
+                schema: *ref_227
+                implementation: Method
+                originalParameter: *ref_642
+                pathToProperty: []
+                required: true
+                targetProperty: *ref_645
+                language: !<!Languages> 
+                  default:
                     name: validityPeriod
                     description: The validity period of SAS tokens created according to the SAS definition.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_650
+              - !<!VirtualParameter> &ref_651
                 schema: *ref_215
                 implementation: Method
-                originalParameter: *ref_641
+                originalParameter: *ref_642
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_645
+                targetProperty: *ref_646
                 language: !<!Languages> 
                   default:
                     name: SasDefinitionAttributes
                     description: The attributes of the SAS definition.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_651
+              - !<!VirtualParameter> &ref_652
                 schema: *ref_228
                 implementation: Method
-                originalParameter: *ref_641
+                originalParameter: *ref_642
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_646
+                targetProperty: *ref_647
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_647
               - *ref_648
               - *ref_649
               - *ref_650
               - *ref_651
+              - *ref_652
             language: !<!Languages> 
               default:
                 name: ''
@@ -16702,9 +17811,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_652
           - *ref_653
           - *ref_654
+          - *ref_655
         responses:
           - !<!SchemaResponse> 
             schema: *ref_224
@@ -16721,7 +17830,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16771,7 +17880,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_667
+          - !<!Parameter> &ref_668
             schema: *ref_0
             implementation: Method
             required: true
@@ -16789,8 +17898,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_668
-            schema: *ref_565
+          - !<!Parameter> &ref_669
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16801,8 +17910,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_669
-            schema: *ref_565
+          - !<!Parameter> &ref_670
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16817,8 +17926,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_656
-                schema: *ref_655
+              - !<!Parameter> &ref_657
+                schema: *ref_656
                 flattened: true
                 implementation: Method
                 required: true
@@ -16832,67 +17941,80 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_662
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_663
                 schema: *ref_229
                 implementation: Method
-                originalParameter: *ref_656
+                originalParameter: *ref_657
                 pathToProperty: []
-                targetProperty: *ref_657
+                targetProperty: *ref_658
                 language: !<!Languages> 
                   default:
                     name: templateUri
                     description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_663
+              - !<!VirtualParameter> &ref_664
                 schema: *ref_221
                 implementation: Method
-                originalParameter: *ref_656
+                originalParameter: *ref_657
                 pathToProperty: []
-                targetProperty: *ref_658
+                targetProperty: *ref_659
                 language: !<!Languages> 
                   default:
                     name: sasType
                     description: The type of SAS token the SAS definition will create.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_664
+              - !<!VirtualParameter> &ref_665
                 schema: *ref_230
                 implementation: Method
-                originalParameter: *ref_656
+                originalParameter: *ref_657
                 pathToProperty: []
-                targetProperty: *ref_659
+                targetProperty: *ref_660
                 language: !<!Languages> 
                   default:
                     name: validityPeriod
                     description: The validity period of SAS tokens created according to the SAS definition.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_665
+              - !<!VirtualParameter> &ref_666
                 schema: *ref_215
                 implementation: Method
-                originalParameter: *ref_656
+                originalParameter: *ref_657
                 pathToProperty: []
-                targetProperty: *ref_660
+                targetProperty: *ref_661
                 language: !<!Languages> 
                   default:
                     name: SasDefinitionAttributes
                     description: The attributes of the SAS definition.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_666
+              - !<!VirtualParameter> &ref_667
                 schema: *ref_231
                 implementation: Method
-                originalParameter: *ref_656
+                originalParameter: *ref_657
                 pathToProperty: []
-                targetProperty: *ref_661
+                targetProperty: *ref_662
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_662
               - *ref_663
               - *ref_664
               - *ref_665
               - *ref_666
+              - *ref_667
             language: !<!Languages> 
               default:
                 name: ''
@@ -16906,9 +18028,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_667
           - *ref_668
           - *ref_669
+          - *ref_670
         responses:
           - !<!SchemaResponse> 
             schema: *ref_224
@@ -16925,7 +18047,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/keyvault/grouped.yaml
+++ b/modelerfour/test/scenarios/keyvault/grouped.yaml
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
           name: boolean
           description: 'True if the secret''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_428
+    - !<!BooleanSchema> &ref_429
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -114,7 +114,7 @@ schemas: !<!Schemas>
           name: integer
           description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_304
+    - !<!NumberSchema> &ref_305
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -883,7 +883,7 @@ schemas: !<!Schemas>
           name: DeletedStorageListResult-nextLink
           description: The URL to get the next set of deleted storage accounts.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_565
+    - !<!StringSchema> &ref_566
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1553,6 +1553,16 @@ schemas: !<!Schemas>
           name: ApiVersion-7.0-preview
           description: Api Version (7.0-preview)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_260
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_15
       type: dictionary
@@ -2164,7 +2174,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_261
+        - !<!Property> &ref_262
           schema: *ref_2
           required: true
           serializedName: kty
@@ -2173,7 +2183,7 @@ schemas: !<!Schemas>
               name: kty
               description: 'The type of key to create. For valid values, see JsonWebKeyType.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_262
+        - !<!Property> &ref_263
           schema: *ref_3
           required: false
           serializedName: key_size
@@ -2182,7 +2192,7 @@ schemas: !<!Schemas>
               name: key_size
               description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_263
+        - !<!Property> &ref_264
           schema: !<!ArraySchema> &ref_233
             type: array
             apiVersions:
@@ -2201,7 +2211,7 @@ schemas: !<!Schemas>
               name: key_ops
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_264
+        - !<!Property> &ref_265
           schema: !<!ObjectSchema> &ref_5
             type: object
             apiVersions:
@@ -2376,7 +2386,7 @@ schemas: !<!Schemas>
               name: keyAttributes
               description: The attributes of a key managed by the key vault service.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_265
+        - !<!Property> &ref_266
           schema: *ref_15
           required: false
           serializedName: tags
@@ -2385,7 +2395,7 @@ schemas: !<!Schemas>
               name: tags
               description: Application specific metadata in the form of key-value pairs.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_266
+        - !<!Property> &ref_267
           schema: *ref_16
           required: false
           serializedName: crv
@@ -2661,7 +2671,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_38
-    - !<!ObjectSchema> &ref_275
+    - !<!ObjectSchema> &ref_276
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2730,13 +2740,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_41
-    - !<!ObjectSchema> &ref_276
+    - !<!ObjectSchema> &ref_277
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_278
+        - !<!Property> &ref_279
           schema: *ref_42
           required: false
           serializedName: Hsm
@@ -2745,7 +2755,7 @@ schemas: !<!Schemas>
               name: Hsm
               description: Whether to import as a hardware key (HSM) or software key.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_279
+        - !<!Property> &ref_280
           schema: *ref_38
           required: true
           serializedName: key
@@ -2754,7 +2764,7 @@ schemas: !<!Schemas>
               name: key
               description: The Json web key
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_280
+        - !<!Property> &ref_281
           schema: *ref_5
           required: false
           serializedName: attributes
@@ -2763,7 +2773,7 @@ schemas: !<!Schemas>
               name: keyAttributes
               description: The key management attributes.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_281
+        - !<!Property> &ref_282
           schema: *ref_43
           required: false
           serializedName: tags
@@ -2783,13 +2793,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_21
-    - !<!ObjectSchema> &ref_290
+    - !<!ObjectSchema> &ref_291
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_292
+        - !<!Property> &ref_293
           schema: !<!ArraySchema> &ref_235
             type: array
             apiVersions:
@@ -2807,7 +2817,7 @@ schemas: !<!Schemas>
               name: key_ops
               description: 'Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_293
+        - !<!Property> &ref_294
           schema: *ref_5
           serializedName: attributes
           language: !<!Languages> 
@@ -2815,7 +2825,7 @@ schemas: !<!Schemas>
               name: keyAttributes
               description: The attributes of a key managed by the key vault service.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_294
+        - !<!Property> &ref_295
           schema: *ref_44
           serializedName: tags
           language: !<!Languages> 
@@ -2833,7 +2843,7 @@ schemas: !<!Schemas>
           description: The key update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_308
+    - !<!ObjectSchema> &ref_309
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2977,7 +2987,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_45
-    - !<!ObjectSchema> &ref_313
+    - !<!ObjectSchema> &ref_314
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3002,13 +3012,13 @@ schemas: !<!Schemas>
           description: 'The backup key result, containing the backup blob.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_314
+    - !<!ObjectSchema> &ref_315
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_316
+        - !<!Property> &ref_317
           schema: *ref_52
           required: true
           serializedName: value
@@ -3027,13 +3037,13 @@ schemas: !<!Schemas>
           description: The key restore parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_319
+    - !<!ObjectSchema> &ref_320
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_321
+        - !<!Property> &ref_322
           schema: *ref_53
           required: true
           serializedName: alg
@@ -3042,7 +3052,7 @@ schemas: !<!Schemas>
               name: algorithm
               description: algorithm identifier
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_322
+        - !<!Property> &ref_323
           schema: *ref_54
           required: true
           serializedName: value
@@ -3061,7 +3071,7 @@ schemas: !<!Schemas>
           description: The key operations parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_328
+    - !<!ObjectSchema> &ref_329
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3095,13 +3105,13 @@ schemas: !<!Schemas>
           description: The key operation result.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_335
+    - !<!ObjectSchema> &ref_336
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_337
+        - !<!Property> &ref_338
           schema: *ref_57
           required: true
           serializedName: alg
@@ -3110,7 +3120,7 @@ schemas: !<!Schemas>
               name: algorithm
               description: 'The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_338
+        - !<!Property> &ref_339
           schema: *ref_58
           required: true
           serializedName: value
@@ -3129,13 +3139,13 @@ schemas: !<!Schemas>
           description: The key operations parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_344
+    - !<!ObjectSchema> &ref_345
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_346
+        - !<!Property> &ref_347
           schema: *ref_57
           required: true
           serializedName: alg
@@ -3144,7 +3154,7 @@ schemas: !<!Schemas>
               name: algorithm
               description: 'The signing/verification algorithm. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_347
+        - !<!Property> &ref_348
           schema: *ref_59
           required: true
           serializedName: digest
@@ -3153,7 +3163,7 @@ schemas: !<!Schemas>
               name: digest
               description: The digest used for signing.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_348
+        - !<!Property> &ref_349
           schema: *ref_60
           required: true
           serializedName: value
@@ -3172,7 +3182,7 @@ schemas: !<!Schemas>
           description: The key verify parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_355
+    - !<!ObjectSchema> &ref_356
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3197,7 +3207,7 @@ schemas: !<!Schemas>
           description: The key verify result.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_370
+    - !<!ObjectSchema> &ref_371
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3242,13 +3252,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_47
-    - !<!ObjectSchema> &ref_377
+    - !<!ObjectSchema> &ref_378
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_379
+        - !<!Property> &ref_380
           schema: *ref_63
           required: true
           serializedName: value
@@ -3257,7 +3267,7 @@ schemas: !<!Schemas>
               name: value
               description: The value of the secret.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_380
+        - !<!Property> &ref_381
           schema: *ref_64
           required: false
           serializedName: tags
@@ -3266,7 +3276,7 @@ schemas: !<!Schemas>
               name: tags
               description: Application specific metadata in the form of key-value pairs.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_381
+        - !<!Property> &ref_382
           schema: *ref_65
           required: false
           serializedName: contentType
@@ -3275,7 +3285,7 @@ schemas: !<!Schemas>
               name: contentType
               description: Type of the secret value such as a password.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_382
+        - !<!Property> &ref_383
           schema: *ref_8
           required: false
           serializedName: attributes
@@ -3421,13 +3431,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_70
-    - !<!ObjectSchema> &ref_391
+    - !<!ObjectSchema> &ref_392
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_393
+        - !<!Property> &ref_394
           schema: *ref_77
           serializedName: contentType
           language: !<!Languages> 
@@ -3435,7 +3445,7 @@ schemas: !<!Schemas>
               name: contentType
               description: Type of the secret value such as a password.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_394
+        - !<!Property> &ref_395
           schema: *ref_8
           serializedName: attributes
           language: !<!Languages> 
@@ -3443,7 +3453,7 @@ schemas: !<!Schemas>
               name: secretAttributes
               description: The secret management attributes.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_395
+        - !<!Property> &ref_396
           schema: *ref_78
           serializedName: tags
           language: !<!Languages> 
@@ -3461,7 +3471,7 @@ schemas: !<!Schemas>
           description: The secret update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_407
+    - !<!ObjectSchema> &ref_408
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3613,7 +3623,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_79
-    - !<!ObjectSchema> &ref_413
+    - !<!ObjectSchema> &ref_414
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3658,7 +3668,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_81
-    - !<!ObjectSchema> &ref_422
+    - !<!ObjectSchema> &ref_423
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3683,13 +3693,13 @@ schemas: !<!Schemas>
           description: 'The backup secret result, containing the backup blob.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_423
+    - !<!ObjectSchema> &ref_424
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_425
+        - !<!Property> &ref_426
           schema: *ref_89
           required: true
           serializedName: value
@@ -3708,7 +3718,7 @@ schemas: !<!Schemas>
           description: The secret restore parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_432
+    - !<!ObjectSchema> &ref_433
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4443,7 +4453,7 @@ schemas: !<!Schemas>
     - *ref_131
     - *ref_132
     - *ref_133
-    - !<!ObjectSchema> &ref_435
+    - !<!ObjectSchema> &ref_436
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4458,7 +4468,7 @@ schemas: !<!Schemas>
               name: id
               description: Identifier for the contacts collection.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_437
+        - !<!Property> &ref_438
           schema: !<!ArraySchema> &ref_247
             type: array
             apiVersions:
@@ -4528,7 +4538,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_138
-    - !<!ObjectSchema> &ref_444
+    - !<!ObjectSchema> &ref_445
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4604,13 +4614,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_142
-    - !<!ObjectSchema> &ref_445
+    - !<!ObjectSchema> &ref_446
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_447
+        - !<!Property> &ref_448
           schema: *ref_143
           required: true
           serializedName: provider
@@ -4619,7 +4629,7 @@ schemas: !<!Schemas>
               name: provider
               description: The issuer provider.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_448
+        - !<!Property> &ref_449
           schema: !<!ObjectSchema> &ref_151
             type: object
             apiVersions:
@@ -4660,7 +4670,7 @@ schemas: !<!Schemas>
               name: credentials
               description: The credentials to be used for the issuer.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_449
+        - !<!Property> &ref_450
           schema: !<!ObjectSchema> &ref_152
             type: object
             apiVersions:
@@ -4759,7 +4769,7 @@ schemas: !<!Schemas>
               name: OrganizationDetails
               description: Details of the organization as provided to the issuer.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_450
+        - !<!Property> &ref_451
           schema: !<!ObjectSchema> &ref_154
             type: object
             apiVersions:
@@ -4824,7 +4834,7 @@ schemas: !<!Schemas>
     - *ref_152
     - *ref_153
     - *ref_154
-    - !<!ObjectSchema> &ref_457
+    - !<!ObjectSchema> &ref_458
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4881,13 +4891,13 @@ schemas: !<!Schemas>
           description: The issuer for Key Vault certificate.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_458
+    - !<!ObjectSchema> &ref_459
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_460
+        - !<!Property> &ref_461
           schema: *ref_157
           serializedName: provider
           language: !<!Languages> 
@@ -4895,7 +4905,7 @@ schemas: !<!Schemas>
               name: provider
               description: The issuer provider.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_461
+        - !<!Property> &ref_462
           schema: *ref_151
           serializedName: credentials
           language: !<!Languages> 
@@ -4903,7 +4913,7 @@ schemas: !<!Schemas>
               name: credentials
               description: The credentials to be used for the issuer.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_462
+        - !<!Property> &ref_463
           schema: *ref_152
           serializedName: org_details
           language: !<!Languages> 
@@ -4911,7 +4921,7 @@ schemas: !<!Schemas>
               name: OrganizationDetails
               description: Details of the organization as provided to the issuer.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_463
+        - !<!Property> &ref_464
           schema: *ref_154
           serializedName: attributes
           language: !<!Languages> 
@@ -4929,13 +4939,13 @@ schemas: !<!Schemas>
           description: The certificate issuer update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_474
+    - !<!ObjectSchema> &ref_475
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_476
+        - !<!Property> &ref_477
           schema: *ref_125
           serializedName: policy
           language: !<!Languages> 
@@ -4943,7 +4953,7 @@ schemas: !<!Schemas>
               name: CertificatePolicy
               description: The management policy for the certificate.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_477
+        - !<!Property> &ref_478
           schema: *ref_9
           serializedName: attributes
           language: !<!Languages> 
@@ -4951,7 +4961,7 @@ schemas: !<!Schemas>
               name: CertificateAttributes
               description: The attributes of the certificate (optional).
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_478
+        - !<!Property> &ref_479
           schema: *ref_158
           serializedName: tags
           language: !<!Languages> 
@@ -4969,7 +4979,7 @@ schemas: !<!Schemas>
           description: The certificate create parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_484
+    - !<!ObjectSchema> &ref_485
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5058,13 +5068,13 @@ schemas: !<!Schemas>
           description: A certificate operation is returned in case of asynchronous requests.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_485
+    - !<!ObjectSchema> &ref_486
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_487
+        - !<!Property> &ref_488
           schema: *ref_166
           required: true
           serializedName: value
@@ -5073,7 +5083,7 @@ schemas: !<!Schemas>
               name: base64EncodedCertificate
               description: Base64 encoded representation of the certificate object to import. This certificate needs to contain the private key.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_488
+        - !<!Property> &ref_489
           schema: *ref_167
           required: false
           serializedName: pwd
@@ -5082,7 +5092,7 @@ schemas: !<!Schemas>
               name: password
               description: 'If the private key in base64EncodedCertificate is encrypted, the password used for encryption.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_489
+        - !<!Property> &ref_490
           schema: *ref_125
           required: false
           serializedName: policy
@@ -5091,7 +5101,7 @@ schemas: !<!Schemas>
               name: CertificatePolicy
               description: The management policy for the certificate.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_490
+        - !<!Property> &ref_491
           schema: *ref_9
           required: false
           serializedName: attributes
@@ -5100,7 +5110,7 @@ schemas: !<!Schemas>
               name: CertificateAttributes
               description: The attributes of the certificate (optional).
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_491
+        - !<!Property> &ref_492
           schema: *ref_168
           required: false
           serializedName: tags
@@ -5119,13 +5129,13 @@ schemas: !<!Schemas>
           description: The certificate import parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_507
+    - !<!ObjectSchema> &ref_508
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_509
+        - !<!Property> &ref_510
           schema: *ref_125
           serializedName: policy
           language: !<!Languages> 
@@ -5133,7 +5143,7 @@ schemas: !<!Schemas>
               name: CertificatePolicy
               description: The management policy for the certificate.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_510
+        - !<!Property> &ref_511
           schema: *ref_9
           serializedName: attributes
           language: !<!Languages> 
@@ -5141,7 +5151,7 @@ schemas: !<!Schemas>
               name: CertificateAttributes
               description: The attributes of the certificate (optional).
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_511
+        - !<!Property> &ref_512
           schema: *ref_169
           serializedName: tags
           language: !<!Languages> 
@@ -5159,13 +5169,13 @@ schemas: !<!Schemas>
           description: The certificate update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_521
+    - !<!ObjectSchema> &ref_522
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_523
+        - !<!Property> &ref_524
           schema: *ref_161
           required: true
           serializedName: cancellation_requested
@@ -5184,13 +5194,13 @@ schemas: !<!Schemas>
           description: The certificate operation update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_531
+    - !<!ObjectSchema> &ref_532
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_533
+        - !<!Property> &ref_534
           schema: !<!ArraySchema> &ref_250
             type: array
             apiVersions:
@@ -5209,7 +5219,7 @@ schemas: !<!Schemas>
               name: x509Certificates
               description: The certificate or the certificate chain to merge.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_534
+        - !<!Property> &ref_535
           schema: *ref_9
           required: false
           serializedName: attributes
@@ -5218,7 +5228,7 @@ schemas: !<!Schemas>
               name: CertificateAttributes
               description: The attributes of the certificate (optional).
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_535
+        - !<!Property> &ref_536
           schema: *ref_171
           required: false
           serializedName: tags
@@ -5237,7 +5247,7 @@ schemas: !<!Schemas>
           description: The certificate merge parameters
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_543
+    - !<!ObjectSchema> &ref_544
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5262,13 +5272,13 @@ schemas: !<!Schemas>
           description: 'The backup certificate result, containing the backup blob.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_544
+    - !<!ObjectSchema> &ref_545
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_546
+        - !<!Property> &ref_547
           schema: *ref_173
           required: true
           serializedName: value
@@ -5287,7 +5297,7 @@ schemas: !<!Schemas>
           description: The certificate restore parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_552
+    - !<!ObjectSchema> &ref_553
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5332,7 +5342,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_94
-    - !<!ObjectSchema> &ref_561
+    - !<!ObjectSchema> &ref_562
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5534,7 +5544,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_175
     - *ref_185
-    - !<!ObjectSchema> &ref_564
+    - !<!ObjectSchema> &ref_565
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5710,7 +5720,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_194
-    - !<!ObjectSchema> &ref_574
+    - !<!ObjectSchema> &ref_575
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5735,13 +5745,13 @@ schemas: !<!Schemas>
           description: 'The backup storage result, containing the backup blob.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_575
+    - !<!ObjectSchema> &ref_576
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_577
+        - !<!Property> &ref_578
           schema: *ref_197
           required: true
           serializedName: value
@@ -5760,13 +5770,13 @@ schemas: !<!Schemas>
           description: The secret restore parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_584
+    - !<!ObjectSchema> &ref_585
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_586
+        - !<!Property> &ref_587
           schema: *ref_198
           required: true
           serializedName: resourceId
@@ -5775,7 +5785,7 @@ schemas: !<!Schemas>
               name: resourceId
               description: Storage account resource id.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_587
+        - !<!Property> &ref_588
           schema: *ref_199
           required: true
           serializedName: activeKeyName
@@ -5784,7 +5794,7 @@ schemas: !<!Schemas>
               name: activeKeyName
               description: Current active storage account key name.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_588
+        - !<!Property> &ref_589
           schema: *ref_191
           required: true
           serializedName: autoRegenerateKey
@@ -5793,7 +5803,7 @@ schemas: !<!Schemas>
               name: autoRegenerateKey
               description: whether keyvault should manage the storage account for the user.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_589
+        - !<!Property> &ref_590
           schema: *ref_200
           required: false
           serializedName: regenerationPeriod
@@ -5802,7 +5812,7 @@ schemas: !<!Schemas>
               name: regenerationPeriod
               description: The key regeneration time duration specified in ISO-8601 format.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_590
+        - !<!Property> &ref_591
           schema: *ref_185
           required: false
           serializedName: attributes
@@ -5811,7 +5821,7 @@ schemas: !<!Schemas>
               name: StorageAccountAttributes
               description: The attributes of the storage account.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_591
+        - !<!Property> &ref_592
           schema: *ref_201
           required: false
           serializedName: tags
@@ -5830,13 +5840,13 @@ schemas: !<!Schemas>
           description: The storage account create parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_600
+    - !<!ObjectSchema> &ref_601
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_602
+        - !<!Property> &ref_603
           schema: *ref_202
           serializedName: activeKeyName
           language: !<!Languages> 
@@ -5844,7 +5854,7 @@ schemas: !<!Schemas>
               name: activeKeyName
               description: The current active storage account key name.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_603
+        - !<!Property> &ref_604
           schema: *ref_191
           serializedName: autoRegenerateKey
           language: !<!Languages> 
@@ -5852,7 +5862,7 @@ schemas: !<!Schemas>
               name: autoRegenerateKey
               description: whether keyvault should manage the storage account for the user.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_604
+        - !<!Property> &ref_605
           schema: *ref_203
           serializedName: regenerationPeriod
           language: !<!Languages> 
@@ -5860,7 +5870,7 @@ schemas: !<!Schemas>
               name: regenerationPeriod
               description: The key regeneration time duration specified in ISO-8601 format.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_605
+        - !<!Property> &ref_606
           schema: *ref_185
           serializedName: attributes
           language: !<!Languages> 
@@ -5868,7 +5878,7 @@ schemas: !<!Schemas>
               name: StorageAccountAttributes
               description: The attributes of the storage account.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_606
+        - !<!Property> &ref_607
           schema: *ref_204
           serializedName: tags
           language: !<!Languages> 
@@ -5886,13 +5896,13 @@ schemas: !<!Schemas>
           description: The storage account update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_614
+    - !<!ObjectSchema> &ref_615
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_616
+        - !<!Property> &ref_617
           schema: *ref_205
           required: true
           serializedName: keyName
@@ -5911,7 +5921,7 @@ schemas: !<!Schemas>
           description: The storage account key regenerate parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_623
+    - !<!ObjectSchema> &ref_624
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -6113,7 +6123,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_206
     - *ref_215
-    - !<!ObjectSchema> &ref_627
+    - !<!ObjectSchema> &ref_628
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -6289,13 +6299,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_224
-    - !<!ObjectSchema> &ref_640
+    - !<!ObjectSchema> &ref_641
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_642
+        - !<!Property> &ref_643
           schema: *ref_226
           required: true
           serializedName: templateUri
@@ -6304,7 +6314,7 @@ schemas: !<!Schemas>
               name: templateUri
               description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_643
+        - !<!Property> &ref_644
           schema: *ref_221
           required: true
           serializedName: sasType
@@ -6313,7 +6323,7 @@ schemas: !<!Schemas>
               name: sasType
               description: The type of SAS token the SAS definition will create.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_644
+        - !<!Property> &ref_645
           schema: *ref_227
           required: true
           serializedName: validityPeriod
@@ -6322,7 +6332,7 @@ schemas: !<!Schemas>
               name: validityPeriod
               description: The validity period of SAS tokens created according to the SAS definition.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_645
+        - !<!Property> &ref_646
           schema: *ref_215
           required: false
           serializedName: attributes
@@ -6331,7 +6341,7 @@ schemas: !<!Schemas>
               name: SasDefinitionAttributes
               description: The attributes of the SAS definition.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_646
+        - !<!Property> &ref_647
           schema: *ref_228
           required: false
           serializedName: tags
@@ -6350,13 +6360,13 @@ schemas: !<!Schemas>
           description: The SAS definition create parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_655
+    - !<!ObjectSchema> &ref_656
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_657
+        - !<!Property> &ref_658
           schema: *ref_229
           serializedName: templateUri
           language: !<!Languages> 
@@ -6364,7 +6374,7 @@ schemas: !<!Schemas>
               name: templateUri
               description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_658
+        - !<!Property> &ref_659
           schema: *ref_221
           serializedName: sasType
           language: !<!Languages> 
@@ -6372,7 +6382,7 @@ schemas: !<!Schemas>
               name: sasType
               description: The type of SAS token the SAS definition will create.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_659
+        - !<!Property> &ref_660
           schema: *ref_230
           serializedName: validityPeriod
           language: !<!Languages> 
@@ -6380,7 +6390,7 @@ schemas: !<!Schemas>
               name: validityPeriod
               description: The validity period of SAS tokens created according to the SAS definition.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_660
+        - !<!Property> &ref_661
           schema: *ref_215
           serializedName: attributes
           language: !<!Languages> 
@@ -6388,7 +6398,7 @@ schemas: !<!Schemas>
               name: SasDefinitionAttributes
               description: The attributes of the SAS definition.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_661
+        - !<!Property> &ref_662
           schema: *ref_231
           serializedName: tags
           language: !<!Languages> 
@@ -6474,7 +6484,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_273
+          - !<!Parameter> &ref_274
             schema: *ref_0
             implementation: Method
             required: true
@@ -6492,7 +6502,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_274
+          - !<!Parameter> &ref_275
             schema: *ref_257
             implementation: Method
             required: true
@@ -6508,7 +6518,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_260
+              - !<!Parameter> &ref_261
                 schema: *ref_259
                 flattened: true
                 implementation: Method
@@ -6523,85 +6533,98 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_267
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_268
                 schema: *ref_2
                 implementation: Method
-                originalParameter: *ref_260
+                originalParameter: *ref_261
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_261
+                targetProperty: *ref_262
                 language: !<!Languages> 
                   default:
                     name: kty
                     description: 'The type of key to create. For valid values, see JsonWebKeyType.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_268
+              - !<!VirtualParameter> &ref_269
                 schema: *ref_3
                 implementation: Method
-                originalParameter: *ref_260
-                pathToProperty: []
-                required: false
-                targetProperty: *ref_262
-                language: !<!Languages> 
-                  default:
-                    name: key_size
-                    description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
-                protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_269
-                schema: *ref_233
-                implementation: Method
-                originalParameter: *ref_260
+                originalParameter: *ref_261
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_263
                 language: !<!Languages> 
                   default:
-                    name: key_ops
-                    description: ''
+                    name: key_size
+                    description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_270
-                schema: *ref_5
+                schema: *ref_233
                 implementation: Method
-                originalParameter: *ref_260
+                originalParameter: *ref_261
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_264
                 language: !<!Languages> 
                   default:
-                    name: keyAttributes
-                    description: The attributes of a key managed by the key vault service.
+                    name: key_ops
+                    description: ''
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_271
-                schema: *ref_15
+                schema: *ref_5
                 implementation: Method
-                originalParameter: *ref_260
+                originalParameter: *ref_261
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_265
                 language: !<!Languages> 
                   default:
-                    name: tags
-                    description: Application specific metadata in the form of key-value pairs.
+                    name: keyAttributes
+                    description: The attributes of a key managed by the key vault service.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_272
-                schema: *ref_16
+                schema: *ref_15
                 implementation: Method
-                originalParameter: *ref_260
+                originalParameter: *ref_261
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_266
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_273
+                schema: *ref_16
+                implementation: Method
+                originalParameter: *ref_261
+                pathToProperty: []
+                required: false
+                targetProperty: *ref_267
                 language: !<!Languages> 
                   default:
                     name: curve
                     description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_267
               - *ref_268
               - *ref_269
               - *ref_270
               - *ref_271
               - *ref_272
+              - *ref_273
             language: !<!Languages> 
               default:
                 name: ''
@@ -6615,8 +6638,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_273
           - *ref_274
+          - *ref_275
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -6633,7 +6656,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -6700,7 +6723,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_286
+          - !<!Parameter> &ref_287
             schema: *ref_0
             implementation: Method
             required: true
@@ -6718,7 +6741,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_287
+          - !<!Parameter> &ref_288
             schema: *ref_257
             implementation: Method
             required: true
@@ -6734,8 +6757,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_277
-                schema: *ref_276
+              - !<!Parameter> &ref_278
+                schema: *ref_277
                 flattened: true
                 implementation: Method
                 required: true
@@ -6749,59 +6772,72 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_282
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_283
                 schema: *ref_42
                 implementation: Method
-                originalParameter: *ref_277
+                originalParameter: *ref_278
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_278
+                targetProperty: *ref_279
                 language: !<!Languages> 
                   default:
                     name: Hsm
                     description: Whether to import as a hardware key (HSM) or software key.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_283
+              - !<!VirtualParameter> &ref_284
                 schema: *ref_38
                 implementation: Method
-                originalParameter: *ref_277
+                originalParameter: *ref_278
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_279
+                targetProperty: *ref_280
                 language: !<!Languages> 
                   default:
                     name: key
                     description: The Json web key
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_284
+              - !<!VirtualParameter> &ref_285
                 schema: *ref_5
                 implementation: Method
-                originalParameter: *ref_277
+                originalParameter: *ref_278
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_280
+                targetProperty: *ref_281
                 language: !<!Languages> 
                   default:
                     name: keyAttributes
                     description: The key management attributes.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_285
+              - !<!VirtualParameter> &ref_286
                 schema: *ref_43
                 implementation: Method
-                originalParameter: *ref_277
+                originalParameter: *ref_278
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_281
+                targetProperty: *ref_282
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_282
               - *ref_283
               - *ref_284
               - *ref_285
+              - *ref_286
             language: !<!Languages> 
               default:
                 name: ''
@@ -6815,8 +6851,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_286
           - *ref_287
+          - *ref_288
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -6833,7 +6869,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -6900,7 +6936,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_288
+          - !<!Parameter> &ref_289
             schema: *ref_0
             implementation: Method
             required: true
@@ -6918,7 +6954,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_289
+          - !<!Parameter> &ref_290
             schema: *ref_1
             implementation: Method
             required: true
@@ -6933,6 +6969,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6943,8 +6994,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_288
           - *ref_289
+          - *ref_290
         responses:
           - !<!SchemaResponse> 
             schema: *ref_21
@@ -6961,7 +7012,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7019,7 +7070,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_298
+          - !<!Parameter> &ref_299
             schema: *ref_0
             implementation: Method
             required: true
@@ -7037,7 +7088,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_299
+          - !<!Parameter> &ref_300
             schema: *ref_1
             implementation: Method
             required: true
@@ -7049,7 +7100,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_300
+          - !<!Parameter> &ref_301
             schema: *ref_1
             implementation: Method
             required: true
@@ -7065,8 +7116,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_291
-                schema: *ref_290
+              - !<!Parameter> &ref_292
+                schema: *ref_291
                 flattened: true
                 implementation: Method
                 required: true
@@ -7080,43 +7131,56 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_295
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_296
                 schema: *ref_235
                 implementation: Method
-                originalParameter: *ref_291
+                originalParameter: *ref_292
                 pathToProperty: []
-                targetProperty: *ref_292
+                targetProperty: *ref_293
                 language: !<!Languages> 
                   default:
                     name: key_ops
                     description: 'Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_296
+              - !<!VirtualParameter> &ref_297
                 schema: *ref_5
                 implementation: Method
-                originalParameter: *ref_291
+                originalParameter: *ref_292
                 pathToProperty: []
-                targetProperty: *ref_293
+                targetProperty: *ref_294
                 language: !<!Languages> 
                   default:
                     name: keyAttributes
                     description: The attributes of a key managed by the key vault service.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_297
+              - !<!VirtualParameter> &ref_298
                 schema: *ref_44
                 implementation: Method
-                originalParameter: *ref_291
+                originalParameter: *ref_292
                 pathToProperty: []
-                targetProperty: *ref_294
+                targetProperty: *ref_295
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_295
               - *ref_296
               - *ref_297
+              - *ref_298
             language: !<!Languages> 
               default:
                 name: ''
@@ -7130,9 +7194,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_298
           - *ref_299
           - *ref_300
+          - *ref_301
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -7149,7 +7213,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7206,7 +7270,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_301
+          - !<!Parameter> &ref_302
             schema: *ref_0
             implementation: Method
             required: true
@@ -7224,7 +7288,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_302
+          - !<!Parameter> &ref_303
             schema: *ref_1
             implementation: Method
             required: true
@@ -7236,7 +7300,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_303
+          - !<!Parameter> &ref_304
             schema: *ref_1
             implementation: Method
             required: true
@@ -7251,6 +7315,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -7261,9 +7340,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_301
           - *ref_302
           - *ref_303
+          - *ref_304
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -7280,7 +7359,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7334,7 +7413,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_305
+          - !<!Parameter> &ref_306
             schema: *ref_0
             implementation: Method
             required: true
@@ -7352,7 +7431,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_306
+          - !<!Parameter> &ref_307
             schema: *ref_1
             implementation: Method
             required: true
@@ -7364,8 +7443,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_307
-            schema: *ref_304
+          - !<!Parameter> &ref_308
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -7378,6 +7457,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -7388,12 +7482,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_305
           - *ref_306
           - *ref_307
+          - *ref_308
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_308
+            schema: *ref_309
             language: !<!Languages> 
               default:
                 name: ''
@@ -7407,7 +7501,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7455,7 +7549,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_309
+          - !<!Parameter> &ref_310
             schema: *ref_0
             implementation: Method
             required: true
@@ -7473,8 +7567,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_310
-            schema: *ref_304
+          - !<!Parameter> &ref_311
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -7487,6 +7581,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -7497,11 +7606,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_309
           - *ref_310
+          - *ref_311
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_308
+            schema: *ref_309
             language: !<!Languages> 
               default:
                 name: ''
@@ -7515,7 +7624,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7563,7 +7672,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_311
+          - !<!Parameter> &ref_312
             schema: *ref_0
             implementation: Method
             required: true
@@ -7581,7 +7690,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_312
+          - !<!Parameter> &ref_313
             schema: *ref_1
             implementation: Method
             required: true
@@ -7596,6 +7705,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -7606,11 +7730,11 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_311
           - *ref_312
+          - *ref_313
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_313
+            schema: *ref_314
             language: !<!Languages> 
               default:
                 name: ''
@@ -7624,7 +7748,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7663,7 +7787,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_318
+          - !<!Parameter> &ref_319
             schema: *ref_0
             implementation: Method
             required: true
@@ -7685,8 +7809,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_315
-                schema: *ref_314
+              - !<!Parameter> &ref_316
+                schema: *ref_315
                 flattened: true
                 implementation: Method
                 required: true
@@ -7700,20 +7824,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_317
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_318
                 schema: *ref_52
                 implementation: Method
-                originalParameter: *ref_315
+                originalParameter: *ref_316
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_316
+                targetProperty: *ref_317
                 language: !<!Languages> 
                   default:
                     name: keyBundleBackup
                     description: The backup blob associated with a key bundle.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_317
+              - *ref_318
             language: !<!Languages> 
               default:
                 name: ''
@@ -7727,7 +7864,7 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_318
+          - *ref_319
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -7744,7 +7881,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7803,7 +7940,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_325
+          - !<!Parameter> &ref_326
             schema: *ref_0
             implementation: Method
             required: true
@@ -7821,7 +7958,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_326
+          - !<!Parameter> &ref_327
             schema: *ref_1
             implementation: Method
             required: true
@@ -7833,7 +7970,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_327
+          - !<!Parameter> &ref_328
             schema: *ref_1
             implementation: Method
             required: true
@@ -7849,8 +7986,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_320
-                schema: *ref_319
+              - !<!Parameter> &ref_321
+                schema: *ref_320
                 flattened: true
                 implementation: Method
                 required: true
@@ -7864,33 +8001,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_323
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_324
                 schema: *ref_53
                 implementation: Method
-                originalParameter: *ref_320
+                originalParameter: *ref_321
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_321
+                targetProperty: *ref_322
                 language: !<!Languages> 
                   default:
                     name: algorithm
                     description: algorithm identifier
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_324
+              - !<!VirtualParameter> &ref_325
                 schema: *ref_54
                 implementation: Method
-                originalParameter: *ref_320
+                originalParameter: *ref_321
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_322
+                targetProperty: *ref_323
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_323
               - *ref_324
+              - *ref_325
             language: !<!Languages> 
               default:
                 name: ''
@@ -7904,12 +8054,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_325
           - *ref_326
           - *ref_327
+          - *ref_328
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_328
+            schema: *ref_329
             language: !<!Languages> 
               default:
                 name: ''
@@ -7923,7 +8073,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7965,7 +8115,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_332
+          - !<!Parameter> &ref_333
             schema: *ref_0
             implementation: Method
             required: true
@@ -7983,7 +8133,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_333
+          - !<!Parameter> &ref_334
             schema: *ref_1
             implementation: Method
             required: true
@@ -7995,7 +8145,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_334
+          - !<!Parameter> &ref_335
             schema: *ref_1
             implementation: Method
             required: true
@@ -8011,8 +8161,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_329
-                schema: *ref_319
+              - !<!Parameter> &ref_330
+                schema: *ref_320
                 flattened: true
                 implementation: Method
                 required: true
@@ -8026,33 +8176,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_330
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_331
                 schema: *ref_53
                 implementation: Method
-                originalParameter: *ref_329
+                originalParameter: *ref_330
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_321
+                targetProperty: *ref_322
                 language: !<!Languages> 
                   default:
                     name: algorithm
                     description: algorithm identifier
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_331
+              - !<!VirtualParameter> &ref_332
                 schema: *ref_54
                 implementation: Method
-                originalParameter: *ref_329
+                originalParameter: *ref_330
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_322
+                targetProperty: *ref_323
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_330
               - *ref_331
+              - *ref_332
             language: !<!Languages> 
               default:
                 name: ''
@@ -8066,12 +8229,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_332
           - *ref_333
           - *ref_334
+          - *ref_335
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_328
+            schema: *ref_329
             language: !<!Languages> 
               default:
                 name: ''
@@ -8085,7 +8248,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8127,7 +8290,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_341
+          - !<!Parameter> &ref_342
             schema: *ref_0
             implementation: Method
             required: true
@@ -8145,7 +8308,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_342
+          - !<!Parameter> &ref_343
             schema: *ref_1
             implementation: Method
             required: true
@@ -8157,7 +8320,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_343
+          - !<!Parameter> &ref_344
             schema: *ref_1
             implementation: Method
             required: true
@@ -8173,8 +8336,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_336
-                schema: *ref_335
+              - !<!Parameter> &ref_337
+                schema: *ref_336
                 flattened: true
                 implementation: Method
                 required: true
@@ -8188,33 +8351,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_339
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_340
                 schema: *ref_57
                 implementation: Method
-                originalParameter: *ref_336
+                originalParameter: *ref_337
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_337
+                targetProperty: *ref_338
                 language: !<!Languages> 
                   default:
                     name: algorithm
                     description: 'The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_340
+              - !<!VirtualParameter> &ref_341
                 schema: *ref_58
                 implementation: Method
-                originalParameter: *ref_336
+                originalParameter: *ref_337
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_338
+                targetProperty: *ref_339
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_339
               - *ref_340
+              - *ref_341
             language: !<!Languages> 
               default:
                 name: ''
@@ -8228,12 +8404,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_341
           - *ref_342
           - *ref_343
+          - *ref_344
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_328
+            schema: *ref_329
             language: !<!Languages> 
               default:
                 name: ''
@@ -8247,7 +8423,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8286,7 +8462,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_352
+          - !<!Parameter> &ref_353
             schema: *ref_0
             implementation: Method
             required: true
@@ -8304,7 +8480,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_353
+          - !<!Parameter> &ref_354
             schema: *ref_1
             implementation: Method
             required: true
@@ -8316,7 +8492,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_354
+          - !<!Parameter> &ref_355
             schema: *ref_1
             implementation: Method
             required: true
@@ -8332,8 +8508,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_345
-                schema: *ref_344
+              - !<!Parameter> &ref_346
+                schema: *ref_345
                 flattened: true
                 implementation: Method
                 required: true
@@ -8347,46 +8523,59 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_349
-                schema: *ref_57
+              - !<!Parameter> 
+                schema: *ref_260
                 implementation: Method
-                originalParameter: *ref_345
-                pathToProperty: []
+                origin: 'modelerfour:synthesized/accept'
                 required: true
-                targetProperty: *ref_346
                 language: !<!Languages> 
                   default:
-                    name: algorithm
-                    description: 'The signing/verification algorithm. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
-                protocol: !<!Protocols> {}
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - !<!VirtualParameter> &ref_350
-                schema: *ref_59
+                schema: *ref_57
                 implementation: Method
-                originalParameter: *ref_345
+                originalParameter: *ref_346
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_347
                 language: !<!Languages> 
                   default:
-                    name: digest
-                    description: The digest used for signing.
+                    name: algorithm
+                    description: 'The signing/verification algorithm. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_351
-                schema: *ref_60
+                schema: *ref_59
                 implementation: Method
-                originalParameter: *ref_345
+                originalParameter: *ref_346
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_348
+                language: !<!Languages> 
+                  default:
+                    name: digest
+                    description: The digest used for signing.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_352
+                schema: *ref_60
+                implementation: Method
+                originalParameter: *ref_346
+                pathToProperty: []
+                required: true
+                targetProperty: *ref_349
                 language: !<!Languages> 
                   default:
                     name: signature
                     description: The signature to be verified.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_349
               - *ref_350
               - *ref_351
+              - *ref_352
             language: !<!Languages> 
               default:
                 name: ''
@@ -8400,12 +8589,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_352
           - *ref_353
           - *ref_354
+          - *ref_355
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_355
+            schema: *ref_356
             language: !<!Languages> 
               default:
                 name: ''
@@ -8419,7 +8608,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8458,7 +8647,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_359
+          - !<!Parameter> &ref_360
             schema: *ref_0
             implementation: Method
             required: true
@@ -8476,7 +8665,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_360
+          - !<!Parameter> &ref_361
             schema: *ref_1
             implementation: Method
             required: true
@@ -8488,7 +8677,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_361
+          - !<!Parameter> &ref_362
             schema: *ref_1
             implementation: Method
             required: true
@@ -8504,8 +8693,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_356
-                schema: *ref_319
+              - !<!Parameter> &ref_357
+                schema: *ref_320
                 flattened: true
                 implementation: Method
                 required: true
@@ -8519,33 +8708,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_357
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_358
                 schema: *ref_53
                 implementation: Method
-                originalParameter: *ref_356
+                originalParameter: *ref_357
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_321
+                targetProperty: *ref_322
                 language: !<!Languages> 
                   default:
                     name: algorithm
                     description: algorithm identifier
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_358
+              - !<!VirtualParameter> &ref_359
                 schema: *ref_54
                 implementation: Method
-                originalParameter: *ref_356
+                originalParameter: *ref_357
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_322
+                targetProperty: *ref_323
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_357
               - *ref_358
+              - *ref_359
             language: !<!Languages> 
               default:
                 name: ''
@@ -8559,12 +8761,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_359
           - *ref_360
           - *ref_361
+          - *ref_362
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_328
+            schema: *ref_329
             language: !<!Languages> 
               default:
                 name: ''
@@ -8578,7 +8780,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8620,7 +8822,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_365
+          - !<!Parameter> &ref_366
             schema: *ref_0
             implementation: Method
             required: true
@@ -8638,7 +8840,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_366
+          - !<!Parameter> &ref_367
             schema: *ref_1
             implementation: Method
             required: true
@@ -8650,7 +8852,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_367
+          - !<!Parameter> &ref_368
             schema: *ref_1
             implementation: Method
             required: true
@@ -8666,8 +8868,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_362
-                schema: *ref_319
+              - !<!Parameter> &ref_363
+                schema: *ref_320
                 flattened: true
                 implementation: Method
                 required: true
@@ -8681,33 +8883,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_363
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_364
                 schema: *ref_53
                 implementation: Method
-                originalParameter: *ref_362
+                originalParameter: *ref_363
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_321
+                targetProperty: *ref_322
                 language: !<!Languages> 
                   default:
                     name: algorithm
                     description: algorithm identifier
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_364
+              - !<!VirtualParameter> &ref_365
                 schema: *ref_54
                 implementation: Method
-                originalParameter: *ref_362
+                originalParameter: *ref_363
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_322
+                targetProperty: *ref_323
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_363
               - *ref_364
+              - *ref_365
             language: !<!Languages> 
               default:
                 name: ''
@@ -8721,12 +8936,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_365
           - *ref_366
           - *ref_367
+          - *ref_368
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_328
+            schema: *ref_329
             language: !<!Languages> 
               default:
                 name: ''
@@ -8740,7 +8955,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8781,7 +8996,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_368
+          - !<!Parameter> &ref_369
             schema: *ref_0
             implementation: Method
             required: true
@@ -8799,8 +9014,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_369
-            schema: *ref_304
+          - !<!Parameter> &ref_370
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -8813,6 +9028,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -8823,11 +9053,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_368
           - *ref_369
+          - *ref_370
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_370
+            schema: *ref_371
             language: !<!Languages> 
               default:
                 name: ''
@@ -8841,7 +9071,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8892,7 +9122,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_371
+          - !<!Parameter> &ref_372
             schema: *ref_0
             implementation: Method
             required: true
@@ -8910,7 +9140,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_372
+          - !<!Parameter> &ref_373
             schema: *ref_1
             implementation: Method
             required: true
@@ -8925,6 +9155,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -8935,8 +9180,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_371
           - *ref_372
+          - *ref_373
         responses:
           - !<!SchemaResponse> 
             schema: *ref_21
@@ -8953,7 +9198,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9011,7 +9256,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_373
+          - !<!Parameter> &ref_374
             schema: *ref_0
             implementation: Method
             required: true
@@ -9029,7 +9274,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_374
+          - !<!Parameter> &ref_375
             schema: *ref_1
             implementation: Method
             required: true
@@ -9044,6 +9289,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9054,8 +9314,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_373
           - *ref_374
+          - *ref_375
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -9068,7 +9328,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9102,7 +9362,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_375
+          - !<!Parameter> &ref_376
             schema: *ref_0
             implementation: Method
             required: true
@@ -9120,7 +9380,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_376
+          - !<!Parameter> &ref_377
             schema: *ref_1
             implementation: Method
             required: true
@@ -9135,6 +9395,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9145,8 +9420,8 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_375
           - *ref_376
+          - *ref_377
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -9163,7 +9438,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9218,7 +9493,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_387
+          - !<!Parameter> &ref_388
             schema: *ref_0
             implementation: Method
             required: true
@@ -9236,7 +9511,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_388
+          - !<!Parameter> &ref_389
             schema: *ref_257
             implementation: Method
             required: true
@@ -9252,8 +9527,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_378
-                schema: *ref_377
+              - !<!Parameter> &ref_379
+                schema: *ref_378
                 flattened: true
                 implementation: Method
                 required: true
@@ -9267,59 +9542,72 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_383
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_384
                 schema: *ref_63
                 implementation: Method
-                originalParameter: *ref_378
+                originalParameter: *ref_379
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_379
+                targetProperty: *ref_380
                 language: !<!Languages> 
                   default:
                     name: value
                     description: The value of the secret.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_384
+              - !<!VirtualParameter> &ref_385
                 schema: *ref_64
                 implementation: Method
-                originalParameter: *ref_378
-                pathToProperty: []
-                required: false
-                targetProperty: *ref_380
-                language: !<!Languages> 
-                  default:
-                    name: tags
-                    description: Application specific metadata in the form of key-value pairs.
-                protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_385
-                schema: *ref_65
-                implementation: Method
-                originalParameter: *ref_378
+                originalParameter: *ref_379
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_381
                 language: !<!Languages> 
                   default:
-                    name: contentType
-                    description: Type of the secret value such as a password.
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_386
-                schema: *ref_8
+                schema: *ref_65
                 implementation: Method
-                originalParameter: *ref_378
+                originalParameter: *ref_379
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_382
+                language: !<!Languages> 
+                  default:
+                    name: contentType
+                    description: Type of the secret value such as a password.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_387
+                schema: *ref_8
+                implementation: Method
+                originalParameter: *ref_379
+                pathToProperty: []
+                required: false
+                targetProperty: *ref_383
                 language: !<!Languages> 
                   default:
                     name: secretAttributes
                     description: The secret management attributes.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_383
               - *ref_384
               - *ref_385
               - *ref_386
+              - *ref_387
             language: !<!Languages> 
               default:
                 name: ''
@@ -9333,8 +9621,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_387
           - *ref_388
+          - *ref_389
         responses:
           - !<!SchemaResponse> 
             schema: *ref_66
@@ -9351,7 +9639,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9392,7 +9680,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_389
+          - !<!Parameter> &ref_390
             schema: *ref_0
             implementation: Method
             required: true
@@ -9410,7 +9698,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_390
+          - !<!Parameter> &ref_391
             schema: *ref_1
             implementation: Method
             required: true
@@ -9425,6 +9713,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9435,8 +9738,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_389
           - *ref_390
+          - *ref_391
         responses:
           - !<!SchemaResponse> 
             schema: *ref_70
@@ -9453,7 +9756,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9494,7 +9797,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_399
+          - !<!Parameter> &ref_400
             schema: *ref_0
             implementation: Method
             required: true
@@ -9512,7 +9815,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_400
+          - !<!Parameter> &ref_401
             schema: *ref_1
             implementation: Method
             required: true
@@ -9524,7 +9827,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_401
+          - !<!Parameter> &ref_402
             schema: *ref_1
             implementation: Method
             required: true
@@ -9540,8 +9843,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_392
-                schema: *ref_391
+              - !<!Parameter> &ref_393
+                schema: *ref_392
                 flattened: true
                 implementation: Method
                 required: true
@@ -9555,43 +9858,56 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_396
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_397
                 schema: *ref_77
                 implementation: Method
-                originalParameter: *ref_392
+                originalParameter: *ref_393
                 pathToProperty: []
-                targetProperty: *ref_393
+                targetProperty: *ref_394
                 language: !<!Languages> 
                   default:
                     name: contentType
                     description: Type of the secret value such as a password.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_397
+              - !<!VirtualParameter> &ref_398
                 schema: *ref_8
                 implementation: Method
-                originalParameter: *ref_392
+                originalParameter: *ref_393
                 pathToProperty: []
-                targetProperty: *ref_394
+                targetProperty: *ref_395
                 language: !<!Languages> 
                   default:
                     name: secretAttributes
                     description: The secret management attributes.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_398
+              - !<!VirtualParameter> &ref_399
                 schema: *ref_78
                 implementation: Method
-                originalParameter: *ref_392
+                originalParameter: *ref_393
                 pathToProperty: []
-                targetProperty: *ref_395
+                targetProperty: *ref_396
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_396
               - *ref_397
               - *ref_398
+              - *ref_399
             language: !<!Languages> 
               default:
                 name: ''
@@ -9605,9 +9921,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_399
           - *ref_400
           - *ref_401
+          - *ref_402
         responses:
           - !<!SchemaResponse> 
             schema: *ref_66
@@ -9624,7 +9940,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9674,7 +9990,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_402
+          - !<!Parameter> &ref_403
             schema: *ref_0
             implementation: Method
             required: true
@@ -9692,7 +10008,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_403
+          - !<!Parameter> &ref_404
             schema: *ref_1
             implementation: Method
             required: true
@@ -9704,7 +10020,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_404
+          - !<!Parameter> &ref_405
             schema: *ref_1
             implementation: Method
             required: true
@@ -9719,6 +10035,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9729,9 +10060,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_402
           - *ref_403
           - *ref_404
+          - *ref_405
         responses:
           - !<!SchemaResponse> 
             schema: *ref_66
@@ -9748,7 +10079,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9788,7 +10119,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_405
+          - !<!Parameter> &ref_406
             schema: *ref_0
             implementation: Method
             required: true
@@ -9806,8 +10137,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_406
-            schema: *ref_304
+          - !<!Parameter> &ref_407
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -9820,6 +10151,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9830,11 +10176,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_405
           - *ref_406
+          - *ref_407
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_407
+            schema: *ref_408
             language: !<!Languages> 
               default:
                 name: ''
@@ -9848,7 +10194,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9895,7 +10241,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_408
+          - !<!Parameter> &ref_409
             schema: *ref_0
             implementation: Method
             required: true
@@ -9913,7 +10259,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_409
+          - !<!Parameter> &ref_410
             schema: *ref_1
             implementation: Method
             required: true
@@ -9925,8 +10271,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_410
-            schema: *ref_304
+          - !<!Parameter> &ref_411
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -9939,6 +10285,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9949,12 +10310,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_408
           - *ref_409
           - *ref_410
+          - *ref_411
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_407
+            schema: *ref_408
             language: !<!Languages> 
               default:
                 name: ''
@@ -9968,7 +10329,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10013,7 +10374,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_411
+          - !<!Parameter> &ref_412
             schema: *ref_0
             implementation: Method
             required: true
@@ -10031,8 +10392,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_412
-            schema: *ref_304
+          - !<!Parameter> &ref_413
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -10045,6 +10406,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10055,11 +10431,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_411
           - *ref_412
+          - *ref_413
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_413
+            schema: *ref_414
             language: !<!Languages> 
               default:
                 name: ''
@@ -10073,7 +10449,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10123,7 +10499,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_414
+          - !<!Parameter> &ref_415
             schema: *ref_0
             implementation: Method
             required: true
@@ -10141,7 +10517,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_415
+          - !<!Parameter> &ref_416
             schema: *ref_1
             implementation: Method
             required: true
@@ -10156,6 +10532,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10166,8 +10557,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_414
           - *ref_415
+          - *ref_416
         responses:
           - !<!SchemaResponse> 
             schema: *ref_70
@@ -10184,7 +10575,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10225,7 +10616,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_416
+          - !<!Parameter> &ref_417
             schema: *ref_0
             implementation: Method
             required: true
@@ -10243,7 +10634,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_417
+          - !<!Parameter> &ref_418
             schema: *ref_1
             implementation: Method
             required: true
@@ -10258,6 +10649,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10268,8 +10674,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_416
           - *ref_417
+          - *ref_418
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -10282,7 +10688,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10314,7 +10720,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_418
+          - !<!Parameter> &ref_419
             schema: *ref_0
             implementation: Method
             required: true
@@ -10332,7 +10738,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_419
+          - !<!Parameter> &ref_420
             schema: *ref_1
             implementation: Method
             required: true
@@ -10347,6 +10753,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10357,8 +10778,8 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_418
           - *ref_419
+          - *ref_420
         responses:
           - !<!SchemaResponse> 
             schema: *ref_66
@@ -10375,7 +10796,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10413,7 +10834,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_420
+          - !<!Parameter> &ref_421
             schema: *ref_0
             implementation: Method
             required: true
@@ -10431,7 +10852,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_421
+          - !<!Parameter> &ref_422
             schema: *ref_1
             implementation: Method
             required: true
@@ -10446,6 +10867,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10456,11 +10892,11 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_420
           - *ref_421
+          - *ref_422
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_422
+            schema: *ref_423
             language: !<!Languages> 
               default:
                 name: ''
@@ -10474,7 +10910,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10508,7 +10944,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_427
+          - !<!Parameter> &ref_428
             schema: *ref_0
             implementation: Method
             required: true
@@ -10530,8 +10966,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_424
-                schema: *ref_423
+              - !<!Parameter> &ref_425
+                schema: *ref_424
                 flattened: true
                 implementation: Method
                 required: true
@@ -10545,20 +10981,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_426
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_427
                 schema: *ref_89
                 implementation: Method
-                originalParameter: *ref_424
+                originalParameter: *ref_425
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_425
+                targetProperty: *ref_426
                 language: !<!Languages> 
                   default:
                     name: secretBundleBackup
                     description: The backup blob associated with a secret bundle.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_426
+              - *ref_427
             language: !<!Languages> 
               default:
                 name: ''
@@ -10572,7 +11021,7 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_427
+          - *ref_428
         responses:
           - !<!SchemaResponse> 
             schema: *ref_66
@@ -10589,7 +11038,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10632,7 +11081,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_429
+          - !<!Parameter> &ref_430
             schema: *ref_0
             implementation: Method
             required: true
@@ -10650,8 +11099,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_430
-            schema: *ref_304
+          - !<!Parameter> &ref_431
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -10661,8 +11110,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_431
-            schema: *ref_428
+          - !<!Parameter> &ref_432
+            schema: *ref_429
             implementation: Method
             language: !<!Languages> 
               default:
@@ -10675,6 +11124,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10685,12 +11149,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_429
           - *ref_430
           - *ref_431
+          - *ref_432
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_432
+            schema: *ref_433
             language: !<!Languages> 
               default:
                 name: ''
@@ -10704,7 +11168,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10757,7 +11221,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_433
+          - !<!Parameter> &ref_434
             schema: *ref_0
             implementation: Method
             required: true
@@ -10775,7 +11239,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_434
+          - !<!Parameter> &ref_435
             schema: *ref_1
             implementation: Method
             required: true
@@ -10790,6 +11254,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10800,8 +11279,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_433
           - *ref_434
+          - *ref_435
         responses:
           - !<!SchemaResponse> 
             schema: *ref_99
@@ -10818,7 +11297,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10895,7 +11374,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_439
+          - !<!Parameter> &ref_440
             schema: *ref_0
             implementation: Method
             required: true
@@ -10917,8 +11396,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_436
-                schema: *ref_435
+              - !<!Parameter> &ref_437
+                schema: *ref_436
                 flattened: true
                 implementation: Method
                 required: true
@@ -10930,19 +11409,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_438
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_439
                 schema: *ref_247
                 implementation: Method
-                originalParameter: *ref_436
+                originalParameter: *ref_437
                 pathToProperty: []
-                targetProperty: *ref_437
+                targetProperty: *ref_438
                 language: !<!Languages> 
                   default:
                     name: ContactList
                     description: The contact list for the vault certificates.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_438
+              - *ref_439
             language: !<!Languages> 
               default:
                 name: ''
@@ -10956,10 +11448,10 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_439
+          - *ref_440
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_435
+            schema: *ref_436
             language: !<!Languages> 
               default:
                 name: ''
@@ -10973,7 +11465,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11020,7 +11512,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_440
+          - !<!Parameter> &ref_441
             schema: *ref_0
             implementation: Method
             required: true
@@ -11041,6 +11533,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11051,10 +11558,10 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_440
+          - *ref_441
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_435
+            schema: *ref_436
             language: !<!Languages> 
               default:
                 name: ''
@@ -11068,7 +11575,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11107,7 +11614,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_441
+          - !<!Parameter> &ref_442
             schema: *ref_0
             implementation: Method
             required: true
@@ -11128,6 +11635,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11138,10 +11660,10 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_441
+          - *ref_442
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_435
+            schema: *ref_436
             language: !<!Languages> 
               default:
                 name: ''
@@ -11155,7 +11677,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11194,7 +11716,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_442
+          - !<!Parameter> &ref_443
             schema: *ref_0
             implementation: Method
             required: true
@@ -11212,8 +11734,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_443
-            schema: *ref_304
+          - !<!Parameter> &ref_444
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -11226,6 +11748,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11236,11 +11773,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_442
           - *ref_443
+          - *ref_444
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_444
+            schema: *ref_445
             language: !<!Languages> 
               default:
                 name: ''
@@ -11254,7 +11791,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11297,7 +11834,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_455
+          - !<!Parameter> &ref_456
             schema: *ref_0
             implementation: Method
             required: true
@@ -11315,7 +11852,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_456
+          - !<!Parameter> &ref_457
             schema: *ref_1
             implementation: Method
             required: true
@@ -11331,8 +11868,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_446
-                schema: *ref_445
+              - !<!Parameter> &ref_447
+                schema: *ref_446
                 flattened: true
                 implementation: Method
                 required: true
@@ -11346,59 +11883,72 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_451
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_452
                 schema: *ref_143
                 implementation: Method
-                originalParameter: *ref_446
+                originalParameter: *ref_447
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_447
+                targetProperty: *ref_448
                 language: !<!Languages> 
                   default:
                     name: provider
                     description: The issuer provider.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_452
+              - !<!VirtualParameter> &ref_453
                 schema: *ref_151
                 implementation: Method
-                originalParameter: *ref_446
-                pathToProperty: []
-                required: false
-                targetProperty: *ref_448
-                language: !<!Languages> 
-                  default:
-                    name: credentials
-                    description: The credentials to be used for the issuer.
-                protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_453
-                schema: *ref_152
-                implementation: Method
-                originalParameter: *ref_446
+                originalParameter: *ref_447
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_449
                 language: !<!Languages> 
                   default:
-                    name: OrganizationDetails
-                    description: Details of the organization as provided to the issuer.
+                    name: credentials
+                    description: The credentials to be used for the issuer.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_454
-                schema: *ref_154
+                schema: *ref_152
                 implementation: Method
-                originalParameter: *ref_446
+                originalParameter: *ref_447
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_450
+                language: !<!Languages> 
+                  default:
+                    name: OrganizationDetails
+                    description: Details of the organization as provided to the issuer.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_455
+                schema: *ref_154
+                implementation: Method
+                originalParameter: *ref_447
+                pathToProperty: []
+                required: false
+                targetProperty: *ref_451
                 language: !<!Languages> 
                   default:
                     name: attributes
                     description: Attributes of the issuer object.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_451
               - *ref_452
               - *ref_453
               - *ref_454
+              - *ref_455
             language: !<!Languages> 
               default:
                 name: ''
@@ -11412,11 +11962,11 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_455
           - *ref_456
+          - *ref_457
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_457
+            schema: *ref_458
             language: !<!Languages> 
               default:
                 name: ''
@@ -11430,7 +11980,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11488,7 +12038,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_468
+          - !<!Parameter> &ref_469
             schema: *ref_0
             implementation: Method
             required: true
@@ -11506,7 +12056,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_469
+          - !<!Parameter> &ref_470
             schema: *ref_1
             implementation: Method
             required: true
@@ -11522,8 +12072,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_459
-                schema: *ref_458
+              - !<!Parameter> &ref_460
+                schema: *ref_459
                 flattened: true
                 implementation: Method
                 required: true
@@ -11537,55 +12087,68 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_464
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_465
                 schema: *ref_157
                 implementation: Method
-                originalParameter: *ref_459
+                originalParameter: *ref_460
                 pathToProperty: []
-                targetProperty: *ref_460
+                targetProperty: *ref_461
                 language: !<!Languages> 
                   default:
                     name: provider
                     description: The issuer provider.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_465
+              - !<!VirtualParameter> &ref_466
                 schema: *ref_151
                 implementation: Method
-                originalParameter: *ref_459
+                originalParameter: *ref_460
                 pathToProperty: []
-                targetProperty: *ref_461
+                targetProperty: *ref_462
                 language: !<!Languages> 
                   default:
                     name: credentials
                     description: The credentials to be used for the issuer.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_466
+              - !<!VirtualParameter> &ref_467
                 schema: *ref_152
                 implementation: Method
-                originalParameter: *ref_459
+                originalParameter: *ref_460
                 pathToProperty: []
-                targetProperty: *ref_462
+                targetProperty: *ref_463
                 language: !<!Languages> 
                   default:
                     name: OrganizationDetails
                     description: Details of the organization as provided to the issuer.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_467
+              - !<!VirtualParameter> &ref_468
                 schema: *ref_154
                 implementation: Method
-                originalParameter: *ref_459
+                originalParameter: *ref_460
                 pathToProperty: []
-                targetProperty: *ref_463
+                targetProperty: *ref_464
                 language: !<!Languages> 
                   default:
                     name: attributes
                     description: Attributes of the issuer object.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_464
               - *ref_465
               - *ref_466
               - *ref_467
+              - *ref_468
             language: !<!Languages> 
               default:
                 name: ''
@@ -11599,11 +12162,11 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_468
           - *ref_469
+          - *ref_470
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_457
+            schema: *ref_458
             language: !<!Languages> 
               default:
                 name: ''
@@ -11617,7 +12180,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11669,7 +12232,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_470
+          - !<!Parameter> &ref_471
             schema: *ref_0
             implementation: Method
             required: true
@@ -11687,7 +12250,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_471
+          - !<!Parameter> &ref_472
             schema: *ref_1
             implementation: Method
             required: true
@@ -11702,6 +12265,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11712,11 +12290,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_470
           - *ref_471
+          - *ref_472
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_457
+            schema: *ref_458
             language: !<!Languages> 
               default:
                 name: ''
@@ -11730,7 +12308,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11777,7 +12355,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_472
+          - !<!Parameter> &ref_473
             schema: *ref_0
             implementation: Method
             required: true
@@ -11795,7 +12373,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_473
+          - !<!Parameter> &ref_474
             schema: *ref_1
             implementation: Method
             required: true
@@ -11810,6 +12388,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11820,11 +12413,11 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_472
           - *ref_473
+          - *ref_474
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_457
+            schema: *ref_458
             language: !<!Languages> 
               default:
                 name: ''
@@ -11838,7 +12431,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11885,7 +12478,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_482
+          - !<!Parameter> &ref_483
             schema: *ref_0
             implementation: Method
             required: true
@@ -11903,7 +12496,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_483
+          - !<!Parameter> &ref_484
             schema: *ref_257
             implementation: Method
             required: true
@@ -11919,8 +12512,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_475
-                schema: *ref_474
+              - !<!Parameter> &ref_476
+                schema: *ref_475
                 flattened: true
                 implementation: Method
                 required: true
@@ -11934,43 +12527,56 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_479
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_480
                 schema: *ref_125
                 implementation: Method
-                originalParameter: *ref_475
+                originalParameter: *ref_476
                 pathToProperty: []
-                targetProperty: *ref_476
+                targetProperty: *ref_477
                 language: !<!Languages> 
                   default:
                     name: CertificatePolicy
                     description: The management policy for the certificate.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_480
+              - !<!VirtualParameter> &ref_481
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_475
+                originalParameter: *ref_476
                 pathToProperty: []
-                targetProperty: *ref_477
+                targetProperty: *ref_478
                 language: !<!Languages> 
                   default:
                     name: CertificateAttributes
                     description: The attributes of the certificate (optional).
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_481
+              - !<!VirtualParameter> &ref_482
                 schema: *ref_158
                 implementation: Method
-                originalParameter: *ref_475
+                originalParameter: *ref_476
                 pathToProperty: []
-                targetProperty: *ref_478
+                targetProperty: *ref_479
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_479
               - *ref_480
               - *ref_481
+              - *ref_482
             language: !<!Languages> 
               default:
                 name: ''
@@ -11984,11 +12590,11 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_482
           - *ref_483
+          - *ref_484
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_484
+            schema: *ref_485
             language: !<!Languages> 
               default:
                 name: ''
@@ -12002,7 +12608,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12060,7 +12666,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_497
+          - !<!Parameter> &ref_498
             schema: *ref_0
             implementation: Method
             required: true
@@ -12078,7 +12684,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_498
+          - !<!Parameter> &ref_499
             schema: *ref_257
             implementation: Method
             required: true
@@ -12094,8 +12700,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_486
-                schema: *ref_485
+              - !<!Parameter> &ref_487
+                schema: *ref_486
                 flattened: true
                 implementation: Method
                 required: true
@@ -12109,72 +12715,85 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_492
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_493
                 schema: *ref_166
                 implementation: Method
-                originalParameter: *ref_486
+                originalParameter: *ref_487
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_487
+                targetProperty: *ref_488
                 language: !<!Languages> 
                   default:
                     name: base64EncodedCertificate
                     description: Base64 encoded representation of the certificate object to import. This certificate needs to contain the private key.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_493
+              - !<!VirtualParameter> &ref_494
                 schema: *ref_167
                 implementation: Method
-                originalParameter: *ref_486
-                pathToProperty: []
-                required: false
-                targetProperty: *ref_488
-                language: !<!Languages> 
-                  default:
-                    name: password
-                    description: 'If the private key in base64EncodedCertificate is encrypted, the password used for encryption.'
-                protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_494
-                schema: *ref_125
-                implementation: Method
-                originalParameter: *ref_486
+                originalParameter: *ref_487
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_489
                 language: !<!Languages> 
                   default:
-                    name: CertificatePolicy
-                    description: The management policy for the certificate.
+                    name: password
+                    description: 'If the private key in base64EncodedCertificate is encrypted, the password used for encryption.'
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_495
-                schema: *ref_9
+                schema: *ref_125
                 implementation: Method
-                originalParameter: *ref_486
+                originalParameter: *ref_487
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_490
                 language: !<!Languages> 
                   default:
-                    name: CertificateAttributes
-                    description: The attributes of the certificate (optional).
+                    name: CertificatePolicy
+                    description: The management policy for the certificate.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_496
-                schema: *ref_168
+                schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_486
+                originalParameter: *ref_487
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_491
+                language: !<!Languages> 
+                  default:
+                    name: CertificateAttributes
+                    description: The attributes of the certificate (optional).
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_497
+                schema: *ref_168
+                implementation: Method
+                originalParameter: *ref_487
+                pathToProperty: []
+                required: false
+                targetProperty: *ref_492
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_492
               - *ref_493
               - *ref_494
               - *ref_495
               - *ref_496
+              - *ref_497
             language: !<!Languages> 
               default:
                 name: ''
@@ -12188,8 +12807,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_497
           - *ref_498
+          - *ref_499
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -12206,7 +12825,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12292,7 +12911,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_499
+          - !<!Parameter> &ref_500
             schema: *ref_0
             implementation: Method
             required: true
@@ -12310,7 +12929,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_500
+          - !<!Parameter> &ref_501
             schema: *ref_1
             implementation: Method
             required: true
@@ -12322,8 +12941,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_501
-            schema: *ref_304
+          - !<!Parameter> &ref_502
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -12336,6 +12955,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12346,12 +12980,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_499
           - *ref_500
           - *ref_501
+          - *ref_502
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_432
+            schema: *ref_433
             language: !<!Languages> 
               default:
                 name: ''
@@ -12365,7 +12999,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12419,7 +13053,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_502
+          - !<!Parameter> &ref_503
             schema: *ref_0
             implementation: Method
             required: true
@@ -12437,7 +13071,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_503
+          - !<!Parameter> &ref_504
             schema: *ref_1
             implementation: Method
             required: true
@@ -12452,6 +13086,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12462,8 +13111,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_502
           - *ref_503
+          - *ref_504
         responses:
           - !<!SchemaResponse> 
             schema: *ref_125
@@ -12480,7 +13129,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12538,7 +13187,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_505
+          - !<!Parameter> &ref_506
             schema: *ref_0
             implementation: Method
             required: true
@@ -12556,7 +13205,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_506
+          - !<!Parameter> &ref_507
             schema: *ref_1
             implementation: Method
             required: true
@@ -12572,7 +13221,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_504
+              - !<!Parameter> &ref_505
                 schema: *ref_125
                 implementation: Method
                 required: true
@@ -12584,8 +13233,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_504
+              - *ref_505
             language: !<!Languages> 
               default:
                 name: ''
@@ -12599,8 +13261,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_505
           - *ref_506
+          - *ref_507
         responses:
           - !<!SchemaResponse> 
             schema: *ref_125
@@ -12617,7 +13279,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12697,7 +13359,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_515
+          - !<!Parameter> &ref_516
             schema: *ref_0
             implementation: Method
             required: true
@@ -12715,7 +13377,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_516
+          - !<!Parameter> &ref_517
             schema: *ref_1
             implementation: Method
             required: true
@@ -12727,7 +13389,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_517
+          - !<!Parameter> &ref_518
             schema: *ref_1
             implementation: Method
             required: true
@@ -12743,8 +13405,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_508
-                schema: *ref_507
+              - !<!Parameter> &ref_509
+                schema: *ref_508
                 flattened: true
                 implementation: Method
                 required: true
@@ -12758,43 +13420,56 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_512
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_513
                 schema: *ref_125
                 implementation: Method
-                originalParameter: *ref_508
+                originalParameter: *ref_509
                 pathToProperty: []
-                targetProperty: *ref_509
+                targetProperty: *ref_510
                 language: !<!Languages> 
                   default:
                     name: CertificatePolicy
                     description: The management policy for the certificate.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_513
+              - !<!VirtualParameter> &ref_514
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_508
+                originalParameter: *ref_509
                 pathToProperty: []
-                targetProperty: *ref_510
+                targetProperty: *ref_511
                 language: !<!Languages> 
                   default:
                     name: CertificateAttributes
                     description: The attributes of the certificate (optional).
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_514
+              - !<!VirtualParameter> &ref_515
                 schema: *ref_169
                 implementation: Method
-                originalParameter: *ref_508
+                originalParameter: *ref_509
                 pathToProperty: []
-                targetProperty: *ref_511
+                targetProperty: *ref_512
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_512
               - *ref_513
               - *ref_514
+              - *ref_515
             language: !<!Languages> 
               default:
                 name: ''
@@ -12808,9 +13483,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_515
           - *ref_516
           - *ref_517
+          - *ref_518
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -12827,7 +13502,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12881,7 +13556,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_518
+          - !<!Parameter> &ref_519
             schema: *ref_0
             implementation: Method
             required: true
@@ -12899,7 +13574,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_519
+          - !<!Parameter> &ref_520
             schema: *ref_1
             implementation: Method
             required: true
@@ -12911,7 +13586,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_520
+          - !<!Parameter> &ref_521
             schema: *ref_1
             implementation: Method
             required: true
@@ -12926,6 +13601,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12936,9 +13626,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_518
           - *ref_519
           - *ref_520
+          - *ref_521
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -12955,7 +13645,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12997,7 +13687,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_525
+          - !<!Parameter> &ref_526
             schema: *ref_0
             implementation: Method
             required: true
@@ -13015,7 +13705,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_526
+          - !<!Parameter> &ref_527
             schema: *ref_1
             implementation: Method
             required: true
@@ -13031,8 +13721,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_522
-                schema: *ref_521
+              - !<!Parameter> &ref_523
+                schema: *ref_522
                 flattened: true
                 implementation: Method
                 required: true
@@ -13046,20 +13736,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_524
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_525
                 schema: *ref_161
                 implementation: Method
-                originalParameter: *ref_522
+                originalParameter: *ref_523
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_523
+                targetProperty: *ref_524
                 language: !<!Languages> 
                   default:
                     name: cancellation_requested
                     description: Indicates if cancellation was requested on the certificate operation.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_524
+              - *ref_525
             language: !<!Languages> 
               default:
                 name: ''
@@ -13073,11 +13776,11 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_525
           - *ref_526
+          - *ref_527
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_484
+            schema: *ref_485
             language: !<!Languages> 
               default:
                 name: ''
@@ -13091,7 +13794,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13134,7 +13837,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_527
+          - !<!Parameter> &ref_528
             schema: *ref_0
             implementation: Method
             required: true
@@ -13152,7 +13855,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_528
+          - !<!Parameter> &ref_529
             schema: *ref_1
             implementation: Method
             required: true
@@ -13167,6 +13870,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13177,11 +13895,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_527
           - *ref_528
+          - *ref_529
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_484
+            schema: *ref_485
             language: !<!Languages> 
               default:
                 name: ''
@@ -13195,7 +13913,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13236,7 +13954,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_529
+          - !<!Parameter> &ref_530
             schema: *ref_0
             implementation: Method
             required: true
@@ -13254,7 +13972,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_530
+          - !<!Parameter> &ref_531
             schema: *ref_1
             implementation: Method
             required: true
@@ -13269,6 +13987,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13279,11 +14012,11 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_529
           - *ref_530
+          - *ref_531
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_484
+            schema: *ref_485
             language: !<!Languages> 
               default:
                 name: ''
@@ -13297,7 +14030,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13338,7 +14071,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_539
+          - !<!Parameter> &ref_540
             schema: *ref_0
             implementation: Method
             required: true
@@ -13356,7 +14089,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_540
+          - !<!Parameter> &ref_541
             schema: *ref_1
             implementation: Method
             required: true
@@ -13372,8 +14105,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_532
-                schema: *ref_531
+              - !<!Parameter> &ref_533
+                schema: *ref_532
                 flattened: true
                 implementation: Method
                 required: true
@@ -13387,46 +14120,59 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_536
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_537
                 schema: *ref_250
                 implementation: Method
-                originalParameter: *ref_532
+                originalParameter: *ref_533
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_533
+                targetProperty: *ref_534
                 language: !<!Languages> 
                   default:
                     name: x509Certificates
                     description: The certificate or the certificate chain to merge.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_537
+              - !<!VirtualParameter> &ref_538
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_532
+                originalParameter: *ref_533
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_534
+                targetProperty: *ref_535
                 language: !<!Languages> 
                   default:
                     name: CertificateAttributes
                     description: The attributes of the certificate (optional).
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_538
+              - !<!VirtualParameter> &ref_539
                 schema: *ref_171
                 implementation: Method
-                originalParameter: *ref_532
+                originalParameter: *ref_533
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_535
+                targetProperty: *ref_536
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_536
               - *ref_537
               - *ref_538
+              - *ref_539
             language: !<!Languages> 
               default:
                 name: ''
@@ -13440,8 +14186,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_539
           - *ref_540
+          - *ref_541
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -13458,7 +14204,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13532,7 +14278,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_541
+          - !<!Parameter> &ref_542
             schema: *ref_0
             implementation: Method
             required: true
@@ -13550,7 +14296,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_542
+          - !<!Parameter> &ref_543
             schema: *ref_1
             implementation: Method
             required: true
@@ -13565,6 +14311,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13575,11 +14336,11 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_541
           - *ref_542
+          - *ref_543
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_543
+            schema: *ref_544
             language: !<!Languages> 
               default:
                 name: ''
@@ -13593,7 +14354,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13627,7 +14388,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_548
+          - !<!Parameter> &ref_549
             schema: *ref_0
             implementation: Method
             required: true
@@ -13649,8 +14410,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_545
-                schema: *ref_544
+              - !<!Parameter> &ref_546
+                schema: *ref_545
                 flattened: true
                 implementation: Method
                 required: true
@@ -13664,20 +14425,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_547
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_548
                 schema: *ref_173
                 implementation: Method
-                originalParameter: *ref_545
+                originalParameter: *ref_546
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_546
+                targetProperty: *ref_547
                 language: !<!Languages> 
                   default:
                     name: certificateBundleBackup
                     description: The backup blob associated with a certificate bundle.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_547
+              - *ref_548
             language: !<!Languages> 
               default:
                 name: ''
@@ -13691,7 +14465,7 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_548
+          - *ref_549
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -13708,7 +14482,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13786,7 +14560,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_549
+          - !<!Parameter> &ref_550
             schema: *ref_0
             implementation: Method
             required: true
@@ -13804,8 +14578,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_550
-            schema: *ref_304
+          - !<!Parameter> &ref_551
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -13815,8 +14589,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_551
-            schema: *ref_428
+          - !<!Parameter> &ref_552
+            schema: *ref_429
             implementation: Method
             language: !<!Languages> 
               default:
@@ -13829,6 +14603,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13839,12 +14628,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_549
           - *ref_550
           - *ref_551
+          - *ref_552
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_552
+            schema: *ref_553
             language: !<!Languages> 
               default:
                 name: ''
@@ -13858,7 +14647,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13911,7 +14700,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_553
+          - !<!Parameter> &ref_554
             schema: *ref_0
             implementation: Method
             required: true
@@ -13929,7 +14718,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_554
+          - !<!Parameter> &ref_555
             schema: *ref_1
             implementation: Method
             required: true
@@ -13944,6 +14733,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13954,8 +14758,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_553
           - *ref_554
+          - *ref_555
         responses:
           - !<!SchemaResponse> 
             schema: *ref_99
@@ -13972,7 +14776,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14050,7 +14854,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_555
+          - !<!Parameter> &ref_556
             schema: *ref_0
             implementation: Method
             required: true
@@ -14068,7 +14872,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_556
+          - !<!Parameter> &ref_557
             schema: *ref_1
             implementation: Method
             required: true
@@ -14083,6 +14887,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14093,8 +14912,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_555
           - *ref_556
+          - *ref_557
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -14107,7 +14926,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14141,7 +14960,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_557
+          - !<!Parameter> &ref_558
             schema: *ref_0
             implementation: Method
             required: true
@@ -14159,7 +14978,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_558
+          - !<!Parameter> &ref_559
             schema: *ref_1
             implementation: Method
             required: true
@@ -14174,6 +14993,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14184,8 +15018,8 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_557
           - *ref_558
+          - *ref_559
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -14202,7 +15036,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14276,7 +15110,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_559
+          - !<!Parameter> &ref_560
             schema: *ref_0
             implementation: Method
             required: true
@@ -14294,8 +15128,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_560
-            schema: *ref_304
+          - !<!Parameter> &ref_561
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14308,6 +15142,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14318,11 +15167,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_559
           - *ref_560
+          - *ref_561
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_561
+            schema: *ref_562
             language: !<!Languages> 
               default:
                 name: ''
@@ -14336,7 +15185,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14394,7 +15243,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_562
+          - !<!Parameter> &ref_563
             schema: *ref_0
             implementation: Method
             required: true
@@ -14412,8 +15261,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_563
-            schema: *ref_304
+          - !<!Parameter> &ref_564
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14426,6 +15275,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14436,11 +15300,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_562
           - *ref_563
+          - *ref_564
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_564
+            schema: *ref_565
             language: !<!Languages> 
               default:
                 name: ''
@@ -14454,7 +15318,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14519,7 +15383,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_566
+          - !<!Parameter> &ref_567
             schema: *ref_0
             implementation: Method
             required: true
@@ -14537,8 +15401,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_567
-            schema: *ref_565
+          - !<!Parameter> &ref_568
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14552,6 +15416,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14562,8 +15441,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_566
           - *ref_567
+          - *ref_568
         responses:
           - !<!SchemaResponse> 
             schema: *ref_187
@@ -14580,7 +15459,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14630,7 +15509,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_568
+          - !<!Parameter> &ref_569
             schema: *ref_0
             implementation: Method
             required: true
@@ -14648,8 +15527,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_569
-            schema: *ref_565
+          - !<!Parameter> &ref_570
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14663,6 +15542,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14673,8 +15567,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_568
           - *ref_569
+          - *ref_570
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -14687,7 +15581,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14723,7 +15617,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_570
+          - !<!Parameter> &ref_571
             schema: *ref_0
             implementation: Method
             required: true
@@ -14741,8 +15635,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_571
-            schema: *ref_565
+          - !<!Parameter> &ref_572
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14756,6 +15650,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14766,8 +15675,8 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_570
           - *ref_571
+          - *ref_572
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -14784,7 +15693,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14831,7 +15740,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_572
+          - !<!Parameter> &ref_573
             schema: *ref_0
             implementation: Method
             required: true
@@ -14849,7 +15758,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_573
+          - !<!Parameter> &ref_574
             schema: *ref_1
             implementation: Method
             required: true
@@ -14864,6 +15773,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14874,11 +15798,11 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_572
           - *ref_573
+          - *ref_574
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_574
+            schema: *ref_575
             language: !<!Languages> 
               default:
                 name: ''
@@ -14892,7 +15816,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14928,7 +15852,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_579
+          - !<!Parameter> &ref_580
             schema: *ref_0
             implementation: Method
             required: true
@@ -14950,8 +15874,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_576
-                schema: *ref_575
+              - !<!Parameter> &ref_577
+                schema: *ref_576
                 flattened: true
                 implementation: Method
                 required: true
@@ -14965,20 +15889,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_578
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_579
                 schema: *ref_197
                 implementation: Method
-                originalParameter: *ref_576
+                originalParameter: *ref_577
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_577
+                targetProperty: *ref_578
                 language: !<!Languages> 
                   default:
                     name: storageBundleBackup
                     description: The backup blob associated with a storage account.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_578
+              - *ref_579
             language: !<!Languages> 
               default:
                 name: ''
@@ -14992,7 +15929,7 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_579
+          - *ref_580
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -15009,7 +15946,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15059,7 +15996,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_580
+          - !<!Parameter> &ref_581
             schema: *ref_0
             implementation: Method
             required: true
@@ -15077,8 +16014,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_581
-            schema: *ref_565
+          - !<!Parameter> &ref_582
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15092,6 +16029,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15102,8 +16054,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_580
           - *ref_581
+          - *ref_582
         responses:
           - !<!SchemaResponse> 
             schema: *ref_187
@@ -15120,7 +16072,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15169,7 +16121,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_582
+          - !<!Parameter> &ref_583
             schema: *ref_0
             implementation: Method
             required: true
@@ -15187,8 +16139,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_583
-            schema: *ref_565
+          - !<!Parameter> &ref_584
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15202,6 +16154,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15212,8 +16179,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_582
           - *ref_583
+          - *ref_584
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -15230,7 +16197,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15276,7 +16243,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_598
+          - !<!Parameter> &ref_599
             schema: *ref_0
             implementation: Method
             required: true
@@ -15294,8 +16261,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_599
-            schema: *ref_565
+          - !<!Parameter> &ref_600
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15310,8 +16277,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_585
-                schema: *ref_584
+              - !<!Parameter> &ref_586
+                schema: *ref_585
                 flattened: true
                 implementation: Method
                 required: true
@@ -15325,85 +16292,98 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_592
-                schema: *ref_198
+              - !<!Parameter> 
+                schema: *ref_260
                 implementation: Method
-                originalParameter: *ref_585
-                pathToProperty: []
+                origin: 'modelerfour:synthesized/accept'
                 required: true
-                targetProperty: *ref_586
                 language: !<!Languages> 
                   default:
-                    name: resourceId
-                    description: Storage account resource id.
-                protocol: !<!Protocols> {}
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - !<!VirtualParameter> &ref_593
-                schema: *ref_199
+                schema: *ref_198
                 implementation: Method
-                originalParameter: *ref_585
+                originalParameter: *ref_586
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_587
                 language: !<!Languages> 
                   default:
-                    name: activeKeyName
-                    description: Current active storage account key name.
+                    name: resourceId
+                    description: Storage account resource id.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_594
-                schema: *ref_191
+                schema: *ref_199
                 implementation: Method
-                originalParameter: *ref_585
+                originalParameter: *ref_586
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_588
                 language: !<!Languages> 
                   default:
-                    name: autoRegenerateKey
-                    description: whether keyvault should manage the storage account for the user.
+                    name: activeKeyName
+                    description: Current active storage account key name.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_595
-                schema: *ref_200
+                schema: *ref_191
                 implementation: Method
-                originalParameter: *ref_585
+                originalParameter: *ref_586
                 pathToProperty: []
-                required: false
+                required: true
                 targetProperty: *ref_589
                 language: !<!Languages> 
                   default:
-                    name: regenerationPeriod
-                    description: The key regeneration time duration specified in ISO-8601 format.
+                    name: autoRegenerateKey
+                    description: whether keyvault should manage the storage account for the user.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_596
-                schema: *ref_185
+                schema: *ref_200
                 implementation: Method
-                originalParameter: *ref_585
+                originalParameter: *ref_586
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_590
                 language: !<!Languages> 
                   default:
-                    name: StorageAccountAttributes
-                    description: The attributes of the storage account.
+                    name: regenerationPeriod
+                    description: The key regeneration time duration specified in ISO-8601 format.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_597
-                schema: *ref_201
+                schema: *ref_185
                 implementation: Method
-                originalParameter: *ref_585
+                originalParameter: *ref_586
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_591
+                language: !<!Languages> 
+                  default:
+                    name: StorageAccountAttributes
+                    description: The attributes of the storage account.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_598
+                schema: *ref_201
+                implementation: Method
+                originalParameter: *ref_586
+                pathToProperty: []
+                required: false
+                targetProperty: *ref_592
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_592
               - *ref_593
               - *ref_594
               - *ref_595
               - *ref_596
               - *ref_597
+              - *ref_598
             language: !<!Languages> 
               default:
                 name: ''
@@ -15417,8 +16397,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_598
           - *ref_599
+          - *ref_600
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -15435,7 +16415,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15491,7 +16471,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_612
+          - !<!Parameter> &ref_613
             schema: *ref_0
             implementation: Method
             required: true
@@ -15509,8 +16489,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_613
-            schema: *ref_565
+          - !<!Parameter> &ref_614
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15525,8 +16505,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_601
-                schema: *ref_600
+              - !<!Parameter> &ref_602
+                schema: *ref_601
                 flattened: true
                 implementation: Method
                 required: true
@@ -15540,67 +16520,80 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_607
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_608
                 schema: *ref_202
                 implementation: Method
-                originalParameter: *ref_601
+                originalParameter: *ref_602
                 pathToProperty: []
-                targetProperty: *ref_602
+                targetProperty: *ref_603
                 language: !<!Languages> 
                   default:
                     name: activeKeyName
                     description: The current active storage account key name.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_608
+              - !<!VirtualParameter> &ref_609
                 schema: *ref_191
                 implementation: Method
-                originalParameter: *ref_601
+                originalParameter: *ref_602
                 pathToProperty: []
-                targetProperty: *ref_603
+                targetProperty: *ref_604
                 language: !<!Languages> 
                   default:
                     name: autoRegenerateKey
                     description: whether keyvault should manage the storage account for the user.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_609
+              - !<!VirtualParameter> &ref_610
                 schema: *ref_203
                 implementation: Method
-                originalParameter: *ref_601
+                originalParameter: *ref_602
                 pathToProperty: []
-                targetProperty: *ref_604
+                targetProperty: *ref_605
                 language: !<!Languages> 
                   default:
                     name: regenerationPeriod
                     description: The key regeneration time duration specified in ISO-8601 format.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_610
+              - !<!VirtualParameter> &ref_611
                 schema: *ref_185
                 implementation: Method
-                originalParameter: *ref_601
+                originalParameter: *ref_602
                 pathToProperty: []
-                targetProperty: *ref_605
+                targetProperty: *ref_606
                 language: !<!Languages> 
                   default:
                     name: StorageAccountAttributes
                     description: The attributes of the storage account.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_611
+              - !<!VirtualParameter> &ref_612
                 schema: *ref_204
                 implementation: Method
-                originalParameter: *ref_601
+                originalParameter: *ref_602
                 pathToProperty: []
-                targetProperty: *ref_606
+                targetProperty: *ref_607
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_607
               - *ref_608
               - *ref_609
               - *ref_610
               - *ref_611
+              - *ref_612
             language: !<!Languages> 
               default:
                 name: ''
@@ -15614,8 +16607,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_612
           - *ref_613
+          - *ref_614
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -15632,7 +16625,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15681,7 +16674,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_618
+          - !<!Parameter> &ref_619
             schema: *ref_0
             implementation: Method
             required: true
@@ -15699,8 +16692,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_619
-            schema: *ref_565
+          - !<!Parameter> &ref_620
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15715,8 +16708,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_615
-                schema: *ref_614
+              - !<!Parameter> &ref_616
+                schema: *ref_615
                 flattened: true
                 implementation: Method
                 required: true
@@ -15730,20 +16723,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_617
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_618
                 schema: *ref_205
                 implementation: Method
-                originalParameter: *ref_615
+                originalParameter: *ref_616
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_616
+                targetProperty: *ref_617
                 language: !<!Languages> 
                   default:
                     name: keyName
                     description: The storage account key name.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_617
+              - *ref_618
             language: !<!Languages> 
               default:
                 name: ''
@@ -15757,8 +16763,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_618
           - *ref_619
+          - *ref_620
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -15775,7 +16781,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15823,7 +16829,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_620
+          - !<!Parameter> &ref_621
             schema: *ref_0
             implementation: Method
             required: true
@@ -15841,8 +16847,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_621
-            schema: *ref_565
+          - !<!Parameter> &ref_622
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15853,8 +16859,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_622
-            schema: *ref_304
+          - !<!Parameter> &ref_623
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15867,6 +16873,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15877,12 +16898,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_620
           - *ref_621
           - *ref_622
+          - *ref_623
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_623
+            schema: *ref_624
             language: !<!Languages> 
               default:
                 name: ''
@@ -15896,7 +16917,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15949,7 +16970,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_624
+          - !<!Parameter> &ref_625
             schema: *ref_0
             implementation: Method
             required: true
@@ -15967,8 +16988,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_625
-            schema: *ref_565
+          - !<!Parameter> &ref_626
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15979,8 +17000,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_626
-            schema: *ref_304
+          - !<!Parameter> &ref_627
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15993,6 +17014,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16003,12 +17039,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_624
           - *ref_625
           - *ref_626
+          - *ref_627
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_627
+            schema: *ref_628
             language: !<!Languages> 
               default:
                 name: ''
@@ -16022,7 +17058,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16082,7 +17118,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_628
+          - !<!Parameter> &ref_629
             schema: *ref_0
             implementation: Method
             required: true
@@ -16100,8 +17136,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_629
-            schema: *ref_565
+          - !<!Parameter> &ref_630
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16112,8 +17148,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_630
-            schema: *ref_565
+          - !<!Parameter> &ref_631
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16127,6 +17163,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16137,9 +17188,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_628
           - *ref_629
           - *ref_630
+          - *ref_631
         responses:
           - !<!SchemaResponse> 
             schema: *ref_217
@@ -16156,7 +17207,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16204,7 +17255,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_631
+          - !<!Parameter> &ref_632
             schema: *ref_0
             implementation: Method
             required: true
@@ -16222,8 +17273,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_632
-            schema: *ref_565
+          - !<!Parameter> &ref_633
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16234,8 +17285,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_633
-            schema: *ref_565
+          - !<!Parameter> &ref_634
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16249,6 +17300,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16259,9 +17325,9 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_631
           - *ref_632
           - *ref_633
+          - *ref_634
         responses:
           - !<!SchemaResponse> 
             schema: *ref_224
@@ -16278,7 +17344,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16323,7 +17389,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_634
+          - !<!Parameter> &ref_635
             schema: *ref_0
             implementation: Method
             required: true
@@ -16341,8 +17407,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_635
-            schema: *ref_565
+          - !<!Parameter> &ref_636
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16353,8 +17419,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_636
-            schema: *ref_565
+          - !<!Parameter> &ref_637
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16368,6 +17434,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16378,9 +17459,9 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_634
           - *ref_635
           - *ref_636
+          - *ref_637
         responses:
           - !<!SchemaResponse> 
             schema: *ref_217
@@ -16397,7 +17478,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16444,7 +17525,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_637
+          - !<!Parameter> &ref_638
             schema: *ref_0
             implementation: Method
             required: true
@@ -16462,8 +17543,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_638
-            schema: *ref_565
+          - !<!Parameter> &ref_639
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16474,8 +17555,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_639
-            schema: *ref_565
+          - !<!Parameter> &ref_640
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16489,6 +17570,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16499,9 +17595,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_637
           - *ref_638
           - *ref_639
+          - *ref_640
         responses:
           - !<!SchemaResponse> 
             schema: *ref_224
@@ -16518,7 +17614,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16562,7 +17658,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_652
+          - !<!Parameter> &ref_653
             schema: *ref_0
             implementation: Method
             required: true
@@ -16580,8 +17676,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_653
-            schema: *ref_565
+          - !<!Parameter> &ref_654
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16592,8 +17688,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_654
-            schema: *ref_565
+          - !<!Parameter> &ref_655
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16608,8 +17704,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_641
-                schema: *ref_640
+              - !<!Parameter> &ref_642
+                schema: *ref_641
                 flattened: true
                 implementation: Method
                 required: true
@@ -16623,72 +17719,85 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_647
-                schema: *ref_226
+              - !<!Parameter> 
+                schema: *ref_260
                 implementation: Method
-                originalParameter: *ref_641
-                pathToProperty: []
+                origin: 'modelerfour:synthesized/accept'
                 required: true
-                targetProperty: *ref_642
                 language: !<!Languages> 
                   default:
-                    name: templateUri
-                    description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
-                protocol: !<!Protocols> {}
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - !<!VirtualParameter> &ref_648
-                schema: *ref_221
+                schema: *ref_226
                 implementation: Method
-                originalParameter: *ref_641
+                originalParameter: *ref_642
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_643
                 language: !<!Languages> 
                   default:
-                    name: sasType
-                    description: The type of SAS token the SAS definition will create.
+                    name: templateUri
+                    description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_649
-                schema: *ref_227
+                schema: *ref_221
                 implementation: Method
-                originalParameter: *ref_641
+                originalParameter: *ref_642
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_644
                 language: !<!Languages> 
                   default:
+                    name: sasType
+                    description: The type of SAS token the SAS definition will create.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_650
+                schema: *ref_227
+                implementation: Method
+                originalParameter: *ref_642
+                pathToProperty: []
+                required: true
+                targetProperty: *ref_645
+                language: !<!Languages> 
+                  default:
                     name: validityPeriod
                     description: The validity period of SAS tokens created according to the SAS definition.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_650
+              - !<!VirtualParameter> &ref_651
                 schema: *ref_215
                 implementation: Method
-                originalParameter: *ref_641
+                originalParameter: *ref_642
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_645
+                targetProperty: *ref_646
                 language: !<!Languages> 
                   default:
                     name: SasDefinitionAttributes
                     description: The attributes of the SAS definition.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_651
+              - !<!VirtualParameter> &ref_652
                 schema: *ref_228
                 implementation: Method
-                originalParameter: *ref_641
+                originalParameter: *ref_642
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_646
+                targetProperty: *ref_647
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_647
               - *ref_648
               - *ref_649
               - *ref_650
               - *ref_651
+              - *ref_652
             language: !<!Languages> 
               default:
                 name: ''
@@ -16702,9 +17811,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_652
           - *ref_653
           - *ref_654
+          - *ref_655
         responses:
           - !<!SchemaResponse> 
             schema: *ref_224
@@ -16721,7 +17830,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16771,7 +17880,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_667
+          - !<!Parameter> &ref_668
             schema: *ref_0
             implementation: Method
             required: true
@@ -16789,8 +17898,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_668
-            schema: *ref_565
+          - !<!Parameter> &ref_669
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16801,8 +17910,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_669
-            schema: *ref_565
+          - !<!Parameter> &ref_670
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16817,8 +17926,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_656
-                schema: *ref_655
+              - !<!Parameter> &ref_657
+                schema: *ref_656
                 flattened: true
                 implementation: Method
                 required: true
@@ -16832,67 +17941,80 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_662
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_663
                 schema: *ref_229
                 implementation: Method
-                originalParameter: *ref_656
+                originalParameter: *ref_657
                 pathToProperty: []
-                targetProperty: *ref_657
+                targetProperty: *ref_658
                 language: !<!Languages> 
                   default:
                     name: templateUri
                     description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_663
+              - !<!VirtualParameter> &ref_664
                 schema: *ref_221
                 implementation: Method
-                originalParameter: *ref_656
+                originalParameter: *ref_657
                 pathToProperty: []
-                targetProperty: *ref_658
+                targetProperty: *ref_659
                 language: !<!Languages> 
                   default:
                     name: sasType
                     description: The type of SAS token the SAS definition will create.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_664
+              - !<!VirtualParameter> &ref_665
                 schema: *ref_230
                 implementation: Method
-                originalParameter: *ref_656
+                originalParameter: *ref_657
                 pathToProperty: []
-                targetProperty: *ref_659
+                targetProperty: *ref_660
                 language: !<!Languages> 
                   default:
                     name: validityPeriod
                     description: The validity period of SAS tokens created according to the SAS definition.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_665
+              - !<!VirtualParameter> &ref_666
                 schema: *ref_215
                 implementation: Method
-                originalParameter: *ref_656
+                originalParameter: *ref_657
                 pathToProperty: []
-                targetProperty: *ref_660
+                targetProperty: *ref_661
                 language: !<!Languages> 
                   default:
                     name: SasDefinitionAttributes
                     description: The attributes of the SAS definition.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_666
+              - !<!VirtualParameter> &ref_667
                 schema: *ref_231
                 implementation: Method
-                originalParameter: *ref_656
+                originalParameter: *ref_657
                 pathToProperty: []
-                targetProperty: *ref_661
+                targetProperty: *ref_662
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_662
               - *ref_663
               - *ref_664
               - *ref_665
               - *ref_666
+              - *ref_667
             language: !<!Languages> 
               default:
                 name: ''
@@ -16906,9 +18028,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_667
           - *ref_668
           - *ref_669
+          - *ref_670
         responses:
           - !<!SchemaResponse> 
             schema: *ref_224
@@ -16925,7 +18047,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/keyvault/modeler.yaml
+++ b/modelerfour/test/scenarios/keyvault/modeler.yaml
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
           name: boolean
           description: 'True if the secret''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_364
+    - !<!BooleanSchema> &ref_365
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -114,7 +114,7 @@ schemas: !<!Schemas>
           name: integer
           description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_278
+    - !<!NumberSchema> &ref_279
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -883,7 +883,7 @@ schemas: !<!Schemas>
           name: DeletedStorageListResult-nextLink
           description: The URL to get the next set of deleted storage accounts.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_451
+    - !<!StringSchema> &ref_452
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1552,6 +1552,16 @@ schemas: !<!Schemas>
         default:
           name: ApiVersion-7.0-preview
           description: Api Version (7.0-preview)
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_261
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
       protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_204
@@ -2661,7 +2671,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_14
-    - !<!ObjectSchema> &ref_262
+    - !<!ObjectSchema> &ref_263
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2730,7 +2740,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_17
-    - !<!ObjectSchema> &ref_266
+    - !<!ObjectSchema> &ref_267
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2783,7 +2793,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_13
-    - !<!ObjectSchema> &ref_273
+    - !<!ObjectSchema> &ref_274
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2833,7 +2843,7 @@ schemas: !<!Schemas>
           description: The key update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_282
+    - !<!ObjectSchema> &ref_283
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2977,7 +2987,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_24
-    - !<!ObjectSchema> &ref_287
+    - !<!ObjectSchema> &ref_288
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3002,7 +3012,7 @@ schemas: !<!Schemas>
           description: 'The backup key result, containing the backup blob.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_289
+    - !<!ObjectSchema> &ref_290
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3027,7 +3037,7 @@ schemas: !<!Schemas>
           description: The key restore parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_294
+    - !<!ObjectSchema> &ref_295
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3061,7 +3071,7 @@ schemas: !<!Schemas>
           description: The key operations parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_296
+    - !<!ObjectSchema> &ref_297
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3095,7 +3105,7 @@ schemas: !<!Schemas>
           description: The key operation result.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_304
+    - !<!ObjectSchema> &ref_305
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3129,7 +3139,7 @@ schemas: !<!Schemas>
           description: The key operations parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_309
+    - !<!ObjectSchema> &ref_310
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3172,7 +3182,7 @@ schemas: !<!Schemas>
           description: The key verify parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_311
+    - !<!ObjectSchema> &ref_312
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3197,7 +3207,7 @@ schemas: !<!Schemas>
           description: The key verify result.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_322
+    - !<!ObjectSchema> &ref_323
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3242,7 +3252,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_25
-    - !<!ObjectSchema> &ref_331
+    - !<!ObjectSchema> &ref_332
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3421,7 +3431,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_38
-    - !<!ObjectSchema> &ref_338
+    - !<!ObjectSchema> &ref_339
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3461,7 +3471,7 @@ schemas: !<!Schemas>
           description: The secret update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_345
+    - !<!ObjectSchema> &ref_346
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3613,7 +3623,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_45
-    - !<!ObjectSchema> &ref_351
+    - !<!ObjectSchema> &ref_352
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3658,7 +3668,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_46
-    - !<!ObjectSchema> &ref_360
+    - !<!ObjectSchema> &ref_361
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3683,7 +3693,7 @@ schemas: !<!Schemas>
           description: 'The backup secret result, containing the backup blob.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_362
+    - !<!ObjectSchema> &ref_363
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3708,7 +3718,7 @@ schemas: !<!Schemas>
           description: The secret restore parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_368
+    - !<!ObjectSchema> &ref_369
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4443,7 +4453,7 @@ schemas: !<!Schemas>
     - *ref_80
     - *ref_81
     - *ref_82
-    - !<!ObjectSchema> &ref_372
+    - !<!ObjectSchema> &ref_373
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4528,7 +4538,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_87
-    - !<!ObjectSchema> &ref_378
+    - !<!ObjectSchema> &ref_379
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4604,7 +4614,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_91
-    - !<!ObjectSchema> &ref_381
+    - !<!ObjectSchema> &ref_382
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4824,7 +4834,7 @@ schemas: !<!Schemas>
     - *ref_102
     - *ref_103
     - *ref_104
-    - !<!ObjectSchema> &ref_383
+    - !<!ObjectSchema> &ref_384
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4881,7 +4891,7 @@ schemas: !<!Schemas>
           description: The issuer for Key Vault certificate.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_386
+    - !<!ObjectSchema> &ref_387
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4929,7 +4939,7 @@ schemas: !<!Schemas>
           description: The certificate issuer update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_394
+    - !<!ObjectSchema> &ref_395
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4969,7 +4979,7 @@ schemas: !<!Schemas>
           description: The certificate create parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_396
+    - !<!ObjectSchema> &ref_397
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5058,7 +5068,7 @@ schemas: !<!Schemas>
           description: A certificate operation is returned in case of asynchronous requests.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_399
+    - !<!ObjectSchema> &ref_400
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5119,7 +5129,7 @@ schemas: !<!Schemas>
           description: The certificate import parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_412
+    - !<!ObjectSchema> &ref_413
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5159,7 +5169,7 @@ schemas: !<!Schemas>
           description: The certificate update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_419
+    - !<!ObjectSchema> &ref_420
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5184,7 +5194,7 @@ schemas: !<!Schemas>
           description: The certificate operation update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_427
+    - !<!ObjectSchema> &ref_428
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5237,7 +5247,7 @@ schemas: !<!Schemas>
           description: The certificate merge parameters
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_431
+    - !<!ObjectSchema> &ref_432
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5262,7 +5272,7 @@ schemas: !<!Schemas>
           description: 'The backup certificate result, containing the backup blob.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_433
+    - !<!ObjectSchema> &ref_434
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5287,7 +5297,7 @@ schemas: !<!Schemas>
           description: The certificate restore parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_438
+    - !<!ObjectSchema> &ref_439
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5332,7 +5342,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_52
-    - !<!ObjectSchema> &ref_447
+    - !<!ObjectSchema> &ref_448
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5534,7 +5544,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_120
     - *ref_123
-    - !<!ObjectSchema> &ref_450
+    - !<!ObjectSchema> &ref_451
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5710,7 +5720,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_133
-    - !<!ObjectSchema> &ref_460
+    - !<!ObjectSchema> &ref_461
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5735,7 +5745,7 @@ schemas: !<!Schemas>
           description: 'The backup storage result, containing the backup blob.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_462
+    - !<!ObjectSchema> &ref_463
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5760,7 +5770,7 @@ schemas: !<!Schemas>
           description: The secret restore parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_470
+    - !<!ObjectSchema> &ref_471
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5830,7 +5840,7 @@ schemas: !<!Schemas>
           description: The storage account create parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_474
+    - !<!ObjectSchema> &ref_475
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5886,7 +5896,7 @@ schemas: !<!Schemas>
           description: The storage account update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_478
+    - !<!ObjectSchema> &ref_479
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5911,7 +5921,7 @@ schemas: !<!Schemas>
           description: The storage account key regenerate parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_483
+    - !<!ObjectSchema> &ref_484
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -6113,7 +6123,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_145
     - *ref_148
-    - !<!ObjectSchema> &ref_487
+    - !<!ObjectSchema> &ref_488
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -6289,7 +6299,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_158
-    - !<!ObjectSchema> &ref_503
+    - !<!ObjectSchema> &ref_504
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -6350,7 +6360,7 @@ schemas: !<!Schemas>
           description: The SAS definition create parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_508
+    - !<!ObjectSchema> &ref_509
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -6452,7 +6462,7 @@ schemas: !<!Schemas>
     - *ref_191
     - *ref_192
 globalParameters:
-  - !<!Parameter> &ref_263
+  - !<!Parameter> &ref_264
     schema: *ref_257
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -6504,11 +6514,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_261
+              - !<!Parameter> &ref_262
                 schema: *ref_260
                 implementation: Method
                 required: true
@@ -6522,8 +6532,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_261
+              - *ref_262
             language: !<!Languages> 
               default:
                 name: ''
@@ -6555,7 +6578,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -6622,7 +6645,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_264
+          - !<!Parameter> &ref_265
             schema: *ref_0
             implementation: Method
             required: true
@@ -6640,7 +6663,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_265
+          - !<!Parameter> &ref_266
             schema: *ref_256
             implementation: Method
             required: true
@@ -6652,12 +6675,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_267
-                schema: *ref_266
+              - !<!Parameter> &ref_268
+                schema: *ref_267
                 implementation: Method
                 required: true
                 extensions:
@@ -6670,8 +6693,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_267
+              - *ref_268
             language: !<!Languages> 
               default:
                 name: ''
@@ -6685,8 +6721,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_264
           - *ref_265
+          - *ref_266
         responses:
           - !<!SchemaResponse> 
             schema: *ref_12
@@ -6703,7 +6739,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -6770,7 +6806,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_268
+          - !<!Parameter> &ref_269
             schema: *ref_0
             implementation: Method
             required: true
@@ -6788,7 +6824,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_269
+          - !<!Parameter> &ref_270
             schema: *ref_6
             implementation: Method
             required: true
@@ -6800,9 +6836,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6813,8 +6864,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_268
           - *ref_269
+          - *ref_270
         responses:
           - !<!SchemaResponse> 
             schema: *ref_13
@@ -6831,7 +6882,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -6889,7 +6940,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_270
+          - !<!Parameter> &ref_271
             schema: *ref_0
             implementation: Method
             required: true
@@ -6907,7 +6958,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_271
+          - !<!Parameter> &ref_272
             schema: *ref_6
             implementation: Method
             required: true
@@ -6919,7 +6970,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_272
+          - !<!Parameter> &ref_273
             schema: *ref_6
             implementation: Method
             required: true
@@ -6931,12 +6982,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_274
-                schema: *ref_273
+              - !<!Parameter> &ref_275
+                schema: *ref_274
                 implementation: Method
                 required: true
                 extensions:
@@ -6949,8 +7000,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_274
+              - *ref_275
             language: !<!Languages> 
               default:
                 name: ''
@@ -6964,9 +7028,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_270
           - *ref_271
           - *ref_272
+          - *ref_273
         responses:
           - !<!SchemaResponse> 
             schema: *ref_12
@@ -6983,7 +7047,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -7040,7 +7104,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_275
+          - !<!Parameter> &ref_276
             schema: *ref_0
             implementation: Method
             required: true
@@ -7058,7 +7122,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_276
+          - !<!Parameter> &ref_277
             schema: *ref_6
             implementation: Method
             required: true
@@ -7070,7 +7134,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_277
+          - !<!Parameter> &ref_278
             schema: *ref_6
             implementation: Method
             required: true
@@ -7082,9 +7146,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -7095,9 +7174,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_275
           - *ref_276
           - *ref_277
+          - *ref_278
         responses:
           - !<!SchemaResponse> 
             schema: *ref_12
@@ -7114,7 +7193,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -7168,7 +7247,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_279
+          - !<!Parameter> &ref_280
             schema: *ref_0
             implementation: Method
             required: true
@@ -7186,7 +7265,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_280
+          - !<!Parameter> &ref_281
             schema: *ref_6
             implementation: Method
             required: true
@@ -7198,8 +7277,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_281
-            schema: *ref_278
+          - !<!Parameter> &ref_282
+            schema: *ref_279
             implementation: Method
             language: !<!Languages> 
               default:
@@ -7209,9 +7288,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -7222,12 +7316,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_279
           - *ref_280
           - *ref_281
+          - *ref_282
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_282
+            schema: *ref_283
             language: !<!Languages> 
               default:
                 name: ''
@@ -7241,7 +7335,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -7289,7 +7383,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_283
+          - !<!Parameter> &ref_284
             schema: *ref_0
             implementation: Method
             required: true
@@ -7307,8 +7401,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_284
-            schema: *ref_278
+          - !<!Parameter> &ref_285
+            schema: *ref_279
             implementation: Method
             language: !<!Languages> 
               default:
@@ -7318,9 +7412,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -7331,11 +7440,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_283
           - *ref_284
+          - *ref_285
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_282
+            schema: *ref_283
             language: !<!Languages> 
               default:
                 name: ''
@@ -7349,7 +7458,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -7397,7 +7506,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_285
+          - !<!Parameter> &ref_286
             schema: *ref_0
             implementation: Method
             required: true
@@ -7415,7 +7524,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_286
+          - !<!Parameter> &ref_287
             schema: *ref_6
             implementation: Method
             required: true
@@ -7427,9 +7536,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -7440,11 +7564,11 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_285
           - *ref_286
+          - *ref_287
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_287
+            schema: *ref_288
             language: !<!Languages> 
               default:
                 name: ''
@@ -7458,7 +7582,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -7497,7 +7621,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_288
+          - !<!Parameter> &ref_289
             schema: *ref_0
             implementation: Method
             required: true
@@ -7515,12 +7639,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_290
-                schema: *ref_289
+              - !<!Parameter> &ref_291
+                schema: *ref_290
                 implementation: Method
                 required: true
                 extensions:
@@ -7533,8 +7657,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_290
+              - *ref_291
             language: !<!Languages> 
               default:
                 name: ''
@@ -7548,7 +7685,7 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_288
+          - *ref_289
         responses:
           - !<!SchemaResponse> 
             schema: *ref_12
@@ -7565,7 +7702,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -7624,7 +7761,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_291
+          - !<!Parameter> &ref_292
             schema: *ref_0
             implementation: Method
             required: true
@@ -7642,7 +7779,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_292
+          - !<!Parameter> &ref_293
             schema: *ref_6
             implementation: Method
             required: true
@@ -7654,7 +7791,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_293
+          - !<!Parameter> &ref_294
             schema: *ref_6
             implementation: Method
             required: true
@@ -7666,12 +7803,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_295
-                schema: *ref_294
+              - !<!Parameter> &ref_296
+                schema: *ref_295
                 implementation: Method
                 required: true
                 extensions:
@@ -7684,8 +7821,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_295
+              - *ref_296
             language: !<!Languages> 
               default:
                 name: ''
@@ -7699,12 +7849,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_291
           - *ref_292
           - *ref_293
+          - *ref_294
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_296
+            schema: *ref_297
             language: !<!Languages> 
               default:
                 name: ''
@@ -7718,7 +7868,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -7760,7 +7910,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_297
+          - !<!Parameter> &ref_298
             schema: *ref_0
             implementation: Method
             required: true
@@ -7778,7 +7928,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_298
+          - !<!Parameter> &ref_299
             schema: *ref_6
             implementation: Method
             required: true
@@ -7790,7 +7940,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_299
+          - !<!Parameter> &ref_300
             schema: *ref_6
             implementation: Method
             required: true
@@ -7802,12 +7952,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_300
-                schema: *ref_294
+              - !<!Parameter> &ref_301
+                schema: *ref_295
                 implementation: Method
                 required: true
                 extensions:
@@ -7820,8 +7970,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_300
+              - *ref_301
             language: !<!Languages> 
               default:
                 name: ''
@@ -7835,12 +7998,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_297
           - *ref_298
           - *ref_299
+          - *ref_300
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_296
+            schema: *ref_297
             language: !<!Languages> 
               default:
                 name: ''
@@ -7854,7 +8017,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -7896,7 +8059,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_301
+          - !<!Parameter> &ref_302
             schema: *ref_0
             implementation: Method
             required: true
@@ -7914,7 +8077,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_302
+          - !<!Parameter> &ref_303
             schema: *ref_6
             implementation: Method
             required: true
@@ -7926,7 +8089,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_303
+          - !<!Parameter> &ref_304
             schema: *ref_6
             implementation: Method
             required: true
@@ -7938,12 +8101,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_305
-                schema: *ref_304
+              - !<!Parameter> &ref_306
+                schema: *ref_305
                 implementation: Method
                 required: true
                 extensions:
@@ -7956,8 +8119,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_305
+              - *ref_306
             language: !<!Languages> 
               default:
                 name: ''
@@ -7971,12 +8147,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_301
           - *ref_302
           - *ref_303
+          - *ref_304
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_296
+            schema: *ref_297
             language: !<!Languages> 
               default:
                 name: ''
@@ -7990,7 +8166,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -8029,7 +8205,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_306
+          - !<!Parameter> &ref_307
             schema: *ref_0
             implementation: Method
             required: true
@@ -8047,7 +8223,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_307
+          - !<!Parameter> &ref_308
             schema: *ref_6
             implementation: Method
             required: true
@@ -8059,7 +8235,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_308
+          - !<!Parameter> &ref_309
             schema: *ref_6
             implementation: Method
             required: true
@@ -8071,12 +8247,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_310
-                schema: *ref_309
+              - !<!Parameter> &ref_311
+                schema: *ref_310
                 implementation: Method
                 required: true
                 extensions:
@@ -8089,8 +8265,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_310
+              - *ref_311
             language: !<!Languages> 
               default:
                 name: ''
@@ -8104,12 +8293,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_306
           - *ref_307
           - *ref_308
+          - *ref_309
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_311
+            schema: *ref_312
             language: !<!Languages> 
               default:
                 name: ''
@@ -8123,7 +8312,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -8162,7 +8351,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_312
+          - !<!Parameter> &ref_313
             schema: *ref_0
             implementation: Method
             required: true
@@ -8180,7 +8369,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_313
+          - !<!Parameter> &ref_314
             schema: *ref_6
             implementation: Method
             required: true
@@ -8192,7 +8381,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_314
+          - !<!Parameter> &ref_315
             schema: *ref_6
             implementation: Method
             required: true
@@ -8204,12 +8393,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_315
-                schema: *ref_294
+              - !<!Parameter> &ref_316
+                schema: *ref_295
                 implementation: Method
                 required: true
                 extensions:
@@ -8222,8 +8411,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_315
+              - *ref_316
             language: !<!Languages> 
               default:
                 name: ''
@@ -8237,12 +8439,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_312
           - *ref_313
           - *ref_314
+          - *ref_315
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_296
+            schema: *ref_297
             language: !<!Languages> 
               default:
                 name: ''
@@ -8256,7 +8458,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -8298,7 +8500,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_316
+          - !<!Parameter> &ref_317
             schema: *ref_0
             implementation: Method
             required: true
@@ -8316,7 +8518,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_317
+          - !<!Parameter> &ref_318
             schema: *ref_6
             implementation: Method
             required: true
@@ -8328,7 +8530,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_318
+          - !<!Parameter> &ref_319
             schema: *ref_6
             implementation: Method
             required: true
@@ -8340,12 +8542,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_319
-                schema: *ref_294
+              - !<!Parameter> &ref_320
+                schema: *ref_295
                 implementation: Method
                 required: true
                 extensions:
@@ -8358,8 +8560,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_319
+              - *ref_320
             language: !<!Languages> 
               default:
                 name: ''
@@ -8373,12 +8588,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_316
           - *ref_317
           - *ref_318
+          - *ref_319
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_296
+            schema: *ref_297
             language: !<!Languages> 
               default:
                 name: ''
@@ -8392,7 +8607,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -8433,7 +8648,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_320
+          - !<!Parameter> &ref_321
             schema: *ref_0
             implementation: Method
             required: true
@@ -8451,8 +8666,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_321
-            schema: *ref_278
+          - !<!Parameter> &ref_322
+            schema: *ref_279
             implementation: Method
             language: !<!Languages> 
               default:
@@ -8462,9 +8677,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -8475,11 +8705,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_320
           - *ref_321
+          - *ref_322
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_322
+            schema: *ref_323
             language: !<!Languages> 
               default:
                 name: ''
@@ -8493,7 +8723,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -8544,7 +8774,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_323
+          - !<!Parameter> &ref_324
             schema: *ref_0
             implementation: Method
             required: true
@@ -8562,7 +8792,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_324
+          - !<!Parameter> &ref_325
             schema: *ref_6
             implementation: Method
             required: true
@@ -8574,9 +8804,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -8587,8 +8832,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_323
           - *ref_324
+          - *ref_325
         responses:
           - !<!SchemaResponse> 
             schema: *ref_13
@@ -8605,7 +8850,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -8663,7 +8908,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_325
+          - !<!Parameter> &ref_326
             schema: *ref_0
             implementation: Method
             required: true
@@ -8681,7 +8926,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_326
+          - !<!Parameter> &ref_327
             schema: *ref_6
             implementation: Method
             required: true
@@ -8693,9 +8938,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -8706,8 +8966,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_325
           - *ref_326
+          - *ref_327
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -8720,7 +8980,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -8754,7 +9014,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_327
+          - !<!Parameter> &ref_328
             schema: *ref_0
             implementation: Method
             required: true
@@ -8772,7 +9032,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_328
+          - !<!Parameter> &ref_329
             schema: *ref_6
             implementation: Method
             required: true
@@ -8784,9 +9044,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -8797,8 +9072,8 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_327
           - *ref_328
+          - *ref_329
         responses:
           - !<!SchemaResponse> 
             schema: *ref_12
@@ -8815,7 +9090,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -8870,7 +9145,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_329
+          - !<!Parameter> &ref_330
             schema: *ref_0
             implementation: Method
             required: true
@@ -8888,7 +9163,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_330
+          - !<!Parameter> &ref_331
             schema: *ref_256
             implementation: Method
             required: true
@@ -8900,12 +9175,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_332
-                schema: *ref_331
+              - !<!Parameter> &ref_333
+                schema: *ref_332
                 implementation: Method
                 required: true
                 extensions:
@@ -8918,8 +9193,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_332
+              - *ref_333
             language: !<!Languages> 
               default:
                 name: ''
@@ -8933,8 +9221,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_329
           - *ref_330
+          - *ref_331
         responses:
           - !<!SchemaResponse> 
             schema: *ref_37
@@ -8951,7 +9239,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -8992,7 +9280,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_333
+          - !<!Parameter> &ref_334
             schema: *ref_0
             implementation: Method
             required: true
@@ -9010,7 +9298,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_334
+          - !<!Parameter> &ref_335
             schema: *ref_6
             implementation: Method
             required: true
@@ -9022,9 +9310,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9035,8 +9338,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_333
           - *ref_334
+          - *ref_335
         responses:
           - !<!SchemaResponse> 
             schema: *ref_38
@@ -9053,7 +9356,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -9094,7 +9397,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_335
+          - !<!Parameter> &ref_336
             schema: *ref_0
             implementation: Method
             required: true
@@ -9112,7 +9415,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_336
+          - !<!Parameter> &ref_337
             schema: *ref_6
             implementation: Method
             required: true
@@ -9124,7 +9427,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_337
+          - !<!Parameter> &ref_338
             schema: *ref_6
             implementation: Method
             required: true
@@ -9136,12 +9439,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_339
-                schema: *ref_338
+              - !<!Parameter> &ref_340
+                schema: *ref_339
                 implementation: Method
                 required: true
                 extensions:
@@ -9154,8 +9457,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_339
+              - *ref_340
             language: !<!Languages> 
               default:
                 name: ''
@@ -9169,9 +9485,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_335
           - *ref_336
           - *ref_337
+          - *ref_338
         responses:
           - !<!SchemaResponse> 
             schema: *ref_37
@@ -9188,7 +9504,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -9238,7 +9554,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_340
+          - !<!Parameter> &ref_341
             schema: *ref_0
             implementation: Method
             required: true
@@ -9256,7 +9572,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_341
+          - !<!Parameter> &ref_342
             schema: *ref_6
             implementation: Method
             required: true
@@ -9268,7 +9584,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_342
+          - !<!Parameter> &ref_343
             schema: *ref_6
             implementation: Method
             required: true
@@ -9280,9 +9596,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9293,9 +9624,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_340
           - *ref_341
           - *ref_342
+          - *ref_343
         responses:
           - !<!SchemaResponse> 
             schema: *ref_37
@@ -9312,7 +9643,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -9352,7 +9683,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_343
+          - !<!Parameter> &ref_344
             schema: *ref_0
             implementation: Method
             required: true
@@ -9370,8 +9701,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_344
-            schema: *ref_278
+          - !<!Parameter> &ref_345
+            schema: *ref_279
             implementation: Method
             language: !<!Languages> 
               default:
@@ -9381,9 +9712,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9394,11 +9740,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_343
           - *ref_344
+          - *ref_345
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_345
+            schema: *ref_346
             language: !<!Languages> 
               default:
                 name: ''
@@ -9412,7 +9758,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -9459,7 +9805,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_346
+          - !<!Parameter> &ref_347
             schema: *ref_0
             implementation: Method
             required: true
@@ -9477,7 +9823,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_347
+          - !<!Parameter> &ref_348
             schema: *ref_6
             implementation: Method
             required: true
@@ -9489,8 +9835,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_348
-            schema: *ref_278
+          - !<!Parameter> &ref_349
+            schema: *ref_279
             implementation: Method
             language: !<!Languages> 
               default:
@@ -9500,9 +9846,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9513,12 +9874,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_346
           - *ref_347
           - *ref_348
+          - *ref_349
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_345
+            schema: *ref_346
             language: !<!Languages> 
               default:
                 name: ''
@@ -9532,7 +9893,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -9577,7 +9938,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_349
+          - !<!Parameter> &ref_350
             schema: *ref_0
             implementation: Method
             required: true
@@ -9595,8 +9956,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_350
-            schema: *ref_278
+          - !<!Parameter> &ref_351
+            schema: *ref_279
             implementation: Method
             language: !<!Languages> 
               default:
@@ -9606,9 +9967,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9619,11 +9995,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_349
           - *ref_350
+          - *ref_351
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_351
+            schema: *ref_352
             language: !<!Languages> 
               default:
                 name: ''
@@ -9637,7 +10013,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -9687,7 +10063,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_352
+          - !<!Parameter> &ref_353
             schema: *ref_0
             implementation: Method
             required: true
@@ -9705,7 +10081,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_353
+          - !<!Parameter> &ref_354
             schema: *ref_6
             implementation: Method
             required: true
@@ -9717,9 +10093,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9730,8 +10121,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_352
           - *ref_353
+          - *ref_354
         responses:
           - !<!SchemaResponse> 
             schema: *ref_38
@@ -9748,7 +10139,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -9789,7 +10180,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_354
+          - !<!Parameter> &ref_355
             schema: *ref_0
             implementation: Method
             required: true
@@ -9807,7 +10198,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_355
+          - !<!Parameter> &ref_356
             schema: *ref_6
             implementation: Method
             required: true
@@ -9819,9 +10210,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9832,8 +10238,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_354
           - *ref_355
+          - *ref_356
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -9846,7 +10252,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -9878,7 +10284,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_356
+          - !<!Parameter> &ref_357
             schema: *ref_0
             implementation: Method
             required: true
@@ -9896,7 +10302,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_357
+          - !<!Parameter> &ref_358
             schema: *ref_6
             implementation: Method
             required: true
@@ -9908,9 +10314,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9921,8 +10342,8 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_356
           - *ref_357
+          - *ref_358
         responses:
           - !<!SchemaResponse> 
             schema: *ref_37
@@ -9939,7 +10360,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -9977,7 +10398,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_358
+          - !<!Parameter> &ref_359
             schema: *ref_0
             implementation: Method
             required: true
@@ -9995,7 +10416,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_359
+          - !<!Parameter> &ref_360
             schema: *ref_6
             implementation: Method
             required: true
@@ -10007,9 +10428,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10020,11 +10456,11 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_358
           - *ref_359
+          - *ref_360
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_360
+            schema: *ref_361
             language: !<!Languages> 
               default:
                 name: ''
@@ -10038,7 +10474,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -10072,7 +10508,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_361
+          - !<!Parameter> &ref_362
             schema: *ref_0
             implementation: Method
             required: true
@@ -10090,12 +10526,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_363
-                schema: *ref_362
+              - !<!Parameter> &ref_364
+                schema: *ref_363
                 implementation: Method
                 required: true
                 extensions:
@@ -10108,8 +10544,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_363
+              - *ref_364
             language: !<!Languages> 
               default:
                 name: ''
@@ -10123,7 +10572,7 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_361
+          - *ref_362
         responses:
           - !<!SchemaResponse> 
             schema: *ref_37
@@ -10140,7 +10589,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -10183,7 +10632,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_365
+          - !<!Parameter> &ref_366
             schema: *ref_0
             implementation: Method
             required: true
@@ -10201,8 +10650,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_366
-            schema: *ref_278
+          - !<!Parameter> &ref_367
+            schema: *ref_279
             implementation: Method
             language: !<!Languages> 
               default:
@@ -10212,8 +10661,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_367
-            schema: *ref_364
+          - !<!Parameter> &ref_368
+            schema: *ref_365
             implementation: Method
             language: !<!Languages> 
               default:
@@ -10223,9 +10672,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10236,12 +10700,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_365
           - *ref_366
           - *ref_367
+          - *ref_368
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_368
+            schema: *ref_369
             language: !<!Languages> 
               default:
                 name: ''
@@ -10255,7 +10719,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -10308,7 +10772,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_369
+          - !<!Parameter> &ref_370
             schema: *ref_0
             implementation: Method
             required: true
@@ -10326,7 +10790,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_370
+          - !<!Parameter> &ref_371
             schema: *ref_6
             implementation: Method
             required: true
@@ -10338,9 +10802,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10351,8 +10830,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_369
           - *ref_370
+          - *ref_371
         responses:
           - !<!SchemaResponse> 
             schema: *ref_72
@@ -10369,7 +10848,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -10446,7 +10925,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_371
+          - !<!Parameter> &ref_372
             schema: *ref_0
             implementation: Method
             required: true
@@ -10464,12 +10943,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_373
-                schema: *ref_372
+              - !<!Parameter> &ref_374
+                schema: *ref_373
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -10480,8 +10959,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_373
+              - *ref_374
             language: !<!Languages> 
               default:
                 name: ''
@@ -10495,10 +10987,10 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_371
+          - *ref_372
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_372
+            schema: *ref_373
             language: !<!Languages> 
               default:
                 name: ''
@@ -10512,7 +11004,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -10559,7 +11051,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_374
+          - !<!Parameter> &ref_375
             schema: *ref_0
             implementation: Method
             required: true
@@ -10577,9 +11069,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10590,10 +11097,10 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_374
+          - *ref_375
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_372
+            schema: *ref_373
             language: !<!Languages> 
               default:
                 name: ''
@@ -10607,7 +11114,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -10646,7 +11153,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_375
+          - !<!Parameter> &ref_376
             schema: *ref_0
             implementation: Method
             required: true
@@ -10664,9 +11171,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10677,10 +11199,10 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_375
+          - *ref_376
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_372
+            schema: *ref_373
             language: !<!Languages> 
               default:
                 name: ''
@@ -10694,7 +11216,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -10733,7 +11255,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_376
+          - !<!Parameter> &ref_377
             schema: *ref_0
             implementation: Method
             required: true
@@ -10751,8 +11273,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_377
-            schema: *ref_278
+          - !<!Parameter> &ref_378
+            schema: *ref_279
             implementation: Method
             language: !<!Languages> 
               default:
@@ -10762,9 +11284,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10775,11 +11312,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_376
           - *ref_377
+          - *ref_378
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_378
+            schema: *ref_379
             language: !<!Languages> 
               default:
                 name: ''
@@ -10793,7 +11330,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -10836,7 +11373,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_379
+          - !<!Parameter> &ref_380
             schema: *ref_0
             implementation: Method
             required: true
@@ -10854,7 +11391,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_380
+          - !<!Parameter> &ref_381
             schema: *ref_6
             implementation: Method
             required: true
@@ -10866,12 +11403,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_382
-                schema: *ref_381
+              - !<!Parameter> &ref_383
+                schema: *ref_382
                 implementation: Method
                 required: true
                 extensions:
@@ -10884,8 +11421,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_382
+              - *ref_383
             language: !<!Languages> 
               default:
                 name: ''
@@ -10899,11 +11449,11 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_379
           - *ref_380
+          - *ref_381
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_383
+            schema: *ref_384
             language: !<!Languages> 
               default:
                 name: ''
@@ -10917,7 +11467,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -10975,7 +11525,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_384
+          - !<!Parameter> &ref_385
             schema: *ref_0
             implementation: Method
             required: true
@@ -10993,7 +11543,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_385
+          - !<!Parameter> &ref_386
             schema: *ref_6
             implementation: Method
             required: true
@@ -11005,12 +11555,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_387
-                schema: *ref_386
+              - !<!Parameter> &ref_388
+                schema: *ref_387
                 implementation: Method
                 required: true
                 extensions:
@@ -11023,8 +11573,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_387
+              - *ref_388
             language: !<!Languages> 
               default:
                 name: ''
@@ -11038,11 +11601,11 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_384
           - *ref_385
+          - *ref_386
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_383
+            schema: *ref_384
             language: !<!Languages> 
               default:
                 name: ''
@@ -11056,7 +11619,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -11108,7 +11671,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_388
+          - !<!Parameter> &ref_389
             schema: *ref_0
             implementation: Method
             required: true
@@ -11126,7 +11689,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_389
+          - !<!Parameter> &ref_390
             schema: *ref_6
             implementation: Method
             required: true
@@ -11138,9 +11701,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11151,11 +11729,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_388
           - *ref_389
+          - *ref_390
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_383
+            schema: *ref_384
             language: !<!Languages> 
               default:
                 name: ''
@@ -11169,7 +11747,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -11216,7 +11794,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_390
+          - !<!Parameter> &ref_391
             schema: *ref_0
             implementation: Method
             required: true
@@ -11234,7 +11812,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_391
+          - !<!Parameter> &ref_392
             schema: *ref_6
             implementation: Method
             required: true
@@ -11246,9 +11824,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11259,11 +11852,11 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_390
           - *ref_391
+          - *ref_392
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_383
+            schema: *ref_384
             language: !<!Languages> 
               default:
                 name: ''
@@ -11277,7 +11870,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -11324,7 +11917,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_392
+          - !<!Parameter> &ref_393
             schema: *ref_0
             implementation: Method
             required: true
@@ -11342,7 +11935,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_393
+          - !<!Parameter> &ref_394
             schema: *ref_256
             implementation: Method
             required: true
@@ -11354,12 +11947,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_395
-                schema: *ref_394
+              - !<!Parameter> &ref_396
+                schema: *ref_395
                 implementation: Method
                 required: true
                 extensions:
@@ -11372,8 +11965,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_395
+              - *ref_396
             language: !<!Languages> 
               default:
                 name: ''
@@ -11387,11 +11993,11 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_392
           - *ref_393
+          - *ref_394
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_396
+            schema: *ref_397
             language: !<!Languages> 
               default:
                 name: ''
@@ -11405,7 +12011,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -11463,7 +12069,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_397
+          - !<!Parameter> &ref_398
             schema: *ref_0
             implementation: Method
             required: true
@@ -11481,7 +12087,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_398
+          - !<!Parameter> &ref_399
             schema: *ref_256
             implementation: Method
             required: true
@@ -11493,12 +12099,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_400
-                schema: *ref_399
+              - !<!Parameter> &ref_401
+                schema: *ref_400
                 implementation: Method
                 required: true
                 extensions:
@@ -11511,8 +12117,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_400
+              - *ref_401
             language: !<!Languages> 
               default:
                 name: ''
@@ -11526,8 +12145,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_397
           - *ref_398
+          - *ref_399
         responses:
           - !<!SchemaResponse> 
             schema: *ref_73
@@ -11544,7 +12163,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -11630,7 +12249,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_401
+          - !<!Parameter> &ref_402
             schema: *ref_0
             implementation: Method
             required: true
@@ -11648,7 +12267,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_402
+          - !<!Parameter> &ref_403
             schema: *ref_6
             implementation: Method
             required: true
@@ -11660,8 +12279,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_403
-            schema: *ref_278
+          - !<!Parameter> &ref_404
+            schema: *ref_279
             implementation: Method
             language: !<!Languages> 
               default:
@@ -11671,9 +12290,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11684,12 +12318,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_401
           - *ref_402
           - *ref_403
+          - *ref_404
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_368
+            schema: *ref_369
             language: !<!Languages> 
               default:
                 name: ''
@@ -11703,7 +12337,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -11757,7 +12391,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_404
+          - !<!Parameter> &ref_405
             schema: *ref_0
             implementation: Method
             required: true
@@ -11775,7 +12409,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_405
+          - !<!Parameter> &ref_406
             schema: *ref_6
             implementation: Method
             required: true
@@ -11787,9 +12421,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11800,8 +12449,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_404
           - *ref_405
+          - *ref_406
         responses:
           - !<!SchemaResponse> 
             schema: *ref_74
@@ -11818,7 +12467,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -11876,7 +12525,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_406
+          - !<!Parameter> &ref_407
             schema: *ref_0
             implementation: Method
             required: true
@@ -11894,7 +12543,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_407
+          - !<!Parameter> &ref_408
             schema: *ref_6
             implementation: Method
             required: true
@@ -11906,11 +12555,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_408
+              - !<!Parameter> &ref_409
                 schema: *ref_74
                 implementation: Method
                 required: true
@@ -11922,8 +12571,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_408
+              - *ref_409
             language: !<!Languages> 
               default:
                 name: ''
@@ -11937,8 +12599,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_406
           - *ref_407
+          - *ref_408
         responses:
           - !<!SchemaResponse> 
             schema: *ref_74
@@ -11955,7 +12617,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -12035,7 +12697,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_409
+          - !<!Parameter> &ref_410
             schema: *ref_0
             implementation: Method
             required: true
@@ -12053,7 +12715,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_410
+          - !<!Parameter> &ref_411
             schema: *ref_6
             implementation: Method
             required: true
@@ -12065,7 +12727,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_411
+          - !<!Parameter> &ref_412
             schema: *ref_6
             implementation: Method
             required: true
@@ -12077,12 +12739,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_413
-                schema: *ref_412
+              - !<!Parameter> &ref_414
+                schema: *ref_413
                 implementation: Method
                 required: true
                 extensions:
@@ -12095,8 +12757,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_413
+              - *ref_414
             language: !<!Languages> 
               default:
                 name: ''
@@ -12110,9 +12785,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_409
           - *ref_410
           - *ref_411
+          - *ref_412
         responses:
           - !<!SchemaResponse> 
             schema: *ref_73
@@ -12129,7 +12804,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -12183,7 +12858,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_414
+          - !<!Parameter> &ref_415
             schema: *ref_0
             implementation: Method
             required: true
@@ -12201,7 +12876,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_415
+          - !<!Parameter> &ref_416
             schema: *ref_6
             implementation: Method
             required: true
@@ -12213,7 +12888,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_416
+          - !<!Parameter> &ref_417
             schema: *ref_6
             implementation: Method
             required: true
@@ -12225,9 +12900,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12238,9 +12928,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_414
           - *ref_415
           - *ref_416
+          - *ref_417
         responses:
           - !<!SchemaResponse> 
             schema: *ref_73
@@ -12257,7 +12947,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -12299,7 +12989,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_417
+          - !<!Parameter> &ref_418
             schema: *ref_0
             implementation: Method
             required: true
@@ -12317,7 +13007,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_418
+          - !<!Parameter> &ref_419
             schema: *ref_6
             implementation: Method
             required: true
@@ -12329,12 +13019,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_420
-                schema: *ref_419
+              - !<!Parameter> &ref_421
+                schema: *ref_420
                 implementation: Method
                 required: true
                 extensions:
@@ -12347,8 +13037,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_420
+              - *ref_421
             language: !<!Languages> 
               default:
                 name: ''
@@ -12362,11 +13065,11 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_417
           - *ref_418
+          - *ref_419
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_396
+            schema: *ref_397
             language: !<!Languages> 
               default:
                 name: ''
@@ -12380,7 +13083,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -12423,7 +13126,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_421
+          - !<!Parameter> &ref_422
             schema: *ref_0
             implementation: Method
             required: true
@@ -12441,7 +13144,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_422
+          - !<!Parameter> &ref_423
             schema: *ref_6
             implementation: Method
             required: true
@@ -12453,9 +13156,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12466,11 +13184,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_421
           - *ref_422
+          - *ref_423
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_396
+            schema: *ref_397
             language: !<!Languages> 
               default:
                 name: ''
@@ -12484,7 +13202,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -12525,7 +13243,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_423
+          - !<!Parameter> &ref_424
             schema: *ref_0
             implementation: Method
             required: true
@@ -12543,7 +13261,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_424
+          - !<!Parameter> &ref_425
             schema: *ref_6
             implementation: Method
             required: true
@@ -12555,9 +13273,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12568,11 +13301,11 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_423
           - *ref_424
+          - *ref_425
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_396
+            schema: *ref_397
             language: !<!Languages> 
               default:
                 name: ''
@@ -12586,7 +13319,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -12627,7 +13360,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_425
+          - !<!Parameter> &ref_426
             schema: *ref_0
             implementation: Method
             required: true
@@ -12645,7 +13378,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_426
+          - !<!Parameter> &ref_427
             schema: *ref_6
             implementation: Method
             required: true
@@ -12657,12 +13390,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_428
-                schema: *ref_427
+              - !<!Parameter> &ref_429
+                schema: *ref_428
                 implementation: Method
                 required: true
                 extensions:
@@ -12675,8 +13408,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_428
+              - *ref_429
             language: !<!Languages> 
               default:
                 name: ''
@@ -12690,8 +13436,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_425
           - *ref_426
+          - *ref_427
         responses:
           - !<!SchemaResponse> 
             schema: *ref_73
@@ -12708,7 +13454,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -12782,7 +13528,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_429
+          - !<!Parameter> &ref_430
             schema: *ref_0
             implementation: Method
             required: true
@@ -12800,7 +13546,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_430
+          - !<!Parameter> &ref_431
             schema: *ref_6
             implementation: Method
             required: true
@@ -12812,9 +13558,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12825,11 +13586,11 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_429
           - *ref_430
+          - *ref_431
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_431
+            schema: *ref_432
             language: !<!Languages> 
               default:
                 name: ''
@@ -12843,7 +13604,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -12877,7 +13638,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_432
+          - !<!Parameter> &ref_433
             schema: *ref_0
             implementation: Method
             required: true
@@ -12895,12 +13656,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_434
-                schema: *ref_433
+              - !<!Parameter> &ref_435
+                schema: *ref_434
                 implementation: Method
                 required: true
                 extensions:
@@ -12913,8 +13674,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_434
+              - *ref_435
             language: !<!Languages> 
               default:
                 name: ''
@@ -12928,7 +13702,7 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_432
+          - *ref_433
         responses:
           - !<!SchemaResponse> 
             schema: *ref_73
@@ -12945,7 +13719,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -13023,7 +13797,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_435
+          - !<!Parameter> &ref_436
             schema: *ref_0
             implementation: Method
             required: true
@@ -13041,8 +13815,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_436
-            schema: *ref_278
+          - !<!Parameter> &ref_437
+            schema: *ref_279
             implementation: Method
             language: !<!Languages> 
               default:
@@ -13052,8 +13826,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_437
-            schema: *ref_364
+          - !<!Parameter> &ref_438
+            schema: *ref_365
             implementation: Method
             language: !<!Languages> 
               default:
@@ -13063,9 +13837,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13076,12 +13865,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_435
           - *ref_436
           - *ref_437
+          - *ref_438
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_438
+            schema: *ref_439
             language: !<!Languages> 
               default:
                 name: ''
@@ -13095,7 +13884,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -13148,7 +13937,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_439
+          - !<!Parameter> &ref_440
             schema: *ref_0
             implementation: Method
             required: true
@@ -13166,7 +13955,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_440
+          - !<!Parameter> &ref_441
             schema: *ref_6
             implementation: Method
             required: true
@@ -13178,9 +13967,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13191,8 +13995,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_439
           - *ref_440
+          - *ref_441
         responses:
           - !<!SchemaResponse> 
             schema: *ref_72
@@ -13209,7 +14013,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -13287,7 +14091,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_441
+          - !<!Parameter> &ref_442
             schema: *ref_0
             implementation: Method
             required: true
@@ -13305,7 +14109,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_442
+          - !<!Parameter> &ref_443
             schema: *ref_6
             implementation: Method
             required: true
@@ -13317,9 +14121,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13330,8 +14149,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_441
           - *ref_442
+          - *ref_443
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -13344,7 +14163,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -13378,7 +14197,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_443
+          - !<!Parameter> &ref_444
             schema: *ref_0
             implementation: Method
             required: true
@@ -13396,7 +14215,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_444
+          - !<!Parameter> &ref_445
             schema: *ref_6
             implementation: Method
             required: true
@@ -13408,9 +14227,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13421,8 +14255,8 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_443
           - *ref_444
+          - *ref_445
         responses:
           - !<!SchemaResponse> 
             schema: *ref_73
@@ -13439,7 +14273,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -13513,7 +14347,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_445
+          - !<!Parameter> &ref_446
             schema: *ref_0
             implementation: Method
             required: true
@@ -13531,8 +14365,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_446
-            schema: *ref_278
+          - !<!Parameter> &ref_447
+            schema: *ref_279
             implementation: Method
             language: !<!Languages> 
               default:
@@ -13542,9 +14376,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13555,11 +14404,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_445
           - *ref_446
+          - *ref_447
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_447
+            schema: *ref_448
             language: !<!Languages> 
               default:
                 name: ''
@@ -13573,7 +14422,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -13631,7 +14480,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_448
+          - !<!Parameter> &ref_449
             schema: *ref_0
             implementation: Method
             required: true
@@ -13649,8 +14498,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_449
-            schema: *ref_278
+          - !<!Parameter> &ref_450
+            schema: *ref_279
             implementation: Method
             language: !<!Languages> 
               default:
@@ -13660,9 +14509,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13673,11 +14537,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_448
           - *ref_449
+          - *ref_450
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_450
+            schema: *ref_451
             language: !<!Languages> 
               default:
                 name: ''
@@ -13691,7 +14555,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -13756,7 +14620,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_452
+          - !<!Parameter> &ref_453
             schema: *ref_0
             implementation: Method
             required: true
@@ -13774,8 +14638,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_453
-            schema: *ref_451
+          - !<!Parameter> &ref_454
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13786,9 +14650,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13799,8 +14678,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_452
           - *ref_453
+          - *ref_454
         responses:
           - !<!SchemaResponse> 
             schema: *ref_132
@@ -13817,7 +14696,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -13867,7 +14746,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_454
+          - !<!Parameter> &ref_455
             schema: *ref_0
             implementation: Method
             required: true
@@ -13885,8 +14764,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_455
-            schema: *ref_451
+          - !<!Parameter> &ref_456
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13897,9 +14776,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13910,8 +14804,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_454
           - *ref_455
+          - *ref_456
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -13924,7 +14818,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -13960,7 +14854,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_456
+          - !<!Parameter> &ref_457
             schema: *ref_0
             implementation: Method
             required: true
@@ -13978,8 +14872,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_457
-            schema: *ref_451
+          - !<!Parameter> &ref_458
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -13990,9 +14884,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14003,8 +14912,8 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_456
           - *ref_457
+          - *ref_458
         responses:
           - !<!SchemaResponse> 
             schema: *ref_133
@@ -14021,7 +14930,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -14068,7 +14977,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_458
+          - !<!Parameter> &ref_459
             schema: *ref_0
             implementation: Method
             required: true
@@ -14086,7 +14995,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_459
+          - !<!Parameter> &ref_460
             schema: *ref_6
             implementation: Method
             required: true
@@ -14098,9 +15007,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14111,11 +15035,11 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_458
           - *ref_459
+          - *ref_460
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_460
+            schema: *ref_461
             language: !<!Languages> 
               default:
                 name: ''
@@ -14129,7 +15053,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -14165,7 +15089,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_461
+          - !<!Parameter> &ref_462
             schema: *ref_0
             implementation: Method
             required: true
@@ -14183,12 +15107,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_463
-                schema: *ref_462
+              - !<!Parameter> &ref_464
+                schema: *ref_463
                 implementation: Method
                 required: true
                 extensions:
@@ -14201,8 +15125,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_463
+              - *ref_464
             language: !<!Languages> 
               default:
                 name: ''
@@ -14216,7 +15153,7 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_461
+          - *ref_462
         responses:
           - !<!SchemaResponse> 
             schema: *ref_133
@@ -14233,7 +15170,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -14283,7 +15220,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_464
+          - !<!Parameter> &ref_465
             schema: *ref_0
             implementation: Method
             required: true
@@ -14301,8 +15238,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_465
-            schema: *ref_451
+          - !<!Parameter> &ref_466
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14313,9 +15250,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14326,8 +15278,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_464
           - *ref_465
+          - *ref_466
         responses:
           - !<!SchemaResponse> 
             schema: *ref_132
@@ -14344,7 +15296,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -14393,7 +15345,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_466
+          - !<!Parameter> &ref_467
             schema: *ref_0
             implementation: Method
             required: true
@@ -14411,8 +15363,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_467
-            schema: *ref_451
+          - !<!Parameter> &ref_468
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14423,9 +15375,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14436,8 +15403,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_466
           - *ref_467
+          - *ref_468
         responses:
           - !<!SchemaResponse> 
             schema: *ref_133
@@ -14454,7 +15421,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -14500,7 +15467,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_468
+          - !<!Parameter> &ref_469
             schema: *ref_0
             implementation: Method
             required: true
@@ -14518,8 +15485,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_469
-            schema: *ref_451
+          - !<!Parameter> &ref_470
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14530,12 +15497,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_471
-                schema: *ref_470
+              - !<!Parameter> &ref_472
+                schema: *ref_471
                 implementation: Method
                 required: true
                 extensions:
@@ -14548,8 +15515,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_471
+              - *ref_472
             language: !<!Languages> 
               default:
                 name: ''
@@ -14563,8 +15543,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_468
           - *ref_469
+          - *ref_470
         responses:
           - !<!SchemaResponse> 
             schema: *ref_133
@@ -14581,7 +15561,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -14637,7 +15617,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_472
+          - !<!Parameter> &ref_473
             schema: *ref_0
             implementation: Method
             required: true
@@ -14655,8 +15635,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_473
-            schema: *ref_451
+          - !<!Parameter> &ref_474
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14667,12 +15647,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_475
-                schema: *ref_474
+              - !<!Parameter> &ref_476
+                schema: *ref_475
                 implementation: Method
                 required: true
                 extensions:
@@ -14685,8 +15665,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_475
+              - *ref_476
             language: !<!Languages> 
               default:
                 name: ''
@@ -14700,8 +15693,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_472
           - *ref_473
+          - *ref_474
         responses:
           - !<!SchemaResponse> 
             schema: *ref_133
@@ -14718,7 +15711,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -14767,7 +15760,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_476
+          - !<!Parameter> &ref_477
             schema: *ref_0
             implementation: Method
             required: true
@@ -14785,8 +15778,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_477
-            schema: *ref_451
+          - !<!Parameter> &ref_478
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14797,12 +15790,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_479
-                schema: *ref_478
+              - !<!Parameter> &ref_480
+                schema: *ref_479
                 implementation: Method
                 required: true
                 extensions:
@@ -14815,8 +15808,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_479
+              - *ref_480
             language: !<!Languages> 
               default:
                 name: ''
@@ -14830,8 +15836,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_476
           - *ref_477
+          - *ref_478
         responses:
           - !<!SchemaResponse> 
             schema: *ref_133
@@ -14848,7 +15854,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -14896,7 +15902,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_480
+          - !<!Parameter> &ref_481
             schema: *ref_0
             implementation: Method
             required: true
@@ -14914,8 +15920,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_481
-            schema: *ref_451
+          - !<!Parameter> &ref_482
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14926,8 +15932,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_482
-            schema: *ref_278
+          - !<!Parameter> &ref_483
+            schema: *ref_279
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14937,9 +15943,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14950,12 +15971,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_480
           - *ref_481
           - *ref_482
+          - *ref_483
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_483
+            schema: *ref_484
             language: !<!Languages> 
               default:
                 name: ''
@@ -14969,7 +15990,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -15022,7 +16043,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_484
+          - !<!Parameter> &ref_485
             schema: *ref_0
             implementation: Method
             required: true
@@ -15040,8 +16061,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_485
-            schema: *ref_451
+          - !<!Parameter> &ref_486
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15052,8 +16073,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_486
-            schema: *ref_278
+          - !<!Parameter> &ref_487
+            schema: *ref_279
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15063,9 +16084,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15076,12 +16112,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_484
           - *ref_485
           - *ref_486
+          - *ref_487
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_487
+            schema: *ref_488
             language: !<!Languages> 
               default:
                 name: ''
@@ -15095,7 +16131,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -15155,7 +16191,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_488
+          - !<!Parameter> &ref_489
             schema: *ref_0
             implementation: Method
             required: true
@@ -15173,8 +16209,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_489
-            schema: *ref_451
+          - !<!Parameter> &ref_490
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15185,8 +16221,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_490
-            schema: *ref_451
+          - !<!Parameter> &ref_491
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15197,9 +16233,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15210,9 +16261,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_488
           - *ref_489
           - *ref_490
+          - *ref_491
         responses:
           - !<!SchemaResponse> 
             schema: *ref_157
@@ -15229,7 +16280,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -15277,7 +16328,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_491
+          - !<!Parameter> &ref_492
             schema: *ref_0
             implementation: Method
             required: true
@@ -15295,8 +16346,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_492
-            schema: *ref_451
+          - !<!Parameter> &ref_493
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15307,8 +16358,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_493
-            schema: *ref_451
+          - !<!Parameter> &ref_494
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15319,9 +16370,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15332,9 +16398,9 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_491
           - *ref_492
           - *ref_493
+          - *ref_494
         responses:
           - !<!SchemaResponse> 
             schema: *ref_158
@@ -15351,7 +16417,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -15396,7 +16462,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_494
+          - !<!Parameter> &ref_495
             schema: *ref_0
             implementation: Method
             required: true
@@ -15414,8 +16480,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_495
-            schema: *ref_451
+          - !<!Parameter> &ref_496
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15426,8 +16492,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_496
-            schema: *ref_451
+          - !<!Parameter> &ref_497
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15438,9 +16504,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15451,9 +16532,9 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_494
           - *ref_495
           - *ref_496
+          - *ref_497
         responses:
           - !<!SchemaResponse> 
             schema: *ref_157
@@ -15470,7 +16551,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -15517,7 +16598,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_497
+          - !<!Parameter> &ref_498
             schema: *ref_0
             implementation: Method
             required: true
@@ -15535,8 +16616,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_498
-            schema: *ref_451
+          - !<!Parameter> &ref_499
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15547,8 +16628,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_499
-            schema: *ref_451
+          - !<!Parameter> &ref_500
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15559,9 +16640,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15572,9 +16668,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_497
           - *ref_498
           - *ref_499
+          - *ref_500
         responses:
           - !<!SchemaResponse> 
             schema: *ref_158
@@ -15591,7 +16687,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -15635,7 +16731,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_500
+          - !<!Parameter> &ref_501
             schema: *ref_0
             implementation: Method
             required: true
@@ -15653,8 +16749,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_501
-            schema: *ref_451
+          - !<!Parameter> &ref_502
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15665,8 +16761,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_502
-            schema: *ref_451
+          - !<!Parameter> &ref_503
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15677,12 +16773,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_504
-                schema: *ref_503
+              - !<!Parameter> &ref_505
+                schema: *ref_504
                 implementation: Method
                 required: true
                 extensions:
@@ -15695,8 +16791,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_504
+              - *ref_505
             language: !<!Languages> 
               default:
                 name: ''
@@ -15710,9 +16819,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_500
           - *ref_501
           - *ref_502
+          - *ref_503
         responses:
           - !<!SchemaResponse> 
             schema: *ref_158
@@ -15729,7 +16838,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''
@@ -15779,7 +16888,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_505
+          - !<!Parameter> &ref_506
             schema: *ref_0
             implementation: Method
             required: true
@@ -15797,8 +16906,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_506
-            schema: *ref_451
+          - !<!Parameter> &ref_507
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15809,8 +16918,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_507
-            schema: *ref_451
+          - !<!Parameter> &ref_508
+            schema: *ref_452
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15821,12 +16930,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_263
+          - *ref_264
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_509
-                schema: *ref_508
+              - !<!Parameter> &ref_510
+                schema: *ref_509
                 implementation: Method
                 required: true
                 extensions:
@@ -15839,8 +16948,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_261
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_509
+              - *ref_510
             language: !<!Languages> 
               default:
                 name: ''
@@ -15854,9 +16976,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_505
           - *ref_506
           - *ref_507
+          - *ref_508
         responses:
           - !<!SchemaResponse> 
             schema: *ref_158
@@ -15873,7 +16995,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_262
+            schema: *ref_263
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/keyvault/namer.yaml
+++ b/modelerfour/test/scenarios/keyvault/namer.yaml
@@ -46,7 +46,7 @@ schemas: !<!Schemas>
           name: Boolean
           description: 'True if the secret''s lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.'
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_428
+    - !<!BooleanSchema> &ref_429
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -114,7 +114,7 @@ schemas: !<!Schemas>
           name: Integer
           description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_304
+    - !<!NumberSchema> &ref_305
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -883,7 +883,7 @@ schemas: !<!Schemas>
           name: DeletedStorageListResultNextLink
           description: The URL to get the next set of deleted storage accounts.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_565
+    - !<!StringSchema> &ref_566
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -1553,6 +1553,16 @@ schemas: !<!Schemas>
           name: ApiVersion70Preview
           description: Api Version (7.0-preview)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_260
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_15
       type: dictionary
@@ -2164,7 +2174,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_261
+        - !<!Property> &ref_262
           schema: *ref_2
           required: true
           serializedName: kty
@@ -2173,7 +2183,7 @@ schemas: !<!Schemas>
               name: kty
               description: 'The type of key to create. For valid values, see JsonWebKeyType.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_262
+        - !<!Property> &ref_263
           schema: *ref_3
           required: false
           serializedName: key_size
@@ -2182,7 +2192,7 @@ schemas: !<!Schemas>
               name: keySize
               description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_263
+        - !<!Property> &ref_264
           schema: !<!ArraySchema> &ref_233
             type: array
             apiVersions:
@@ -2201,7 +2211,7 @@ schemas: !<!Schemas>
               name: keyOps
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_264
+        - !<!Property> &ref_265
           schema: !<!ObjectSchema> &ref_5
             type: object
             apiVersions:
@@ -2376,7 +2386,7 @@ schemas: !<!Schemas>
               name: keyAttributes
               description: The attributes of a key managed by the key vault service.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_265
+        - !<!Property> &ref_266
           schema: *ref_15
           required: false
           serializedName: tags
@@ -2385,7 +2395,7 @@ schemas: !<!Schemas>
               name: tags
               description: Application specific metadata in the form of key-value pairs.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_266
+        - !<!Property> &ref_267
           schema: *ref_16
           required: false
           serializedName: crv
@@ -2661,7 +2671,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_38
-    - !<!ObjectSchema> &ref_275
+    - !<!ObjectSchema> &ref_276
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2730,13 +2740,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_41
-    - !<!ObjectSchema> &ref_276
+    - !<!ObjectSchema> &ref_277
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_278
+        - !<!Property> &ref_279
           schema: *ref_42
           required: false
           serializedName: Hsm
@@ -2745,7 +2755,7 @@ schemas: !<!Schemas>
               name: hsm
               description: Whether to import as a hardware key (HSM) or software key.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_279
+        - !<!Property> &ref_280
           schema: *ref_38
           required: true
           serializedName: key
@@ -2754,7 +2764,7 @@ schemas: !<!Schemas>
               name: key
               description: The Json web key
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_280
+        - !<!Property> &ref_281
           schema: *ref_5
           required: false
           serializedName: attributes
@@ -2763,7 +2773,7 @@ schemas: !<!Schemas>
               name: keyAttributes
               description: The key management attributes.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_281
+        - !<!Property> &ref_282
           schema: *ref_43
           required: false
           serializedName: tags
@@ -2783,13 +2793,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_21
-    - !<!ObjectSchema> &ref_290
+    - !<!ObjectSchema> &ref_291
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_292
+        - !<!Property> &ref_293
           schema: !<!ArraySchema> &ref_235
             type: array
             apiVersions:
@@ -2807,7 +2817,7 @@ schemas: !<!Schemas>
               name: keyOps
               description: 'Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_293
+        - !<!Property> &ref_294
           schema: *ref_5
           serializedName: attributes
           language: !<!Languages> 
@@ -2815,7 +2825,7 @@ schemas: !<!Schemas>
               name: keyAttributes
               description: The attributes of a key managed by the key vault service.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_294
+        - !<!Property> &ref_295
           schema: *ref_44
           serializedName: tags
           language: !<!Languages> 
@@ -2833,7 +2843,7 @@ schemas: !<!Schemas>
           description: The key update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_308
+    - !<!ObjectSchema> &ref_309
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2977,7 +2987,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_45
-    - !<!ObjectSchema> &ref_313
+    - !<!ObjectSchema> &ref_314
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3002,13 +3012,13 @@ schemas: !<!Schemas>
           description: 'The backup key result, containing the backup blob.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_314
+    - !<!ObjectSchema> &ref_315
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_316
+        - !<!Property> &ref_317
           schema: *ref_52
           required: true
           serializedName: value
@@ -3027,13 +3037,13 @@ schemas: !<!Schemas>
           description: The key restore parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_319
+    - !<!ObjectSchema> &ref_320
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_321
+        - !<!Property> &ref_322
           schema: *ref_53
           required: true
           serializedName: alg
@@ -3042,7 +3052,7 @@ schemas: !<!Schemas>
               name: algorithm
               description: algorithm identifier
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_322
+        - !<!Property> &ref_323
           schema: *ref_54
           required: true
           serializedName: value
@@ -3061,7 +3071,7 @@ schemas: !<!Schemas>
           description: The key operations parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_328
+    - !<!ObjectSchema> &ref_329
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3095,13 +3105,13 @@ schemas: !<!Schemas>
           description: The key operation result.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_335
+    - !<!ObjectSchema> &ref_336
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_337
+        - !<!Property> &ref_338
           schema: *ref_57
           required: true
           serializedName: alg
@@ -3110,7 +3120,7 @@ schemas: !<!Schemas>
               name: algorithm
               description: 'The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_338
+        - !<!Property> &ref_339
           schema: *ref_58
           required: true
           serializedName: value
@@ -3129,13 +3139,13 @@ schemas: !<!Schemas>
           description: The key operations parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_344
+    - !<!ObjectSchema> &ref_345
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_346
+        - !<!Property> &ref_347
           schema: *ref_57
           required: true
           serializedName: alg
@@ -3144,7 +3154,7 @@ schemas: !<!Schemas>
               name: algorithm
               description: 'The signing/verification algorithm. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_347
+        - !<!Property> &ref_348
           schema: *ref_59
           required: true
           serializedName: digest
@@ -3153,7 +3163,7 @@ schemas: !<!Schemas>
               name: digest
               description: The digest used for signing.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_348
+        - !<!Property> &ref_349
           schema: *ref_60
           required: true
           serializedName: value
@@ -3172,7 +3182,7 @@ schemas: !<!Schemas>
           description: The key verify parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_355
+    - !<!ObjectSchema> &ref_356
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3197,7 +3207,7 @@ schemas: !<!Schemas>
           description: The key verify result.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_370
+    - !<!ObjectSchema> &ref_371
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3242,13 +3252,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_47
-    - !<!ObjectSchema> &ref_377
+    - !<!ObjectSchema> &ref_378
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_379
+        - !<!Property> &ref_380
           schema: *ref_63
           required: true
           serializedName: value
@@ -3257,7 +3267,7 @@ schemas: !<!Schemas>
               name: value
               description: The value of the secret.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_380
+        - !<!Property> &ref_381
           schema: *ref_64
           required: false
           serializedName: tags
@@ -3266,7 +3276,7 @@ schemas: !<!Schemas>
               name: tags
               description: Application specific metadata in the form of key-value pairs.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_381
+        - !<!Property> &ref_382
           schema: *ref_65
           required: false
           serializedName: contentType
@@ -3275,7 +3285,7 @@ schemas: !<!Schemas>
               name: contentType
               description: Type of the secret value such as a password.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_382
+        - !<!Property> &ref_383
           schema: *ref_8
           required: false
           serializedName: attributes
@@ -3421,13 +3431,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_70
-    - !<!ObjectSchema> &ref_391
+    - !<!ObjectSchema> &ref_392
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_393
+        - !<!Property> &ref_394
           schema: *ref_77
           serializedName: contentType
           language: !<!Languages> 
@@ -3435,7 +3445,7 @@ schemas: !<!Schemas>
               name: contentType
               description: Type of the secret value such as a password.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_394
+        - !<!Property> &ref_395
           schema: *ref_8
           serializedName: attributes
           language: !<!Languages> 
@@ -3443,7 +3453,7 @@ schemas: !<!Schemas>
               name: secretAttributes
               description: The secret management attributes.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_395
+        - !<!Property> &ref_396
           schema: *ref_78
           serializedName: tags
           language: !<!Languages> 
@@ -3461,7 +3471,7 @@ schemas: !<!Schemas>
           description: The secret update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_407
+    - !<!ObjectSchema> &ref_408
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3613,7 +3623,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_79
-    - !<!ObjectSchema> &ref_413
+    - !<!ObjectSchema> &ref_414
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3658,7 +3668,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_81
-    - !<!ObjectSchema> &ref_422
+    - !<!ObjectSchema> &ref_423
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -3683,13 +3693,13 @@ schemas: !<!Schemas>
           description: 'The backup secret result, containing the backup blob.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_423
+    - !<!ObjectSchema> &ref_424
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_425
+        - !<!Property> &ref_426
           schema: *ref_89
           required: true
           serializedName: value
@@ -3708,7 +3718,7 @@ schemas: !<!Schemas>
           description: The secret restore parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_432
+    - !<!ObjectSchema> &ref_433
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4443,7 +4453,7 @@ schemas: !<!Schemas>
     - *ref_131
     - *ref_132
     - *ref_133
-    - !<!ObjectSchema> &ref_435
+    - !<!ObjectSchema> &ref_436
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4458,7 +4468,7 @@ schemas: !<!Schemas>
               name: id
               description: Identifier for the contacts collection.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_437
+        - !<!Property> &ref_438
           schema: !<!ArraySchema> &ref_247
             type: array
             apiVersions:
@@ -4528,7 +4538,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_138
-    - !<!ObjectSchema> &ref_444
+    - !<!ObjectSchema> &ref_445
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4604,13 +4614,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_142
-    - !<!ObjectSchema> &ref_445
+    - !<!ObjectSchema> &ref_446
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_447
+        - !<!Property> &ref_448
           schema: *ref_143
           required: true
           serializedName: provider
@@ -4619,7 +4629,7 @@ schemas: !<!Schemas>
               name: provider
               description: The issuer provider.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_448
+        - !<!Property> &ref_449
           schema: !<!ObjectSchema> &ref_151
             type: object
             apiVersions:
@@ -4660,7 +4670,7 @@ schemas: !<!Schemas>
               name: credentials
               description: The credentials to be used for the issuer.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_449
+        - !<!Property> &ref_450
           schema: !<!ObjectSchema> &ref_152
             type: object
             apiVersions:
@@ -4759,7 +4769,7 @@ schemas: !<!Schemas>
               name: organizationDetails
               description: Details of the organization as provided to the issuer.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_450
+        - !<!Property> &ref_451
           schema: !<!ObjectSchema> &ref_154
             type: object
             apiVersions:
@@ -4824,7 +4834,7 @@ schemas: !<!Schemas>
     - *ref_152
     - *ref_153
     - *ref_154
-    - !<!ObjectSchema> &ref_457
+    - !<!ObjectSchema> &ref_458
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -4881,13 +4891,13 @@ schemas: !<!Schemas>
           description: The issuer for Key Vault certificate.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_458
+    - !<!ObjectSchema> &ref_459
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_460
+        - !<!Property> &ref_461
           schema: *ref_157
           serializedName: provider
           language: !<!Languages> 
@@ -4895,7 +4905,7 @@ schemas: !<!Schemas>
               name: provider
               description: The issuer provider.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_461
+        - !<!Property> &ref_462
           schema: *ref_151
           serializedName: credentials
           language: !<!Languages> 
@@ -4903,7 +4913,7 @@ schemas: !<!Schemas>
               name: credentials
               description: The credentials to be used for the issuer.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_462
+        - !<!Property> &ref_463
           schema: *ref_152
           serializedName: org_details
           language: !<!Languages> 
@@ -4911,7 +4921,7 @@ schemas: !<!Schemas>
               name: organizationDetails
               description: Details of the organization as provided to the issuer.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_463
+        - !<!Property> &ref_464
           schema: *ref_154
           serializedName: attributes
           language: !<!Languages> 
@@ -4929,13 +4939,13 @@ schemas: !<!Schemas>
           description: The certificate issuer update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_474
+    - !<!ObjectSchema> &ref_475
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_476
+        - !<!Property> &ref_477
           schema: *ref_125
           serializedName: policy
           language: !<!Languages> 
@@ -4943,7 +4953,7 @@ schemas: !<!Schemas>
               name: certificatePolicy
               description: The management policy for the certificate.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_477
+        - !<!Property> &ref_478
           schema: *ref_9
           serializedName: attributes
           language: !<!Languages> 
@@ -4951,7 +4961,7 @@ schemas: !<!Schemas>
               name: certificateAttributes
               description: The attributes of the certificate (optional).
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_478
+        - !<!Property> &ref_479
           schema: *ref_158
           serializedName: tags
           language: !<!Languages> 
@@ -4969,7 +4979,7 @@ schemas: !<!Schemas>
           description: The certificate create parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_484
+    - !<!ObjectSchema> &ref_485
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5058,13 +5068,13 @@ schemas: !<!Schemas>
           description: A certificate operation is returned in case of asynchronous requests.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_485
+    - !<!ObjectSchema> &ref_486
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_487
+        - !<!Property> &ref_488
           schema: *ref_166
           required: true
           serializedName: value
@@ -5073,7 +5083,7 @@ schemas: !<!Schemas>
               name: base64EncodedCertificate
               description: Base64 encoded representation of the certificate object to import. This certificate needs to contain the private key.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_488
+        - !<!Property> &ref_489
           schema: *ref_167
           required: false
           serializedName: pwd
@@ -5082,7 +5092,7 @@ schemas: !<!Schemas>
               name: password
               description: 'If the private key in base64EncodedCertificate is encrypted, the password used for encryption.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_489
+        - !<!Property> &ref_490
           schema: *ref_125
           required: false
           serializedName: policy
@@ -5091,7 +5101,7 @@ schemas: !<!Schemas>
               name: certificatePolicy
               description: The management policy for the certificate.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_490
+        - !<!Property> &ref_491
           schema: *ref_9
           required: false
           serializedName: attributes
@@ -5100,7 +5110,7 @@ schemas: !<!Schemas>
               name: certificateAttributes
               description: The attributes of the certificate (optional).
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_491
+        - !<!Property> &ref_492
           schema: *ref_168
           required: false
           serializedName: tags
@@ -5119,13 +5129,13 @@ schemas: !<!Schemas>
           description: The certificate import parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_507
+    - !<!ObjectSchema> &ref_508
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_509
+        - !<!Property> &ref_510
           schema: *ref_125
           serializedName: policy
           language: !<!Languages> 
@@ -5133,7 +5143,7 @@ schemas: !<!Schemas>
               name: certificatePolicy
               description: The management policy for the certificate.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_510
+        - !<!Property> &ref_511
           schema: *ref_9
           serializedName: attributes
           language: !<!Languages> 
@@ -5141,7 +5151,7 @@ schemas: !<!Schemas>
               name: certificateAttributes
               description: The attributes of the certificate (optional).
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_511
+        - !<!Property> &ref_512
           schema: *ref_169
           serializedName: tags
           language: !<!Languages> 
@@ -5159,13 +5169,13 @@ schemas: !<!Schemas>
           description: The certificate update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_521
+    - !<!ObjectSchema> &ref_522
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_523
+        - !<!Property> &ref_524
           schema: *ref_161
           required: true
           serializedName: cancellation_requested
@@ -5184,13 +5194,13 @@ schemas: !<!Schemas>
           description: The certificate operation update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_531
+    - !<!ObjectSchema> &ref_532
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_533
+        - !<!Property> &ref_534
           schema: !<!ArraySchema> &ref_250
             type: array
             apiVersions:
@@ -5209,7 +5219,7 @@ schemas: !<!Schemas>
               name: x509Certificates
               description: The certificate or the certificate chain to merge.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_534
+        - !<!Property> &ref_535
           schema: *ref_9
           required: false
           serializedName: attributes
@@ -5218,7 +5228,7 @@ schemas: !<!Schemas>
               name: certificateAttributes
               description: The attributes of the certificate (optional).
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_535
+        - !<!Property> &ref_536
           schema: *ref_171
           required: false
           serializedName: tags
@@ -5237,7 +5247,7 @@ schemas: !<!Schemas>
           description: The certificate merge parameters
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_543
+    - !<!ObjectSchema> &ref_544
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5262,13 +5272,13 @@ schemas: !<!Schemas>
           description: 'The backup certificate result, containing the backup blob.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_544
+    - !<!ObjectSchema> &ref_545
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_546
+        - !<!Property> &ref_547
           schema: *ref_173
           required: true
           serializedName: value
@@ -5287,7 +5297,7 @@ schemas: !<!Schemas>
           description: The certificate restore parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_552
+    - !<!ObjectSchema> &ref_553
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5332,7 +5342,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_94
-    - !<!ObjectSchema> &ref_561
+    - !<!ObjectSchema> &ref_562
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5534,7 +5544,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_175
     - *ref_185
-    - !<!ObjectSchema> &ref_564
+    - !<!ObjectSchema> &ref_565
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5710,7 +5720,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_194
-    - !<!ObjectSchema> &ref_574
+    - !<!ObjectSchema> &ref_575
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -5735,13 +5745,13 @@ schemas: !<!Schemas>
           description: 'The backup storage result, containing the backup blob.'
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_575
+    - !<!ObjectSchema> &ref_576
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_577
+        - !<!Property> &ref_578
           schema: *ref_197
           required: true
           serializedName: value
@@ -5760,13 +5770,13 @@ schemas: !<!Schemas>
           description: The secret restore parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_584
+    - !<!ObjectSchema> &ref_585
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_586
+        - !<!Property> &ref_587
           schema: *ref_198
           required: true
           serializedName: resourceId
@@ -5775,7 +5785,7 @@ schemas: !<!Schemas>
               name: resourceId
               description: Storage account resource id.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_587
+        - !<!Property> &ref_588
           schema: *ref_199
           required: true
           serializedName: activeKeyName
@@ -5784,7 +5794,7 @@ schemas: !<!Schemas>
               name: activeKeyName
               description: Current active storage account key name.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_588
+        - !<!Property> &ref_589
           schema: *ref_191
           required: true
           serializedName: autoRegenerateKey
@@ -5793,7 +5803,7 @@ schemas: !<!Schemas>
               name: autoRegenerateKey
               description: whether keyvault should manage the storage account for the user.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_589
+        - !<!Property> &ref_590
           schema: *ref_200
           required: false
           serializedName: regenerationPeriod
@@ -5802,7 +5812,7 @@ schemas: !<!Schemas>
               name: regenerationPeriod
               description: The key regeneration time duration specified in ISO-8601 format.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_590
+        - !<!Property> &ref_591
           schema: *ref_185
           required: false
           serializedName: attributes
@@ -5811,7 +5821,7 @@ schemas: !<!Schemas>
               name: storageAccountAttributes
               description: The attributes of the storage account.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_591
+        - !<!Property> &ref_592
           schema: *ref_201
           required: false
           serializedName: tags
@@ -5830,13 +5840,13 @@ schemas: !<!Schemas>
           description: The storage account create parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_600
+    - !<!ObjectSchema> &ref_601
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_602
+        - !<!Property> &ref_603
           schema: *ref_202
           serializedName: activeKeyName
           language: !<!Languages> 
@@ -5844,7 +5854,7 @@ schemas: !<!Schemas>
               name: activeKeyName
               description: The current active storage account key name.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_603
+        - !<!Property> &ref_604
           schema: *ref_191
           serializedName: autoRegenerateKey
           language: !<!Languages> 
@@ -5852,7 +5862,7 @@ schemas: !<!Schemas>
               name: autoRegenerateKey
               description: whether keyvault should manage the storage account for the user.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_604
+        - !<!Property> &ref_605
           schema: *ref_203
           serializedName: regenerationPeriod
           language: !<!Languages> 
@@ -5860,7 +5870,7 @@ schemas: !<!Schemas>
               name: regenerationPeriod
               description: The key regeneration time duration specified in ISO-8601 format.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_605
+        - !<!Property> &ref_606
           schema: *ref_185
           serializedName: attributes
           language: !<!Languages> 
@@ -5868,7 +5878,7 @@ schemas: !<!Schemas>
               name: storageAccountAttributes
               description: The attributes of the storage account.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_606
+        - !<!Property> &ref_607
           schema: *ref_204
           serializedName: tags
           language: !<!Languages> 
@@ -5886,13 +5896,13 @@ schemas: !<!Schemas>
           description: The storage account update parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_614
+    - !<!ObjectSchema> &ref_615
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_616
+        - !<!Property> &ref_617
           schema: *ref_205
           required: true
           serializedName: keyName
@@ -5911,7 +5921,7 @@ schemas: !<!Schemas>
           description: The storage account key regenerate parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_623
+    - !<!ObjectSchema> &ref_624
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -6113,7 +6123,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_206
     - *ref_215
-    - !<!ObjectSchema> &ref_627
+    - !<!ObjectSchema> &ref_628
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -6289,13 +6299,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_224
-    - !<!ObjectSchema> &ref_640
+    - !<!ObjectSchema> &ref_641
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_642
+        - !<!Property> &ref_643
           schema: *ref_226
           required: true
           serializedName: templateUri
@@ -6304,7 +6314,7 @@ schemas: !<!Schemas>
               name: templateUri
               description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_643
+        - !<!Property> &ref_644
           schema: *ref_221
           required: true
           serializedName: sasType
@@ -6313,7 +6323,7 @@ schemas: !<!Schemas>
               name: sasType
               description: The type of SAS token the SAS definition will create.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_644
+        - !<!Property> &ref_645
           schema: *ref_227
           required: true
           serializedName: validityPeriod
@@ -6322,7 +6332,7 @@ schemas: !<!Schemas>
               name: validityPeriod
               description: The validity period of SAS tokens created according to the SAS definition.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_645
+        - !<!Property> &ref_646
           schema: *ref_215
           required: false
           serializedName: attributes
@@ -6331,7 +6341,7 @@ schemas: !<!Schemas>
               name: sasDefinitionAttributes
               description: The attributes of the SAS definition.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_646
+        - !<!Property> &ref_647
           schema: *ref_228
           required: false
           serializedName: tags
@@ -6350,13 +6360,13 @@ schemas: !<!Schemas>
           description: The SAS definition create parameters.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_655
+    - !<!ObjectSchema> &ref_656
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 7.0-preview
       properties:
-        - !<!Property> &ref_657
+        - !<!Property> &ref_658
           schema: *ref_229
           serializedName: templateUri
           language: !<!Languages> 
@@ -6364,7 +6374,7 @@ schemas: !<!Schemas>
               name: templateUri
               description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_658
+        - !<!Property> &ref_659
           schema: *ref_221
           serializedName: sasType
           language: !<!Languages> 
@@ -6372,7 +6382,7 @@ schemas: !<!Schemas>
               name: sasType
               description: The type of SAS token the SAS definition will create.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_659
+        - !<!Property> &ref_660
           schema: *ref_230
           serializedName: validityPeriod
           language: !<!Languages> 
@@ -6380,7 +6390,7 @@ schemas: !<!Schemas>
               name: validityPeriod
               description: The validity period of SAS tokens created according to the SAS definition.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_660
+        - !<!Property> &ref_661
           schema: *ref_215
           serializedName: attributes
           language: !<!Languages> 
@@ -6388,7 +6398,7 @@ schemas: !<!Schemas>
               name: sasDefinitionAttributes
               description: The attributes of the SAS definition.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_661
+        - !<!Property> &ref_662
           schema: *ref_231
           serializedName: tags
           language: !<!Languages> 
@@ -6474,7 +6484,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_273
+          - !<!Parameter> &ref_274
             schema: *ref_0
             implementation: Method
             required: true
@@ -6492,7 +6502,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_274
+          - !<!Parameter> &ref_275
             schema: *ref_257
             implementation: Method
             required: true
@@ -6508,7 +6518,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_260
+              - !<!Parameter> &ref_261
                 schema: *ref_259
                 flattened: true
                 implementation: Method
@@ -6523,85 +6533,98 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_267
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_268
                 schema: *ref_2
                 implementation: Method
-                originalParameter: *ref_260
+                originalParameter: *ref_261
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_261
+                targetProperty: *ref_262
                 language: !<!Languages> 
                   default:
                     name: kty
                     description: 'The type of key to create. For valid values, see JsonWebKeyType.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_268
+              - !<!VirtualParameter> &ref_269
                 schema: *ref_3
                 implementation: Method
-                originalParameter: *ref_260
-                pathToProperty: []
-                required: false
-                targetProperty: *ref_262
-                language: !<!Languages> 
-                  default:
-                    name: keySize
-                    description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
-                protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_269
-                schema: *ref_233
-                implementation: Method
-                originalParameter: *ref_260
+                originalParameter: *ref_261
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_263
                 language: !<!Languages> 
                   default:
-                    name: keyOps
-                    description: ''
+                    name: keySize
+                    description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_270
-                schema: *ref_5
+                schema: *ref_233
                 implementation: Method
-                originalParameter: *ref_260
+                originalParameter: *ref_261
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_264
                 language: !<!Languages> 
                   default:
-                    name: keyAttributes
-                    description: The attributes of a key managed by the key vault service.
+                    name: keyOps
+                    description: ''
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_271
-                schema: *ref_15
+                schema: *ref_5
                 implementation: Method
-                originalParameter: *ref_260
+                originalParameter: *ref_261
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_265
                 language: !<!Languages> 
                   default:
-                    name: tags
-                    description: Application specific metadata in the form of key-value pairs.
+                    name: keyAttributes
+                    description: The attributes of a key managed by the key vault service.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_272
-                schema: *ref_16
+                schema: *ref_15
                 implementation: Method
-                originalParameter: *ref_260
+                originalParameter: *ref_261
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_266
+                language: !<!Languages> 
+                  default:
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_273
+                schema: *ref_16
+                implementation: Method
+                originalParameter: *ref_261
+                pathToProperty: []
+                required: false
+                targetProperty: *ref_267
                 language: !<!Languages> 
                   default:
                     name: curve
                     description: 'Elliptic curve name. For valid values, see JsonWebKeyCurveName.'
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_267
               - *ref_268
               - *ref_269
               - *ref_270
               - *ref_271
               - *ref_272
+              - *ref_273
             language: !<!Languages> 
               default:
                 name: ''
@@ -6615,8 +6638,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_273
           - *ref_274
+          - *ref_275
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -6633,7 +6656,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -6700,7 +6723,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_286
+          - !<!Parameter> &ref_287
             schema: *ref_0
             implementation: Method
             required: true
@@ -6718,7 +6741,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_287
+          - !<!Parameter> &ref_288
             schema: *ref_257
             implementation: Method
             required: true
@@ -6734,8 +6757,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_277
-                schema: *ref_276
+              - !<!Parameter> &ref_278
+                schema: *ref_277
                 flattened: true
                 implementation: Method
                 required: true
@@ -6749,59 +6772,72 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_282
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_283
                 schema: *ref_42
                 implementation: Method
-                originalParameter: *ref_277
+                originalParameter: *ref_278
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_278
+                targetProperty: *ref_279
                 language: !<!Languages> 
                   default:
                     name: hsm
                     description: Whether to import as a hardware key (HSM) or software key.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_283
+              - !<!VirtualParameter> &ref_284
                 schema: *ref_38
                 implementation: Method
-                originalParameter: *ref_277
+                originalParameter: *ref_278
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_279
+                targetProperty: *ref_280
                 language: !<!Languages> 
                   default:
                     name: key
                     description: The Json web key
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_284
+              - !<!VirtualParameter> &ref_285
                 schema: *ref_5
                 implementation: Method
-                originalParameter: *ref_277
+                originalParameter: *ref_278
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_280
+                targetProperty: *ref_281
                 language: !<!Languages> 
                   default:
                     name: keyAttributes
                     description: The key management attributes.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_285
+              - !<!VirtualParameter> &ref_286
                 schema: *ref_43
                 implementation: Method
-                originalParameter: *ref_277
+                originalParameter: *ref_278
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_281
+                targetProperty: *ref_282
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_282
               - *ref_283
               - *ref_284
               - *ref_285
+              - *ref_286
             language: !<!Languages> 
               default:
                 name: ''
@@ -6815,8 +6851,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_286
           - *ref_287
+          - *ref_288
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -6833,7 +6869,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -6900,7 +6936,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_288
+          - !<!Parameter> &ref_289
             schema: *ref_0
             implementation: Method
             required: true
@@ -6918,7 +6954,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_289
+          - !<!Parameter> &ref_290
             schema: *ref_1
             implementation: Method
             required: true
@@ -6933,6 +6969,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6943,8 +6994,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_288
           - *ref_289
+          - *ref_290
         responses:
           - !<!SchemaResponse> 
             schema: *ref_21
@@ -6961,7 +7012,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7019,7 +7070,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_298
+          - !<!Parameter> &ref_299
             schema: *ref_0
             implementation: Method
             required: true
@@ -7037,7 +7088,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_299
+          - !<!Parameter> &ref_300
             schema: *ref_1
             implementation: Method
             required: true
@@ -7049,7 +7100,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_300
+          - !<!Parameter> &ref_301
             schema: *ref_1
             implementation: Method
             required: true
@@ -7065,8 +7116,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_291
-                schema: *ref_290
+              - !<!Parameter> &ref_292
+                schema: *ref_291
                 flattened: true
                 implementation: Method
                 required: true
@@ -7080,43 +7131,56 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_295
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_296
                 schema: *ref_235
                 implementation: Method
-                originalParameter: *ref_291
+                originalParameter: *ref_292
                 pathToProperty: []
-                targetProperty: *ref_292
+                targetProperty: *ref_293
                 language: !<!Languages> 
                   default:
                     name: keyOps
                     description: 'Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_296
+              - !<!VirtualParameter> &ref_297
                 schema: *ref_5
                 implementation: Method
-                originalParameter: *ref_291
+                originalParameter: *ref_292
                 pathToProperty: []
-                targetProperty: *ref_293
+                targetProperty: *ref_294
                 language: !<!Languages> 
                   default:
                     name: keyAttributes
                     description: The attributes of a key managed by the key vault service.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_297
+              - !<!VirtualParameter> &ref_298
                 schema: *ref_44
                 implementation: Method
-                originalParameter: *ref_291
+                originalParameter: *ref_292
                 pathToProperty: []
-                targetProperty: *ref_294
+                targetProperty: *ref_295
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_295
               - *ref_296
               - *ref_297
+              - *ref_298
             language: !<!Languages> 
               default:
                 name: ''
@@ -7130,9 +7194,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_298
           - *ref_299
           - *ref_300
+          - *ref_301
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -7149,7 +7213,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7206,7 +7270,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_301
+          - !<!Parameter> &ref_302
             schema: *ref_0
             implementation: Method
             required: true
@@ -7224,7 +7288,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_302
+          - !<!Parameter> &ref_303
             schema: *ref_1
             implementation: Method
             required: true
@@ -7236,7 +7300,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_303
+          - !<!Parameter> &ref_304
             schema: *ref_1
             implementation: Method
             required: true
@@ -7251,6 +7315,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -7261,9 +7340,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_301
           - *ref_302
           - *ref_303
+          - *ref_304
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -7280,7 +7359,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7334,7 +7413,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_305
+          - !<!Parameter> &ref_306
             schema: *ref_0
             implementation: Method
             required: true
@@ -7352,7 +7431,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_306
+          - !<!Parameter> &ref_307
             schema: *ref_1
             implementation: Method
             required: true
@@ -7364,8 +7443,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_307
-            schema: *ref_304
+          - !<!Parameter> &ref_308
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -7378,6 +7457,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -7388,12 +7482,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_305
           - *ref_306
           - *ref_307
+          - *ref_308
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_308
+            schema: *ref_309
             language: !<!Languages> 
               default:
                 name: ''
@@ -7407,7 +7501,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7455,7 +7549,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_309
+          - !<!Parameter> &ref_310
             schema: *ref_0
             implementation: Method
             required: true
@@ -7473,8 +7567,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_310
-            schema: *ref_304
+          - !<!Parameter> &ref_311
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -7487,6 +7581,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -7497,11 +7606,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_309
           - *ref_310
+          - *ref_311
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_308
+            schema: *ref_309
             language: !<!Languages> 
               default:
                 name: ''
@@ -7515,7 +7624,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7563,7 +7672,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_311
+          - !<!Parameter> &ref_312
             schema: *ref_0
             implementation: Method
             required: true
@@ -7581,7 +7690,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_312
+          - !<!Parameter> &ref_313
             schema: *ref_1
             implementation: Method
             required: true
@@ -7596,6 +7705,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -7606,11 +7730,11 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_311
           - *ref_312
+          - *ref_313
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_313
+            schema: *ref_314
             language: !<!Languages> 
               default:
                 name: ''
@@ -7624,7 +7748,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7663,7 +7787,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_318
+          - !<!Parameter> &ref_319
             schema: *ref_0
             implementation: Method
             required: true
@@ -7685,8 +7809,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_315
-                schema: *ref_314
+              - !<!Parameter> &ref_316
+                schema: *ref_315
                 flattened: true
                 implementation: Method
                 required: true
@@ -7700,20 +7824,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_317
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_318
                 schema: *ref_52
                 implementation: Method
-                originalParameter: *ref_315
+                originalParameter: *ref_316
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_316
+                targetProperty: *ref_317
                 language: !<!Languages> 
                   default:
                     name: keyBundleBackup
                     description: The backup blob associated with a key bundle.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_317
+              - *ref_318
             language: !<!Languages> 
               default:
                 name: ''
@@ -7727,7 +7864,7 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_318
+          - *ref_319
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -7744,7 +7881,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7803,7 +7940,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_325
+          - !<!Parameter> &ref_326
             schema: *ref_0
             implementation: Method
             required: true
@@ -7821,7 +7958,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_326
+          - !<!Parameter> &ref_327
             schema: *ref_1
             implementation: Method
             required: true
@@ -7833,7 +7970,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_327
+          - !<!Parameter> &ref_328
             schema: *ref_1
             implementation: Method
             required: true
@@ -7849,8 +7986,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_320
-                schema: *ref_319
+              - !<!Parameter> &ref_321
+                schema: *ref_320
                 flattened: true
                 implementation: Method
                 required: true
@@ -7864,33 +8001,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_323
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_324
                 schema: *ref_53
                 implementation: Method
-                originalParameter: *ref_320
+                originalParameter: *ref_321
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_321
+                targetProperty: *ref_322
                 language: !<!Languages> 
                   default:
                     name: algorithm
                     description: algorithm identifier
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_324
+              - !<!VirtualParameter> &ref_325
                 schema: *ref_54
                 implementation: Method
-                originalParameter: *ref_320
+                originalParameter: *ref_321
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_322
+                targetProperty: *ref_323
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_323
               - *ref_324
+              - *ref_325
             language: !<!Languages> 
               default:
                 name: ''
@@ -7904,12 +8054,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_325
           - *ref_326
           - *ref_327
+          - *ref_328
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_328
+            schema: *ref_329
             language: !<!Languages> 
               default:
                 name: ''
@@ -7923,7 +8073,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -7965,7 +8115,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_332
+          - !<!Parameter> &ref_333
             schema: *ref_0
             implementation: Method
             required: true
@@ -7983,7 +8133,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_333
+          - !<!Parameter> &ref_334
             schema: *ref_1
             implementation: Method
             required: true
@@ -7995,7 +8145,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_334
+          - !<!Parameter> &ref_335
             schema: *ref_1
             implementation: Method
             required: true
@@ -8011,8 +8161,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_329
-                schema: *ref_319
+              - !<!Parameter> &ref_330
+                schema: *ref_320
                 flattened: true
                 implementation: Method
                 required: true
@@ -8026,33 +8176,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_330
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_331
                 schema: *ref_53
                 implementation: Method
-                originalParameter: *ref_329
+                originalParameter: *ref_330
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_321
+                targetProperty: *ref_322
                 language: !<!Languages> 
                   default:
                     name: algorithm
                     description: algorithm identifier
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_331
+              - !<!VirtualParameter> &ref_332
                 schema: *ref_54
                 implementation: Method
-                originalParameter: *ref_329
+                originalParameter: *ref_330
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_322
+                targetProperty: *ref_323
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_330
               - *ref_331
+              - *ref_332
             language: !<!Languages> 
               default:
                 name: ''
@@ -8066,12 +8229,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_332
           - *ref_333
           - *ref_334
+          - *ref_335
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_328
+            schema: *ref_329
             language: !<!Languages> 
               default:
                 name: ''
@@ -8085,7 +8248,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8127,7 +8290,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_341
+          - !<!Parameter> &ref_342
             schema: *ref_0
             implementation: Method
             required: true
@@ -8145,7 +8308,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_342
+          - !<!Parameter> &ref_343
             schema: *ref_1
             implementation: Method
             required: true
@@ -8157,7 +8320,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_343
+          - !<!Parameter> &ref_344
             schema: *ref_1
             implementation: Method
             required: true
@@ -8173,8 +8336,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_336
-                schema: *ref_335
+              - !<!Parameter> &ref_337
+                schema: *ref_336
                 flattened: true
                 implementation: Method
                 required: true
@@ -8188,33 +8351,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_339
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_340
                 schema: *ref_57
                 implementation: Method
-                originalParameter: *ref_336
+                originalParameter: *ref_337
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_337
+                targetProperty: *ref_338
                 language: !<!Languages> 
                   default:
                     name: algorithm
                     description: 'The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_340
+              - !<!VirtualParameter> &ref_341
                 schema: *ref_58
                 implementation: Method
-                originalParameter: *ref_336
+                originalParameter: *ref_337
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_338
+                targetProperty: *ref_339
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_339
               - *ref_340
+              - *ref_341
             language: !<!Languages> 
               default:
                 name: ''
@@ -8228,12 +8404,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_341
           - *ref_342
           - *ref_343
+          - *ref_344
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_328
+            schema: *ref_329
             language: !<!Languages> 
               default:
                 name: ''
@@ -8247,7 +8423,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8286,7 +8462,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_352
+          - !<!Parameter> &ref_353
             schema: *ref_0
             implementation: Method
             required: true
@@ -8304,7 +8480,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_353
+          - !<!Parameter> &ref_354
             schema: *ref_1
             implementation: Method
             required: true
@@ -8316,7 +8492,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_354
+          - !<!Parameter> &ref_355
             schema: *ref_1
             implementation: Method
             required: true
@@ -8332,8 +8508,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_345
-                schema: *ref_344
+              - !<!Parameter> &ref_346
+                schema: *ref_345
                 flattened: true
                 implementation: Method
                 required: true
@@ -8347,46 +8523,59 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_349
-                schema: *ref_57
+              - !<!Parameter> 
+                schema: *ref_260
                 implementation: Method
-                originalParameter: *ref_345
-                pathToProperty: []
+                origin: 'modelerfour:synthesized/accept'
                 required: true
-                targetProperty: *ref_346
                 language: !<!Languages> 
                   default:
-                    name: algorithm
-                    description: 'The signing/verification algorithm. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
-                protocol: !<!Protocols> {}
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - !<!VirtualParameter> &ref_350
-                schema: *ref_59
+                schema: *ref_57
                 implementation: Method
-                originalParameter: *ref_345
+                originalParameter: *ref_346
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_347
                 language: !<!Languages> 
                   default:
-                    name: digest
-                    description: The digest used for signing.
+                    name: algorithm
+                    description: 'The signing/verification algorithm. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.'
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_351
-                schema: *ref_60
+                schema: *ref_59
                 implementation: Method
-                originalParameter: *ref_345
+                originalParameter: *ref_346
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_348
+                language: !<!Languages> 
+                  default:
+                    name: digest
+                    description: The digest used for signing.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_352
+                schema: *ref_60
+                implementation: Method
+                originalParameter: *ref_346
+                pathToProperty: []
+                required: true
+                targetProperty: *ref_349
                 language: !<!Languages> 
                   default:
                     name: signature
                     description: The signature to be verified.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_349
               - *ref_350
               - *ref_351
+              - *ref_352
             language: !<!Languages> 
               default:
                 name: ''
@@ -8400,12 +8589,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_352
           - *ref_353
           - *ref_354
+          - *ref_355
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_355
+            schema: *ref_356
             language: !<!Languages> 
               default:
                 name: ''
@@ -8419,7 +8608,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8458,7 +8647,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_359
+          - !<!Parameter> &ref_360
             schema: *ref_0
             implementation: Method
             required: true
@@ -8476,7 +8665,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_360
+          - !<!Parameter> &ref_361
             schema: *ref_1
             implementation: Method
             required: true
@@ -8488,7 +8677,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_361
+          - !<!Parameter> &ref_362
             schema: *ref_1
             implementation: Method
             required: true
@@ -8504,8 +8693,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_356
-                schema: *ref_319
+              - !<!Parameter> &ref_357
+                schema: *ref_320
                 flattened: true
                 implementation: Method
                 required: true
@@ -8519,33 +8708,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_357
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_358
                 schema: *ref_53
                 implementation: Method
-                originalParameter: *ref_356
+                originalParameter: *ref_357
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_321
+                targetProperty: *ref_322
                 language: !<!Languages> 
                   default:
                     name: algorithm
                     description: algorithm identifier
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_358
+              - !<!VirtualParameter> &ref_359
                 schema: *ref_54
                 implementation: Method
-                originalParameter: *ref_356
+                originalParameter: *ref_357
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_322
+                targetProperty: *ref_323
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_357
               - *ref_358
+              - *ref_359
             language: !<!Languages> 
               default:
                 name: ''
@@ -8559,12 +8761,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_359
           - *ref_360
           - *ref_361
+          - *ref_362
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_328
+            schema: *ref_329
             language: !<!Languages> 
               default:
                 name: ''
@@ -8578,7 +8780,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8620,7 +8822,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_365
+          - !<!Parameter> &ref_366
             schema: *ref_0
             implementation: Method
             required: true
@@ -8638,7 +8840,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_366
+          - !<!Parameter> &ref_367
             schema: *ref_1
             implementation: Method
             required: true
@@ -8650,7 +8852,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_367
+          - !<!Parameter> &ref_368
             schema: *ref_1
             implementation: Method
             required: true
@@ -8666,8 +8868,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_362
-                schema: *ref_319
+              - !<!Parameter> &ref_363
+                schema: *ref_320
                 flattened: true
                 implementation: Method
                 required: true
@@ -8681,33 +8883,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_363
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_364
                 schema: *ref_53
                 implementation: Method
-                originalParameter: *ref_362
+                originalParameter: *ref_363
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_321
+                targetProperty: *ref_322
                 language: !<!Languages> 
                   default:
                     name: algorithm
                     description: algorithm identifier
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_364
+              - !<!VirtualParameter> &ref_365
                 schema: *ref_54
                 implementation: Method
-                originalParameter: *ref_362
+                originalParameter: *ref_363
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_322
+                targetProperty: *ref_323
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_363
               - *ref_364
+              - *ref_365
             language: !<!Languages> 
               default:
                 name: ''
@@ -8721,12 +8936,12 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_365
           - *ref_366
           - *ref_367
+          - *ref_368
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_328
+            schema: *ref_329
             language: !<!Languages> 
               default:
                 name: ''
@@ -8740,7 +8955,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8781,7 +8996,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_368
+          - !<!Parameter> &ref_369
             schema: *ref_0
             implementation: Method
             required: true
@@ -8799,8 +9014,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_369
-            schema: *ref_304
+          - !<!Parameter> &ref_370
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -8813,6 +9028,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -8823,11 +9053,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_368
           - *ref_369
+          - *ref_370
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_370
+            schema: *ref_371
             language: !<!Languages> 
               default:
                 name: ''
@@ -8841,7 +9071,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -8892,7 +9122,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_371
+          - !<!Parameter> &ref_372
             schema: *ref_0
             implementation: Method
             required: true
@@ -8910,7 +9140,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_372
+          - !<!Parameter> &ref_373
             schema: *ref_1
             implementation: Method
             required: true
@@ -8925,6 +9155,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -8935,8 +9180,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_371
           - *ref_372
+          - *ref_373
         responses:
           - !<!SchemaResponse> 
             schema: *ref_21
@@ -8953,7 +9198,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9011,7 +9256,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_373
+          - !<!Parameter> &ref_374
             schema: *ref_0
             implementation: Method
             required: true
@@ -9029,7 +9274,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_374
+          - !<!Parameter> &ref_375
             schema: *ref_1
             implementation: Method
             required: true
@@ -9044,6 +9289,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9054,8 +9314,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_373
           - *ref_374
+          - *ref_375
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -9068,7 +9328,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9102,7 +9362,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_375
+          - !<!Parameter> &ref_376
             schema: *ref_0
             implementation: Method
             required: true
@@ -9120,7 +9380,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_376
+          - !<!Parameter> &ref_377
             schema: *ref_1
             implementation: Method
             required: true
@@ -9135,6 +9395,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9145,8 +9420,8 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_375
           - *ref_376
+          - *ref_377
         responses:
           - !<!SchemaResponse> 
             schema: *ref_17
@@ -9163,7 +9438,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9218,7 +9493,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_387
+          - !<!Parameter> &ref_388
             schema: *ref_0
             implementation: Method
             required: true
@@ -9236,7 +9511,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_388
+          - !<!Parameter> &ref_389
             schema: *ref_257
             implementation: Method
             required: true
@@ -9252,8 +9527,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_378
-                schema: *ref_377
+              - !<!Parameter> &ref_379
+                schema: *ref_378
                 flattened: true
                 implementation: Method
                 required: true
@@ -9267,59 +9542,72 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_383
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_384
                 schema: *ref_63
                 implementation: Method
-                originalParameter: *ref_378
+                originalParameter: *ref_379
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_379
+                targetProperty: *ref_380
                 language: !<!Languages> 
                   default:
                     name: value
                     description: The value of the secret.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_384
+              - !<!VirtualParameter> &ref_385
                 schema: *ref_64
                 implementation: Method
-                originalParameter: *ref_378
-                pathToProperty: []
-                required: false
-                targetProperty: *ref_380
-                language: !<!Languages> 
-                  default:
-                    name: tags
-                    description: Application specific metadata in the form of key-value pairs.
-                protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_385
-                schema: *ref_65
-                implementation: Method
-                originalParameter: *ref_378
+                originalParameter: *ref_379
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_381
                 language: !<!Languages> 
                   default:
-                    name: contentType
-                    description: Type of the secret value such as a password.
+                    name: tags
+                    description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_386
-                schema: *ref_8
+                schema: *ref_65
                 implementation: Method
-                originalParameter: *ref_378
+                originalParameter: *ref_379
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_382
+                language: !<!Languages> 
+                  default:
+                    name: contentType
+                    description: Type of the secret value such as a password.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_387
+                schema: *ref_8
+                implementation: Method
+                originalParameter: *ref_379
+                pathToProperty: []
+                required: false
+                targetProperty: *ref_383
                 language: !<!Languages> 
                   default:
                     name: secretAttributes
                     description: The secret management attributes.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_383
               - *ref_384
               - *ref_385
               - *ref_386
+              - *ref_387
             language: !<!Languages> 
               default:
                 name: ''
@@ -9333,8 +9621,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_387
           - *ref_388
+          - *ref_389
         responses:
           - !<!SchemaResponse> 
             schema: *ref_66
@@ -9351,7 +9639,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9392,7 +9680,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_389
+          - !<!Parameter> &ref_390
             schema: *ref_0
             implementation: Method
             required: true
@@ -9410,7 +9698,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_390
+          - !<!Parameter> &ref_391
             schema: *ref_1
             implementation: Method
             required: true
@@ -9425,6 +9713,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9435,8 +9738,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_389
           - *ref_390
+          - *ref_391
         responses:
           - !<!SchemaResponse> 
             schema: *ref_70
@@ -9453,7 +9756,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9494,7 +9797,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_399
+          - !<!Parameter> &ref_400
             schema: *ref_0
             implementation: Method
             required: true
@@ -9512,7 +9815,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_400
+          - !<!Parameter> &ref_401
             schema: *ref_1
             implementation: Method
             required: true
@@ -9524,7 +9827,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_401
+          - !<!Parameter> &ref_402
             schema: *ref_1
             implementation: Method
             required: true
@@ -9540,8 +9843,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_392
-                schema: *ref_391
+              - !<!Parameter> &ref_393
+                schema: *ref_392
                 flattened: true
                 implementation: Method
                 required: true
@@ -9555,43 +9858,56 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_396
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_397
                 schema: *ref_77
                 implementation: Method
-                originalParameter: *ref_392
+                originalParameter: *ref_393
                 pathToProperty: []
-                targetProperty: *ref_393
+                targetProperty: *ref_394
                 language: !<!Languages> 
                   default:
                     name: contentType
                     description: Type of the secret value such as a password.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_397
+              - !<!VirtualParameter> &ref_398
                 schema: *ref_8
                 implementation: Method
-                originalParameter: *ref_392
+                originalParameter: *ref_393
                 pathToProperty: []
-                targetProperty: *ref_394
+                targetProperty: *ref_395
                 language: !<!Languages> 
                   default:
                     name: secretAttributes
                     description: The secret management attributes.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_398
+              - !<!VirtualParameter> &ref_399
                 schema: *ref_78
                 implementation: Method
-                originalParameter: *ref_392
+                originalParameter: *ref_393
                 pathToProperty: []
-                targetProperty: *ref_395
+                targetProperty: *ref_396
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_396
               - *ref_397
               - *ref_398
+              - *ref_399
             language: !<!Languages> 
               default:
                 name: ''
@@ -9605,9 +9921,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_399
           - *ref_400
           - *ref_401
+          - *ref_402
         responses:
           - !<!SchemaResponse> 
             schema: *ref_66
@@ -9624,7 +9940,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9674,7 +9990,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_402
+          - !<!Parameter> &ref_403
             schema: *ref_0
             implementation: Method
             required: true
@@ -9692,7 +10008,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_403
+          - !<!Parameter> &ref_404
             schema: *ref_1
             implementation: Method
             required: true
@@ -9704,7 +10020,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_404
+          - !<!Parameter> &ref_405
             schema: *ref_1
             implementation: Method
             required: true
@@ -9719,6 +10035,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9729,9 +10060,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_402
           - *ref_403
           - *ref_404
+          - *ref_405
         responses:
           - !<!SchemaResponse> 
             schema: *ref_66
@@ -9748,7 +10079,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9788,7 +10119,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_405
+          - !<!Parameter> &ref_406
             schema: *ref_0
             implementation: Method
             required: true
@@ -9806,8 +10137,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_406
-            schema: *ref_304
+          - !<!Parameter> &ref_407
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -9820,6 +10151,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9830,11 +10176,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_405
           - *ref_406
+          - *ref_407
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_407
+            schema: *ref_408
             language: !<!Languages> 
               default:
                 name: ''
@@ -9848,7 +10194,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -9895,7 +10241,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_408
+          - !<!Parameter> &ref_409
             schema: *ref_0
             implementation: Method
             required: true
@@ -9913,7 +10259,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_409
+          - !<!Parameter> &ref_410
             schema: *ref_1
             implementation: Method
             required: true
@@ -9925,8 +10271,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_410
-            schema: *ref_304
+          - !<!Parameter> &ref_411
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -9939,6 +10285,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -9949,12 +10310,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_408
           - *ref_409
           - *ref_410
+          - *ref_411
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_407
+            schema: *ref_408
             language: !<!Languages> 
               default:
                 name: ''
@@ -9968,7 +10329,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10013,7 +10374,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_411
+          - !<!Parameter> &ref_412
             schema: *ref_0
             implementation: Method
             required: true
@@ -10031,8 +10392,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_412
-            schema: *ref_304
+          - !<!Parameter> &ref_413
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -10045,6 +10406,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10055,11 +10431,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_411
           - *ref_412
+          - *ref_413
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_413
+            schema: *ref_414
             language: !<!Languages> 
               default:
                 name: ''
@@ -10073,7 +10449,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10123,7 +10499,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_414
+          - !<!Parameter> &ref_415
             schema: *ref_0
             implementation: Method
             required: true
@@ -10141,7 +10517,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_415
+          - !<!Parameter> &ref_416
             schema: *ref_1
             implementation: Method
             required: true
@@ -10156,6 +10532,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10166,8 +10557,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_414
           - *ref_415
+          - *ref_416
         responses:
           - !<!SchemaResponse> 
             schema: *ref_70
@@ -10184,7 +10575,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10225,7 +10616,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_416
+          - !<!Parameter> &ref_417
             schema: *ref_0
             implementation: Method
             required: true
@@ -10243,7 +10634,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_417
+          - !<!Parameter> &ref_418
             schema: *ref_1
             implementation: Method
             required: true
@@ -10258,6 +10649,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10268,8 +10674,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_416
           - *ref_417
+          - *ref_418
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -10282,7 +10688,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10314,7 +10720,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_418
+          - !<!Parameter> &ref_419
             schema: *ref_0
             implementation: Method
             required: true
@@ -10332,7 +10738,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_419
+          - !<!Parameter> &ref_420
             schema: *ref_1
             implementation: Method
             required: true
@@ -10347,6 +10753,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10357,8 +10778,8 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_418
           - *ref_419
+          - *ref_420
         responses:
           - !<!SchemaResponse> 
             schema: *ref_66
@@ -10375,7 +10796,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10413,7 +10834,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_420
+          - !<!Parameter> &ref_421
             schema: *ref_0
             implementation: Method
             required: true
@@ -10431,7 +10852,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_421
+          - !<!Parameter> &ref_422
             schema: *ref_1
             implementation: Method
             required: true
@@ -10446,6 +10867,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10456,11 +10892,11 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_420
           - *ref_421
+          - *ref_422
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_422
+            schema: *ref_423
             language: !<!Languages> 
               default:
                 name: ''
@@ -10474,7 +10910,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10508,7 +10944,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_427
+          - !<!Parameter> &ref_428
             schema: *ref_0
             implementation: Method
             required: true
@@ -10530,8 +10966,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_424
-                schema: *ref_423
+              - !<!Parameter> &ref_425
+                schema: *ref_424
                 flattened: true
                 implementation: Method
                 required: true
@@ -10545,20 +10981,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_426
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_427
                 schema: *ref_89
                 implementation: Method
-                originalParameter: *ref_424
+                originalParameter: *ref_425
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_425
+                targetProperty: *ref_426
                 language: !<!Languages> 
                   default:
                     name: secretBundleBackup
                     description: The backup blob associated with a secret bundle.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_426
+              - *ref_427
             language: !<!Languages> 
               default:
                 name: ''
@@ -10572,7 +11021,7 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_427
+          - *ref_428
         responses:
           - !<!SchemaResponse> 
             schema: *ref_66
@@ -10589,7 +11038,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10632,7 +11081,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_429
+          - !<!Parameter> &ref_430
             schema: *ref_0
             implementation: Method
             required: true
@@ -10650,8 +11099,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_430
-            schema: *ref_304
+          - !<!Parameter> &ref_431
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -10661,8 +11110,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_431
-            schema: *ref_428
+          - !<!Parameter> &ref_432
+            schema: *ref_429
             implementation: Method
             language: !<!Languages> 
               default:
@@ -10675,6 +11124,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10685,12 +11149,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_429
           - *ref_430
           - *ref_431
+          - *ref_432
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_432
+            schema: *ref_433
             language: !<!Languages> 
               default:
                 name: ''
@@ -10704,7 +11168,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10757,7 +11221,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_433
+          - !<!Parameter> &ref_434
             schema: *ref_0
             implementation: Method
             required: true
@@ -10775,7 +11239,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_434
+          - !<!Parameter> &ref_435
             schema: *ref_1
             implementation: Method
             required: true
@@ -10790,6 +11254,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -10800,8 +11279,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_433
           - *ref_434
+          - *ref_435
         responses:
           - !<!SchemaResponse> 
             schema: *ref_99
@@ -10818,7 +11297,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -10895,7 +11374,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_439
+          - !<!Parameter> &ref_440
             schema: *ref_0
             implementation: Method
             required: true
@@ -10917,8 +11396,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_436
-                schema: *ref_435
+              - !<!Parameter> &ref_437
+                schema: *ref_436
                 flattened: true
                 implementation: Method
                 required: true
@@ -10930,19 +11409,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_438
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_439
                 schema: *ref_247
                 implementation: Method
-                originalParameter: *ref_436
+                originalParameter: *ref_437
                 pathToProperty: []
-                targetProperty: *ref_437
+                targetProperty: *ref_438
                 language: !<!Languages> 
                   default:
                     name: contactList
                     description: The contact list for the vault certificates.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_438
+              - *ref_439
             language: !<!Languages> 
               default:
                 name: ''
@@ -10956,10 +11448,10 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_439
+          - *ref_440
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_435
+            schema: *ref_436
             language: !<!Languages> 
               default:
                 name: ''
@@ -10973,7 +11465,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11020,7 +11512,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_440
+          - !<!Parameter> &ref_441
             schema: *ref_0
             implementation: Method
             required: true
@@ -11041,6 +11533,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11051,10 +11558,10 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_440
+          - *ref_441
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_435
+            schema: *ref_436
             language: !<!Languages> 
               default:
                 name: ''
@@ -11068,7 +11575,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11107,7 +11614,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_441
+          - !<!Parameter> &ref_442
             schema: *ref_0
             implementation: Method
             required: true
@@ -11128,6 +11635,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11138,10 +11660,10 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_441
+          - *ref_442
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_435
+            schema: *ref_436
             language: !<!Languages> 
               default:
                 name: ''
@@ -11155,7 +11677,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11194,7 +11716,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_442
+          - !<!Parameter> &ref_443
             schema: *ref_0
             implementation: Method
             required: true
@@ -11212,8 +11734,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_443
-            schema: *ref_304
+          - !<!Parameter> &ref_444
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -11226,6 +11748,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11236,11 +11773,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_442
           - *ref_443
+          - *ref_444
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_444
+            schema: *ref_445
             language: !<!Languages> 
               default:
                 name: ''
@@ -11254,7 +11791,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11297,7 +11834,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_455
+          - !<!Parameter> &ref_456
             schema: *ref_0
             implementation: Method
             required: true
@@ -11315,7 +11852,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_456
+          - !<!Parameter> &ref_457
             schema: *ref_1
             implementation: Method
             required: true
@@ -11331,8 +11868,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_446
-                schema: *ref_445
+              - !<!Parameter> &ref_447
+                schema: *ref_446
                 flattened: true
                 implementation: Method
                 required: true
@@ -11346,59 +11883,72 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_451
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_452
                 schema: *ref_143
                 implementation: Method
-                originalParameter: *ref_446
+                originalParameter: *ref_447
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_447
+                targetProperty: *ref_448
                 language: !<!Languages> 
                   default:
                     name: provider
                     description: The issuer provider.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_452
+              - !<!VirtualParameter> &ref_453
                 schema: *ref_151
                 implementation: Method
-                originalParameter: *ref_446
-                pathToProperty: []
-                required: false
-                targetProperty: *ref_448
-                language: !<!Languages> 
-                  default:
-                    name: credentials
-                    description: The credentials to be used for the issuer.
-                protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_453
-                schema: *ref_152
-                implementation: Method
-                originalParameter: *ref_446
+                originalParameter: *ref_447
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_449
                 language: !<!Languages> 
                   default:
-                    name: organizationDetails
-                    description: Details of the organization as provided to the issuer.
+                    name: credentials
+                    description: The credentials to be used for the issuer.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_454
-                schema: *ref_154
+                schema: *ref_152
                 implementation: Method
-                originalParameter: *ref_446
+                originalParameter: *ref_447
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_450
+                language: !<!Languages> 
+                  default:
+                    name: organizationDetails
+                    description: Details of the organization as provided to the issuer.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_455
+                schema: *ref_154
+                implementation: Method
+                originalParameter: *ref_447
+                pathToProperty: []
+                required: false
+                targetProperty: *ref_451
                 language: !<!Languages> 
                   default:
                     name: attributes
                     description: Attributes of the issuer object.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_451
               - *ref_452
               - *ref_453
               - *ref_454
+              - *ref_455
             language: !<!Languages> 
               default:
                 name: ''
@@ -11412,11 +11962,11 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_455
           - *ref_456
+          - *ref_457
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_457
+            schema: *ref_458
             language: !<!Languages> 
               default:
                 name: ''
@@ -11430,7 +11980,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11488,7 +12038,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_468
+          - !<!Parameter> &ref_469
             schema: *ref_0
             implementation: Method
             required: true
@@ -11506,7 +12056,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_469
+          - !<!Parameter> &ref_470
             schema: *ref_1
             implementation: Method
             required: true
@@ -11522,8 +12072,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_459
-                schema: *ref_458
+              - !<!Parameter> &ref_460
+                schema: *ref_459
                 flattened: true
                 implementation: Method
                 required: true
@@ -11537,55 +12087,68 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_464
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_465
                 schema: *ref_157
                 implementation: Method
-                originalParameter: *ref_459
+                originalParameter: *ref_460
                 pathToProperty: []
-                targetProperty: *ref_460
+                targetProperty: *ref_461
                 language: !<!Languages> 
                   default:
                     name: provider
                     description: The issuer provider.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_465
+              - !<!VirtualParameter> &ref_466
                 schema: *ref_151
                 implementation: Method
-                originalParameter: *ref_459
+                originalParameter: *ref_460
                 pathToProperty: []
-                targetProperty: *ref_461
+                targetProperty: *ref_462
                 language: !<!Languages> 
                   default:
                     name: credentials
                     description: The credentials to be used for the issuer.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_466
+              - !<!VirtualParameter> &ref_467
                 schema: *ref_152
                 implementation: Method
-                originalParameter: *ref_459
+                originalParameter: *ref_460
                 pathToProperty: []
-                targetProperty: *ref_462
+                targetProperty: *ref_463
                 language: !<!Languages> 
                   default:
                     name: organizationDetails
                     description: Details of the organization as provided to the issuer.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_467
+              - !<!VirtualParameter> &ref_468
                 schema: *ref_154
                 implementation: Method
-                originalParameter: *ref_459
+                originalParameter: *ref_460
                 pathToProperty: []
-                targetProperty: *ref_463
+                targetProperty: *ref_464
                 language: !<!Languages> 
                   default:
                     name: attributes
                     description: Attributes of the issuer object.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_464
               - *ref_465
               - *ref_466
               - *ref_467
+              - *ref_468
             language: !<!Languages> 
               default:
                 name: ''
@@ -11599,11 +12162,11 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_468
           - *ref_469
+          - *ref_470
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_457
+            schema: *ref_458
             language: !<!Languages> 
               default:
                 name: ''
@@ -11617,7 +12180,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11669,7 +12232,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_470
+          - !<!Parameter> &ref_471
             schema: *ref_0
             implementation: Method
             required: true
@@ -11687,7 +12250,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_471
+          - !<!Parameter> &ref_472
             schema: *ref_1
             implementation: Method
             required: true
@@ -11702,6 +12265,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11712,11 +12290,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_470
           - *ref_471
+          - *ref_472
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_457
+            schema: *ref_458
             language: !<!Languages> 
               default:
                 name: ''
@@ -11730,7 +12308,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11777,7 +12355,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_472
+          - !<!Parameter> &ref_473
             schema: *ref_0
             implementation: Method
             required: true
@@ -11795,7 +12373,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_473
+          - !<!Parameter> &ref_474
             schema: *ref_1
             implementation: Method
             required: true
@@ -11810,6 +12388,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -11820,11 +12413,11 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_472
           - *ref_473
+          - *ref_474
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_457
+            schema: *ref_458
             language: !<!Languages> 
               default:
                 name: ''
@@ -11838,7 +12431,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -11885,7 +12478,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_482
+          - !<!Parameter> &ref_483
             schema: *ref_0
             implementation: Method
             required: true
@@ -11903,7 +12496,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_483
+          - !<!Parameter> &ref_484
             schema: *ref_257
             implementation: Method
             required: true
@@ -11919,8 +12512,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_475
-                schema: *ref_474
+              - !<!Parameter> &ref_476
+                schema: *ref_475
                 flattened: true
                 implementation: Method
                 required: true
@@ -11934,43 +12527,56 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_479
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_480
                 schema: *ref_125
                 implementation: Method
-                originalParameter: *ref_475
+                originalParameter: *ref_476
                 pathToProperty: []
-                targetProperty: *ref_476
+                targetProperty: *ref_477
                 language: !<!Languages> 
                   default:
                     name: certificatePolicy
                     description: The management policy for the certificate.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_480
+              - !<!VirtualParameter> &ref_481
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_475
+                originalParameter: *ref_476
                 pathToProperty: []
-                targetProperty: *ref_477
+                targetProperty: *ref_478
                 language: !<!Languages> 
                   default:
                     name: certificateAttributes
                     description: The attributes of the certificate (optional).
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_481
+              - !<!VirtualParameter> &ref_482
                 schema: *ref_158
                 implementation: Method
-                originalParameter: *ref_475
+                originalParameter: *ref_476
                 pathToProperty: []
-                targetProperty: *ref_478
+                targetProperty: *ref_479
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_479
               - *ref_480
               - *ref_481
+              - *ref_482
             language: !<!Languages> 
               default:
                 name: ''
@@ -11984,11 +12590,11 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_482
           - *ref_483
+          - *ref_484
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_484
+            schema: *ref_485
             language: !<!Languages> 
               default:
                 name: ''
@@ -12002,7 +12608,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12060,7 +12666,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_497
+          - !<!Parameter> &ref_498
             schema: *ref_0
             implementation: Method
             required: true
@@ -12078,7 +12684,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_498
+          - !<!Parameter> &ref_499
             schema: *ref_257
             implementation: Method
             required: true
@@ -12094,8 +12700,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_486
-                schema: *ref_485
+              - !<!Parameter> &ref_487
+                schema: *ref_486
                 flattened: true
                 implementation: Method
                 required: true
@@ -12109,72 +12715,85 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_492
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_493
                 schema: *ref_166
                 implementation: Method
-                originalParameter: *ref_486
+                originalParameter: *ref_487
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_487
+                targetProperty: *ref_488
                 language: !<!Languages> 
                   default:
                     name: base64EncodedCertificate
                     description: Base64 encoded representation of the certificate object to import. This certificate needs to contain the private key.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_493
+              - !<!VirtualParameter> &ref_494
                 schema: *ref_167
                 implementation: Method
-                originalParameter: *ref_486
-                pathToProperty: []
-                required: false
-                targetProperty: *ref_488
-                language: !<!Languages> 
-                  default:
-                    name: password
-                    description: 'If the private key in base64EncodedCertificate is encrypted, the password used for encryption.'
-                protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_494
-                schema: *ref_125
-                implementation: Method
-                originalParameter: *ref_486
+                originalParameter: *ref_487
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_489
                 language: !<!Languages> 
                   default:
-                    name: certificatePolicy
-                    description: The management policy for the certificate.
+                    name: password
+                    description: 'If the private key in base64EncodedCertificate is encrypted, the password used for encryption.'
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_495
-                schema: *ref_9
+                schema: *ref_125
                 implementation: Method
-                originalParameter: *ref_486
+                originalParameter: *ref_487
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_490
                 language: !<!Languages> 
                   default:
-                    name: certificateAttributes
-                    description: The attributes of the certificate (optional).
+                    name: certificatePolicy
+                    description: The management policy for the certificate.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_496
-                schema: *ref_168
+                schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_486
+                originalParameter: *ref_487
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_491
+                language: !<!Languages> 
+                  default:
+                    name: certificateAttributes
+                    description: The attributes of the certificate (optional).
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_497
+                schema: *ref_168
+                implementation: Method
+                originalParameter: *ref_487
+                pathToProperty: []
+                required: false
+                targetProperty: *ref_492
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_492
               - *ref_493
               - *ref_494
               - *ref_495
               - *ref_496
+              - *ref_497
             language: !<!Languages> 
               default:
                 name: ''
@@ -12188,8 +12807,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_497
           - *ref_498
+          - *ref_499
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -12206,7 +12825,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12292,7 +12911,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_499
+          - !<!Parameter> &ref_500
             schema: *ref_0
             implementation: Method
             required: true
@@ -12310,7 +12929,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_500
+          - !<!Parameter> &ref_501
             schema: *ref_1
             implementation: Method
             required: true
@@ -12322,8 +12941,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_501
-            schema: *ref_304
+          - !<!Parameter> &ref_502
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -12336,6 +12955,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12346,12 +12980,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_499
           - *ref_500
           - *ref_501
+          - *ref_502
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_432
+            schema: *ref_433
             language: !<!Languages> 
               default:
                 name: ''
@@ -12365,7 +12999,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12419,7 +13053,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_502
+          - !<!Parameter> &ref_503
             schema: *ref_0
             implementation: Method
             required: true
@@ -12437,7 +13071,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_503
+          - !<!Parameter> &ref_504
             schema: *ref_1
             implementation: Method
             required: true
@@ -12452,6 +13086,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12462,8 +13111,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_502
           - *ref_503
+          - *ref_504
         responses:
           - !<!SchemaResponse> 
             schema: *ref_125
@@ -12480,7 +13129,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12538,7 +13187,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_505
+          - !<!Parameter> &ref_506
             schema: *ref_0
             implementation: Method
             required: true
@@ -12556,7 +13205,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_506
+          - !<!Parameter> &ref_507
             schema: *ref_1
             implementation: Method
             required: true
@@ -12572,7 +13221,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_504
+              - !<!Parameter> &ref_505
                 schema: *ref_125
                 implementation: Method
                 required: true
@@ -12584,8 +13233,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_504
+              - *ref_505
             language: !<!Languages> 
               default:
                 name: ''
@@ -12599,8 +13261,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_505
           - *ref_506
+          - *ref_507
         responses:
           - !<!SchemaResponse> 
             schema: *ref_125
@@ -12617,7 +13279,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12697,7 +13359,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_515
+          - !<!Parameter> &ref_516
             schema: *ref_0
             implementation: Method
             required: true
@@ -12715,7 +13377,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_516
+          - !<!Parameter> &ref_517
             schema: *ref_1
             implementation: Method
             required: true
@@ -12727,7 +13389,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_517
+          - !<!Parameter> &ref_518
             schema: *ref_1
             implementation: Method
             required: true
@@ -12743,8 +13405,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_508
-                schema: *ref_507
+              - !<!Parameter> &ref_509
+                schema: *ref_508
                 flattened: true
                 implementation: Method
                 required: true
@@ -12758,43 +13420,56 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_512
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_513
                 schema: *ref_125
                 implementation: Method
-                originalParameter: *ref_508
+                originalParameter: *ref_509
                 pathToProperty: []
-                targetProperty: *ref_509
+                targetProperty: *ref_510
                 language: !<!Languages> 
                   default:
                     name: certificatePolicy
                     description: The management policy for the certificate.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_513
+              - !<!VirtualParameter> &ref_514
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_508
+                originalParameter: *ref_509
                 pathToProperty: []
-                targetProperty: *ref_510
+                targetProperty: *ref_511
                 language: !<!Languages> 
                   default:
                     name: certificateAttributes
                     description: The attributes of the certificate (optional).
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_514
+              - !<!VirtualParameter> &ref_515
                 schema: *ref_169
                 implementation: Method
-                originalParameter: *ref_508
+                originalParameter: *ref_509
                 pathToProperty: []
-                targetProperty: *ref_511
+                targetProperty: *ref_512
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_512
               - *ref_513
               - *ref_514
+              - *ref_515
             language: !<!Languages> 
               default:
                 name: ''
@@ -12808,9 +13483,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_515
           - *ref_516
           - *ref_517
+          - *ref_518
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -12827,7 +13502,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12881,7 +13556,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_518
+          - !<!Parameter> &ref_519
             schema: *ref_0
             implementation: Method
             required: true
@@ -12899,7 +13574,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_519
+          - !<!Parameter> &ref_520
             schema: *ref_1
             implementation: Method
             required: true
@@ -12911,7 +13586,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_520
+          - !<!Parameter> &ref_521
             schema: *ref_1
             implementation: Method
             required: true
@@ -12926,6 +13601,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -12936,9 +13626,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_518
           - *ref_519
           - *ref_520
+          - *ref_521
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -12955,7 +13645,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -12997,7 +13687,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_525
+          - !<!Parameter> &ref_526
             schema: *ref_0
             implementation: Method
             required: true
@@ -13015,7 +13705,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_526
+          - !<!Parameter> &ref_527
             schema: *ref_1
             implementation: Method
             required: true
@@ -13031,8 +13721,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_522
-                schema: *ref_521
+              - !<!Parameter> &ref_523
+                schema: *ref_522
                 flattened: true
                 implementation: Method
                 required: true
@@ -13046,20 +13736,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_524
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_525
                 schema: *ref_161
                 implementation: Method
-                originalParameter: *ref_522
+                originalParameter: *ref_523
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_523
+                targetProperty: *ref_524
                 language: !<!Languages> 
                   default:
                     name: cancellationRequested
                     description: Indicates if cancellation was requested on the certificate operation.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_524
+              - *ref_525
             language: !<!Languages> 
               default:
                 name: ''
@@ -13073,11 +13776,11 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_525
           - *ref_526
+          - *ref_527
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_484
+            schema: *ref_485
             language: !<!Languages> 
               default:
                 name: ''
@@ -13091,7 +13794,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13134,7 +13837,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_527
+          - !<!Parameter> &ref_528
             schema: *ref_0
             implementation: Method
             required: true
@@ -13152,7 +13855,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_528
+          - !<!Parameter> &ref_529
             schema: *ref_1
             implementation: Method
             required: true
@@ -13167,6 +13870,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13177,11 +13895,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_527
           - *ref_528
+          - *ref_529
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_484
+            schema: *ref_485
             language: !<!Languages> 
               default:
                 name: ''
@@ -13195,7 +13913,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13236,7 +13954,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_529
+          - !<!Parameter> &ref_530
             schema: *ref_0
             implementation: Method
             required: true
@@ -13254,7 +13972,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_530
+          - !<!Parameter> &ref_531
             schema: *ref_1
             implementation: Method
             required: true
@@ -13269,6 +13987,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13279,11 +14012,11 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_529
           - *ref_530
+          - *ref_531
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_484
+            schema: *ref_485
             language: !<!Languages> 
               default:
                 name: ''
@@ -13297,7 +14030,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13338,7 +14071,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_539
+          - !<!Parameter> &ref_540
             schema: *ref_0
             implementation: Method
             required: true
@@ -13356,7 +14089,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_540
+          - !<!Parameter> &ref_541
             schema: *ref_1
             implementation: Method
             required: true
@@ -13372,8 +14105,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_532
-                schema: *ref_531
+              - !<!Parameter> &ref_533
+                schema: *ref_532
                 flattened: true
                 implementation: Method
                 required: true
@@ -13387,46 +14120,59 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_536
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_537
                 schema: *ref_250
                 implementation: Method
-                originalParameter: *ref_532
+                originalParameter: *ref_533
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_533
+                targetProperty: *ref_534
                 language: !<!Languages> 
                   default:
                     name: x509Certificates
                     description: The certificate or the certificate chain to merge.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_537
+              - !<!VirtualParameter> &ref_538
                 schema: *ref_9
                 implementation: Method
-                originalParameter: *ref_532
+                originalParameter: *ref_533
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_534
+                targetProperty: *ref_535
                 language: !<!Languages> 
                   default:
                     name: certificateAttributes
                     description: The attributes of the certificate (optional).
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_538
+              - !<!VirtualParameter> &ref_539
                 schema: *ref_171
                 implementation: Method
-                originalParameter: *ref_532
+                originalParameter: *ref_533
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_535
+                targetProperty: *ref_536
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_536
               - *ref_537
               - *ref_538
+              - *ref_539
             language: !<!Languages> 
               default:
                 name: ''
@@ -13440,8 +14186,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_539
           - *ref_540
+          - *ref_541
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -13458,7 +14204,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13532,7 +14278,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_541
+          - !<!Parameter> &ref_542
             schema: *ref_0
             implementation: Method
             required: true
@@ -13550,7 +14296,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_542
+          - !<!Parameter> &ref_543
             schema: *ref_1
             implementation: Method
             required: true
@@ -13565,6 +14311,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13575,11 +14336,11 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_541
           - *ref_542
+          - *ref_543
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_543
+            schema: *ref_544
             language: !<!Languages> 
               default:
                 name: ''
@@ -13593,7 +14354,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13627,7 +14388,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_548
+          - !<!Parameter> &ref_549
             schema: *ref_0
             implementation: Method
             required: true
@@ -13649,8 +14410,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_545
-                schema: *ref_544
+              - !<!Parameter> &ref_546
+                schema: *ref_545
                 flattened: true
                 implementation: Method
                 required: true
@@ -13664,20 +14425,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_547
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_548
                 schema: *ref_173
                 implementation: Method
-                originalParameter: *ref_545
+                originalParameter: *ref_546
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_546
+                targetProperty: *ref_547
                 language: !<!Languages> 
                   default:
                     name: certificateBundleBackup
                     description: The backup blob associated with a certificate bundle.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_547
+              - *ref_548
             language: !<!Languages> 
               default:
                 name: ''
@@ -13691,7 +14465,7 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_548
+          - *ref_549
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -13708,7 +14482,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13786,7 +14560,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_549
+          - !<!Parameter> &ref_550
             schema: *ref_0
             implementation: Method
             required: true
@@ -13804,8 +14578,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_550
-            schema: *ref_304
+          - !<!Parameter> &ref_551
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -13815,8 +14589,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_551
-            schema: *ref_428
+          - !<!Parameter> &ref_552
+            schema: *ref_429
             implementation: Method
             language: !<!Languages> 
               default:
@@ -13829,6 +14603,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13839,12 +14628,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_549
           - *ref_550
           - *ref_551
+          - *ref_552
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_552
+            schema: *ref_553
             language: !<!Languages> 
               default:
                 name: ''
@@ -13858,7 +14647,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -13911,7 +14700,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_553
+          - !<!Parameter> &ref_554
             schema: *ref_0
             implementation: Method
             required: true
@@ -13929,7 +14718,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_554
+          - !<!Parameter> &ref_555
             schema: *ref_1
             implementation: Method
             required: true
@@ -13944,6 +14733,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -13954,8 +14758,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_553
           - *ref_554
+          - *ref_555
         responses:
           - !<!SchemaResponse> 
             schema: *ref_99
@@ -13972,7 +14776,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14050,7 +14854,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_555
+          - !<!Parameter> &ref_556
             schema: *ref_0
             implementation: Method
             required: true
@@ -14068,7 +14872,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_556
+          - !<!Parameter> &ref_557
             schema: *ref_1
             implementation: Method
             required: true
@@ -14083,6 +14887,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14093,8 +14912,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_555
           - *ref_556
+          - *ref_557
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -14107,7 +14926,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14141,7 +14960,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_557
+          - !<!Parameter> &ref_558
             schema: *ref_0
             implementation: Method
             required: true
@@ -14159,7 +14978,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_558
+          - !<!Parameter> &ref_559
             schema: *ref_1
             implementation: Method
             required: true
@@ -14174,6 +14993,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14184,8 +15018,8 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_557
           - *ref_558
+          - *ref_559
         responses:
           - !<!SchemaResponse> 
             schema: *ref_123
@@ -14202,7 +15036,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14276,7 +15110,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_559
+          - !<!Parameter> &ref_560
             schema: *ref_0
             implementation: Method
             required: true
@@ -14294,8 +15128,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_560
-            schema: *ref_304
+          - !<!Parameter> &ref_561
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14308,6 +15142,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14318,11 +15167,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_559
           - *ref_560
+          - *ref_561
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_561
+            schema: *ref_562
             language: !<!Languages> 
               default:
                 name: ''
@@ -14336,7 +15185,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14394,7 +15243,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_562
+          - !<!Parameter> &ref_563
             schema: *ref_0
             implementation: Method
             required: true
@@ -14412,8 +15261,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_563
-            schema: *ref_304
+          - !<!Parameter> &ref_564
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -14426,6 +15275,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14436,11 +15300,11 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_562
           - *ref_563
+          - *ref_564
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_564
+            schema: *ref_565
             language: !<!Languages> 
               default:
                 name: ''
@@ -14454,7 +15318,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14519,7 +15383,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_566
+          - !<!Parameter> &ref_567
             schema: *ref_0
             implementation: Method
             required: true
@@ -14537,8 +15401,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_567
-            schema: *ref_565
+          - !<!Parameter> &ref_568
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14552,6 +15416,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14562,8 +15441,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_566
           - *ref_567
+          - *ref_568
         responses:
           - !<!SchemaResponse> 
             schema: *ref_187
@@ -14580,7 +15459,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14630,7 +15509,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_568
+          - !<!Parameter> &ref_569
             schema: *ref_0
             implementation: Method
             required: true
@@ -14648,8 +15527,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_569
-            schema: *ref_565
+          - !<!Parameter> &ref_570
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14663,6 +15542,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14673,8 +15567,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_568
           - *ref_569
+          - *ref_570
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -14687,7 +15581,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14723,7 +15617,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_570
+          - !<!Parameter> &ref_571
             schema: *ref_0
             implementation: Method
             required: true
@@ -14741,8 +15635,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_571
-            schema: *ref_565
+          - !<!Parameter> &ref_572
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -14756,6 +15650,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14766,8 +15675,8 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_570
           - *ref_571
+          - *ref_572
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -14784,7 +15693,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14831,7 +15740,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_572
+          - !<!Parameter> &ref_573
             schema: *ref_0
             implementation: Method
             required: true
@@ -14849,7 +15758,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_573
+          - !<!Parameter> &ref_574
             schema: *ref_1
             implementation: Method
             required: true
@@ -14864,6 +15773,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -14874,11 +15798,11 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_572
           - *ref_573
+          - *ref_574
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_574
+            schema: *ref_575
             language: !<!Languages> 
               default:
                 name: ''
@@ -14892,7 +15816,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -14928,7 +15852,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_579
+          - !<!Parameter> &ref_580
             schema: *ref_0
             implementation: Method
             required: true
@@ -14950,8 +15874,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_576
-                schema: *ref_575
+              - !<!Parameter> &ref_577
+                schema: *ref_576
                 flattened: true
                 implementation: Method
                 required: true
@@ -14965,20 +15889,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_578
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_579
                 schema: *ref_197
                 implementation: Method
-                originalParameter: *ref_576
+                originalParameter: *ref_577
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_577
+                targetProperty: *ref_578
                 language: !<!Languages> 
                   default:
                     name: storageBundleBackup
                     description: The backup blob associated with a storage account.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_578
+              - *ref_579
             language: !<!Languages> 
               default:
                 name: ''
@@ -14992,7 +15929,7 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_579
+          - *ref_580
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -15009,7 +15946,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15059,7 +15996,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_580
+          - !<!Parameter> &ref_581
             schema: *ref_0
             implementation: Method
             required: true
@@ -15077,8 +16014,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_581
-            schema: *ref_565
+          - !<!Parameter> &ref_582
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15092,6 +16029,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15102,8 +16054,8 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_580
           - *ref_581
+          - *ref_582
         responses:
           - !<!SchemaResponse> 
             schema: *ref_187
@@ -15120,7 +16072,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15169,7 +16121,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_582
+          - !<!Parameter> &ref_583
             schema: *ref_0
             implementation: Method
             required: true
@@ -15187,8 +16139,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_583
-            schema: *ref_565
+          - !<!Parameter> &ref_584
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15202,6 +16154,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15212,8 +16179,8 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_582
           - *ref_583
+          - *ref_584
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -15230,7 +16197,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15276,7 +16243,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_598
+          - !<!Parameter> &ref_599
             schema: *ref_0
             implementation: Method
             required: true
@@ -15294,8 +16261,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_599
-            schema: *ref_565
+          - !<!Parameter> &ref_600
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15310,8 +16277,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_585
-                schema: *ref_584
+              - !<!Parameter> &ref_586
+                schema: *ref_585
                 flattened: true
                 implementation: Method
                 required: true
@@ -15325,85 +16292,98 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_592
-                schema: *ref_198
+              - !<!Parameter> 
+                schema: *ref_260
                 implementation: Method
-                originalParameter: *ref_585
-                pathToProperty: []
+                origin: 'modelerfour:synthesized/accept'
                 required: true
-                targetProperty: *ref_586
                 language: !<!Languages> 
                   default:
-                    name: resourceId
-                    description: Storage account resource id.
-                protocol: !<!Protocols> {}
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - !<!VirtualParameter> &ref_593
-                schema: *ref_199
+                schema: *ref_198
                 implementation: Method
-                originalParameter: *ref_585
+                originalParameter: *ref_586
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_587
                 language: !<!Languages> 
                   default:
-                    name: activeKeyName
-                    description: Current active storage account key name.
+                    name: resourceId
+                    description: Storage account resource id.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_594
-                schema: *ref_191
+                schema: *ref_199
                 implementation: Method
-                originalParameter: *ref_585
+                originalParameter: *ref_586
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_588
                 language: !<!Languages> 
                   default:
-                    name: autoRegenerateKey
-                    description: whether keyvault should manage the storage account for the user.
+                    name: activeKeyName
+                    description: Current active storage account key name.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_595
-                schema: *ref_200
+                schema: *ref_191
                 implementation: Method
-                originalParameter: *ref_585
+                originalParameter: *ref_586
                 pathToProperty: []
-                required: false
+                required: true
                 targetProperty: *ref_589
                 language: !<!Languages> 
                   default:
-                    name: regenerationPeriod
-                    description: The key regeneration time duration specified in ISO-8601 format.
+                    name: autoRegenerateKey
+                    description: whether keyvault should manage the storage account for the user.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_596
-                schema: *ref_185
+                schema: *ref_200
                 implementation: Method
-                originalParameter: *ref_585
+                originalParameter: *ref_586
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_590
                 language: !<!Languages> 
                   default:
-                    name: storageAccountAttributes
-                    description: The attributes of the storage account.
+                    name: regenerationPeriod
+                    description: The key regeneration time duration specified in ISO-8601 format.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_597
-                schema: *ref_201
+                schema: *ref_185
                 implementation: Method
-                originalParameter: *ref_585
+                originalParameter: *ref_586
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_591
+                language: !<!Languages> 
+                  default:
+                    name: storageAccountAttributes
+                    description: The attributes of the storage account.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_598
+                schema: *ref_201
+                implementation: Method
+                originalParameter: *ref_586
+                pathToProperty: []
+                required: false
+                targetProperty: *ref_592
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_592
               - *ref_593
               - *ref_594
               - *ref_595
               - *ref_596
               - *ref_597
+              - *ref_598
             language: !<!Languages> 
               default:
                 name: ''
@@ -15417,8 +16397,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_598
           - *ref_599
+          - *ref_600
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -15435,7 +16415,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15491,7 +16471,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_612
+          - !<!Parameter> &ref_613
             schema: *ref_0
             implementation: Method
             required: true
@@ -15509,8 +16489,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_613
-            schema: *ref_565
+          - !<!Parameter> &ref_614
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15525,8 +16505,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_601
-                schema: *ref_600
+              - !<!Parameter> &ref_602
+                schema: *ref_601
                 flattened: true
                 implementation: Method
                 required: true
@@ -15540,67 +16520,80 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_607
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_608
                 schema: *ref_202
                 implementation: Method
-                originalParameter: *ref_601
+                originalParameter: *ref_602
                 pathToProperty: []
-                targetProperty: *ref_602
+                targetProperty: *ref_603
                 language: !<!Languages> 
                   default:
                     name: activeKeyName
                     description: The current active storage account key name.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_608
+              - !<!VirtualParameter> &ref_609
                 schema: *ref_191
                 implementation: Method
-                originalParameter: *ref_601
+                originalParameter: *ref_602
                 pathToProperty: []
-                targetProperty: *ref_603
+                targetProperty: *ref_604
                 language: !<!Languages> 
                   default:
                     name: autoRegenerateKey
                     description: whether keyvault should manage the storage account for the user.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_609
+              - !<!VirtualParameter> &ref_610
                 schema: *ref_203
                 implementation: Method
-                originalParameter: *ref_601
+                originalParameter: *ref_602
                 pathToProperty: []
-                targetProperty: *ref_604
+                targetProperty: *ref_605
                 language: !<!Languages> 
                   default:
                     name: regenerationPeriod
                     description: The key regeneration time duration specified in ISO-8601 format.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_610
+              - !<!VirtualParameter> &ref_611
                 schema: *ref_185
                 implementation: Method
-                originalParameter: *ref_601
+                originalParameter: *ref_602
                 pathToProperty: []
-                targetProperty: *ref_605
+                targetProperty: *ref_606
                 language: !<!Languages> 
                   default:
                     name: storageAccountAttributes
                     description: The attributes of the storage account.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_611
+              - !<!VirtualParameter> &ref_612
                 schema: *ref_204
                 implementation: Method
-                originalParameter: *ref_601
+                originalParameter: *ref_602
                 pathToProperty: []
-                targetProperty: *ref_606
+                targetProperty: *ref_607
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_607
               - *ref_608
               - *ref_609
               - *ref_610
               - *ref_611
+              - *ref_612
             language: !<!Languages> 
               default:
                 name: ''
@@ -15614,8 +16607,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_612
           - *ref_613
+          - *ref_614
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -15632,7 +16625,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15681,7 +16674,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_618
+          - !<!Parameter> &ref_619
             schema: *ref_0
             implementation: Method
             required: true
@@ -15699,8 +16692,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_619
-            schema: *ref_565
+          - !<!Parameter> &ref_620
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15715,8 +16708,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_615
-                schema: *ref_614
+              - !<!Parameter> &ref_616
+                schema: *ref_615
                 flattened: true
                 implementation: Method
                 required: true
@@ -15730,20 +16723,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_617
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_618
                 schema: *ref_205
                 implementation: Method
-                originalParameter: *ref_615
+                originalParameter: *ref_616
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_616
+                targetProperty: *ref_617
                 language: !<!Languages> 
                   default:
                     name: keyName
                     description: The storage account key name.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_617
+              - *ref_618
             language: !<!Languages> 
               default:
                 name: ''
@@ -15757,8 +16763,8 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_618
           - *ref_619
+          - *ref_620
         responses:
           - !<!SchemaResponse> 
             schema: *ref_194
@@ -15775,7 +16781,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15823,7 +16829,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_620
+          - !<!Parameter> &ref_621
             schema: *ref_0
             implementation: Method
             required: true
@@ -15841,8 +16847,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_621
-            schema: *ref_565
+          - !<!Parameter> &ref_622
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15853,8 +16859,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_622
-            schema: *ref_304
+          - !<!Parameter> &ref_623
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15867,6 +16873,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -15877,12 +16898,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_620
           - *ref_621
           - *ref_622
+          - *ref_623
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_623
+            schema: *ref_624
             language: !<!Languages> 
               default:
                 name: ''
@@ -15896,7 +16917,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -15949,7 +16970,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_624
+          - !<!Parameter> &ref_625
             schema: *ref_0
             implementation: Method
             required: true
@@ -15967,8 +16988,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_625
-            schema: *ref_565
+          - !<!Parameter> &ref_626
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -15979,8 +17000,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_626
-            schema: *ref_304
+          - !<!Parameter> &ref_627
+            schema: *ref_305
             implementation: Method
             language: !<!Languages> 
               default:
@@ -15993,6 +17014,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16003,12 +17039,12 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_624
           - *ref_625
           - *ref_626
+          - *ref_627
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_627
+            schema: *ref_628
             language: !<!Languages> 
               default:
                 name: ''
@@ -16022,7 +17058,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16082,7 +17118,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_628
+          - !<!Parameter> &ref_629
             schema: *ref_0
             implementation: Method
             required: true
@@ -16100,8 +17136,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_629
-            schema: *ref_565
+          - !<!Parameter> &ref_630
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16112,8 +17148,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_630
-            schema: *ref_565
+          - !<!Parameter> &ref_631
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16127,6 +17163,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16137,9 +17188,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_628
           - *ref_629
           - *ref_630
+          - *ref_631
         responses:
           - !<!SchemaResponse> 
             schema: *ref_217
@@ -16156,7 +17207,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16204,7 +17255,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_631
+          - !<!Parameter> &ref_632
             schema: *ref_0
             implementation: Method
             required: true
@@ -16222,8 +17273,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_632
-            schema: *ref_565
+          - !<!Parameter> &ref_633
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16234,8 +17285,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_633
-            schema: *ref_565
+          - !<!Parameter> &ref_634
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16249,6 +17300,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16259,9 +17325,9 @@ operationGroups:
                 method: post
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_631
           - *ref_632
           - *ref_633
+          - *ref_634
         responses:
           - !<!SchemaResponse> 
             schema: *ref_224
@@ -16278,7 +17344,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16323,7 +17389,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_634
+          - !<!Parameter> &ref_635
             schema: *ref_0
             implementation: Method
             required: true
@@ -16341,8 +17407,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_635
-            schema: *ref_565
+          - !<!Parameter> &ref_636
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16353,8 +17419,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_636
-            schema: *ref_565
+          - !<!Parameter> &ref_637
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16368,6 +17434,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16378,9 +17459,9 @@ operationGroups:
                 method: delete
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_634
           - *ref_635
           - *ref_636
+          - *ref_637
         responses:
           - !<!SchemaResponse> 
             schema: *ref_217
@@ -16397,7 +17478,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16444,7 +17525,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_637
+          - !<!Parameter> &ref_638
             schema: *ref_0
             implementation: Method
             required: true
@@ -16462,8 +17543,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_638
-            schema: *ref_565
+          - !<!Parameter> &ref_639
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16474,8 +17555,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_639
-            schema: *ref_565
+          - !<!Parameter> &ref_640
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16489,6 +17570,21 @@ operationGroups:
           - *ref_258
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -16499,9 +17595,9 @@ operationGroups:
                 method: get
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_637
           - *ref_638
           - *ref_639
+          - *ref_640
         responses:
           - !<!SchemaResponse> 
             schema: *ref_224
@@ -16518,7 +17614,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16562,7 +17658,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_652
+          - !<!Parameter> &ref_653
             schema: *ref_0
             implementation: Method
             required: true
@@ -16580,8 +17676,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_653
-            schema: *ref_565
+          - !<!Parameter> &ref_654
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16592,8 +17688,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_654
-            schema: *ref_565
+          - !<!Parameter> &ref_655
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16608,8 +17704,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_641
-                schema: *ref_640
+              - !<!Parameter> &ref_642
+                schema: *ref_641
                 flattened: true
                 implementation: Method
                 required: true
@@ -16623,72 +17719,85 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_647
-                schema: *ref_226
+              - !<!Parameter> 
+                schema: *ref_260
                 implementation: Method
-                originalParameter: *ref_641
-                pathToProperty: []
+                origin: 'modelerfour:synthesized/accept'
                 required: true
-                targetProperty: *ref_642
                 language: !<!Languages> 
                   default:
-                    name: templateUri
-                    description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
-                protocol: !<!Protocols> {}
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - !<!VirtualParameter> &ref_648
-                schema: *ref_221
+                schema: *ref_226
                 implementation: Method
-                originalParameter: *ref_641
+                originalParameter: *ref_642
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_643
                 language: !<!Languages> 
                   default:
-                    name: sasType
-                    description: The type of SAS token the SAS definition will create.
+                    name: templateUri
+                    description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
                 protocol: !<!Protocols> {}
               - !<!VirtualParameter> &ref_649
-                schema: *ref_227
+                schema: *ref_221
                 implementation: Method
-                originalParameter: *ref_641
+                originalParameter: *ref_642
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_644
                 language: !<!Languages> 
                   default:
+                    name: sasType
+                    description: The type of SAS token the SAS definition will create.
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_650
+                schema: *ref_227
+                implementation: Method
+                originalParameter: *ref_642
+                pathToProperty: []
+                required: true
+                targetProperty: *ref_645
+                language: !<!Languages> 
+                  default:
                     name: validityPeriod
                     description: The validity period of SAS tokens created according to the SAS definition.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_650
+              - !<!VirtualParameter> &ref_651
                 schema: *ref_215
                 implementation: Method
-                originalParameter: *ref_641
+                originalParameter: *ref_642
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_645
+                targetProperty: *ref_646
                 language: !<!Languages> 
                   default:
                     name: sasDefinitionAttributes
                     description: The attributes of the SAS definition.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_651
+              - !<!VirtualParameter> &ref_652
                 schema: *ref_228
                 implementation: Method
-                originalParameter: *ref_641
+                originalParameter: *ref_642
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_646
+                targetProperty: *ref_647
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_647
               - *ref_648
               - *ref_649
               - *ref_650
               - *ref_651
+              - *ref_652
             language: !<!Languages> 
               default:
                 name: ''
@@ -16702,9 +17811,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_652
           - *ref_653
           - *ref_654
+          - *ref_655
         responses:
           - !<!SchemaResponse> 
             schema: *ref_224
@@ -16721,7 +17830,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''
@@ -16771,7 +17880,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 7.0-preview
         parameters:
-          - !<!Parameter> &ref_667
+          - !<!Parameter> &ref_668
             schema: *ref_0
             implementation: Method
             required: true
@@ -16789,8 +17898,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: uri
-          - !<!Parameter> &ref_668
-            schema: *ref_565
+          - !<!Parameter> &ref_669
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16801,8 +17910,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_669
-            schema: *ref_565
+          - !<!Parameter> &ref_670
+            schema: *ref_566
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -16817,8 +17926,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_656
-                schema: *ref_655
+              - !<!Parameter> &ref_657
+                schema: *ref_656
                 flattened: true
                 implementation: Method
                 required: true
@@ -16832,67 +17941,80 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_662
+              - !<!Parameter> 
+                schema: *ref_260
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_663
                 schema: *ref_229
                 implementation: Method
-                originalParameter: *ref_656
+                originalParameter: *ref_657
                 pathToProperty: []
-                targetProperty: *ref_657
+                targetProperty: *ref_658
                 language: !<!Languages> 
                   default:
                     name: templateUri
                     description: The SAS definition token template signed with an arbitrary key.  Tokens created according to the SAS definition will have the same properties as the template.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_663
+              - !<!VirtualParameter> &ref_664
                 schema: *ref_221
                 implementation: Method
-                originalParameter: *ref_656
+                originalParameter: *ref_657
                 pathToProperty: []
-                targetProperty: *ref_658
+                targetProperty: *ref_659
                 language: !<!Languages> 
                   default:
                     name: sasType
                     description: The type of SAS token the SAS definition will create.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_664
+              - !<!VirtualParameter> &ref_665
                 schema: *ref_230
                 implementation: Method
-                originalParameter: *ref_656
+                originalParameter: *ref_657
                 pathToProperty: []
-                targetProperty: *ref_659
+                targetProperty: *ref_660
                 language: !<!Languages> 
                   default:
                     name: validityPeriod
                     description: The validity period of SAS tokens created according to the SAS definition.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_665
+              - !<!VirtualParameter> &ref_666
                 schema: *ref_215
                 implementation: Method
-                originalParameter: *ref_656
+                originalParameter: *ref_657
                 pathToProperty: []
-                targetProperty: *ref_660
+                targetProperty: *ref_661
                 language: !<!Languages> 
                   default:
                     name: sasDefinitionAttributes
                     description: The attributes of the SAS definition.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_666
+              - !<!VirtualParameter> &ref_667
                 schema: *ref_231
                 implementation: Method
-                originalParameter: *ref_656
+                originalParameter: *ref_657
                 pathToProperty: []
-                targetProperty: *ref_661
+                targetProperty: *ref_662
                 language: !<!Languages> 
                   default:
                     name: tags
                     description: Application specific metadata in the form of key-value pairs.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_662
               - *ref_663
               - *ref_664
               - *ref_665
               - *ref_666
+              - *ref_667
             language: !<!Languages> 
               default:
                 name: ''
@@ -16906,9 +18028,9 @@ operationGroups:
                   - application/json
                 uri: '{vaultBaseUrl}'
         signatureParameters:
-          - *ref_667
           - *ref_668
           - *ref_669
+          - *ref_670
         responses:
           - !<!SchemaResponse> 
             schema: *ref_224
@@ -16925,7 +18047,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_275
+            schema: *ref_276
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/lro/flattened.yaml
+++ b/modelerfour/test/scenarios/lro/flattened.yaml
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_35
+    - !<!NumberSchema> &ref_36
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -396,6 +396,17 @@ schemas: !<!Schemas>
           name: OperationResult-status
           description: The status of the request
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_25
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_5
       type: dictionary
@@ -518,7 +529,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_8
-    - !<!ObjectSchema> &ref_26
+    - !<!ObjectSchema> &ref_27
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -552,13 +563,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_40
+    - !<!ObjectSchema> &ref_41
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_42
+        - !<!Property> &ref_43
           schema: *ref_13
           serializedName: name
           language: !<!Languages> 
@@ -566,7 +577,7 @@ schemas: !<!Schemas>
               name: name
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_43
+        - !<!Property> &ref_44
           schema: *ref_14
           serializedName: id
           language: !<!Languages> 
@@ -628,7 +639,7 @@ schemas: !<!Schemas>
         immediate:
           - *ref_17
       properties:
-        - !<!Property> &ref_50
+        - !<!Property> &ref_51
           schema: *ref_18
           flattenedNames:
             - properties
@@ -749,7 +760,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_25
+              - !<!Parameter> &ref_26
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -761,8 +772,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_25
+              - *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -801,7 +825,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -829,7 +853,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_27
+              - !<!Parameter> &ref_28
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -841,8 +865,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_27
+              - *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -872,7 +909,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -900,7 +937,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_28
+              - !<!Parameter> &ref_29
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -912,8 +949,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_28
+              - *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -943,7 +993,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -971,7 +1021,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_29
+              - !<!Parameter> &ref_30
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -983,8 +1033,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_29
+              - *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1027,7 +1090,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1055,7 +1118,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_30
+              - !<!Parameter> &ref_31
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1067,8 +1130,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_30
+              - *ref_31
             language: !<!Languages> 
               default:
                 name: ''
@@ -1098,7 +1174,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1126,7 +1202,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
+              - !<!Parameter> &ref_32
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1138,8 +1214,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_31
+              - *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -1182,7 +1271,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1210,7 +1299,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_32
+              - !<!Parameter> &ref_33
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1222,8 +1311,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_32
+              - *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -1253,7 +1355,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1281,7 +1383,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
+              - !<!Parameter> &ref_34
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1293,8 +1395,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1332,7 +1447,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1360,7 +1475,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
+              - !<!Parameter> &ref_35
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1372,8 +1487,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -1412,7 +1540,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -1425,7 +1553,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1453,7 +1581,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
+              - !<!Parameter> &ref_37
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1465,8 +1593,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -1511,7 +1652,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1539,7 +1680,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_37
+              - !<!Parameter> &ref_38
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1551,8 +1692,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_37
+              - *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1591,7 +1745,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -1604,7 +1758,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1632,7 +1786,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_38
+              - !<!Parameter> &ref_39
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1644,8 +1798,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_38
+              - *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -1690,7 +1857,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1718,7 +1885,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_39
+              - !<!Parameter> &ref_40
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1730,8 +1897,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_39
+              - *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1769,7 +1949,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1797,8 +1977,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_41
-                schema: *ref_40
+              - !<!Parameter> &ref_42
+                schema: *ref_41
                 flattened: true
                 implementation: Method
                 required: false
@@ -1810,31 +1990,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_44
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_45
                 schema: *ref_13
                 implementation: Method
-                originalParameter: *ref_41
+                originalParameter: *ref_42
                 pathToProperty: []
-                targetProperty: *ref_42
+                targetProperty: *ref_43
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_45
+              - !<!VirtualParameter> &ref_46
                 schema: *ref_14
                 implementation: Method
-                originalParameter: *ref_41
+                originalParameter: *ref_42
                 pathToProperty: []
-                targetProperty: *ref_43
+                targetProperty: *ref_44
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_44
               - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -1850,7 +2043,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -1864,7 +2057,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1892,8 +2085,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_46
-                schema: *ref_40
+              - !<!Parameter> &ref_47
+                schema: *ref_41
                 flattened: true
                 implementation: Method
                 required: false
@@ -1905,31 +2098,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_47
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_48
                 schema: *ref_13
                 implementation: Method
-                originalParameter: *ref_46
+                originalParameter: *ref_47
                 pathToProperty: []
-                targetProperty: *ref_42
+                targetProperty: *ref_43
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_48
+              - !<!VirtualParameter> &ref_49
                 schema: *ref_14
                 implementation: Method
-                originalParameter: *ref_46
+                originalParameter: *ref_47
                 pathToProperty: []
-                targetProperty: *ref_43
+                targetProperty: *ref_44
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_47
               - *ref_48
+              - *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -1945,7 +2151,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -1959,7 +2165,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1987,7 +2193,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_49
+              - !<!Parameter> &ref_50
                 schema: *ref_15
                 flattened: true
                 implementation: Method
@@ -2000,19 +2206,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_51
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_52
                 schema: *ref_18
                 implementation: Method
-                originalParameter: *ref_49
+                originalParameter: *ref_50
                 pathToProperty: []
-                targetProperty: *ref_50
+                targetProperty: *ref_51
                 language: !<!Languages> 
                   default:
                     name: provisioningState
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_51
+              - *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -2042,7 +2261,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2070,7 +2289,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_52
+              - !<!Parameter> &ref_53
                 schema: *ref_15
                 flattened: true
                 implementation: Method
@@ -2083,19 +2302,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_53
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_54
                 schema: *ref_18
                 implementation: Method
-                originalParameter: *ref_52
+                originalParameter: *ref_53
                 pathToProperty: []
-                targetProperty: *ref_50
+                targetProperty: *ref_51
                 language: !<!Languages> 
                   default:
                     name: provisioningState
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_53
+              - *ref_54
             language: !<!Languages> 
               default:
                 name: ''
@@ -2125,7 +2357,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2152,6 +2384,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2193,7 +2440,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2206,7 +2453,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2235,6 +2482,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2276,7 +2538,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2289,7 +2551,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2316,6 +2578,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2357,7 +2634,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2370,7 +2647,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2399,6 +2676,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2421,7 +2713,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2448,6 +2740,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2488,7 +2795,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2498,7 +2805,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2525,6 +2832,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2565,7 +2887,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2575,7 +2897,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2602,6 +2924,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2641,7 +2978,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2668,6 +3005,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2707,7 +3059,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2734,6 +3086,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2768,7 +3135,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2778,7 +3145,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2805,6 +3172,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2839,7 +3221,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2849,7 +3231,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2876,6 +3258,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2910,7 +3307,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2920,7 +3317,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2947,6 +3344,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2981,7 +3393,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2991,7 +3403,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3018,6 +3430,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3030,7 +3457,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -3043,7 +3470,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -3057,7 +3484,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3085,7 +3512,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_54
+              - !<!Parameter> &ref_55
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3097,8 +3524,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_54
+              - *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -3129,7 +3569,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3139,7 +3579,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3167,7 +3607,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_55
+              - !<!Parameter> &ref_56
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3179,8 +3619,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_55
+              - *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3212,7 +3665,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3225,7 +3678,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3252,6 +3705,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3278,7 +3746,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3307,6 +3775,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3333,7 +3816,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3362,6 +3845,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3388,7 +3886,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3418,7 +3916,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_56
+              - !<!Parameter> &ref_57
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3430,8 +3928,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_56
+              - *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3482,7 +3993,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3492,7 +4003,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3520,7 +4031,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_57
+              - !<!Parameter> &ref_58
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3532,8 +4043,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_57
+              - *ref_58
             language: !<!Languages> 
               default:
                 name: ''
@@ -3584,7 +4108,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3594,7 +4118,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3622,7 +4146,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_58
+              - !<!Parameter> &ref_59
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3634,8 +4158,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_58
+              - *ref_59
             language: !<!Languages> 
               default:
                 name: ''
@@ -3673,7 +4210,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3683,7 +4220,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3711,7 +4248,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_59
+              - !<!Parameter> &ref_60
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3723,8 +4260,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_59
+              - *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3762,7 +4312,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3772,7 +4322,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3808,7 +4358,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_60
+              - !<!Parameter> &ref_61
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3820,8 +4370,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_60
+              - *ref_61
             language: !<!Languages> 
               default:
                 name: ''
@@ -3864,7 +4427,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3894,7 +4457,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_61
+              - !<!Parameter> &ref_62
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3906,8 +4469,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_61
+              - *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3946,7 +4522,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3959,7 +4535,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3986,6 +4562,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4027,7 +4618,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4040,7 +4631,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4069,6 +4660,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4096,7 +4702,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4106,7 +4712,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4133,6 +4739,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4167,7 +4788,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4177,7 +4798,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4205,7 +4826,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_62
+              - !<!Parameter> &ref_63
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4217,8 +4838,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_62
+              - *ref_63
             language: !<!Languages> 
               default:
                 name: ''
@@ -4249,7 +4883,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4259,7 +4893,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4287,7 +4921,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_63
+              - !<!Parameter> &ref_64
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4299,8 +4933,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -4338,7 +4985,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4348,7 +4995,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4386,7 +5033,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_64
+              - !<!Parameter> &ref_65
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4398,8 +5045,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_64
+              - *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4442,7 +5102,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4470,7 +5130,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_65
+              - !<!Parameter> &ref_66
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4482,8 +5142,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_65
+              - *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -4526,7 +5199,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4554,7 +5227,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_66
+              - !<!Parameter> &ref_67
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4566,8 +5239,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_66
+              - *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -4610,7 +5296,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4638,7 +5324,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_67
+              - !<!Parameter> &ref_68
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4650,8 +5336,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_67
+              - *ref_68
             language: !<!Languages> 
               default:
                 name: ''
@@ -4690,7 +5389,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4703,7 +5402,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4730,6 +5429,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4757,7 +5471,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4767,7 +5481,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4794,6 +5508,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4821,7 +5550,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4831,7 +5560,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4858,6 +5587,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4892,7 +5636,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4902,7 +5646,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4930,7 +5674,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_68
+              - !<!Parameter> &ref_69
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4942,8 +5686,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_68
+              - *ref_69
             language: !<!Languages> 
               default:
                 name: ''
@@ -4974,7 +5731,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4984,7 +5741,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5012,7 +5769,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_69
+              - !<!Parameter> &ref_70
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5024,8 +5781,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_69
+              - *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -5056,7 +5826,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5066,7 +5836,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5094,7 +5864,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_70
+              - !<!Parameter> &ref_71
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5106,8 +5876,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_70
+              - *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -5145,7 +5928,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5155,7 +5938,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5183,7 +5966,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_71
+              - !<!Parameter> &ref_72
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5195,8 +5978,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_71
+              - *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5239,7 +6035,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5267,7 +6063,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_72
+              - !<!Parameter> &ref_73
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5279,8 +6075,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_72
+              - *ref_73
             language: !<!Languages> 
               default:
                 name: ''
@@ -5319,7 +6128,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5332,7 +6141,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5360,7 +6169,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_73
+              - !<!Parameter> &ref_74
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5372,8 +6181,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_73
+              - *ref_74
             language: !<!Languages> 
               default:
                 name: ''
@@ -5412,7 +6234,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5425,7 +6247,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5452,6 +6274,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5474,7 +6311,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5501,6 +6338,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5535,7 +6387,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5545,7 +6397,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5573,7 +6425,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_74
+              - !<!Parameter> &ref_75
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5585,8 +6437,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_74
+              - *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -5617,7 +6482,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5627,7 +6492,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5655,7 +6520,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_75
+              - !<!Parameter> &ref_76
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5667,8 +6532,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_75
+              - *ref_76
             language: !<!Languages> 
               default:
                 name: ''
@@ -5706,7 +6584,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5716,7 +6594,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5744,7 +6622,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_76
+              - !<!Parameter> &ref_77
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5756,8 +6634,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_76
+              - *ref_77
             language: !<!Languages> 
               default:
                 name: ''
@@ -5796,7 +6687,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5824,7 +6715,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_77
+              - !<!Parameter> &ref_78
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5836,8 +6727,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_77
+              - *ref_78
             language: !<!Languages> 
               default:
                 name: ''
@@ -5876,7 +6780,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5889,7 +6793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5917,7 +6821,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_78
+              - !<!Parameter> &ref_79
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5929,8 +6833,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_78
+              - *ref_79
             language: !<!Languages> 
               default:
                 name: ''
@@ -5969,7 +6886,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5982,7 +6899,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6009,6 +6926,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6036,7 +6968,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6046,7 +6978,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6073,6 +7005,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6107,7 +7054,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6117,7 +7064,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6144,6 +7091,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6178,7 +7140,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6188,7 +7150,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6216,7 +7178,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_79
+              - !<!Parameter> &ref_80
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6228,8 +7190,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_79
+              - *ref_80
             language: !<!Languages> 
               default:
                 name: ''
@@ -6260,7 +7235,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6270,7 +7245,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6298,7 +7273,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_80
+              - !<!Parameter> &ref_81
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6310,8 +7285,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_80
+              - *ref_81
             language: !<!Languages> 
               default:
                 name: ''
@@ -6349,7 +7337,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6359,7 +7347,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6387,7 +7375,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_81
+              - !<!Parameter> &ref_82
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6399,8 +7387,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_81
+              - *ref_82
             language: !<!Languages> 
               default:
                 name: ''
@@ -6438,7 +7439,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6448,7 +7449,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6484,7 +7485,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_82
+              - !<!Parameter> &ref_83
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6496,8 +7497,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_82
+              - *ref_83
             language: !<!Languages> 
               default:
                 name: ''
@@ -6536,7 +7550,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6549,7 +7563,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6579,7 +7593,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_83
+              - !<!Parameter> &ref_84
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6591,8 +7605,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_83
+              - *ref_84
             language: !<!Languages> 
               default:
                 name: ''
@@ -6635,7 +7662,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6665,7 +7692,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_84
+              - !<!Parameter> &ref_85
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6677,8 +7704,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_84
+              - *ref_85
             language: !<!Languages> 
               default:
                 name: ''
@@ -6709,7 +7749,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6719,7 +7759,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6749,7 +7789,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_85
+              - !<!Parameter> &ref_86
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6761,8 +7801,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_85
+              - *ref_86
             language: !<!Languages> 
               default:
                 name: ''
@@ -6800,7 +7853,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6810,7 +7863,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/lro/grouped.yaml
+++ b/modelerfour/test/scenarios/lro/grouped.yaml
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_35
+    - !<!NumberSchema> &ref_36
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -396,6 +396,17 @@ schemas: !<!Schemas>
           name: OperationResult-status
           description: The status of the request
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_25
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_5
       type: dictionary
@@ -518,7 +529,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_8
-    - !<!ObjectSchema> &ref_26
+    - !<!ObjectSchema> &ref_27
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -552,13 +563,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_40
+    - !<!ObjectSchema> &ref_41
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_42
+        - !<!Property> &ref_43
           schema: *ref_13
           serializedName: name
           language: !<!Languages> 
@@ -566,7 +577,7 @@ schemas: !<!Schemas>
               name: name
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_43
+        - !<!Property> &ref_44
           schema: *ref_14
           serializedName: id
           language: !<!Languages> 
@@ -628,7 +639,7 @@ schemas: !<!Schemas>
         immediate:
           - *ref_17
       properties:
-        - !<!Property> &ref_50
+        - !<!Property> &ref_51
           schema: *ref_18
           flattenedNames:
             - properties
@@ -749,7 +760,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_25
+              - !<!Parameter> &ref_26
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -761,8 +772,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_25
+              - *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -801,7 +825,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -829,7 +853,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_27
+              - !<!Parameter> &ref_28
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -841,8 +865,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_27
+              - *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -872,7 +909,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -900,7 +937,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_28
+              - !<!Parameter> &ref_29
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -912,8 +949,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_28
+              - *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -943,7 +993,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -971,7 +1021,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_29
+              - !<!Parameter> &ref_30
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -983,8 +1033,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_29
+              - *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1027,7 +1090,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1055,7 +1118,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_30
+              - !<!Parameter> &ref_31
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1067,8 +1130,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_30
+              - *ref_31
             language: !<!Languages> 
               default:
                 name: ''
@@ -1098,7 +1174,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1126,7 +1202,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
+              - !<!Parameter> &ref_32
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1138,8 +1214,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_31
+              - *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -1182,7 +1271,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1210,7 +1299,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_32
+              - !<!Parameter> &ref_33
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1222,8 +1311,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_32
+              - *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -1253,7 +1355,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1281,7 +1383,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
+              - !<!Parameter> &ref_34
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1293,8 +1395,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1332,7 +1447,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1360,7 +1475,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
+              - !<!Parameter> &ref_35
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1372,8 +1487,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -1412,7 +1540,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -1425,7 +1553,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1453,7 +1581,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
+              - !<!Parameter> &ref_37
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1465,8 +1593,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -1511,7 +1652,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1539,7 +1680,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_37
+              - !<!Parameter> &ref_38
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1551,8 +1692,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_37
+              - *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1591,7 +1745,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -1604,7 +1758,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1632,7 +1786,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_38
+              - !<!Parameter> &ref_39
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1644,8 +1798,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_38
+              - *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -1690,7 +1857,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1718,7 +1885,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_39
+              - !<!Parameter> &ref_40
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1730,8 +1897,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_39
+              - *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1769,7 +1949,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1797,8 +1977,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_41
-                schema: *ref_40
+              - !<!Parameter> &ref_42
+                schema: *ref_41
                 flattened: true
                 implementation: Method
                 required: false
@@ -1810,31 +1990,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_44
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_45
                 schema: *ref_13
                 implementation: Method
-                originalParameter: *ref_41
+                originalParameter: *ref_42
                 pathToProperty: []
-                targetProperty: *ref_42
+                targetProperty: *ref_43
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_45
+              - !<!VirtualParameter> &ref_46
                 schema: *ref_14
                 implementation: Method
-                originalParameter: *ref_41
+                originalParameter: *ref_42
                 pathToProperty: []
-                targetProperty: *ref_43
+                targetProperty: *ref_44
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_44
               - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -1850,7 +2043,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -1864,7 +2057,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1892,8 +2085,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_46
-                schema: *ref_40
+              - !<!Parameter> &ref_47
+                schema: *ref_41
                 flattened: true
                 implementation: Method
                 required: false
@@ -1905,31 +2098,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_47
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_48
                 schema: *ref_13
                 implementation: Method
-                originalParameter: *ref_46
+                originalParameter: *ref_47
                 pathToProperty: []
-                targetProperty: *ref_42
+                targetProperty: *ref_43
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_48
+              - !<!VirtualParameter> &ref_49
                 schema: *ref_14
                 implementation: Method
-                originalParameter: *ref_46
+                originalParameter: *ref_47
                 pathToProperty: []
-                targetProperty: *ref_43
+                targetProperty: *ref_44
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_47
               - *ref_48
+              - *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -1945,7 +2151,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -1959,7 +2165,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1987,7 +2193,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_49
+              - !<!Parameter> &ref_50
                 schema: *ref_15
                 flattened: true
                 implementation: Method
@@ -2000,19 +2206,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_51
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_52
                 schema: *ref_18
                 implementation: Method
-                originalParameter: *ref_49
+                originalParameter: *ref_50
                 pathToProperty: []
-                targetProperty: *ref_50
+                targetProperty: *ref_51
                 language: !<!Languages> 
                   default:
                     name: provisioningState
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_51
+              - *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -2042,7 +2261,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2070,7 +2289,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_52
+              - !<!Parameter> &ref_53
                 schema: *ref_15
                 flattened: true
                 implementation: Method
@@ -2083,19 +2302,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_53
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_54
                 schema: *ref_18
                 implementation: Method
-                originalParameter: *ref_52
+                originalParameter: *ref_53
                 pathToProperty: []
-                targetProperty: *ref_50
+                targetProperty: *ref_51
                 language: !<!Languages> 
                   default:
                     name: provisioningState
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_53
+              - *ref_54
             language: !<!Languages> 
               default:
                 name: ''
@@ -2125,7 +2357,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2152,6 +2384,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2193,7 +2440,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2206,7 +2453,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2235,6 +2482,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2276,7 +2538,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2289,7 +2551,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2316,6 +2578,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2357,7 +2634,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2370,7 +2647,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2399,6 +2676,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2421,7 +2713,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2448,6 +2740,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2488,7 +2795,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2498,7 +2805,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2525,6 +2832,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2565,7 +2887,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2575,7 +2897,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2602,6 +2924,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2641,7 +2978,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2668,6 +3005,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2707,7 +3059,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2734,6 +3086,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2768,7 +3135,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2778,7 +3145,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2805,6 +3172,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2839,7 +3221,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2849,7 +3231,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2876,6 +3258,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2910,7 +3307,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2920,7 +3317,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2947,6 +3344,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2981,7 +3393,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2991,7 +3403,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3018,6 +3430,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3030,7 +3457,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -3043,7 +3470,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -3057,7 +3484,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3085,7 +3512,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_54
+              - !<!Parameter> &ref_55
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3097,8 +3524,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_54
+              - *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -3129,7 +3569,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3139,7 +3579,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3167,7 +3607,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_55
+              - !<!Parameter> &ref_56
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3179,8 +3619,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_55
+              - *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3212,7 +3665,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3225,7 +3678,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3252,6 +3705,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3278,7 +3746,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3307,6 +3775,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3333,7 +3816,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3362,6 +3845,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3388,7 +3886,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3418,7 +3916,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_56
+              - !<!Parameter> &ref_57
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3430,8 +3928,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_56
+              - *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3482,7 +3993,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3492,7 +4003,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3520,7 +4031,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_57
+              - !<!Parameter> &ref_58
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3532,8 +4043,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_57
+              - *ref_58
             language: !<!Languages> 
               default:
                 name: ''
@@ -3584,7 +4108,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3594,7 +4118,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3622,7 +4146,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_58
+              - !<!Parameter> &ref_59
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3634,8 +4158,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_58
+              - *ref_59
             language: !<!Languages> 
               default:
                 name: ''
@@ -3673,7 +4210,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3683,7 +4220,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3711,7 +4248,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_59
+              - !<!Parameter> &ref_60
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3723,8 +4260,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_59
+              - *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3762,7 +4312,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3772,7 +4322,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3808,7 +4358,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_60
+              - !<!Parameter> &ref_61
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3820,8 +4370,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_60
+              - *ref_61
             language: !<!Languages> 
               default:
                 name: ''
@@ -3864,7 +4427,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3894,7 +4457,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_61
+              - !<!Parameter> &ref_62
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3906,8 +4469,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_61
+              - *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3946,7 +4522,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3959,7 +4535,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3986,6 +4562,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4027,7 +4618,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4040,7 +4631,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4069,6 +4660,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4096,7 +4702,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4106,7 +4712,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4133,6 +4739,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4167,7 +4788,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4177,7 +4798,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4205,7 +4826,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_62
+              - !<!Parameter> &ref_63
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4217,8 +4838,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_62
+              - *ref_63
             language: !<!Languages> 
               default:
                 name: ''
@@ -4249,7 +4883,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4259,7 +4893,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4287,7 +4921,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_63
+              - !<!Parameter> &ref_64
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4299,8 +4933,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -4338,7 +4985,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4348,7 +4995,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4386,7 +5033,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_64
+              - !<!Parameter> &ref_65
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4398,8 +5045,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_64
+              - *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4442,7 +5102,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4470,7 +5130,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_65
+              - !<!Parameter> &ref_66
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4482,8 +5142,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_65
+              - *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -4526,7 +5199,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4554,7 +5227,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_66
+              - !<!Parameter> &ref_67
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4566,8 +5239,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_66
+              - *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -4610,7 +5296,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4638,7 +5324,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_67
+              - !<!Parameter> &ref_68
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4650,8 +5336,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_67
+              - *ref_68
             language: !<!Languages> 
               default:
                 name: ''
@@ -4690,7 +5389,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4703,7 +5402,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4730,6 +5429,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4757,7 +5471,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4767,7 +5481,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4794,6 +5508,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4821,7 +5550,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4831,7 +5560,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4858,6 +5587,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4892,7 +5636,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4902,7 +5646,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4930,7 +5674,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_68
+              - !<!Parameter> &ref_69
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4942,8 +5686,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_68
+              - *ref_69
             language: !<!Languages> 
               default:
                 name: ''
@@ -4974,7 +5731,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4984,7 +5741,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5012,7 +5769,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_69
+              - !<!Parameter> &ref_70
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5024,8 +5781,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_69
+              - *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -5056,7 +5826,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5066,7 +5836,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5094,7 +5864,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_70
+              - !<!Parameter> &ref_71
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5106,8 +5876,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_70
+              - *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -5145,7 +5928,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5155,7 +5938,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5183,7 +5966,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_71
+              - !<!Parameter> &ref_72
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5195,8 +5978,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_71
+              - *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5239,7 +6035,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5267,7 +6063,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_72
+              - !<!Parameter> &ref_73
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5279,8 +6075,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_72
+              - *ref_73
             language: !<!Languages> 
               default:
                 name: ''
@@ -5319,7 +6128,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5332,7 +6141,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5360,7 +6169,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_73
+              - !<!Parameter> &ref_74
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5372,8 +6181,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_73
+              - *ref_74
             language: !<!Languages> 
               default:
                 name: ''
@@ -5412,7 +6234,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5425,7 +6247,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5452,6 +6274,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5474,7 +6311,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5501,6 +6338,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5535,7 +6387,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5545,7 +6397,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5573,7 +6425,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_74
+              - !<!Parameter> &ref_75
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5585,8 +6437,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_74
+              - *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -5617,7 +6482,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5627,7 +6492,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5655,7 +6520,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_75
+              - !<!Parameter> &ref_76
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5667,8 +6532,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_75
+              - *ref_76
             language: !<!Languages> 
               default:
                 name: ''
@@ -5706,7 +6584,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5716,7 +6594,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5744,7 +6622,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_76
+              - !<!Parameter> &ref_77
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5756,8 +6634,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_76
+              - *ref_77
             language: !<!Languages> 
               default:
                 name: ''
@@ -5796,7 +6687,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5824,7 +6715,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_77
+              - !<!Parameter> &ref_78
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5836,8 +6727,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_77
+              - *ref_78
             language: !<!Languages> 
               default:
                 name: ''
@@ -5876,7 +6780,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5889,7 +6793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5917,7 +6821,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_78
+              - !<!Parameter> &ref_79
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5929,8 +6833,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_78
+              - *ref_79
             language: !<!Languages> 
               default:
                 name: ''
@@ -5969,7 +6886,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5982,7 +6899,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6009,6 +6926,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6036,7 +6968,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6046,7 +6978,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6073,6 +7005,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6107,7 +7054,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6117,7 +7064,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6144,6 +7091,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6178,7 +7140,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6188,7 +7150,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6216,7 +7178,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_79
+              - !<!Parameter> &ref_80
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6228,8 +7190,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_79
+              - *ref_80
             language: !<!Languages> 
               default:
                 name: ''
@@ -6260,7 +7235,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6270,7 +7245,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6298,7 +7273,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_80
+              - !<!Parameter> &ref_81
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6310,8 +7285,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_80
+              - *ref_81
             language: !<!Languages> 
               default:
                 name: ''
@@ -6349,7 +7337,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6359,7 +7347,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6387,7 +7375,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_81
+              - !<!Parameter> &ref_82
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6399,8 +7387,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_81
+              - *ref_82
             language: !<!Languages> 
               default:
                 name: ''
@@ -6438,7 +7439,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6448,7 +7449,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6484,7 +7485,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_82
+              - !<!Parameter> &ref_83
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6496,8 +7497,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_82
+              - *ref_83
             language: !<!Languages> 
               default:
                 name: ''
@@ -6536,7 +7550,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6549,7 +7563,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6579,7 +7593,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_83
+              - !<!Parameter> &ref_84
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6591,8 +7605,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_83
+              - *ref_84
             language: !<!Languages> 
               default:
                 name: ''
@@ -6635,7 +7662,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6665,7 +7692,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_84
+              - !<!Parameter> &ref_85
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6677,8 +7704,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_84
+              - *ref_85
             language: !<!Languages> 
               default:
                 name: ''
@@ -6709,7 +7749,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6719,7 +7759,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6749,7 +7789,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_85
+              - !<!Parameter> &ref_86
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6761,8 +7801,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_85
+              - *ref_86
             language: !<!Languages> 
               default:
                 name: ''
@@ -6800,7 +7853,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6810,7 +7863,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/lro/modeler.yaml
+++ b/modelerfour/test/scenarios/lro/modeler.yaml
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_37
+    - !<!NumberSchema> &ref_38
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -396,6 +396,17 @@ schemas: !<!Schemas>
           name: OperationResult-status
           description: The status of the request
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_26
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_23
       type: dictionary
@@ -541,7 +552,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_9
     - *ref_8
-    - !<!ObjectSchema> &ref_27
+    - !<!ObjectSchema> &ref_28
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -575,7 +586,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_42
+    - !<!ObjectSchema> &ref_43
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -766,7 +777,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_19
 globalParameters:
-  - !<!Parameter> &ref_28
+  - !<!Parameter> &ref_29
     schema: *ref_1
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -791,11 +802,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_26
+              - !<!Parameter> &ref_27
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -807,8 +818,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_26
+              - *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -847,7 +871,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -871,11 +895,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_29
+              - !<!Parameter> &ref_30
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -887,8 +911,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_29
+              - *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -918,7 +955,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -942,11 +979,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_30
+              - !<!Parameter> &ref_31
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -958,8 +995,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_30
+              - *ref_31
             language: !<!Languages> 
               default:
                 name: ''
@@ -989,7 +1039,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1013,11 +1063,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
+              - !<!Parameter> &ref_32
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -1029,8 +1079,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_31
+              - *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -1073,7 +1136,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1097,11 +1160,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_32
+              - !<!Parameter> &ref_33
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -1113,8 +1176,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_32
+              - *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -1144,7 +1220,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1168,11 +1244,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
+              - !<!Parameter> &ref_34
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -1184,8 +1260,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1228,7 +1317,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1252,11 +1341,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
+              - !<!Parameter> &ref_35
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -1268,8 +1357,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -1299,7 +1401,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1323,11 +1425,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_35
+              - !<!Parameter> &ref_36
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -1339,8 +1441,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_35
+              - *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1378,7 +1493,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1402,11 +1517,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
+              - !<!Parameter> &ref_37
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -1418,8 +1533,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -1458,7 +1586,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -1471,7 +1599,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1495,11 +1623,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_38
+              - !<!Parameter> &ref_39
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -1511,8 +1639,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_38
+              - *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -1557,7 +1698,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1581,11 +1722,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_39
+              - !<!Parameter> &ref_40
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -1597,8 +1738,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_39
+              - *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1637,7 +1791,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -1650,7 +1804,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1674,11 +1828,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_40
+              - !<!Parameter> &ref_41
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -1690,8 +1844,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_40
+              - *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -1736,7 +1903,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1760,11 +1927,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_41
+              - !<!Parameter> &ref_42
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -1776,8 +1943,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_41
+              - *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -1815,7 +1995,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1839,12 +2019,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_43
-                schema: *ref_42
+              - !<!Parameter> &ref_44
+                schema: *ref_43
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1855,8 +2035,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_43
+              - *ref_44
             language: !<!Languages> 
               default:
                 name: ''
@@ -1872,7 +2065,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_42
+            schema: *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -1886,7 +2079,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1910,12 +2103,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_44
-                schema: *ref_42
+              - !<!Parameter> &ref_45
+                schema: *ref_43
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1926,8 +2119,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_44
+              - *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -1943,7 +2149,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_42
+            schema: *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -1957,7 +2163,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -1981,11 +2187,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_45
+              - !<!Parameter> &ref_46
                 schema: *ref_15
                 implementation: Method
                 required: false
@@ -1997,8 +2203,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -2028,7 +2247,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2052,11 +2271,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_46
+              - !<!Parameter> &ref_47
                 schema: *ref_15
                 implementation: Method
                 required: false
@@ -2068,8 +2287,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_46
+              - *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2099,7 +2331,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2123,9 +2355,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2167,7 +2414,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -2180,7 +2427,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2206,9 +2453,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2250,7 +2512,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -2263,7 +2525,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2287,9 +2549,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2331,7 +2608,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -2344,7 +2621,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2370,9 +2647,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2395,7 +2687,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2419,9 +2711,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2462,7 +2769,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -2472,7 +2779,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2496,9 +2803,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2539,7 +2861,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -2549,7 +2871,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2573,9 +2895,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2615,7 +2952,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2639,9 +2976,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2681,7 +3033,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2705,9 +3057,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2742,7 +3109,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -2752,7 +3119,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2776,9 +3143,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2813,7 +3195,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -2823,7 +3205,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2847,9 +3229,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2884,7 +3281,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -2894,7 +3291,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2918,9 +3315,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2955,7 +3367,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -2965,7 +3377,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -2989,9 +3401,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3004,7 +3431,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_42
+            schema: *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -3017,7 +3444,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_42
+            schema: *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -3031,7 +3458,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3055,11 +3482,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_47
+              - !<!Parameter> &ref_48
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -3071,8 +3498,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_47
+              - *ref_48
             language: !<!Languages> 
               default:
                 name: ''
@@ -3103,7 +3543,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -3113,7 +3553,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3137,11 +3577,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_48
+              - !<!Parameter> &ref_49
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -3153,8 +3593,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_48
+              - *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -3186,7 +3639,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -3199,7 +3652,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3223,9 +3676,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3252,7 +3720,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3278,9 +3746,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3307,7 +3790,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3333,9 +3816,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3362,7 +3860,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3388,11 +3886,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_49
+              - !<!Parameter> &ref_50
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -3404,8 +3902,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_49
+              - *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -3456,7 +3967,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -3466,7 +3977,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3490,11 +4001,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_50
+              - !<!Parameter> &ref_51
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -3506,8 +4017,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_50
+              - *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -3558,7 +4082,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -3568,7 +4092,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3592,11 +4116,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_51
+              - !<!Parameter> &ref_52
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -3608,8 +4132,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_51
+              - *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -3647,7 +4184,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -3657,7 +4194,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3681,11 +4218,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_52
+              - !<!Parameter> &ref_53
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -3697,8 +4234,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_52
+              - *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -3736,7 +4286,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -3746,7 +4296,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3778,11 +4328,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_53
+              - !<!Parameter> &ref_54
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -3794,8 +4344,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_53
+              - *ref_54
             language: !<!Languages> 
               default:
                 name: ''
@@ -3838,7 +4401,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3864,11 +4427,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_54
+              - !<!Parameter> &ref_55
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -3880,8 +4443,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_54
+              - *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -3920,7 +4496,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -3933,7 +4509,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -3957,9 +4533,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4001,7 +4592,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -4014,7 +4605,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4040,9 +4631,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4070,7 +4676,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -4080,7 +4686,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4104,9 +4710,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4141,7 +4762,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -4151,7 +4772,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4175,11 +4796,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_55
+              - !<!Parameter> &ref_56
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -4191,8 +4812,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_55
+              - *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -4223,7 +4857,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -4233,7 +4867,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4257,11 +4891,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_56
+              - !<!Parameter> &ref_57
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -4273,8 +4907,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_56
+              - *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -4312,7 +4959,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -4322,7 +4969,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4356,11 +5003,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_57
+              - !<!Parameter> &ref_58
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -4372,8 +5019,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_57
+              - *ref_58
             language: !<!Languages> 
               default:
                 name: ''
@@ -4416,7 +5076,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4440,11 +5100,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_58
+              - !<!Parameter> &ref_59
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -4456,8 +5116,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_58
+              - *ref_59
             language: !<!Languages> 
               default:
                 name: ''
@@ -4500,7 +5173,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4524,11 +5197,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_59
+              - !<!Parameter> &ref_60
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -4540,8 +5213,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_59
+              - *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -4584,7 +5270,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4608,11 +5294,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_60
+              - !<!Parameter> &ref_61
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -4624,8 +5310,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_60
+              - *ref_61
             language: !<!Languages> 
               default:
                 name: ''
@@ -4664,7 +5363,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -4677,7 +5376,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4701,9 +5400,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4731,7 +5445,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -4741,7 +5455,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4765,9 +5479,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4795,7 +5524,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -4805,7 +5534,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4829,9 +5558,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4866,7 +5610,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -4876,7 +5620,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4900,11 +5644,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_61
+              - !<!Parameter> &ref_62
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -4916,8 +5660,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_61
+              - *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -4948,7 +5705,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -4958,7 +5715,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -4982,11 +5739,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_62
+              - !<!Parameter> &ref_63
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -4998,8 +5755,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_62
+              - *ref_63
             language: !<!Languages> 
               default:
                 name: ''
@@ -5030,7 +5800,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -5040,7 +5810,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -5064,11 +5834,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_63
+              - !<!Parameter> &ref_64
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -5080,8 +5850,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -5119,7 +5902,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -5129,7 +5912,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -5153,11 +5936,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_64
+              - !<!Parameter> &ref_65
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -5169,8 +5952,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_64
+              - *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -5213,7 +6009,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -5237,11 +6033,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_65
+              - !<!Parameter> &ref_66
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -5253,8 +6049,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_65
+              - *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -5293,7 +6102,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -5306,7 +6115,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -5330,11 +6139,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_66
+              - !<!Parameter> &ref_67
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -5346,8 +6155,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_66
+              - *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -5386,7 +6208,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -5399,7 +6221,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -5423,9 +6245,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5448,7 +6285,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -5472,9 +6309,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5509,7 +6361,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -5519,7 +6371,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -5543,11 +6395,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_67
+              - !<!Parameter> &ref_68
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -5559,8 +6411,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_67
+              - *ref_68
             language: !<!Languages> 
               default:
                 name: ''
@@ -5591,7 +6456,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -5601,7 +6466,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -5625,11 +6490,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_68
+              - !<!Parameter> &ref_69
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -5641,8 +6506,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_68
+              - *ref_69
             language: !<!Languages> 
               default:
                 name: ''
@@ -5680,7 +6558,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -5690,7 +6568,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -5714,11 +6592,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_69
+              - !<!Parameter> &ref_70
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -5730,8 +6608,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_69
+              - *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -5770,7 +6661,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -5794,11 +6685,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_70
+              - !<!Parameter> &ref_71
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -5810,8 +6701,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_70
+              - *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -5850,7 +6754,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -5863,7 +6767,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -5887,11 +6791,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_71
+              - !<!Parameter> &ref_72
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -5903,8 +6807,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_71
+              - *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5943,7 +6860,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -5956,7 +6873,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -5980,9 +6897,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6010,7 +6942,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -6020,7 +6952,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -6044,9 +6976,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6081,7 +7028,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -6091,7 +7038,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -6115,9 +7062,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6152,7 +7114,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -6162,7 +7124,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -6186,11 +7148,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_72
+              - !<!Parameter> &ref_73
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -6202,8 +7164,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_72
+              - *ref_73
             language: !<!Languages> 
               default:
                 name: ''
@@ -6234,7 +7209,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -6244,7 +7219,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -6268,11 +7243,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_73
+              - !<!Parameter> &ref_74
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -6284,8 +7259,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_73
+              - *ref_74
             language: !<!Languages> 
               default:
                 name: ''
@@ -6323,7 +7311,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -6333,7 +7321,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -6357,11 +7345,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_74
+              - !<!Parameter> &ref_75
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -6373,8 +7361,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_74
+              - *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -6412,7 +7413,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -6422,7 +7423,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -6454,11 +7455,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_75
+              - !<!Parameter> &ref_76
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -6470,8 +7471,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_75
+              - *ref_76
             language: !<!Languages> 
               default:
                 name: ''
@@ -6510,7 +7524,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -6523,7 +7537,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -6549,11 +7563,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_76
+              - !<!Parameter> &ref_77
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -6565,8 +7579,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_76
+              - *ref_77
             language: !<!Languages> 
               default:
                 name: ''
@@ -6609,7 +7636,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -6635,11 +7662,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_77
+              - !<!Parameter> &ref_78
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -6651,8 +7678,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_77
+              - *ref_78
             language: !<!Languages> 
               default:
                 name: ''
@@ -6683,7 +7723,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -6693,7 +7733,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -6719,11 +7759,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_78
+              - !<!Parameter> &ref_79
                 schema: *ref_7
                 implementation: Method
                 required: false
@@ -6735,8 +7775,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_78
+              - *ref_79
             language: !<!Languages> 
               default:
                 name: ''
@@ -6774,7 +7827,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_37
+                    schema: *ref_38
                     header: Retry-After
                     language:
                       default:
@@ -6784,7 +7837,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/lro/namer.yaml
+++ b/modelerfour/test/scenarios/lro/namer.yaml
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_35
+    - !<!NumberSchema> &ref_36
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -396,6 +396,17 @@ schemas: !<!Schemas>
           name: OperationResultStatus
           description: The status of the request
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_25
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_5
       type: dictionary
@@ -518,7 +529,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_8
-    - !<!ObjectSchema> &ref_26
+    - !<!ObjectSchema> &ref_27
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -552,13 +563,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_40
+    - !<!ObjectSchema> &ref_41
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_42
+        - !<!Property> &ref_43
           schema: *ref_13
           serializedName: name
           language: !<!Languages> 
@@ -566,7 +577,7 @@ schemas: !<!Schemas>
               name: name
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_43
+        - !<!Property> &ref_44
           schema: *ref_14
           serializedName: id
           language: !<!Languages> 
@@ -628,7 +639,7 @@ schemas: !<!Schemas>
         immediate:
           - *ref_17
       properties:
-        - !<!Property> &ref_50
+        - !<!Property> &ref_51
           schema: *ref_18
           flattenedNames:
             - properties
@@ -749,7 +760,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_25
+              - !<!Parameter> &ref_26
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -761,8 +772,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_25
+              - *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -801,7 +825,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -829,7 +853,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_27
+              - !<!Parameter> &ref_28
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -841,8 +865,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_27
+              - *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -872,7 +909,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -900,7 +937,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_28
+              - !<!Parameter> &ref_29
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -912,8 +949,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_28
+              - *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -943,7 +993,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -971,7 +1021,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_29
+              - !<!Parameter> &ref_30
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -983,8 +1033,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_29
+              - *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1027,7 +1090,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1055,7 +1118,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_30
+              - !<!Parameter> &ref_31
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1067,8 +1130,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_30
+              - *ref_31
             language: !<!Languages> 
               default:
                 name: ''
@@ -1098,7 +1174,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1126,7 +1202,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
+              - !<!Parameter> &ref_32
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1138,8 +1214,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_31
+              - *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -1182,7 +1271,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1210,7 +1299,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_32
+              - !<!Parameter> &ref_33
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1222,8 +1311,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_32
+              - *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -1253,7 +1355,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1281,7 +1383,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
+              - !<!Parameter> &ref_34
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1293,8 +1395,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1332,7 +1447,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1360,7 +1475,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
+              - !<!Parameter> &ref_35
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1372,8 +1487,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -1412,7 +1540,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -1425,7 +1553,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1453,7 +1581,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
+              - !<!Parameter> &ref_37
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1465,8 +1593,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -1511,7 +1652,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1539,7 +1680,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_37
+              - !<!Parameter> &ref_38
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1551,8 +1692,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_37
+              - *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1591,7 +1745,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -1604,7 +1758,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1632,7 +1786,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_38
+              - !<!Parameter> &ref_39
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1644,8 +1798,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_38
+              - *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -1690,7 +1857,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1718,7 +1885,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_39
+              - !<!Parameter> &ref_40
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -1730,8 +1897,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_39
+              - *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1769,7 +1949,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1797,8 +1977,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_41
-                schema: *ref_40
+              - !<!Parameter> &ref_42
+                schema: *ref_41
                 flattened: true
                 implementation: Method
                 required: false
@@ -1810,31 +1990,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_44
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_45
                 schema: *ref_13
                 implementation: Method
-                originalParameter: *ref_41
+                originalParameter: *ref_42
                 pathToProperty: []
-                targetProperty: *ref_42
+                targetProperty: *ref_43
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_45
+              - !<!VirtualParameter> &ref_46
                 schema: *ref_14
                 implementation: Method
-                originalParameter: *ref_41
+                originalParameter: *ref_42
                 pathToProperty: []
-                targetProperty: *ref_43
+                targetProperty: *ref_44
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_44
               - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -1850,7 +2043,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -1864,7 +2057,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1892,8 +2085,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_46
-                schema: *ref_40
+              - !<!Parameter> &ref_47
+                schema: *ref_41
                 flattened: true
                 implementation: Method
                 required: false
@@ -1905,31 +2098,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_47
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_48
                 schema: *ref_13
                 implementation: Method
-                originalParameter: *ref_46
+                originalParameter: *ref_47
                 pathToProperty: []
-                targetProperty: *ref_42
+                targetProperty: *ref_43
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_48
+              - !<!VirtualParameter> &ref_49
                 schema: *ref_14
                 implementation: Method
-                originalParameter: *ref_46
+                originalParameter: *ref_47
                 pathToProperty: []
-                targetProperty: *ref_43
+                targetProperty: *ref_44
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_47
               - *ref_48
+              - *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -1945,7 +2151,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -1959,7 +2165,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1987,7 +2193,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_49
+              - !<!Parameter> &ref_50
                 schema: *ref_15
                 flattened: true
                 implementation: Method
@@ -2000,19 +2206,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_51
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_52
                 schema: *ref_18
                 implementation: Method
-                originalParameter: *ref_49
+                originalParameter: *ref_50
                 pathToProperty: []
-                targetProperty: *ref_50
+                targetProperty: *ref_51
                 language: !<!Languages> 
                   default:
                     name: provisioningState
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_51
+              - *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -2042,7 +2261,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2070,7 +2289,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_52
+              - !<!Parameter> &ref_53
                 schema: *ref_15
                 flattened: true
                 implementation: Method
@@ -2083,19 +2302,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_53
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_54
                 schema: *ref_18
                 implementation: Method
-                originalParameter: *ref_52
+                originalParameter: *ref_53
                 pathToProperty: []
-                targetProperty: *ref_50
+                targetProperty: *ref_51
                 language: !<!Languages> 
                   default:
                     name: provisioningState
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_53
+              - *ref_54
             language: !<!Languages> 
               default:
                 name: ''
@@ -2125,7 +2357,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2152,6 +2384,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2193,7 +2440,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2206,7 +2453,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2235,6 +2482,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2276,7 +2538,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2289,7 +2551,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2316,6 +2578,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2357,7 +2634,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2370,7 +2647,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2399,6 +2676,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2421,7 +2713,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2448,6 +2740,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2488,7 +2795,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2498,7 +2805,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2525,6 +2832,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2565,7 +2887,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2575,7 +2897,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2602,6 +2924,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2641,7 +2978,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2668,6 +3005,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2707,7 +3059,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2734,6 +3086,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2768,7 +3135,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2778,7 +3145,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2805,6 +3172,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2839,7 +3221,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2849,7 +3231,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2876,6 +3258,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2910,7 +3307,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2920,7 +3317,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -2947,6 +3344,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2981,7 +3393,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -2991,7 +3403,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3018,6 +3430,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3030,7 +3457,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -3043,7 +3470,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -3057,7 +3484,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3085,7 +3512,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_54
+              - !<!Parameter> &ref_55
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3097,8 +3524,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_54
+              - *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -3129,7 +3569,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3139,7 +3579,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3167,7 +3607,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_55
+              - !<!Parameter> &ref_56
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3179,8 +3619,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_55
+              - *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -3212,7 +3665,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3225,7 +3678,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3252,6 +3705,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3278,7 +3746,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3307,6 +3775,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3333,7 +3816,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3362,6 +3845,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3388,7 +3886,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3418,7 +3916,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_56
+              - !<!Parameter> &ref_57
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3430,8 +3928,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_56
+              - *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -3482,7 +3993,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3492,7 +4003,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3520,7 +4031,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_57
+              - !<!Parameter> &ref_58
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3532,8 +4043,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_57
+              - *ref_58
             language: !<!Languages> 
               default:
                 name: ''
@@ -3584,7 +4108,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3594,7 +4118,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3622,7 +4146,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_58
+              - !<!Parameter> &ref_59
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3634,8 +4158,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_58
+              - *ref_59
             language: !<!Languages> 
               default:
                 name: ''
@@ -3673,7 +4210,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3683,7 +4220,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3711,7 +4248,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_59
+              - !<!Parameter> &ref_60
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3723,8 +4260,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_59
+              - *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -3762,7 +4312,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3772,7 +4322,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3808,7 +4358,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_60
+              - !<!Parameter> &ref_61
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3820,8 +4370,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_60
+              - *ref_61
             language: !<!Languages> 
               default:
                 name: ''
@@ -3864,7 +4427,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3894,7 +4457,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_61
+              - !<!Parameter> &ref_62
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -3906,8 +4469,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_61
+              - *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -3946,7 +4522,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -3959,7 +4535,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -3986,6 +4562,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4027,7 +4618,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4040,7 +4631,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4069,6 +4660,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4096,7 +4702,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4106,7 +4712,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4133,6 +4739,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4167,7 +4788,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4177,7 +4798,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4205,7 +4826,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_62
+              - !<!Parameter> &ref_63
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4217,8 +4838,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_62
+              - *ref_63
             language: !<!Languages> 
               default:
                 name: ''
@@ -4249,7 +4883,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4259,7 +4893,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4287,7 +4921,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_63
+              - !<!Parameter> &ref_64
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4299,8 +4933,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -4338,7 +4985,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4348,7 +4995,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4386,7 +5033,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_64
+              - !<!Parameter> &ref_65
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4398,8 +5045,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_64
+              - *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -4442,7 +5102,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4470,7 +5130,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_65
+              - !<!Parameter> &ref_66
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4482,8 +5142,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_65
+              - *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -4526,7 +5199,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4554,7 +5227,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_66
+              - !<!Parameter> &ref_67
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4566,8 +5239,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_66
+              - *ref_67
             language: !<!Languages> 
               default:
                 name: ''
@@ -4610,7 +5296,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4638,7 +5324,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_67
+              - !<!Parameter> &ref_68
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4650,8 +5336,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_67
+              - *ref_68
             language: !<!Languages> 
               default:
                 name: ''
@@ -4690,7 +5389,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4703,7 +5402,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4730,6 +5429,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4757,7 +5471,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4767,7 +5481,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4794,6 +5508,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4821,7 +5550,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4831,7 +5560,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4858,6 +5587,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4892,7 +5636,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4902,7 +5646,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -4930,7 +5674,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_68
+              - !<!Parameter> &ref_69
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -4942,8 +5686,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_68
+              - *ref_69
             language: !<!Languages> 
               default:
                 name: ''
@@ -4974,7 +5731,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -4984,7 +5741,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5012,7 +5769,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_69
+              - !<!Parameter> &ref_70
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5024,8 +5781,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_69
+              - *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -5056,7 +5826,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5066,7 +5836,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5094,7 +5864,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_70
+              - !<!Parameter> &ref_71
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5106,8 +5876,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_70
+              - *ref_71
             language: !<!Languages> 
               default:
                 name: ''
@@ -5145,7 +5928,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5155,7 +5938,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5183,7 +5966,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_71
+              - !<!Parameter> &ref_72
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5195,8 +5978,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_71
+              - *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -5239,7 +6035,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5267,7 +6063,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_72
+              - !<!Parameter> &ref_73
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5279,8 +6075,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_72
+              - *ref_73
             language: !<!Languages> 
               default:
                 name: ''
@@ -5319,7 +6128,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5332,7 +6141,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5360,7 +6169,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_73
+              - !<!Parameter> &ref_74
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5372,8 +6181,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_73
+              - *ref_74
             language: !<!Languages> 
               default:
                 name: ''
@@ -5412,7 +6234,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5425,7 +6247,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5452,6 +6274,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5474,7 +6311,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5501,6 +6338,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -5535,7 +6387,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5545,7 +6397,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5573,7 +6425,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_74
+              - !<!Parameter> &ref_75
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5585,8 +6437,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_74
+              - *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -5617,7 +6482,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5627,7 +6492,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5655,7 +6520,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_75
+              - !<!Parameter> &ref_76
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5667,8 +6532,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_75
+              - *ref_76
             language: !<!Languages> 
               default:
                 name: ''
@@ -5706,7 +6584,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5716,7 +6594,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5744,7 +6622,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_76
+              - !<!Parameter> &ref_77
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5756,8 +6634,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_76
+              - *ref_77
             language: !<!Languages> 
               default:
                 name: ''
@@ -5796,7 +6687,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5824,7 +6715,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_77
+              - !<!Parameter> &ref_78
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5836,8 +6727,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_77
+              - *ref_78
             language: !<!Languages> 
               default:
                 name: ''
@@ -5876,7 +6780,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5889,7 +6793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -5917,7 +6821,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_78
+              - !<!Parameter> &ref_79
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -5929,8 +6833,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_78
+              - *ref_79
             language: !<!Languages> 
               default:
                 name: ''
@@ -5969,7 +6886,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -5982,7 +6899,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6009,6 +6926,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6036,7 +6968,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6046,7 +6978,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6073,6 +7005,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6107,7 +7054,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6117,7 +7064,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6144,6 +7091,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -6178,7 +7140,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6188,7 +7150,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6216,7 +7178,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_79
+              - !<!Parameter> &ref_80
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6228,8 +7190,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_79
+              - *ref_80
             language: !<!Languages> 
               default:
                 name: ''
@@ -6260,7 +7235,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6270,7 +7245,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6298,7 +7273,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_80
+              - !<!Parameter> &ref_81
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6310,8 +7285,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_80
+              - *ref_81
             language: !<!Languages> 
               default:
                 name: ''
@@ -6349,7 +7337,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6359,7 +7347,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6387,7 +7375,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_81
+              - !<!Parameter> &ref_82
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6399,8 +7387,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_81
+              - *ref_82
             language: !<!Languages> 
               default:
                 name: ''
@@ -6438,7 +7439,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6448,7 +7449,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6484,7 +7485,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_82
+              - !<!Parameter> &ref_83
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6496,8 +7497,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_82
+              - *ref_83
             language: !<!Languages> 
               default:
                 name: ''
@@ -6536,7 +7550,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6549,7 +7563,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6579,7 +7593,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_83
+              - !<!Parameter> &ref_84
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6591,8 +7605,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_83
+              - *ref_84
             language: !<!Languages> 
               default:
                 name: ''
@@ -6635,7 +7662,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6665,7 +7692,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_84
+              - !<!Parameter> &ref_85
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6677,8 +7704,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_84
+              - *ref_85
             language: !<!Languages> 
               default:
                 name: ''
@@ -6709,7 +7749,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6719,7 +7759,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -6749,7 +7789,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_85
+              - !<!Parameter> &ref_86
                 schema: *ref_2
                 implementation: Method
                 required: false
@@ -6761,8 +7801,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_85
+              - *ref_86
             language: !<!Languages> 
               default:
                 name: ''
@@ -6800,7 +7853,7 @@ operationGroups:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
                   - !<!HttpHeader> 
-                    schema: *ref_35
+                    schema: *ref_36
                     header: Retry-After
                     language:
                       default:
@@ -6810,7 +7863,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/media_types/flattened.yaml
+++ b/modelerfour/test/scenarios/media_types/flattened.yaml
@@ -22,7 +22,7 @@ schemas: !<!Schemas>
           name: SourcePath-source
           description: File source path.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -66,6 +66,17 @@ schemas: !<!Schemas>
           name: ContentType
           description: Content type for upload
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   binaries:
     - !<!BinarySchema> &ref_4
       type: binary
@@ -78,13 +89,13 @@ schemas: !<!Schemas>
           description: Uri or local path to source data.
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 2.0-preview
       properties:
-        - !<!Property> &ref_9
+        - !<!Property> &ref_10
           schema: *ref_1
           serializedName: source
           language: !<!Languages> 
@@ -132,7 +143,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_5
+              - !<!Parameter> &ref_6
                 schema: *ref_3
                 implementation: Method
                 origin: 'modelerfour:synthesized/content-type'
@@ -145,7 +156,7 @@ operationGroups:
                 protocol: !<!Protocols> 
                   http: !<!HttpParameter> 
                     in: header
-              - !<!Parameter> &ref_6
+              - !<!Parameter> &ref_7
                 schema: *ref_4
                 implementation: Method
                 required: true
@@ -157,9 +168,22 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_5
               - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -178,8 +202,8 @@ operationGroups:
                 uri: '{$host}'
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_7
+              - !<!Parameter> &ref_9
+                schema: *ref_8
                 flattened: true
                 implementation: Method
                 required: false
@@ -191,19 +215,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_10
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_11
                 schema: *ref_1
                 implementation: Method
-                originalParameter: *ref_8
+                originalParameter: *ref_9
                 pathToProperty: []
-                targetProperty: *ref_9
+                targetProperty: *ref_10
                 language: !<!Languages> 
                   default:
                     name: source
                     description: File source path.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,7 +256,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/media_types/grouped.yaml
+++ b/modelerfour/test/scenarios/media_types/grouped.yaml
@@ -22,7 +22,7 @@ schemas: !<!Schemas>
           name: SourcePath-source
           description: File source path.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -66,6 +66,17 @@ schemas: !<!Schemas>
           name: ContentType
           description: Content type for upload
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   binaries:
     - !<!BinarySchema> &ref_4
       type: binary
@@ -78,13 +89,13 @@ schemas: !<!Schemas>
           description: Uri or local path to source data.
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 2.0-preview
       properties:
-        - !<!Property> &ref_9
+        - !<!Property> &ref_10
           schema: *ref_1
           serializedName: source
           language: !<!Languages> 
@@ -132,7 +143,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_5
+              - !<!Parameter> &ref_6
                 schema: *ref_3
                 implementation: Method
                 origin: 'modelerfour:synthesized/content-type'
@@ -145,7 +156,7 @@ operationGroups:
                 protocol: !<!Protocols> 
                   http: !<!HttpParameter> 
                     in: header
-              - !<!Parameter> &ref_6
+              - !<!Parameter> &ref_7
                 schema: *ref_4
                 implementation: Method
                 required: true
@@ -157,9 +168,22 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_5
               - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -178,8 +202,8 @@ operationGroups:
                 uri: '{$host}'
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_7
+              - !<!Parameter> &ref_9
+                schema: *ref_8
                 flattened: true
                 implementation: Method
                 required: false
@@ -191,19 +215,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_10
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_11
                 schema: *ref_1
                 implementation: Method
-                originalParameter: *ref_8
+                originalParameter: *ref_9
                 pathToProperty: []
-                targetProperty: *ref_9
+                targetProperty: *ref_10
                 language: !<!Languages> 
                   default:
                     name: source
                     description: File source path.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,7 +256,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/media_types/modeler.yaml
+++ b/modelerfour/test/scenarios/media_types/modeler.yaml
@@ -22,7 +22,7 @@ schemas: !<!Schemas>
           name: SourcePath-source
           description: File source path.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -66,6 +66,17 @@ schemas: !<!Schemas>
           name: ContentType
           description: Content type for upload
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_4
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   binaries:
     - !<!BinarySchema> &ref_3
       type: binary
@@ -78,7 +89,7 @@ schemas: !<!Schemas>
           description: Uri or local path to source data.
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_6
+    - !<!ObjectSchema> &ref_7
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -103,7 +114,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_9
+  - !<!Parameter> &ref_10
     schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -128,11 +139,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2.0-preview
         parameters:
-          - *ref_9
+          - *ref_10
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_4
+              - !<!Parameter> &ref_5
                 schema: *ref_2
                 implementation: Method
                 origin: 'modelerfour:synthesized/content-type'
@@ -145,7 +156,7 @@ operationGroups:
                 protocol: !<!Protocols> 
                   http: !<!HttpParameter> 
                     in: header
-              - !<!Parameter> &ref_5
+              - !<!Parameter> &ref_6
                 schema: *ref_3
                 implementation: Method
                 required: true
@@ -157,9 +168,22 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_4
               - *ref_5
+              - *ref_6
             language: !<!Languages> 
               default:
                 name: ''
@@ -178,8 +202,8 @@ operationGroups:
                 uri: '{$host}'
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
-                schema: *ref_6
+              - !<!Parameter> &ref_8
+                schema: *ref_7
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -190,8 +214,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_4
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -207,7 +244,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/media_types/namer.yaml
+++ b/modelerfour/test/scenarios/media_types/namer.yaml
@@ -22,7 +22,7 @@ schemas: !<!Schemas>
           name: SourcePathSource
           description: File source path.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -66,6 +66,17 @@ schemas: !<!Schemas>
           name: ContentType
           description: Content type for upload
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_5
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   binaries:
     - !<!BinarySchema> &ref_4
       type: binary
@@ -78,13 +89,13 @@ schemas: !<!Schemas>
           description: Uri or local path to source data.
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 2.0-preview
       properties:
-        - !<!Property> &ref_9
+        - !<!Property> &ref_10
           schema: *ref_1
           serializedName: source
           language: !<!Languages> 
@@ -132,7 +143,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_5
+              - !<!Parameter> &ref_6
                 schema: *ref_3
                 implementation: Method
                 origin: 'modelerfour:synthesized/content-type'
@@ -145,7 +156,7 @@ operationGroups:
                 protocol: !<!Protocols> 
                   http: !<!HttpParameter> 
                     in: header
-              - !<!Parameter> &ref_6
+              - !<!Parameter> &ref_7
                 schema: *ref_4
                 implementation: Method
                 required: true
@@ -157,9 +168,22 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_5
               - *ref_6
+              - *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -178,8 +202,8 @@ operationGroups:
                 uri: '{$host}'
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_8
-                schema: *ref_7
+              - !<!Parameter> &ref_9
+                schema: *ref_8
                 flattened: true
                 implementation: Method
                 required: false
@@ -191,19 +215,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_10
+              - !<!Parameter> 
+                schema: *ref_5
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_11
                 schema: *ref_1
                 implementation: Method
-                originalParameter: *ref_8
+                originalParameter: *ref_9
                 pathToProperty: []
-                targetProperty: *ref_9
+                targetProperty: *ref_10
                 language: !<!Languages> 
                   default:
                     name: source
                     description: File source path.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_10
+              - *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,7 +256,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/model-flattening/flattened.yaml
+++ b/modelerfour/test/scenarios/model-flattening/flattened.yaml
@@ -250,6 +250,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_33
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_23
       type: constant
       apiVersions:
@@ -272,7 +282,7 @@ schemas: !<!Schemas>
           name: Resource-tags
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_38
+    - !<!DictionarySchema> &ref_39
       type: dictionary
       elementType: !<!ObjectSchema> &ref_2
         type: object
@@ -515,7 +525,7 @@ schemas: !<!Schemas>
           description: The wrapped produc.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_40
+    - !<!ObjectSchema> &ref_41
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -584,7 +594,7 @@ schemas: !<!Schemas>
               immediate:
                 - *ref_18
             properties:
-              - !<!Property> &ref_44
+              - !<!Property> &ref_45
                 schema: *ref_19
                 required: true
                 serializedName: base_product_id
@@ -593,7 +603,7 @@ schemas: !<!Schemas>
                     name: productId
                     description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
                 protocol: !<!Protocols> {}
-              - !<!Property> &ref_45
+              - !<!Property> &ref_46
                 schema: *ref_20
                 required: false
                 serializedName: base_product_description
@@ -616,7 +626,7 @@ schemas: !<!Schemas>
         immediate:
           - *ref_21
       properties:
-        - !<!Property> &ref_46
+        - !<!Property> &ref_47
           schema: *ref_22
           flattenedNames:
             - details
@@ -627,7 +637,7 @@ schemas: !<!Schemas>
               name: max_product_display_name
               description: Display name of product.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_47
+        - !<!Property> &ref_48
           schema: *ref_23
           flattenedNames:
             - details
@@ -638,7 +648,7 @@ schemas: !<!Schemas>
               name: capacity
               description: 'Capacity of product. For example, 4 people.'
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_48
+        - !<!Property> &ref_49
           schema: *ref_24
           flattenedNames:
             - details
@@ -650,7 +660,7 @@ schemas: !<!Schemas>
               name: generic_value
               description: Generic URL value.
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_49
+        - !<!Property> &ref_50
           schema: *ref_25
           flattenedNames:
             - details
@@ -748,7 +758,7 @@ schemas: !<!Schemas>
           name: paths·1wya29p·model_flatten-array·put·requestbody·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_34
+    - !<!ArraySchema> &ref_35
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -759,7 +769,7 @@ schemas: !<!Schemas>
           name: paths·h6wuda·model_flatten-array·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_35
+    - !<!ArraySchema> &ref_36
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -770,7 +780,7 @@ schemas: !<!Schemas>
           name: paths·w59cy5·model_flatten-wrappedarray·put·requestbody·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_37
+    - !<!ArraySchema> &ref_38
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -812,7 +822,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
+              - !<!Parameter> &ref_34
                 schema: *ref_32
                 implementation: Method
                 required: false
@@ -824,8 +834,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_33
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -876,6 +899,21 @@ operationGroups:
           - *ref_31
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_33
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -888,7 +926,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_34
+            schema: *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -928,8 +966,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_35
+              - !<!Parameter> &ref_37
+                schema: *ref_36
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -940,8 +978,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_33
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -992,6 +1043,21 @@ operationGroups:
           - *ref_31
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_33
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1004,7 +1070,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_37
+            schema: *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1044,8 +1110,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_39
-                schema: *ref_38
+              - !<!Parameter> &ref_40
+                schema: *ref_39
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1056,8 +1122,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_33
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_39
+              - *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1108,6 +1187,21 @@ operationGroups:
           - *ref_31
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_33
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1120,7 +1214,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_38
+            schema: *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -1160,8 +1254,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_41
-                schema: *ref_40
+              - !<!Parameter> &ref_42
+                schema: *ref_41
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1172,8 +1266,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_33
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_41
+              - *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -1224,6 +1331,21 @@ operationGroups:
           - *ref_31
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_33
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1236,7 +1358,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -1276,7 +1398,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_42
+              - !<!Parameter> &ref_43
                 schema: *ref_18
                 implementation: Method
                 required: false
@@ -1288,8 +1410,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_33
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_42
+              - *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -1345,7 +1480,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_43
+              - !<!Parameter> &ref_44
                 schema: *ref_18
                 flattened: true
                 implementation: Method
@@ -1360,36 +1495,49 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_50
+              - !<!Parameter> 
+                schema: *ref_33
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_51
                 schema: *ref_19
                 implementation: Method
-                originalParameter: *ref_43
+                originalParameter: *ref_44
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_44
+                targetProperty: *ref_45
                 language: !<!Languages> 
                   default:
                     name: productId
                     description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_51
+              - !<!VirtualParameter> &ref_52
                 schema: *ref_20
                 implementation: Method
-                originalParameter: *ref_43
+                originalParameter: *ref_44
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_45
+                targetProperty: *ref_46
                 language: !<!Languages> 
                   default:
                     name: description
                     description: Description of product.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_52
+              - !<!VirtualParameter> &ref_53
                 schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_43
+                originalParameter: *ref_44
                 pathToProperty: []
-                targetProperty: *ref_46
+                targetProperty: *ref_47
                 language: !<!Languages> 
                   default:
                     name: max_product_display_name
@@ -1398,42 +1546,42 @@ operationGroups:
               - !<!VirtualParameter> 
                 schema: *ref_23
                 implementation: Method
-                originalParameter: *ref_43
+                originalParameter: *ref_44
                 pathToProperty: []
-                targetProperty: *ref_47
+                targetProperty: *ref_48
                 language: !<!Languages> 
                   default:
                     name: capacity
                     description: 'Capacity of product. For example, 4 people.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_53
+              - !<!VirtualParameter> &ref_54
                 schema: *ref_24
                 implementation: Method
-                originalParameter: *ref_43
+                originalParameter: *ref_44
                 pathToProperty: []
-                targetProperty: *ref_48
+                targetProperty: *ref_49
                 language: !<!Languages> 
                   default:
                     name: generic_value
                     description: Generic URL value.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_54
+              - !<!VirtualParameter> &ref_55
                 schema: *ref_25
                 implementation: Method
-                originalParameter: *ref_43
+                originalParameter: *ref_44
                 pathToProperty: []
-                targetProperty: *ref_49
+                targetProperty: *ref_50
                 language: !<!Languages> 
                   default:
                     name: '@odata.value'
                     description: URL value.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_50
               - *ref_51
               - *ref_52
               - *ref_53
               - *ref_54
+              - *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -1486,7 +1634,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_31
-          - !<!Parameter> &ref_62
+          - !<!Parameter> &ref_63
             schema: *ref_1
             implementation: Method
             required: true
@@ -1504,14 +1652,14 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_55
+              - !<!Parameter> &ref_56
                 schema: *ref_18
                 flattened: true
                 implementation: Method
                 required: false
                 extensions:
                   x-ms-client-flatten: true
-                  x-ms-parameter-grouping: &ref_56
+                  x-ms-parameter-grouping: &ref_57
                     name: flatten-parameter-group
                 language: !<!Languages> 
                   default:
@@ -1521,42 +1669,55 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_57
+              - !<!Parameter> 
+                schema: *ref_33
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_58
                 schema: *ref_19
                 implementation: Method
-                originalParameter: *ref_55
+                originalParameter: *ref_56
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_44
+                targetProperty: *ref_45
                 extensions:
-                  x-ms-parameter-grouping: *ref_56
+                  x-ms-parameter-grouping: *ref_57
                 language: !<!Languages> 
                   default:
                     name: productId
                     description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_58
+              - !<!VirtualParameter> &ref_59
                 schema: *ref_20
                 implementation: Method
-                originalParameter: *ref_55
+                originalParameter: *ref_56
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_45
+                targetProperty: *ref_46
                 extensions:
-                  x-ms-parameter-grouping: *ref_56
+                  x-ms-parameter-grouping: *ref_57
                 language: !<!Languages> 
                   default:
                     name: description
                     description: Description of product.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_59
+              - !<!VirtualParameter> &ref_60
                 schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_55
+                originalParameter: *ref_56
                 pathToProperty: []
-                targetProperty: *ref_46
+                targetProperty: *ref_47
                 extensions:
-                  x-ms-parameter-grouping: *ref_56
+                  x-ms-parameter-grouping: *ref_57
                 language: !<!Languages> 
                   default:
                     name: max_product_display_name
@@ -1565,48 +1726,48 @@ operationGroups:
               - !<!VirtualParameter> 
                 schema: *ref_23
                 implementation: Method
-                originalParameter: *ref_55
+                originalParameter: *ref_56
                 pathToProperty: []
-                targetProperty: *ref_47
+                targetProperty: *ref_48
                 extensions:
-                  x-ms-parameter-grouping: *ref_56
+                  x-ms-parameter-grouping: *ref_57
                 language: !<!Languages> 
                   default:
                     name: capacity
                     description: 'Capacity of product. For example, 4 people.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_60
+              - !<!VirtualParameter> &ref_61
                 schema: *ref_24
                 implementation: Method
-                originalParameter: *ref_55
+                originalParameter: *ref_56
                 pathToProperty: []
-                targetProperty: *ref_48
+                targetProperty: *ref_49
                 extensions:
-                  x-ms-parameter-grouping: *ref_56
+                  x-ms-parameter-grouping: *ref_57
                 language: !<!Languages> 
                   default:
                     name: generic_value
                     description: Generic URL value.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_61
+              - !<!VirtualParameter> &ref_62
                 schema: *ref_25
                 implementation: Method
-                originalParameter: *ref_55
+                originalParameter: *ref_56
                 pathToProperty: []
-                targetProperty: *ref_49
+                targetProperty: *ref_50
                 extensions:
-                  x-ms-parameter-grouping: *ref_56
+                  x-ms-parameter-grouping: *ref_57
                 language: !<!Languages> 
                   default:
                     name: '@odata.value'
                     description: URL value.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_57
               - *ref_58
               - *ref_59
               - *ref_60
               - *ref_61
+              - *ref_62
             language: !<!Languages> 
               default:
                 name: ''
@@ -1620,7 +1781,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_62
+          - *ref_63
         responses:
           - !<!SchemaResponse> 
             schema: *ref_18

--- a/modelerfour/test/scenarios/model-flattening/grouped.yaml
+++ b/modelerfour/test/scenarios/model-flattening/grouped.yaml
@@ -250,6 +250,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_41
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_23
       type: constant
       apiVersions:
@@ -272,7 +282,7 @@ schemas: !<!Schemas>
           name: Resource-tags
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_46
+    - !<!DictionarySchema> &ref_47
       type: dictionary
       elementType: !<!ObjectSchema> &ref_2
         type: object
@@ -425,7 +435,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_1
           originalParameter:
-            - !<!Parameter> &ref_58
+            - !<!Parameter> &ref_59
               schema: *ref_1
               groupedBy: !<!Parameter> &ref_32
                 schema: *ref_31
@@ -515,7 +525,7 @@ schemas: !<!Schemas>
                     name: max_product_display_name
                     description: Display name of product.
                 protocol: !<!Protocols> {}
-              - !<!Property> &ref_52
+              - !<!Property> &ref_53
                 schema: *ref_23
                 flattenedNames:
                   - details
@@ -588,7 +598,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_19
           originalParameter:
-            - !<!VirtualParameter> &ref_59
+            - !<!VirtualParameter> &ref_60
               schema: *ref_19
               groupedBy: *ref_32
               implementation: Method
@@ -611,7 +621,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_20
           originalParameter:
-            - !<!VirtualParameter> &ref_60
+            - !<!VirtualParameter> &ref_61
               schema: *ref_20
               groupedBy: *ref_32
               implementation: Method
@@ -634,7 +644,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_22
           originalParameter:
-            - !<!VirtualParameter> &ref_61
+            - !<!VirtualParameter> &ref_62
               schema: *ref_22
               groupedBy: *ref_32
               implementation: Method
@@ -655,7 +665,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_24
           originalParameter:
-            - !<!VirtualParameter> &ref_62
+            - !<!VirtualParameter> &ref_63
               schema: *ref_24
               groupedBy: *ref_32
               implementation: Method
@@ -676,7 +686,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_25
           originalParameter:
-            - !<!VirtualParameter> &ref_63
+            - !<!VirtualParameter> &ref_64
               schema: *ref_25
               groupedBy: *ref_32
               implementation: Method
@@ -798,7 +808,7 @@ schemas: !<!Schemas>
           description: The wrapped produc.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_48
+    - !<!ObjectSchema> &ref_49
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -925,7 +935,7 @@ schemas: !<!Schemas>
           name: paths·1wya29p·model_flatten-array·put·requestbody·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_42
+    - !<!ArraySchema> &ref_43
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -936,7 +946,7 @@ schemas: !<!Schemas>
           name: paths·h6wuda·model_flatten-array·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_43
+    - !<!ArraySchema> &ref_44
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -947,7 +957,7 @@ schemas: !<!Schemas>
           name: paths·w59cy5·model_flatten-wrappedarray·put·requestbody·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_45
+    - !<!ArraySchema> &ref_46
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -989,7 +999,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_41
+              - !<!Parameter> &ref_42
                 schema: *ref_40
                 implementation: Method
                 required: false
@@ -1001,8 +1011,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_41
+              - *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -1053,6 +1076,21 @@ operationGroups:
           - *ref_39
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1065,7 +1103,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_42
+            schema: *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -1105,8 +1143,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_44
-                schema: *ref_43
+              - !<!Parameter> &ref_45
+                schema: *ref_44
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1117,8 +1155,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_44
+              - *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -1169,6 +1220,21 @@ operationGroups:
           - *ref_39
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1181,7 +1247,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_45
+            schema: *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -1221,8 +1287,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_47
-                schema: *ref_46
+              - !<!Parameter> &ref_48
+                schema: *ref_47
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1233,8 +1299,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_47
+              - *ref_48
             language: !<!Languages> 
               default:
                 name: ''
@@ -1285,6 +1364,21 @@ operationGroups:
           - *ref_39
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1297,7 +1391,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -1337,8 +1431,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_49
-                schema: *ref_48
+              - !<!Parameter> &ref_50
+                schema: *ref_49
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1349,8 +1443,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_49
+              - *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -1401,6 +1508,21 @@ operationGroups:
           - *ref_39
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1413,7 +1535,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -1453,7 +1575,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_50
+              - !<!Parameter> &ref_51
                 schema: *ref_18
                 implementation: Method
                 required: false
@@ -1465,8 +1587,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_50
+              - *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -1522,7 +1657,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_51
+              - !<!Parameter> &ref_52
                 schema: *ref_18
                 flattened: true
                 implementation: Method
@@ -1537,10 +1672,23 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_53
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_54
                 schema: *ref_19
                 implementation: Method
-                originalParameter: *ref_51
+                originalParameter: *ref_52
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_34
@@ -1549,10 +1697,10 @@ operationGroups:
                     name: productId
                     description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_54
+              - !<!VirtualParameter> &ref_55
                 schema: *ref_20
                 implementation: Method
-                originalParameter: *ref_51
+                originalParameter: *ref_52
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_35
@@ -1561,10 +1709,10 @@ operationGroups:
                     name: description
                     description: Description of product.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_55
+              - !<!VirtualParameter> &ref_56
                 schema: *ref_22
                 implementation: Method
-                originalParameter: *ref_51
+                originalParameter: *ref_52
                 pathToProperty: []
                 targetProperty: *ref_36
                 language: !<!Languages> 
@@ -1575,18 +1723,18 @@ operationGroups:
               - !<!VirtualParameter> 
                 schema: *ref_23
                 implementation: Method
-                originalParameter: *ref_51
+                originalParameter: *ref_52
                 pathToProperty: []
-                targetProperty: *ref_52
+                targetProperty: *ref_53
                 language: !<!Languages> 
                   default:
                     name: capacity
                     description: 'Capacity of product. For example, 4 people.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_56
+              - !<!VirtualParameter> &ref_57
                 schema: *ref_24
                 implementation: Method
-                originalParameter: *ref_51
+                originalParameter: *ref_52
                 pathToProperty: []
                 targetProperty: *ref_37
                 language: !<!Languages> 
@@ -1594,10 +1742,10 @@ operationGroups:
                     name: generic_value
                     description: Generic URL value.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_57
+              - !<!VirtualParameter> &ref_58
                 schema: *ref_25
                 implementation: Method
-                originalParameter: *ref_51
+                originalParameter: *ref_52
                 pathToProperty: []
                 targetProperty: *ref_38
                 language: !<!Languages> 
@@ -1606,11 +1754,11 @@ operationGroups:
                     description: URL value.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_53
               - *ref_54
               - *ref_55
               - *ref_56
               - *ref_57
+              - *ref_58
             language: !<!Languages> 
               default:
                 name: ''
@@ -1663,20 +1811,33 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_39
-          - *ref_58
+          - *ref_59
         requests:
           - !<!Request> 
             parameters:
               - *ref_33
-              - *ref_59
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_60
               - *ref_61
+              - *ref_62
               - !<!VirtualParameter> 
                 schema: *ref_23
                 implementation: Method
                 originalParameter: *ref_33
                 pathToProperty: []
-                targetProperty: *ref_52
+                targetProperty: *ref_53
                 extensions:
                   x-ms-parameter-grouping:
                     name: flatten-parameter-group
@@ -1685,8 +1846,8 @@ operationGroups:
                     name: capacity
                     description: 'Capacity of product. For example, 4 people.'
                 protocol: !<!Protocols> {}
-              - *ref_62
               - *ref_63
+              - *ref_64
               - *ref_32
             signatureParameters:
               - *ref_32

--- a/modelerfour/test/scenarios/model-flattening/modeler.yaml
+++ b/modelerfour/test/scenarios/model-flattening/modeler.yaml
@@ -171,7 +171,7 @@ schemas: !<!Schemas>
           description: Description of product.
       protocol: !<!Protocols> {}
   choices:
-    - !<!ChoiceSchema> &ref_31
+    - !<!ChoiceSchema> &ref_32
       choices:
         - !<!ChoiceValue> 
           value: Succeeded
@@ -250,7 +250,17 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_32
+    - !<!ConstantSchema> &ref_34
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_7
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_31
       type: constant
       apiVersions:
         - !<!ApiVersion> 
@@ -272,7 +282,7 @@ schemas: !<!Schemas>
           name: Resource-tags
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_40
+    - !<!DictionarySchema> &ref_41
       type: dictionary
       elementType: !<!ObjectSchema> &ref_10
         type: object
@@ -373,7 +383,7 @@ schemas: !<!Schemas>
                       description: ''
                   protocol: !<!Protocols> {}
                 - !<!Property> 
-                  schema: *ref_31
+                  schema: *ref_32
                   readOnly: true
                   serializedName: provisioningStateValues
                   language: !<!Languages> 
@@ -529,7 +539,7 @@ schemas: !<!Schemas>
           description: The wrapped produc.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_42
+    - !<!ObjectSchema> &ref_43
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -647,7 +657,7 @@ schemas: !<!Schemas>
                     description: Display name of product.
                 protocol: !<!Protocols> {}
               - !<!Property> 
-                schema: *ref_32
+                schema: *ref_31
                 required: true
                 serializedName: max_product_capacity
                 language: !<!Languages> 
@@ -770,7 +780,7 @@ schemas: !<!Schemas>
           name: paths·1wya29p·model_flatten-array·put·requestbody·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_36
+    - !<!ArraySchema> &ref_37
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -781,7 +791,7 @@ schemas: !<!Schemas>
           name: paths·h6wuda·model_flatten-array·get·responses·200·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_37
+    - !<!ArraySchema> &ref_38
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -792,7 +802,7 @@ schemas: !<!Schemas>
           name: paths·w59cy5·model_flatten-wrappedarray·put·requestbody·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_39
+    - !<!ArraySchema> &ref_40
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -805,7 +815,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_29
 globalParameters:
-  - !<!Parameter> &ref_35
+  - !<!Parameter> &ref_36
     schema: *ref_7
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -830,11 +840,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_35
+          - *ref_36
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
+              - !<!Parameter> &ref_35
                 schema: *ref_33
                 implementation: Method
                 required: false
@@ -846,8 +856,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_34
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -895,9 +918,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_35
+          - *ref_36
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_34
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -910,7 +948,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_36
+            schema: *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -946,12 +984,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_35
+          - *ref_36
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_38
-                schema: *ref_37
+              - !<!Parameter> &ref_39
+                schema: *ref_38
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -962,8 +1000,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_34
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_38
+              - *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -1011,9 +1062,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_35
+          - *ref_36
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_34
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1026,7 +1092,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_39
+            schema: *ref_40
             language: !<!Languages> 
               default:
                 name: ''
@@ -1062,12 +1128,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_35
+          - *ref_36
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_41
-                schema: *ref_40
+              - !<!Parameter> &ref_42
+                schema: *ref_41
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1078,8 +1144,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_34
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_41
+              - *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -1127,9 +1206,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_35
+          - *ref_36
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_34
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1142,7 +1236,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_40
+            schema: *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -1178,12 +1272,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_35
+          - *ref_36
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_43
-                schema: *ref_42
+              - !<!Parameter> &ref_44
+                schema: *ref_43
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1194,8 +1288,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_34
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_43
+              - *ref_44
             language: !<!Languages> 
               default:
                 name: ''
@@ -1243,9 +1350,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_35
+          - *ref_36
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_34
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1258,7 +1380,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_42
+            schema: *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -1294,11 +1416,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_35
+          - *ref_36
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_44
+              - !<!Parameter> &ref_45
                 schema: *ref_23
                 implementation: Method
                 required: false
@@ -1310,8 +1432,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_34
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_44
+              - *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -1363,11 +1498,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_35
+          - *ref_36
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_45
+              - !<!Parameter> &ref_46
                 schema: *ref_23
                 implementation: Method
                 required: false
@@ -1381,8 +1516,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_34
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -1434,8 +1582,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_35
-          - !<!Parameter> &ref_46
+          - *ref_36
+          - !<!Parameter> &ref_47
             schema: *ref_2
             implementation: Method
             required: true
@@ -1453,7 +1601,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_47
+              - !<!Parameter> &ref_48
                 schema: *ref_23
                 implementation: Method
                 required: false
@@ -1469,8 +1617,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_34
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_47
+              - *ref_48
             language: !<!Languages> 
               default:
                 name: ''
@@ -1484,7 +1645,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_46
+          - *ref_47
         responses:
           - !<!SchemaResponse> 
             schema: *ref_23

--- a/modelerfour/test/scenarios/model-flattening/namer.yaml
+++ b/modelerfour/test/scenarios/model-flattening/namer.yaml
@@ -250,6 +250,16 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
+    - !<!ConstantSchema> &ref_41
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_19
       type: constant
       apiVersions:
@@ -272,7 +282,7 @@ schemas: !<!Schemas>
           name: ResourceTags
           description: Dictionary of <string>
       protocol: !<!Protocols> {}
-    - !<!DictionarySchema> &ref_46
+    - !<!DictionarySchema> &ref_47
       type: dictionary
       elementType: !<!ObjectSchema> &ref_2
         type: object
@@ -425,7 +435,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_1
           originalParameter:
-            - !<!Parameter> &ref_58
+            - !<!Parameter> &ref_59
               schema: *ref_1
               groupedBy: !<!Parameter> &ref_22
                 schema: *ref_13
@@ -515,7 +525,7 @@ schemas: !<!Schemas>
                     name: maxProductDisplayName
                     description: Display name of product.
                 protocol: !<!Protocols> {}
-              - !<!Property> &ref_52
+              - !<!Property> &ref_53
                 schema: *ref_19
                 flattenedNames:
                   - details
@@ -588,7 +598,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_15
           originalParameter:
-            - !<!VirtualParameter> &ref_59
+            - !<!VirtualParameter> &ref_60
               schema: *ref_15
               groupedBy: *ref_22
               implementation: Method
@@ -611,7 +621,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_16
           originalParameter:
-            - !<!VirtualParameter> &ref_60
+            - !<!VirtualParameter> &ref_61
               schema: *ref_16
               groupedBy: *ref_22
               implementation: Method
@@ -634,7 +644,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_18
           originalParameter:
-            - !<!VirtualParameter> &ref_61
+            - !<!VirtualParameter> &ref_62
               schema: *ref_18
               groupedBy: *ref_22
               implementation: Method
@@ -655,7 +665,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_20
           originalParameter:
-            - !<!VirtualParameter> &ref_62
+            - !<!VirtualParameter> &ref_63
               schema: *ref_20
               groupedBy: *ref_22
               implementation: Method
@@ -676,7 +686,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_21
           originalParameter:
-            - !<!VirtualParameter> &ref_63
+            - !<!VirtualParameter> &ref_64
               schema: *ref_21
               groupedBy: *ref_22
               implementation: Method
@@ -798,7 +808,7 @@ schemas: !<!Schemas>
           description: The wrapped produc.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_48
+    - !<!ObjectSchema> &ref_49
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -925,7 +935,7 @@ schemas: !<!Schemas>
           name: ArrayOfResource
           description: Array of Resource
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_42
+    - !<!ArraySchema> &ref_43
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -936,7 +946,7 @@ schemas: !<!Schemas>
           name: ArrayOfFlattenedProduct
           description: Array of FlattenedProduct
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_43
+    - !<!ArraySchema> &ref_44
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -947,7 +957,7 @@ schemas: !<!Schemas>
           name: ArrayOfWrappedProduct
           description: Array of WrappedProduct
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_45
+    - !<!ArraySchema> &ref_46
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -989,7 +999,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_41
+              - !<!Parameter> &ref_42
                 schema: *ref_40
                 implementation: Method
                 required: false
@@ -1001,8 +1011,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_41
+              - *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -1053,6 +1076,21 @@ operationGroups:
           - *ref_39
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1065,7 +1103,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_42
+            schema: *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -1105,8 +1143,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_44
-                schema: *ref_43
+              - !<!Parameter> &ref_45
+                schema: *ref_44
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1117,8 +1155,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_44
+              - *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -1169,6 +1220,21 @@ operationGroups:
           - *ref_39
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1181,7 +1247,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_45
+            schema: *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -1221,8 +1287,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_47
-                schema: *ref_46
+              - !<!Parameter> &ref_48
+                schema: *ref_47
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1233,8 +1299,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_47
+              - *ref_48
             language: !<!Languages> 
               default:
                 name: ''
@@ -1285,6 +1364,21 @@ operationGroups:
           - *ref_39
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1297,7 +1391,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_46
+            schema: *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -1337,8 +1431,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_49
-                schema: *ref_48
+              - !<!Parameter> &ref_50
+                schema: *ref_49
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1349,8 +1443,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_49
+              - *ref_50
             language: !<!Languages> 
               default:
                 name: ''
@@ -1401,6 +1508,21 @@ operationGroups:
           - *ref_39
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1413,7 +1535,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_48
+            schema: *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -1453,7 +1575,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_50
+              - !<!Parameter> &ref_51
                 schema: *ref_14
                 implementation: Method
                 required: false
@@ -1465,8 +1587,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_50
+              - *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -1522,7 +1657,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_51
+              - !<!Parameter> &ref_52
                 schema: *ref_14
                 flattened: true
                 implementation: Method
@@ -1537,10 +1672,23 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_53
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_54
                 schema: *ref_15
                 implementation: Method
-                originalParameter: *ref_51
+                originalParameter: *ref_52
                 pathToProperty: []
                 required: true
                 targetProperty: *ref_24
@@ -1549,10 +1697,10 @@ operationGroups:
                     name: productId
                     description: 'Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_54
+              - !<!VirtualParameter> &ref_55
                 schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_51
+                originalParameter: *ref_52
                 pathToProperty: []
                 required: false
                 targetProperty: *ref_25
@@ -1561,10 +1709,10 @@ operationGroups:
                     name: description
                     description: Description of product.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_55
+              - !<!VirtualParameter> &ref_56
                 schema: *ref_18
                 implementation: Method
-                originalParameter: *ref_51
+                originalParameter: *ref_52
                 pathToProperty: []
                 targetProperty: *ref_26
                 language: !<!Languages> 
@@ -1575,18 +1723,18 @@ operationGroups:
               - !<!VirtualParameter> 
                 schema: *ref_19
                 implementation: Method
-                originalParameter: *ref_51
+                originalParameter: *ref_52
                 pathToProperty: []
-                targetProperty: *ref_52
+                targetProperty: *ref_53
                 language: !<!Languages> 
                   default:
                     name: Capacity
                     description: 'Capacity of product. For example, 4 people.'
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_56
+              - !<!VirtualParameter> &ref_57
                 schema: *ref_20
                 implementation: Method
-                originalParameter: *ref_51
+                originalParameter: *ref_52
                 pathToProperty: []
                 targetProperty: *ref_27
                 language: !<!Languages> 
@@ -1594,10 +1742,10 @@ operationGroups:
                     name: genericValue
                     description: Generic URL value.
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_57
+              - !<!VirtualParameter> &ref_58
                 schema: *ref_21
                 implementation: Method
-                originalParameter: *ref_51
+                originalParameter: *ref_52
                 pathToProperty: []
                 targetProperty: *ref_28
                 language: !<!Languages> 
@@ -1606,11 +1754,11 @@ operationGroups:
                     description: URL value.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_53
               - *ref_54
               - *ref_55
               - *ref_56
               - *ref_57
+              - *ref_58
             language: !<!Languages> 
               default:
                 name: ''
@@ -1663,20 +1811,33 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_39
-          - *ref_58
+          - *ref_59
         requests:
           - !<!Request> 
             parameters:
               - *ref_23
-              - *ref_59
+              - !<!Parameter> 
+                schema: *ref_41
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_60
               - *ref_61
+              - *ref_62
               - !<!VirtualParameter> 
                 schema: *ref_19
                 implementation: Method
                 originalParameter: *ref_23
                 pathToProperty: []
-                targetProperty: *ref_52
+                targetProperty: *ref_53
                 extensions:
                   x-ms-parameter-grouping:
                     name: flatten-parameter-group
@@ -1685,8 +1846,8 @@ operationGroups:
                     name: Capacity
                     description: 'Capacity of product. For example, 4 people.'
                 protocol: !<!Protocols> {}
-              - *ref_62
               - *ref_63
+              - *ref_64
               - *ref_22
             signatureParameters:
               - *ref_22

--- a/modelerfour/test/scenarios/multiapi-v1/flattened.yaml
+++ b/modelerfour/test/scenarios/multiapi-v1/flattened.yaml
@@ -73,8 +73,18 @@ schemas: !<!Schemas>
           name: ApiVersion-1.0.0
           description: Api Version (1.0.0)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_8
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_10
+    - !<!ObjectSchema> &ref_11
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -146,7 +156,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_4
-          - !<!Parameter> &ref_8
+          - !<!Parameter> &ref_9
             schema: *ref_5
             implementation: Method
             required: true
@@ -158,7 +168,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_9
+          - !<!Parameter> &ref_10
             schema: *ref_6
             implementation: Method
             language: !<!Languages> 
@@ -172,6 +182,21 @@ operationGroups:
           - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -182,8 +207,8 @@ operationGroups:
                 method: put
                 uri: '{$host}'
         signatureParameters:
-          - *ref_8
           - *ref_9
+          - *ref_10
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -196,7 +221,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -232,6 +257,21 @@ operationGroups:
           - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -254,7 +294,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/multiapi-v1/grouped.yaml
+++ b/modelerfour/test/scenarios/multiapi-v1/grouped.yaml
@@ -73,8 +73,18 @@ schemas: !<!Schemas>
           name: ApiVersion-1.0.0
           description: Api Version (1.0.0)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_8
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_10
+    - !<!ObjectSchema> &ref_11
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -146,7 +156,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_4
-          - !<!Parameter> &ref_8
+          - !<!Parameter> &ref_9
             schema: *ref_5
             implementation: Method
             required: true
@@ -158,7 +168,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_9
+          - !<!Parameter> &ref_10
             schema: *ref_6
             implementation: Method
             language: !<!Languages> 
@@ -172,6 +182,21 @@ operationGroups:
           - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -182,8 +207,8 @@ operationGroups:
                 method: put
                 uri: '{$host}'
         signatureParameters:
-          - *ref_8
           - *ref_9
+          - *ref_10
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -196,7 +221,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -232,6 +257,21 @@ operationGroups:
           - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -254,7 +294,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/multiapi-v1/modeler.yaml
+++ b/modelerfour/test/scenarios/multiapi-v1/modeler.yaml
@@ -73,8 +73,18 @@ schemas: !<!Schemas>
           name: ApiVersion-1.0.0
           description: Api Version (1.0.0)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_8
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_8
+    - !<!ObjectSchema> &ref_9
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -107,7 +117,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_9
+  - !<!Parameter> &ref_10
     schema: *ref_0
     clientDefaultValue: ''
     implementation: Client
@@ -123,7 +133,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_10
+  - !<!Parameter> &ref_11
     schema: *ref_5
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -145,7 +155,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_9
+          - *ref_10
           - !<!Parameter> &ref_6
             schema: *ref_3
             implementation: Method
@@ -169,9 +179,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_10
+          - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -196,7 +221,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -228,10 +253,25 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_9
           - *ref_10
+          - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -254,7 +294,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/multiapi-v1/namer.yaml
+++ b/modelerfour/test/scenarios/multiapi-v1/namer.yaml
@@ -73,8 +73,18 @@ schemas: !<!Schemas>
           name: ApiVersion10
           description: Api Version (1.0.0)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_8
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_10
+    - !<!ObjectSchema> &ref_11
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -146,7 +156,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_4
-          - !<!Parameter> &ref_8
+          - !<!Parameter> &ref_9
             schema: *ref_5
             implementation: Method
             required: true
@@ -158,7 +168,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_9
+          - !<!Parameter> &ref_10
             schema: *ref_6
             implementation: Method
             language: !<!Languages> 
@@ -172,6 +182,21 @@ operationGroups:
           - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -182,8 +207,8 @@ operationGroups:
                 method: put
                 uri: '{$host}'
         signatureParameters:
-          - *ref_8
           - *ref_9
+          - *ref_10
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -196,7 +221,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -232,6 +257,21 @@ operationGroups:
           - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -254,7 +294,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/multiapi-v2/flattened.yaml
+++ b/modelerfour/test/scenarios/multiapi-v2/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: multiapi-v2
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_18
+    - !<!BooleanSchema> &ref_19
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -94,14 +94,24 @@ schemas: !<!Schemas>
           name: ApiVersion-2.0.0
           description: Api Version (2.0.0)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_9
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_11
+    - !<!ObjectSchema> &ref_12
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 2.0.0
       properties:
-        - !<!Property> &ref_14
+        - !<!Property> &ref_15
           schema: *ref_1
           required: true
           serializedName: id
@@ -110,7 +120,7 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_15
+        - !<!Property> &ref_16
           schema: *ref_2
           required: false
           serializedName: message
@@ -130,7 +140,7 @@ schemas: !<!Schemas>
           description: Only exists in api version 2.0.0
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_12
+    - !<!ObjectSchema> &ref_13
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -202,7 +212,7 @@ operationGroups:
             version: 2.0.0
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_9
+          - !<!Parameter> &ref_10
             schema: *ref_6
             implementation: Method
             required: true
@@ -214,7 +224,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_10
+          - !<!Parameter> &ref_11
             schema: *ref_7
             implementation: Method
             language: !<!Languages> 
@@ -228,6 +238,21 @@ operationGroups:
           - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -238,11 +263,11 @@ operationGroups:
                 method: put
                 uri: '{$host}'
         signatureParameters:
-          - *ref_9
           - *ref_10
+          - *ref_11
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -256,7 +281,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -291,8 +316,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_11
+              - !<!Parameter> &ref_14
+                schema: *ref_12
                 flattened: true
                 implementation: Method
                 required: false
@@ -304,33 +329,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_16
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_17
                 schema: *ref_1
                 implementation: Method
-                originalParameter: *ref_13
+                originalParameter: *ref_14
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_14
+                targetProperty: *ref_15
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_17
+              - !<!VirtualParameter> &ref_18
                 schema: *ref_2
                 implementation: Method
-                originalParameter: *ref_13
+                originalParameter: *ref_14
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_15
+                targetProperty: *ref_16
                 language: !<!Languages> 
                   default:
                     name: message
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_16
               - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -346,7 +384,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -360,7 +398,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -386,6 +424,21 @@ operationGroups:
           - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -408,7 +461,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -439,8 +492,8 @@ operationGroups:
             version: 2.0.0
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_19
-            schema: *ref_18
+          - !<!Parameter> &ref_20
+            schema: *ref_19
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -454,6 +507,21 @@ operationGroups:
           - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -464,7 +532,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_19
+          - *ref_20
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -477,7 +545,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/multiapi-v2/grouped.yaml
+++ b/modelerfour/test/scenarios/multiapi-v2/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: multiapi-v2
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_18
+    - !<!BooleanSchema> &ref_19
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -94,14 +94,24 @@ schemas: !<!Schemas>
           name: ApiVersion-2.0.0
           description: Api Version (2.0.0)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_9
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_11
+    - !<!ObjectSchema> &ref_12
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 2.0.0
       properties:
-        - !<!Property> &ref_14
+        - !<!Property> &ref_15
           schema: *ref_1
           required: true
           serializedName: id
@@ -110,7 +120,7 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_15
+        - !<!Property> &ref_16
           schema: *ref_2
           required: false
           serializedName: message
@@ -130,7 +140,7 @@ schemas: !<!Schemas>
           description: Only exists in api version 2.0.0
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_12
+    - !<!ObjectSchema> &ref_13
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -202,7 +212,7 @@ operationGroups:
             version: 2.0.0
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_9
+          - !<!Parameter> &ref_10
             schema: *ref_6
             implementation: Method
             required: true
@@ -214,7 +224,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_10
+          - !<!Parameter> &ref_11
             schema: *ref_7
             implementation: Method
             language: !<!Languages> 
@@ -228,6 +238,21 @@ operationGroups:
           - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -238,11 +263,11 @@ operationGroups:
                 method: put
                 uri: '{$host}'
         signatureParameters:
-          - *ref_9
           - *ref_10
+          - *ref_11
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -256,7 +281,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -291,8 +316,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_11
+              - !<!Parameter> &ref_14
+                schema: *ref_12
                 flattened: true
                 implementation: Method
                 required: false
@@ -304,33 +329,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_16
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_17
                 schema: *ref_1
                 implementation: Method
-                originalParameter: *ref_13
+                originalParameter: *ref_14
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_14
+                targetProperty: *ref_15
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_17
+              - !<!VirtualParameter> &ref_18
                 schema: *ref_2
                 implementation: Method
-                originalParameter: *ref_13
+                originalParameter: *ref_14
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_15
+                targetProperty: *ref_16
                 language: !<!Languages> 
                   default:
                     name: message
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_16
               - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -346,7 +384,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -360,7 +398,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -386,6 +424,21 @@ operationGroups:
           - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -408,7 +461,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -439,8 +492,8 @@ operationGroups:
             version: 2.0.0
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_19
-            schema: *ref_18
+          - !<!Parameter> &ref_20
+            schema: *ref_19
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -454,6 +507,21 @@ operationGroups:
           - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -464,7 +532,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_19
+          - *ref_20
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -477,7 +545,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/multiapi-v2/modeler.yaml
+++ b/modelerfour/test/scenarios/multiapi-v2/modeler.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: multiapi-v2
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_14
+    - !<!BooleanSchema> &ref_15
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -94,8 +94,18 @@ schemas: !<!Schemas>
           name: ApiVersion-2.0.0
           description: Api Version (2.0.0)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_9
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_9
+    - !<!ObjectSchema> &ref_10
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -130,7 +140,7 @@ schemas: !<!Schemas>
           description: Only exists in api version 2.0.0
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_10
+    - !<!ObjectSchema> &ref_11
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -163,7 +173,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_11
+  - !<!Parameter> &ref_12
     schema: *ref_0
     clientDefaultValue: ''
     implementation: Client
@@ -179,7 +189,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_12
+  - !<!Parameter> &ref_13
     schema: *ref_6
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -201,7 +211,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2.0.0
         parameters:
-          - *ref_11
+          - *ref_12
           - !<!Parameter> &ref_7
             schema: *ref_4
             implementation: Method
@@ -225,9 +235,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -242,7 +267,7 @@ operationGroups:
           - *ref_8
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -256,7 +281,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -286,13 +311,13 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2.0.0
         parameters:
-          - *ref_11
           - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_9
+              - !<!Parameter> &ref_14
+                schema: *ref_10
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -303,8 +328,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_13
+              - *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -320,7 +358,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''
@@ -334,7 +372,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -356,10 +394,25 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2.0.0
         parameters:
-          - *ref_11
           - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -382,7 +435,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''
@@ -412,9 +465,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2.0.0
         parameters:
-          - *ref_11
-          - !<!Parameter> &ref_15
-            schema: *ref_14
+          - *ref_12
+          - !<!Parameter> &ref_16
+            schema: *ref_15
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -425,9 +478,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -438,7 +506,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_15
+          - *ref_16
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -451,7 +519,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_10
+            schema: *ref_11
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/multiapi-v2/namer.yaml
+++ b/modelerfour/test/scenarios/multiapi-v2/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: multiapi-v2
 schemas: !<!Schemas> 
   booleans:
-    - !<!BooleanSchema> &ref_18
+    - !<!BooleanSchema> &ref_19
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -94,14 +94,24 @@ schemas: !<!Schemas>
           name: ApiVersion20
           description: Api Version (2.0.0)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_9
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_11
+    - !<!ObjectSchema> &ref_12
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 2.0.0
       properties:
-        - !<!Property> &ref_14
+        - !<!Property> &ref_15
           schema: *ref_1
           required: true
           serializedName: id
@@ -110,7 +120,7 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_15
+        - !<!Property> &ref_16
           schema: *ref_2
           required: false
           serializedName: message
@@ -130,7 +140,7 @@ schemas: !<!Schemas>
           description: Only exists in api version 2.0.0
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_12
+    - !<!ObjectSchema> &ref_13
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -202,7 +212,7 @@ operationGroups:
             version: 2.0.0
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_9
+          - !<!Parameter> &ref_10
             schema: *ref_6
             implementation: Method
             required: true
@@ -214,7 +224,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_10
+          - !<!Parameter> &ref_11
             schema: *ref_7
             implementation: Method
             language: !<!Languages> 
@@ -228,6 +238,21 @@ operationGroups:
           - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -238,11 +263,11 @@ operationGroups:
                 method: put
                 uri: '{$host}'
         signatureParameters:
-          - *ref_9
           - *ref_10
+          - *ref_11
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -256,7 +281,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -291,8 +316,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_11
+              - !<!Parameter> &ref_14
+                schema: *ref_12
                 flattened: true
                 implementation: Method
                 required: false
@@ -304,33 +329,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_16
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_17
                 schema: *ref_1
                 implementation: Method
-                originalParameter: *ref_13
+                originalParameter: *ref_14
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_14
+                targetProperty: *ref_15
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_17
+              - !<!VirtualParameter> &ref_18
                 schema: *ref_2
                 implementation: Method
-                originalParameter: *ref_13
+                originalParameter: *ref_14
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_15
+                targetProperty: *ref_16
                 language: !<!Languages> 
                   default:
                     name: message
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_16
               - *ref_17
+              - *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -346,7 +384,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -360,7 +398,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -386,6 +424,21 @@ operationGroups:
           - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -408,7 +461,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -439,8 +492,8 @@ operationGroups:
             version: 2.0.0
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_19
-            schema: *ref_18
+          - !<!Parameter> &ref_20
+            schema: *ref_19
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -454,6 +507,21 @@ operationGroups:
           - *ref_8
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -464,7 +532,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_19
+          - *ref_20
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -477,7 +545,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/multiapi-v3/flattened.yaml
+++ b/modelerfour/test/scenarios/multiapi-v3/flattened.yaml
@@ -63,7 +63,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_13
+    - !<!SealedChoiceSchema> &ref_14
       choices:
         - !<!ChoiceValue> 
           value: application/pdf
@@ -107,8 +107,18 @@ schemas: !<!Schemas>
           name: ApiVersion-3.0.0
           description: Api Version (3.0.0)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_9
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   binaries:
-    - !<!BinarySchema> &ref_14
+    - !<!BinarySchema> &ref_15
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -125,7 +135,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 3.0.0
       properties:
-        - !<!Property> &ref_10
+        - !<!Property> &ref_11
           schema: *ref_1
           serializedName: optionalProperty
           language: !<!Languages> 
@@ -144,7 +154,7 @@ schemas: !<!Schemas>
           description: Only exists in api version 3.0.0
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_12
+    - !<!ObjectSchema> &ref_13
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -176,13 +186,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_17
+    - !<!ObjectSchema> &ref_18
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 3.0.0
       properties:
-        - !<!Property> &ref_19
+        - !<!Property> &ref_20
           schema: *ref_4
           serializedName: source
           language: !<!Languages> 
@@ -244,7 +254,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
+              - !<!Parameter> &ref_10
                 schema: *ref_8
                 flattened: true
                 implementation: Method
@@ -257,19 +267,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_11
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_12
                 schema: *ref_1
                 implementation: Method
-                originalParameter: *ref_9
+                originalParameter: *ref_10
                 pathToProperty: []
-                targetProperty: *ref_10
+                targetProperty: *ref_11
                 language: !<!Languages> 
                   default:
                     name: optionalProperty
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_11
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -299,7 +322,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -334,8 +357,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_13
+              - !<!Parameter> &ref_16
+                schema: *ref_14
                 implementation: Method
                 origin: 'modelerfour:synthesized/content-type'
                 required: true
@@ -347,8 +370,8 @@ operationGroups:
                 protocol: !<!Protocols> 
                   http: !<!HttpParameter> 
                     in: header
-              - !<!Parameter> &ref_16
-                schema: *ref_14
+              - !<!Parameter> &ref_17
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -359,9 +382,22 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
               - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -380,8 +416,8 @@ operationGroups:
                 uri: '{$host}'
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_18
-                schema: *ref_17
+              - !<!Parameter> &ref_19
+                schema: *ref_18
                 flattened: true
                 implementation: Method
                 required: false
@@ -393,19 +429,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_20
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_21
                 schema: *ref_4
                 implementation: Method
-                originalParameter: *ref_18
+                originalParameter: *ref_19
                 pathToProperty: []
-                targetProperty: *ref_19
+                targetProperty: *ref_20
                 language: !<!Languages> 
                   default:
                     name: source
                     description: File source path.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_20
+              - *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -431,7 +480,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -459,6 +508,21 @@ operationGroups:
           - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -481,7 +545,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/multiapi-v3/grouped.yaml
+++ b/modelerfour/test/scenarios/multiapi-v3/grouped.yaml
@@ -63,7 +63,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_13
+    - !<!SealedChoiceSchema> &ref_14
       choices:
         - !<!ChoiceValue> 
           value: application/pdf
@@ -107,8 +107,18 @@ schemas: !<!Schemas>
           name: ApiVersion-3.0.0
           description: Api Version (3.0.0)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_9
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   binaries:
-    - !<!BinarySchema> &ref_14
+    - !<!BinarySchema> &ref_15
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -125,7 +135,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 3.0.0
       properties:
-        - !<!Property> &ref_10
+        - !<!Property> &ref_11
           schema: *ref_1
           serializedName: optionalProperty
           language: !<!Languages> 
@@ -144,7 +154,7 @@ schemas: !<!Schemas>
           description: Only exists in api version 3.0.0
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_12
+    - !<!ObjectSchema> &ref_13
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -176,13 +186,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_17
+    - !<!ObjectSchema> &ref_18
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 3.0.0
       properties:
-        - !<!Property> &ref_19
+        - !<!Property> &ref_20
           schema: *ref_4
           serializedName: source
           language: !<!Languages> 
@@ -244,7 +254,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
+              - !<!Parameter> &ref_10
                 schema: *ref_8
                 flattened: true
                 implementation: Method
@@ -257,19 +267,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_11
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_12
                 schema: *ref_1
                 implementation: Method
-                originalParameter: *ref_9
+                originalParameter: *ref_10
                 pathToProperty: []
-                targetProperty: *ref_10
+                targetProperty: *ref_11
                 language: !<!Languages> 
                   default:
                     name: optionalProperty
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_11
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -299,7 +322,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -334,8 +357,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_13
+              - !<!Parameter> &ref_16
+                schema: *ref_14
                 implementation: Method
                 origin: 'modelerfour:synthesized/content-type'
                 required: true
@@ -347,8 +370,8 @@ operationGroups:
                 protocol: !<!Protocols> 
                   http: !<!HttpParameter> 
                     in: header
-              - !<!Parameter> &ref_16
-                schema: *ref_14
+              - !<!Parameter> &ref_17
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -359,9 +382,22 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
               - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -380,8 +416,8 @@ operationGroups:
                 uri: '{$host}'
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_18
-                schema: *ref_17
+              - !<!Parameter> &ref_19
+                schema: *ref_18
                 flattened: true
                 implementation: Method
                 required: false
@@ -393,19 +429,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_20
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_21
                 schema: *ref_4
                 implementation: Method
-                originalParameter: *ref_18
+                originalParameter: *ref_19
                 pathToProperty: []
-                targetProperty: *ref_19
+                targetProperty: *ref_20
                 language: !<!Languages> 
                   default:
                     name: source
                     description: File source path.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_20
+              - *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -431,7 +480,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -459,6 +508,21 @@ operationGroups:
           - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -481,7 +545,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/multiapi-v3/modeler.yaml
+++ b/modelerfour/test/scenarios/multiapi-v3/modeler.yaml
@@ -63,7 +63,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_11
+    - !<!SealedChoiceSchema> &ref_12
       choices:
         - !<!ChoiceValue> 
           value: application/pdf
@@ -107,8 +107,18 @@ schemas: !<!Schemas>
           name: ApiVersion-3.0.0
           description: Api Version (3.0.0)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_7
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   binaries:
-    - !<!BinarySchema> &ref_12
+    - !<!BinarySchema> &ref_13
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -144,7 +154,7 @@ schemas: !<!Schemas>
           description: Only exists in api version 3.0.0
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_8
+    - !<!ObjectSchema> &ref_9
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -176,7 +186,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_15
+    - !<!ObjectSchema> &ref_16
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -201,7 +211,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_9
+  - !<!Parameter> &ref_10
     schema: *ref_0
     clientDefaultValue: ''
     implementation: Client
@@ -217,7 +227,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_10
+  - !<!Parameter> &ref_11
     schema: *ref_5
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -239,12 +249,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 3.0.0
         parameters:
-          - *ref_9
           - *ref_10
+          - *ref_11
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_7
+              - !<!Parameter> &ref_8
                 schema: *ref_6
                 implementation: Method
                 required: false
@@ -256,8 +266,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_7
+              - *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -287,7 +310,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -317,13 +340,13 @@ operationGroups:
           - !<!ApiVersion> 
             version: 3.0.0
         parameters:
-          - *ref_9
           - *ref_10
+          - *ref_11
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_13
-                schema: *ref_11
+              - !<!Parameter> &ref_14
+                schema: *ref_12
                 implementation: Method
                 origin: 'modelerfour:synthesized/content-type'
                 required: true
@@ -335,8 +358,8 @@ operationGroups:
                 protocol: !<!Protocols> 
                   http: !<!HttpParameter> 
                     in: header
-              - !<!Parameter> &ref_14
-                schema: *ref_12
+              - !<!Parameter> &ref_15
+                schema: *ref_13
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -347,9 +370,22 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_13
               - *ref_14
+              - *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -368,8 +404,8 @@ operationGroups:
                 uri: '{$host}'
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_16
-                schema: *ref_15
+              - !<!Parameter> &ref_17
+                schema: *ref_16
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -380,8 +416,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -407,7 +456,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -431,10 +480,25 @@ operationGroups:
           - !<!ApiVersion> 
             version: 3.0.0
         parameters:
-          - *ref_9
           - *ref_10
+          - *ref_11
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -457,7 +521,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/multiapi-v3/namer.yaml
+++ b/modelerfour/test/scenarios/multiapi-v3/namer.yaml
@@ -63,7 +63,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_13
+    - !<!SealedChoiceSchema> &ref_14
       choices:
         - !<!ChoiceValue> 
           value: application/pdf
@@ -107,8 +107,18 @@ schemas: !<!Schemas>
           name: ApiVersion30
           description: Api Version (3.0.0)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_9
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   binaries:
-    - !<!BinarySchema> &ref_14
+    - !<!BinarySchema> &ref_15
       type: binary
       apiVersions:
         - !<!ApiVersion> 
@@ -125,7 +135,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 3.0.0
       properties:
-        - !<!Property> &ref_10
+        - !<!Property> &ref_11
           schema: *ref_1
           serializedName: optionalProperty
           language: !<!Languages> 
@@ -144,7 +154,7 @@ schemas: !<!Schemas>
           description: Only exists in api version 3.0.0
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_12
+    - !<!ObjectSchema> &ref_13
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -176,13 +186,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_17
+    - !<!ObjectSchema> &ref_18
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 3.0.0
       properties:
-        - !<!Property> &ref_19
+        - !<!Property> &ref_20
           schema: *ref_4
           serializedName: source
           language: !<!Languages> 
@@ -244,7 +254,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_9
+              - !<!Parameter> &ref_10
                 schema: *ref_8
                 flattened: true
                 implementation: Method
@@ -257,19 +267,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_11
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_12
                 schema: *ref_1
                 implementation: Method
-                originalParameter: *ref_9
+                originalParameter: *ref_10
                 pathToProperty: []
-                targetProperty: *ref_10
+                targetProperty: *ref_11
                 language: !<!Languages> 
                   default:
                     name: optionalProperty
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_11
+              - *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -299,7 +322,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -334,8 +357,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_15
-                schema: *ref_13
+              - !<!Parameter> &ref_16
+                schema: *ref_14
                 implementation: Method
                 origin: 'modelerfour:synthesized/content-type'
                 required: true
@@ -347,8 +370,8 @@ operationGroups:
                 protocol: !<!Protocols> 
                   http: !<!HttpParameter> 
                     in: header
-              - !<!Parameter> &ref_16
-                schema: *ref_14
+              - !<!Parameter> &ref_17
+                schema: *ref_15
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -359,9 +382,22 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: binary
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_15
               - *ref_16
+              - *ref_17
             language: !<!Languages> 
               default:
                 name: ''
@@ -380,8 +416,8 @@ operationGroups:
                 uri: '{$host}'
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_18
-                schema: *ref_17
+              - !<!Parameter> &ref_19
+                schema: *ref_18
                 flattened: true
                 implementation: Method
                 required: false
@@ -393,19 +429,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_20
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_21
                 schema: *ref_4
                 implementation: Method
-                originalParameter: *ref_18
+                originalParameter: *ref_19
                 pathToProperty: []
-                targetProperty: *ref_19
+                targetProperty: *ref_20
                 language: !<!Languages> 
                   default:
                     name: source
                     description: File source path.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_20
+              - *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -431,7 +480,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -459,6 +508,21 @@ operationGroups:
           - *ref_7
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_9
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -481,7 +545,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/object-type/flattened.yaml
+++ b/modelerfour/test/scenarios/object-type/flattened.yaml
@@ -11,8 +11,19 @@ schemas: !<!Schemas>
           name: string
           description: simple string
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_2
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   any:
-    - !<!AnySchema> &ref_2
+    - !<!AnySchema> &ref_3
       type: any
       language: !<!Languages> 
         default:
@@ -48,6 +59,21 @@ operationGroups:
           - *ref_1
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_2
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -60,7 +86,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -74,7 +100,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -100,8 +126,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_3
-                schema: *ref_2
+              - !<!Parameter> &ref_4
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -112,8 +138,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_2
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_3
+              - *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -139,7 +178,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/object-type/grouped.yaml
+++ b/modelerfour/test/scenarios/object-type/grouped.yaml
@@ -11,8 +11,19 @@ schemas: !<!Schemas>
           name: string
           description: simple string
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_2
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   any:
-    - !<!AnySchema> &ref_2
+    - !<!AnySchema> &ref_3
       type: any
       language: !<!Languages> 
         default:
@@ -48,6 +59,21 @@ operationGroups:
           - *ref_1
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_2
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -60,7 +86,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -74,7 +100,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -100,8 +126,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_3
-                schema: *ref_2
+              - !<!Parameter> &ref_4
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -112,8 +138,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_2
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_3
+              - *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -139,7 +178,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/object-type/modeler.yaml
+++ b/modelerfour/test/scenarios/object-type/modeler.yaml
@@ -11,8 +11,19 @@ schemas: !<!Schemas>
           name: string
           description: simple string
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_1
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   any:
-    - !<!AnySchema> &ref_1
+    - !<!AnySchema> &ref_2
       type: any
       language: !<!Languages> 
         default:
@@ -20,7 +31,7 @@ schemas: !<!Schemas>
           description: Any object
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_2
+  - !<!Parameter> &ref_3
     schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -45,9 +56,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_2
+          - *ref_3
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_1
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -60,7 +86,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -74,7 +100,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''
@@ -96,12 +122,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_2
+          - *ref_3
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_3
-                schema: *ref_1
+              - !<!Parameter> &ref_4
+                schema: *ref_2
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -112,8 +138,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_1
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_3
+              - *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -139,7 +178,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_1
+            schema: *ref_2
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/object-type/namer.yaml
+++ b/modelerfour/test/scenarios/object-type/namer.yaml
@@ -11,8 +11,19 @@ schemas: !<!Schemas>
           name: String
           description: simple string
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_2
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   any:
-    - !<!AnySchema> &ref_2
+    - !<!AnySchema> &ref_3
       type: any
       language: !<!Languages> 
         default:
@@ -48,6 +59,21 @@ operationGroups:
           - *ref_1
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_2
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -60,7 +86,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -74,7 +100,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''
@@ -100,8 +126,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_3
-                schema: *ref_2
+              - !<!Parameter> &ref_4
+                schema: *ref_3
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -112,8 +138,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_2
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_3
+              - *ref_4
             language: !<!Languages> 
               default:
                 name: ''
@@ -139,7 +178,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_2
+            schema: *ref_3
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/paging/flattened.yaml
+++ b/modelerfour/test/scenarios/paging/flattened.yaml
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_16
+    - !<!NumberSchema> &ref_17
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_17
+    - !<!NumberSchema> &ref_18
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -73,7 +73,7 @@ schemas: !<!Schemas>
           name: ProductResult-nextLink
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_15
+    - !<!StringSchema> &ref_16
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -172,8 +172,19 @@ schemas: !<!Schemas>
           name: OperationResult-status
           description: The status of the request
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_13
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_13
+    - !<!ObjectSchema> &ref_14
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -271,7 +282,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_4
     - *ref_5
-    - !<!ObjectSchema> &ref_14
+    - !<!ObjectSchema> &ref_15
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -313,7 +324,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_26
+    - !<!ObjectSchema> &ref_27
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -408,6 +419,21 @@ operationGroups:
           - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -420,7 +446,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -460,6 +486,21 @@ operationGroups:
           - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -472,7 +513,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -514,6 +555,21 @@ operationGroups:
           - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -526,7 +582,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -566,28 +622,14 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_18
-            schema: *ref_15
+          - !<!Parameter> &ref_19
+            schema: *ref_16
             implementation: Method
             language: !<!Languages> 
               default:
                 name: client-request-id
                 description: ''
                 serializedName: client-request-id
-            protocol: !<!Protocols> 
-              http: !<!HttpParameter> 
-                in: header
-          - !<!Parameter> &ref_19
-            schema: *ref_16
-            implementation: Method
-            extensions:
-              x-ms-parameter-grouping: &ref_21
-                postfix: Options
-            language: !<!Languages> 
-              default:
-                name: maxresults
-                description: Sets the maximum number of items to return in the response.
-                serializedName: maxresults
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
@@ -599,6 +641,20 @@ operationGroups:
                 postfix: Options
             language: !<!Languages> 
               default:
+                name: maxresults
+                description: Sets the maximum number of items to return in the response.
+                serializedName: maxresults
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: header
+          - !<!Parameter> &ref_21
+            schema: *ref_18
+            implementation: Method
+            extensions:
+              x-ms-parameter-grouping: &ref_23
+                postfix: Options
+            language: !<!Languages> 
+              default:
                 name: timeout
                 description: 'Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.'
                 serializedName: timeout
@@ -607,6 +663,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -617,12 +688,12 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_18
           - *ref_19
           - *ref_20
+          - *ref_21
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -662,27 +733,14 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_23
-            schema: *ref_15
+          - !<!Parameter> &ref_24
+            schema: *ref_16
             implementation: Method
             language: !<!Languages> 
               default:
                 name: client-request-id
                 description: ''
                 serializedName: client-request-id
-            protocol: !<!Protocols> 
-              http: !<!HttpParameter> 
-                in: header
-          - !<!Parameter> &ref_24
-            schema: *ref_16
-            implementation: Method
-            extensions:
-              x-ms-parameter-grouping: *ref_21
-            language: !<!Languages> 
-              default:
-                name: maxresults
-                description: Sets the maximum number of items to return in the response.
-                serializedName: maxresults
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
@@ -693,6 +751,19 @@ operationGroups:
               x-ms-parameter-grouping: *ref_22
             language: !<!Languages> 
               default:
+                name: maxresults
+                description: Sets the maximum number of items to return in the response.
+                serializedName: maxresults
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: header
+          - !<!Parameter> &ref_26
+            schema: *ref_18
+            implementation: Method
+            extensions:
+              x-ms-parameter-grouping: *ref_23
+            language: !<!Languages> 
+              default:
                 name: timeout
                 description: 'Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.'
                 serializedName: timeout
@@ -701,6 +772,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -711,12 +797,12 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_23
           - *ref_24
           - *ref_25
+          - *ref_26
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -756,8 +842,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_27
-            schema: *ref_15
+          - !<!Parameter> &ref_28
+            schema: *ref_16
             implementation: Method
             language: !<!Languages> 
               default:
@@ -767,11 +853,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_28
-            schema: *ref_16
+          - !<!Parameter> &ref_29
+            schema: *ref_17
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_21
+              x-ms-parameter-grouping: *ref_22
             language: !<!Languages> 
               default:
                 name: maxresults
@@ -780,8 +866,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_29
-            schema: *ref_16
+          - !<!Parameter> &ref_30
+            schema: *ref_17
             implementation: Method
             required: true
             extensions:
@@ -795,11 +881,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_30
-            schema: *ref_17
+          - !<!Parameter> &ref_31
+            schema: *ref_18
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_22
+              x-ms-parameter-grouping: *ref_23
             language: !<!Languages> 
               default:
                 name: timeout
@@ -810,6 +896,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -820,13 +921,13 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_27
           - *ref_28
           - *ref_29
           - *ref_30
+          - *ref_31
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -868,6 +969,21 @@ operationGroups:
           - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -880,7 +996,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -922,6 +1038,21 @@ operationGroups:
           - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -934,7 +1065,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -976,6 +1107,21 @@ operationGroups:
           - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -988,7 +1134,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1030,6 +1176,21 @@ operationGroups:
           - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1042,7 +1203,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1084,6 +1245,21 @@ operationGroups:
           - *ref_12
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1096,7 +1272,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1136,8 +1312,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_31
-            schema: *ref_15
+          - !<!Parameter> &ref_32
+            schema: *ref_16
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1148,8 +1324,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_32
-            schema: *ref_15
+          - !<!Parameter> &ref_33
+            schema: *ref_16
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1162,6 +1338,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1172,11 +1363,11 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_31
           - *ref_32
+          - *ref_33
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1212,14 +1403,14 @@ operationGroups:
               itemName: values
               member: nextFragment
               nextLinkName: odata.nextLink
-              nextLinkOperation: !<!Operation> &ref_36
+              nextLinkOperation: !<!Operation> &ref_37
                 apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
                 parameters:
                   - *ref_12
-                  - !<!Parameter> &ref_33
-                    schema: *ref_15
+                  - !<!Parameter> &ref_34
+                    schema: *ref_16
                     implementation: Method
                     required: true
                     language: !<!Languages> 
@@ -1230,8 +1421,8 @@ operationGroups:
                     protocol: !<!Protocols> 
                       http: !<!HttpParameter> 
                         in: query
-                  - !<!Parameter> &ref_34
-                    schema: *ref_15
+                  - !<!Parameter> &ref_35
+                    schema: *ref_16
                     implementation: Method
                     required: true
                     language: !<!Languages> 
@@ -1242,8 +1433,8 @@ operationGroups:
                     protocol: !<!Protocols> 
                       http: !<!HttpParameter> 
                         in: path
-                  - !<!Parameter> &ref_35
-                    schema: *ref_15
+                  - !<!Parameter> &ref_36
+                    schema: *ref_16
                     implementation: Method
                     required: true
                     extensions:
@@ -1258,6 +1449,21 @@ operationGroups:
                         in: path
                 requests:
                   - !<!Request> 
+                    parameters:
+                      - !<!Parameter> 
+                        schema: *ref_13
+                        implementation: Method
+                        origin: 'modelerfour:synthesized/accept'
+                        required: true
+                        language: !<!Languages> 
+                          default:
+                            name: accept
+                            description: Accept header
+                            serializedName: Accept
+                        protocol: !<!Protocols> 
+                          http: !<!HttpParameter> 
+                            in: header
+                    signatureParameters: []
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -1268,12 +1474,12 @@ operationGroups:
                         method: get
                         uri: '{$host}'
                 signatureParameters:
-                  - *ref_33
                   - *ref_34
                   - *ref_35
+                  - *ref_36
                 responses:
                   - !<!SchemaResponse> 
-                    schema: *ref_26
+                    schema: *ref_27
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -1309,7 +1515,7 @@ operationGroups:
                       itemName: values
                       member: nextFragment
                       nextLinkName: odata.nextLink
-                      nextLinkOperation: *ref_36
+                      nextLinkOperation: *ref_37
                 protocol: !<!Protocols> {}
         protocol: !<!Protocols> {}
       - !<!Operation> 
@@ -1318,12 +1524,12 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_37
-            schema: *ref_15
+          - !<!Parameter> &ref_38
+            schema: *ref_16
             implementation: Method
             required: true
             extensions:
-              x-ms-parameter-grouping: &ref_39
+              x-ms-parameter-grouping: &ref_40
                 name: custom-parameter-group
             language: !<!Languages> 
               default:
@@ -1333,12 +1539,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_38
-            schema: *ref_15
+          - !<!Parameter> &ref_39
+            schema: *ref_16
             implementation: Method
             required: true
             extensions:
-              x-ms-parameter-grouping: &ref_40
+              x-ms-parameter-grouping: &ref_41
                 name: custom-parameter-group
             language: !<!Languages> 
               default:
@@ -1350,6 +1556,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1360,11 +1581,11 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_37
           - *ref_38
+          - *ref_39
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1400,18 +1621,18 @@ operationGroups:
               itemName: values
               member: nextFragmentWithGrouping
               nextLinkName: odata.nextLink
-              nextLinkOperation: !<!Operation> &ref_44
+              nextLinkOperation: !<!Operation> &ref_45
                 apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
                 parameters:
                   - *ref_12
-                  - !<!Parameter> &ref_41
-                    schema: *ref_15
+                  - !<!Parameter> &ref_42
+                    schema: *ref_16
                     implementation: Method
                     required: true
                     extensions:
-                      x-ms-parameter-grouping: *ref_39
+                      x-ms-parameter-grouping: *ref_40
                     language: !<!Languages> 
                       default:
                         name: api_version
@@ -1420,12 +1641,12 @@ operationGroups:
                     protocol: !<!Protocols> 
                       http: !<!HttpParameter> 
                         in: query
-                  - !<!Parameter> &ref_42
-                    schema: *ref_15
+                  - !<!Parameter> &ref_43
+                    schema: *ref_16
                     implementation: Method
                     required: true
                     extensions:
-                      x-ms-parameter-grouping: *ref_40
+                      x-ms-parameter-grouping: *ref_41
                     language: !<!Languages> 
                       default:
                         name: tenant
@@ -1434,8 +1655,8 @@ operationGroups:
                     protocol: !<!Protocols> 
                       http: !<!HttpParameter> 
                         in: path
-                  - !<!Parameter> &ref_43
-                    schema: *ref_15
+                  - !<!Parameter> &ref_44
+                    schema: *ref_16
                     implementation: Method
                     required: true
                     extensions:
@@ -1450,6 +1671,21 @@ operationGroups:
                         in: path
                 requests:
                   - !<!Request> 
+                    parameters:
+                      - !<!Parameter> 
+                        schema: *ref_13
+                        implementation: Method
+                        origin: 'modelerfour:synthesized/accept'
+                        required: true
+                        language: !<!Languages> 
+                          default:
+                            name: accept
+                            description: Accept header
+                            serializedName: Accept
+                        protocol: !<!Protocols> 
+                          http: !<!HttpParameter> 
+                            in: header
+                    signatureParameters: []
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -1460,12 +1696,12 @@ operationGroups:
                         method: get
                         uri: '{$host}'
                 signatureParameters:
-                  - *ref_41
                   - *ref_42
                   - *ref_43
+                  - *ref_44
                 responses:
                   - !<!SchemaResponse> 
-                    schema: *ref_26
+                    schema: *ref_27
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -1501,7 +1737,7 @@ operationGroups:
                       itemName: values
                       member: nextFragmentWithGrouping
                       nextLinkName: odata.nextLink
-                      nextLinkOperation: *ref_44
+                      nextLinkOperation: *ref_45
                 protocol: !<!Protocols> {}
         protocol: !<!Protocols> {}
       - !<!Operation> 
@@ -1510,27 +1746,14 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_45
-            schema: *ref_15
+          - !<!Parameter> &ref_46
+            schema: *ref_16
             implementation: Method
             language: !<!Languages> 
               default:
                 name: client-request-id
                 description: ''
                 serializedName: client-request-id
-            protocol: !<!Protocols> 
-              http: !<!HttpParameter> 
-                in: header
-          - !<!Parameter> &ref_46
-            schema: *ref_16
-            implementation: Method
-            extensions:
-              x-ms-parameter-grouping: *ref_21
-            language: !<!Languages> 
-              default:
-                name: maxresults
-                description: Sets the maximum number of items to return in the response.
-                serializedName: maxresults
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
@@ -1541,6 +1764,19 @@ operationGroups:
               x-ms-parameter-grouping: *ref_22
             language: !<!Languages> 
               default:
+                name: maxresults
+                description: Sets the maximum number of items to return in the response.
+                serializedName: maxresults
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: header
+          - !<!Parameter> &ref_48
+            schema: *ref_18
+            implementation: Method
+            extensions:
+              x-ms-parameter-grouping: *ref_23
+            language: !<!Languages> 
+              default:
                 name: timeout
                 description: 'Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.'
                 serializedName: timeout
@@ -1549,6 +1785,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1559,12 +1810,12 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_45
           - *ref_46
           - *ref_47
+          - *ref_48
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1599,8 +1850,8 @@ operationGroups:
               itemName: values
               nextLinkName: nextLink
         protocol: !<!Protocols> {}
-      - *ref_36
-      - *ref_44
+      - *ref_37
+      - *ref_45
     language: !<!Languages> 
       default:
         name: Paging

--- a/modelerfour/test/scenarios/paging/grouped.yaml
+++ b/modelerfour/test/scenarios/paging/grouped.yaml
@@ -172,6 +172,17 @@ schemas: !<!Schemas>
           name: OperationResult-status
           description: The status of the request
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_27
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   groups:
     - !<!GroupSchema> &ref_13
       type: group
@@ -179,7 +190,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_12
           originalParameter:
-            - !<!Parameter> &ref_29
+            - !<!Parameter> &ref_30
               schema: *ref_12
               groupedBy: !<!Parameter> &ref_15
                 schema: *ref_13
@@ -207,7 +218,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_14
           originalParameter:
-            - !<!Parameter> &ref_30
+            - !<!Parameter> &ref_31
               schema: *ref_14
               groupedBy: *ref_15
               implementation: Method
@@ -238,7 +249,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_12
           originalParameter:
-            - !<!Parameter> &ref_32
+            - !<!Parameter> &ref_33
               schema: *ref_12
               groupedBy: !<!Parameter> &ref_17
                 schema: *ref_16
@@ -266,7 +277,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_14
           originalParameter:
-            - !<!Parameter> &ref_33
+            - !<!Parameter> &ref_34
               schema: *ref_14
               groupedBy: *ref_17
               implementation: Method
@@ -297,7 +308,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_12
           originalParameter:
-            - !<!Parameter> &ref_36
+            - !<!Parameter> &ref_37
               schema: *ref_12
               groupedBy: !<!Parameter> &ref_19
                 schema: *ref_18
@@ -326,7 +337,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_12
           originalParameter:
-            - !<!Parameter> &ref_37
+            - !<!Parameter> &ref_38
               schema: *ref_12
               groupedBy: *ref_19
               implementation: Method
@@ -349,7 +360,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_14
           originalParameter:
-            - !<!Parameter> &ref_38
+            - !<!Parameter> &ref_39
               schema: *ref_14
               groupedBy: *ref_19
               implementation: Method
@@ -380,7 +391,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_20
           originalParameter:
-            - !<!Parameter> &ref_46
+            - !<!Parameter> &ref_47
               schema: *ref_20
               groupedBy: !<!Parameter> &ref_22
                 schema: *ref_21
@@ -401,7 +412,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: query
-            - !<!Parameter> &ref_48
+            - !<!Parameter> &ref_49
               schema: *ref_20
               groupedBy: !<!Parameter> &ref_23
                 schema: *ref_21
@@ -432,7 +443,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_20
           originalParameter:
-            - !<!Parameter> &ref_47
+            - !<!Parameter> &ref_48
               schema: *ref_20
               groupedBy: *ref_22
               implementation: Method
@@ -445,7 +456,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: path
-            - !<!Parameter> &ref_49
+            - !<!Parameter> &ref_50
               schema: *ref_20
               groupedBy: *ref_23
               implementation: Method
@@ -478,7 +489,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_12
           originalParameter:
-            - !<!Parameter> &ref_52
+            - !<!Parameter> &ref_53
               schema: *ref_12
               groupedBy: !<!Parameter> &ref_25
                 schema: *ref_24
@@ -506,7 +517,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_14
           originalParameter:
-            - !<!Parameter> &ref_53
+            - !<!Parameter> &ref_54
               schema: *ref_14
               groupedBy: *ref_25
               implementation: Method
@@ -532,7 +543,7 @@ schemas: !<!Schemas>
           description: Parameter group
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_27
+    - !<!ObjectSchema> &ref_28
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -630,7 +641,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_4
     - *ref_5
-    - !<!ObjectSchema> &ref_28
+    - !<!ObjectSchema> &ref_29
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -672,7 +683,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_35
+    - !<!ObjectSchema> &ref_36
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -767,6 +778,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -779,7 +805,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -819,6 +845,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -831,7 +872,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -873,6 +914,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -885,7 +941,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -925,7 +981,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_26
-          - !<!Parameter> &ref_31
+          - !<!Parameter> &ref_32
             schema: *ref_20
             implementation: Method
             language: !<!Languages> 
@@ -936,11 +992,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_29
           - *ref_30
+          - *ref_31
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_15
             signatureParameters:
               - *ref_15
@@ -954,10 +1023,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_31
+          - *ref_32
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -997,7 +1066,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_26
-          - !<!Parameter> &ref_34
+          - !<!Parameter> &ref_35
             schema: *ref_20
             implementation: Method
             language: !<!Languages> 
@@ -1008,11 +1077,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_32
           - *ref_33
+          - *ref_34
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_17
             signatureParameters:
               - *ref_17
@@ -1026,10 +1108,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_34
+          - *ref_35
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1069,7 +1151,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_26
-          - !<!Parameter> &ref_39
+          - !<!Parameter> &ref_40
             schema: *ref_20
             implementation: Method
             language: !<!Languages> 
@@ -1080,12 +1162,25 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_36
           - *ref_37
           - *ref_38
+          - *ref_39
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_19
             signatureParameters:
               - *ref_19
@@ -1099,10 +1194,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_39
+          - *ref_40
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1144,6 +1239,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1156,7 +1266,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1198,6 +1308,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1210,7 +1335,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1252,6 +1377,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1264,7 +1404,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1306,6 +1446,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1318,7 +1473,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1360,6 +1515,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1372,7 +1542,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1412,7 +1582,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_26
-          - !<!Parameter> &ref_40
+          - !<!Parameter> &ref_41
             schema: *ref_20
             implementation: Method
             required: true
@@ -1424,7 +1594,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_41
+          - !<!Parameter> &ref_42
             schema: *ref_20
             implementation: Method
             required: true
@@ -1438,6 +1608,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1448,11 +1633,11 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_40
           - *ref_41
+          - *ref_42
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1488,13 +1673,13 @@ operationGroups:
               itemName: values
               member: nextFragment
               nextLinkName: odata.nextLink
-              nextLinkOperation: !<!Operation> &ref_45
+              nextLinkOperation: !<!Operation> &ref_46
                 apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
                 parameters:
                   - *ref_26
-                  - !<!Parameter> &ref_42
+                  - !<!Parameter> &ref_43
                     schema: *ref_20
                     implementation: Method
                     required: true
@@ -1506,7 +1691,7 @@ operationGroups:
                     protocol: !<!Protocols> 
                       http: !<!HttpParameter> 
                         in: query
-                  - !<!Parameter> &ref_43
+                  - !<!Parameter> &ref_44
                     schema: *ref_20
                     implementation: Method
                     required: true
@@ -1518,7 +1703,7 @@ operationGroups:
                     protocol: !<!Protocols> 
                       http: !<!HttpParameter> 
                         in: path
-                  - !<!Parameter> &ref_44
+                  - !<!Parameter> &ref_45
                     schema: *ref_20
                     implementation: Method
                     required: true
@@ -1534,6 +1719,21 @@ operationGroups:
                         in: path
                 requests:
                   - !<!Request> 
+                    parameters:
+                      - !<!Parameter> 
+                        schema: *ref_27
+                        implementation: Method
+                        origin: 'modelerfour:synthesized/accept'
+                        required: true
+                        language: !<!Languages> 
+                          default:
+                            name: accept
+                            description: Accept header
+                            serializedName: Accept
+                        protocol: !<!Protocols> 
+                          http: !<!HttpParameter> 
+                            in: header
+                    signatureParameters: []
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -1544,12 +1744,12 @@ operationGroups:
                         method: get
                         uri: '{$host}'
                 signatureParameters:
-                  - *ref_42
                   - *ref_43
                   - *ref_44
+                  - *ref_45
                 responses:
                   - !<!SchemaResponse> 
-                    schema: *ref_35
+                    schema: *ref_36
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -1585,7 +1785,7 @@ operationGroups:
                       itemName: values
                       member: nextFragment
                       nextLinkName: odata.nextLink
-                      nextLinkOperation: *ref_45
+                      nextLinkOperation: *ref_46
                 protocol: !<!Protocols> {}
         protocol: !<!Protocols> {}
       - !<!Operation> 
@@ -1594,11 +1794,24 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_26
-          - *ref_46
           - *ref_47
+          - *ref_48
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_22
             signatureParameters:
               - *ref_22
@@ -1614,7 +1827,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1650,15 +1863,15 @@ operationGroups:
               itemName: values
               member: nextFragmentWithGrouping
               nextLinkName: odata.nextLink
-              nextLinkOperation: !<!Operation> &ref_51
+              nextLinkOperation: !<!Operation> &ref_52
                 apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
                 parameters:
                   - *ref_26
-                  - *ref_48
                   - *ref_49
-                  - !<!Parameter> &ref_50
+                  - *ref_50
+                  - !<!Parameter> &ref_51
                     schema: *ref_20
                     implementation: Method
                     required: true
@@ -1675,6 +1888,19 @@ operationGroups:
                 requests:
                   - !<!Request> 
                     parameters:
+                      - !<!Parameter> 
+                        schema: *ref_27
+                        implementation: Method
+                        origin: 'modelerfour:synthesized/accept'
+                        required: true
+                        language: !<!Languages> 
+                          default:
+                            name: accept
+                            description: Accept header
+                            serializedName: Accept
+                        protocol: !<!Protocols> 
+                          http: !<!HttpParameter> 
+                            in: header
                       - *ref_23
                     signatureParameters:
                       - *ref_23
@@ -1688,10 +1914,10 @@ operationGroups:
                         method: get
                         uri: '{$host}'
                 signatureParameters:
-                  - *ref_50
+                  - *ref_51
                 responses:
                   - !<!SchemaResponse> 
-                    schema: *ref_35
+                    schema: *ref_36
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -1727,7 +1953,7 @@ operationGroups:
                       itemName: values
                       member: nextFragmentWithGrouping
                       nextLinkName: odata.nextLink
-                      nextLinkOperation: *ref_51
+                      nextLinkOperation: *ref_52
                 protocol: !<!Protocols> {}
         protocol: !<!Protocols> {}
       - !<!Operation> 
@@ -1736,7 +1962,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_26
-          - !<!Parameter> &ref_54
+          - !<!Parameter> &ref_55
             schema: *ref_20
             implementation: Method
             language: !<!Languages> 
@@ -1747,11 +1973,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_52
           - *ref_53
+          - *ref_54
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_25
             signatureParameters:
               - *ref_25
@@ -1765,10 +2004,10 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_54
+          - *ref_55
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1803,8 +2042,8 @@ operationGroups:
               itemName: values
               nextLinkName: nextLink
         protocol: !<!Protocols> {}
-      - *ref_45
-      - *ref_51
+      - *ref_46
+      - *ref_52
     language: !<!Languages> 
       default:
         name: Paging

--- a/modelerfour/test/scenarios/paging/modeler.yaml
+++ b/modelerfour/test/scenarios/paging/modeler.yaml
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_16
+    - !<!NumberSchema> &ref_17
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -23,7 +23,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_17
+    - !<!NumberSchema> &ref_18
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -73,7 +73,7 @@ schemas: !<!Schemas>
           name: ProductResult-nextLink
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_15
+    - !<!StringSchema> &ref_16
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -172,8 +172,19 @@ schemas: !<!Schemas>
           name: OperationResult-status
           description: The status of the request
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_12
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_6
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_12
+    - !<!ObjectSchema> &ref_13
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -271,7 +282,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_2
     - *ref_3
-    - !<!ObjectSchema> &ref_14
+    - !<!ObjectSchema> &ref_15
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -313,7 +324,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_26
+    - !<!ObjectSchema> &ref_27
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -380,7 +391,7 @@ schemas: !<!Schemas>
     - *ref_9
     - *ref_10
 globalParameters:
-  - !<!Parameter> &ref_13
+  - !<!Parameter> &ref_14
     schema: *ref_6
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -405,9 +416,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_13
+          - *ref_14
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -420,7 +446,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''
@@ -457,9 +483,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_13
+          - *ref_14
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -472,7 +513,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -511,9 +552,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_13
+          - *ref_14
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -526,7 +582,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -565,29 +621,15 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_13
-          - !<!Parameter> &ref_18
-            schema: *ref_15
+          - *ref_14
+          - !<!Parameter> &ref_19
+            schema: *ref_16
             implementation: Method
             language: !<!Languages> 
               default:
                 name: client-request-id
                 description: ''
                 serializedName: client-request-id
-            protocol: !<!Protocols> 
-              http: !<!HttpParameter> 
-                in: header
-          - !<!Parameter> &ref_19
-            schema: *ref_16
-            implementation: Method
-            extensions:
-              x-ms-parameter-grouping: &ref_21
-                postfix: Options
-            language: !<!Languages> 
-              default:
-                name: maxresults
-                description: Sets the maximum number of items to return in the response.
-                serializedName: maxresults
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
@@ -599,6 +641,20 @@ operationGroups:
                 postfix: Options
             language: !<!Languages> 
               default:
+                name: maxresults
+                description: Sets the maximum number of items to return in the response.
+                serializedName: maxresults
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: header
+          - !<!Parameter> &ref_21
+            schema: *ref_18
+            implementation: Method
+            extensions:
+              x-ms-parameter-grouping: &ref_23
+                postfix: Options
+            language: !<!Languages> 
+              default:
                 name: timeout
                 description: 'Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.'
                 serializedName: timeout
@@ -607,6 +663,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -617,12 +688,12 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_18
           - *ref_19
           - *ref_20
+          - *ref_21
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -661,28 +732,15 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_13
-          - !<!Parameter> &ref_23
-            schema: *ref_15
+          - *ref_14
+          - !<!Parameter> &ref_24
+            schema: *ref_16
             implementation: Method
             language: !<!Languages> 
               default:
                 name: client-request-id
                 description: ''
                 serializedName: client-request-id
-            protocol: !<!Protocols> 
-              http: !<!HttpParameter> 
-                in: header
-          - !<!Parameter> &ref_24
-            schema: *ref_16
-            implementation: Method
-            extensions:
-              x-ms-parameter-grouping: *ref_21
-            language: !<!Languages> 
-              default:
-                name: maxresults
-                description: Sets the maximum number of items to return in the response.
-                serializedName: maxresults
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
@@ -693,6 +751,19 @@ operationGroups:
               x-ms-parameter-grouping: *ref_22
             language: !<!Languages> 
               default:
+                name: maxresults
+                description: Sets the maximum number of items to return in the response.
+                serializedName: maxresults
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: header
+          - !<!Parameter> &ref_26
+            schema: *ref_18
+            implementation: Method
+            extensions:
+              x-ms-parameter-grouping: *ref_23
+            language: !<!Languages> 
+              default:
                 name: timeout
                 description: 'Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.'
                 serializedName: timeout
@@ -701,6 +772,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -711,12 +797,12 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_23
           - *ref_24
           - *ref_25
+          - *ref_26
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -755,9 +841,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_13
-          - !<!Parameter> &ref_27
-            schema: *ref_15
+          - *ref_14
+          - !<!Parameter> &ref_28
+            schema: *ref_16
             implementation: Method
             language: !<!Languages> 
               default:
@@ -767,11 +853,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_28
-            schema: *ref_16
+          - !<!Parameter> &ref_29
+            schema: *ref_17
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_21
+              x-ms-parameter-grouping: *ref_22
             language: !<!Languages> 
               default:
                 name: maxresults
@@ -780,8 +866,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - !<!Parameter> &ref_29
-            schema: *ref_16
+          - !<!Parameter> &ref_30
+            schema: *ref_17
             implementation: Method
             required: true
             extensions:
@@ -795,11 +881,11 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_30
-            schema: *ref_17
+          - !<!Parameter> &ref_31
+            schema: *ref_18
             implementation: Method
             extensions:
-              x-ms-parameter-grouping: *ref_22
+              x-ms-parameter-grouping: *ref_23
             language: !<!Languages> 
               default:
                 name: timeout
@@ -810,6 +896,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -820,13 +921,13 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_27
           - *ref_28
           - *ref_29
           - *ref_30
+          - *ref_31
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -865,9 +966,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_13
+          - *ref_14
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -880,7 +996,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -919,9 +1035,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_13
+          - *ref_14
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -934,7 +1065,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -973,9 +1104,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_13
+          - *ref_14
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -988,7 +1134,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1027,9 +1173,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_13
+          - *ref_14
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1042,7 +1203,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1081,9 +1242,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_13
+          - *ref_14
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1096,7 +1272,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1135,9 +1311,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_13
-          - !<!Parameter> &ref_35
-            schema: *ref_15
+          - *ref_14
+          - !<!Parameter> &ref_36
+            schema: *ref_16
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1148,8 +1324,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_36
-            schema: *ref_15
+          - !<!Parameter> &ref_37
+            schema: *ref_16
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1162,6 +1338,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1172,11 +1363,11 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_35
           - *ref_36
+          - *ref_37
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1212,14 +1403,14 @@ operationGroups:
               itemName: values
               member: nextFragment
               nextLinkName: odata.nextLink
-              nextLinkOperation: !<!Operation> &ref_31
+              nextLinkOperation: !<!Operation> &ref_32
                 apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
                 parameters:
-                  - *ref_13
-                  - !<!Parameter> &ref_32
-                    schema: *ref_15
+                  - *ref_14
+                  - !<!Parameter> &ref_33
+                    schema: *ref_16
                     implementation: Method
                     required: true
                     language: !<!Languages> 
@@ -1230,8 +1421,8 @@ operationGroups:
                     protocol: !<!Protocols> 
                       http: !<!HttpParameter> 
                         in: query
-                  - !<!Parameter> &ref_33
-                    schema: *ref_15
+                  - !<!Parameter> &ref_34
+                    schema: *ref_16
                     implementation: Method
                     required: true
                     language: !<!Languages> 
@@ -1242,8 +1433,8 @@ operationGroups:
                     protocol: !<!Protocols> 
                       http: !<!HttpParameter> 
                         in: path
-                  - !<!Parameter> &ref_34
-                    schema: *ref_15
+                  - !<!Parameter> &ref_35
+                    schema: *ref_16
                     implementation: Method
                     required: true
                     extensions:
@@ -1258,6 +1449,21 @@ operationGroups:
                         in: path
                 requests:
                   - !<!Request> 
+                    parameters:
+                      - !<!Parameter> 
+                        schema: *ref_12
+                        implementation: Method
+                        origin: 'modelerfour:synthesized/accept'
+                        required: true
+                        language: !<!Languages> 
+                          default:
+                            name: accept
+                            description: Accept header
+                            serializedName: Accept
+                        protocol: !<!Protocols> 
+                          http: !<!HttpParameter> 
+                            in: header
+                    signatureParameters: []
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -1268,12 +1474,12 @@ operationGroups:
                         method: get
                         uri: '{$host}'
                 signatureParameters:
-                  - *ref_32
                   - *ref_33
                   - *ref_34
+                  - *ref_35
                 responses:
                   - !<!SchemaResponse> 
-                    schema: *ref_26
+                    schema: *ref_27
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -1309,7 +1515,7 @@ operationGroups:
                       itemName: values
                       member: nextFragment
                       nextLinkName: odata.nextLink
-                      nextLinkOperation: *ref_31
+                      nextLinkOperation: *ref_32
                 protocol: !<!Protocols> {}
         protocol: !<!Protocols> {}
       - !<!Operation> 
@@ -1317,13 +1523,13 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_13
-          - !<!Parameter> &ref_43
-            schema: *ref_15
+          - *ref_14
+          - !<!Parameter> &ref_44
+            schema: *ref_16
             implementation: Method
             required: true
             extensions:
-              x-ms-parameter-grouping: &ref_41
+              x-ms-parameter-grouping: &ref_42
                 name: custom-parameter-group
             language: !<!Languages> 
               default:
@@ -1333,12 +1539,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_44
-            schema: *ref_15
+          - !<!Parameter> &ref_45
+            schema: *ref_16
             implementation: Method
             required: true
             extensions:
-              x-ms-parameter-grouping: &ref_42
+              x-ms-parameter-grouping: &ref_43
                 name: custom-parameter-group
             language: !<!Languages> 
               default:
@@ -1350,6 +1556,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1360,11 +1581,11 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_43
           - *ref_44
+          - *ref_45
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1400,18 +1621,18 @@ operationGroups:
               itemName: values
               member: nextFragmentWithGrouping
               nextLinkName: odata.nextLink
-              nextLinkOperation: !<!Operation> &ref_37
+              nextLinkOperation: !<!Operation> &ref_38
                 apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
                 parameters:
-                  - *ref_13
-                  - !<!Parameter> &ref_38
-                    schema: *ref_15
+                  - *ref_14
+                  - !<!Parameter> &ref_39
+                    schema: *ref_16
                     implementation: Method
                     required: true
                     extensions:
-                      x-ms-parameter-grouping: *ref_41
+                      x-ms-parameter-grouping: *ref_42
                     language: !<!Languages> 
                       default:
                         name: api_version
@@ -1420,12 +1641,12 @@ operationGroups:
                     protocol: !<!Protocols> 
                       http: !<!HttpParameter> 
                         in: query
-                  - !<!Parameter> &ref_39
-                    schema: *ref_15
+                  - !<!Parameter> &ref_40
+                    schema: *ref_16
                     implementation: Method
                     required: true
                     extensions:
-                      x-ms-parameter-grouping: *ref_42
+                      x-ms-parameter-grouping: *ref_43
                     language: !<!Languages> 
                       default:
                         name: tenant
@@ -1434,8 +1655,8 @@ operationGroups:
                     protocol: !<!Protocols> 
                       http: !<!HttpParameter> 
                         in: path
-                  - !<!Parameter> &ref_40
-                    schema: *ref_15
+                  - !<!Parameter> &ref_41
+                    schema: *ref_16
                     implementation: Method
                     required: true
                     extensions:
@@ -1450,6 +1671,21 @@ operationGroups:
                         in: path
                 requests:
                   - !<!Request> 
+                    parameters:
+                      - !<!Parameter> 
+                        schema: *ref_12
+                        implementation: Method
+                        origin: 'modelerfour:synthesized/accept'
+                        required: true
+                        language: !<!Languages> 
+                          default:
+                            name: accept
+                            description: Accept header
+                            serializedName: Accept
+                        protocol: !<!Protocols> 
+                          http: !<!HttpParameter> 
+                            in: header
+                    signatureParameters: []
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -1460,12 +1696,12 @@ operationGroups:
                         method: get
                         uri: '{$host}'
                 signatureParameters:
-                  - *ref_38
                   - *ref_39
                   - *ref_40
+                  - *ref_41
                 responses:
                   - !<!SchemaResponse> 
-                    schema: *ref_26
+                    schema: *ref_27
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -1501,7 +1737,7 @@ operationGroups:
                       itemName: values
                       member: nextFragmentWithGrouping
                       nextLinkName: odata.nextLink
-                      nextLinkOperation: *ref_37
+                      nextLinkOperation: *ref_38
                 protocol: !<!Protocols> {}
         protocol: !<!Protocols> {}
       - !<!Operation> 
@@ -1509,28 +1745,15 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_13
-          - !<!Parameter> &ref_45
-            schema: *ref_15
+          - *ref_14
+          - !<!Parameter> &ref_46
+            schema: *ref_16
             implementation: Method
             language: !<!Languages> 
               default:
                 name: client-request-id
                 description: ''
                 serializedName: client-request-id
-            protocol: !<!Protocols> 
-              http: !<!HttpParameter> 
-                in: header
-          - !<!Parameter> &ref_46
-            schema: *ref_16
-            implementation: Method
-            extensions:
-              x-ms-parameter-grouping: *ref_21
-            language: !<!Languages> 
-              default:
-                name: maxresults
-                description: Sets the maximum number of items to return in the response.
-                serializedName: maxresults
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
@@ -1541,6 +1764,19 @@ operationGroups:
               x-ms-parameter-grouping: *ref_22
             language: !<!Languages> 
               default:
+                name: maxresults
+                description: Sets the maximum number of items to return in the response.
+                serializedName: maxresults
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: header
+          - !<!Parameter> &ref_48
+            schema: *ref_18
+            implementation: Method
+            extensions:
+              x-ms-parameter-grouping: *ref_23
+            language: !<!Languages> 
+              default:
                 name: timeout
                 description: 'Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.'
                 serializedName: timeout
@@ -1549,6 +1785,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_12
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1559,12 +1810,12 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_45
           - *ref_46
           - *ref_47
+          - *ref_48
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1599,8 +1850,8 @@ operationGroups:
               itemName: values
               nextLinkName: nextLink
         protocol: !<!Protocols> {}
-      - *ref_31
-      - *ref_37
+      - *ref_32
+      - *ref_38
     language: !<!Languages> 
       default:
         name: Paging

--- a/modelerfour/test/scenarios/paging/namer.yaml
+++ b/modelerfour/test/scenarios/paging/namer.yaml
@@ -172,6 +172,17 @@ schemas: !<!Schemas>
           name: OperationResultStatus
           description: The status of the request
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_27
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   groups:
     - !<!GroupSchema> &ref_2
       type: group
@@ -179,7 +190,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_1
           originalParameter:
-            - !<!Parameter> &ref_29
+            - !<!Parameter> &ref_30
               schema: *ref_1
               groupedBy: !<!Parameter> &ref_4
                 schema: *ref_2
@@ -207,7 +218,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_3
           originalParameter:
-            - !<!Parameter> &ref_30
+            - !<!Parameter> &ref_31
               schema: *ref_3
               groupedBy: *ref_4
               implementation: Method
@@ -238,7 +249,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_1
           originalParameter:
-            - !<!Parameter> &ref_32
+            - !<!Parameter> &ref_33
               schema: *ref_1
               groupedBy: !<!Parameter> &ref_6
                 schema: *ref_5
@@ -266,7 +277,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_3
           originalParameter:
-            - !<!Parameter> &ref_33
+            - !<!Parameter> &ref_34
               schema: *ref_3
               groupedBy: *ref_6
               implementation: Method
@@ -297,7 +308,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_1
           originalParameter:
-            - !<!Parameter> &ref_36
+            - !<!Parameter> &ref_37
               schema: *ref_1
               groupedBy: !<!Parameter> &ref_8
                 schema: *ref_7
@@ -326,7 +337,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_1
           originalParameter:
-            - !<!Parameter> &ref_37
+            - !<!Parameter> &ref_38
               schema: *ref_1
               groupedBy: *ref_8
               implementation: Method
@@ -349,7 +360,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_3
           originalParameter:
-            - !<!Parameter> &ref_38
+            - !<!Parameter> &ref_39
               schema: *ref_3
               groupedBy: *ref_8
               implementation: Method
@@ -380,7 +391,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_9
           originalParameter:
-            - !<!Parameter> &ref_46
+            - !<!Parameter> &ref_47
               schema: *ref_9
               groupedBy: !<!Parameter> &ref_11
                 schema: *ref_10
@@ -401,7 +412,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: query
-            - !<!Parameter> &ref_48
+            - !<!Parameter> &ref_49
               schema: *ref_9
               groupedBy: !<!Parameter> &ref_12
                 schema: *ref_10
@@ -432,7 +443,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_9
           originalParameter:
-            - !<!Parameter> &ref_47
+            - !<!Parameter> &ref_48
               schema: *ref_9
               groupedBy: *ref_11
               implementation: Method
@@ -445,7 +456,7 @@ schemas: !<!Schemas>
               protocol: !<!Protocols> 
                 http: !<!HttpParameter> 
                   in: path
-            - !<!Parameter> &ref_49
+            - !<!Parameter> &ref_50
               schema: *ref_9
               groupedBy: *ref_12
               implementation: Method
@@ -478,7 +489,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_1
           originalParameter:
-            - !<!Parameter> &ref_52
+            - !<!Parameter> &ref_53
               schema: *ref_1
               groupedBy: !<!Parameter> &ref_14
                 schema: *ref_13
@@ -506,7 +517,7 @@ schemas: !<!Schemas>
         - !<!GroupProperty> 
           schema: *ref_3
           originalParameter:
-            - !<!Parameter> &ref_53
+            - !<!Parameter> &ref_54
               schema: *ref_3
               groupedBy: *ref_14
               implementation: Method
@@ -532,7 +543,7 @@ schemas: !<!Schemas>
           description: Parameter group
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_27
+    - !<!ObjectSchema> &ref_28
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -630,7 +641,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_18
     - *ref_19
-    - !<!ObjectSchema> &ref_28
+    - !<!ObjectSchema> &ref_29
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -672,7 +683,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_35
+    - !<!ObjectSchema> &ref_36
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -767,6 +778,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -779,7 +805,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -819,6 +845,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -831,7 +872,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -873,6 +914,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -885,7 +941,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -925,7 +981,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_26
-          - !<!Parameter> &ref_31
+          - !<!Parameter> &ref_32
             schema: *ref_9
             implementation: Method
             language: !<!Languages> 
@@ -936,11 +992,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_29
           - *ref_30
+          - *ref_31
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_4
             signatureParameters:
               - *ref_4
@@ -954,10 +1023,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_31
+          - *ref_32
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -997,7 +1066,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_26
-          - !<!Parameter> &ref_34
+          - !<!Parameter> &ref_35
             schema: *ref_9
             implementation: Method
             language: !<!Languages> 
@@ -1008,11 +1077,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_32
           - *ref_33
+          - *ref_34
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_6
             signatureParameters:
               - *ref_6
@@ -1026,10 +1108,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_34
+          - *ref_35
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1069,7 +1151,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_26
-          - !<!Parameter> &ref_39
+          - !<!Parameter> &ref_40
             schema: *ref_9
             implementation: Method
             language: !<!Languages> 
@@ -1080,12 +1162,25 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_36
           - *ref_37
           - *ref_38
+          - *ref_39
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_8
             signatureParameters:
               - *ref_8
@@ -1099,10 +1194,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_39
+          - *ref_40
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1144,6 +1239,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1156,7 +1266,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1198,6 +1308,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1210,7 +1335,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1252,6 +1377,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1264,7 +1404,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1306,6 +1446,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1318,7 +1473,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1360,6 +1515,21 @@ operationGroups:
           - *ref_26
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1372,7 +1542,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1412,7 +1582,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_26
-          - !<!Parameter> &ref_40
+          - !<!Parameter> &ref_41
             schema: *ref_9
             implementation: Method
             required: true
@@ -1424,7 +1594,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_41
+          - !<!Parameter> &ref_42
             schema: *ref_9
             implementation: Method
             required: true
@@ -1438,6 +1608,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1448,11 +1633,11 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_40
           - *ref_41
+          - *ref_42
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1488,13 +1673,13 @@ operationGroups:
               itemName: values
               member: NextFragment
               nextLinkName: odata.nextLink
-              nextLinkOperation: !<!Operation> &ref_45
+              nextLinkOperation: !<!Operation> &ref_46
                 apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
                 parameters:
                   - *ref_26
-                  - !<!Parameter> &ref_42
+                  - !<!Parameter> &ref_43
                     schema: *ref_9
                     implementation: Method
                     required: true
@@ -1506,7 +1691,7 @@ operationGroups:
                     protocol: !<!Protocols> 
                       http: !<!HttpParameter> 
                         in: query
-                  - !<!Parameter> &ref_43
+                  - !<!Parameter> &ref_44
                     schema: *ref_9
                     implementation: Method
                     required: true
@@ -1518,7 +1703,7 @@ operationGroups:
                     protocol: !<!Protocols> 
                       http: !<!HttpParameter> 
                         in: path
-                  - !<!Parameter> &ref_44
+                  - !<!Parameter> &ref_45
                     schema: *ref_9
                     implementation: Method
                     required: true
@@ -1534,6 +1719,21 @@ operationGroups:
                         in: path
                 requests:
                   - !<!Request> 
+                    parameters:
+                      - !<!Parameter> 
+                        schema: *ref_27
+                        implementation: Method
+                        origin: 'modelerfour:synthesized/accept'
+                        required: true
+                        language: !<!Languages> 
+                          default:
+                            name: Accept
+                            description: Accept header
+                            serializedName: Accept
+                        protocol: !<!Protocols> 
+                          http: !<!HttpParameter> 
+                            in: header
+                    signatureParameters: []
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -1544,12 +1744,12 @@ operationGroups:
                         method: get
                         uri: '{$host}'
                 signatureParameters:
-                  - *ref_42
                   - *ref_43
                   - *ref_44
+                  - *ref_45
                 responses:
                   - !<!SchemaResponse> 
-                    schema: *ref_35
+                    schema: *ref_36
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -1585,7 +1785,7 @@ operationGroups:
                       itemName: values
                       member: NextFragment
                       nextLinkName: odata.nextLink
-                      nextLinkOperation: *ref_45
+                      nextLinkOperation: *ref_46
                 protocol: !<!Protocols> {}
         protocol: !<!Protocols> {}
       - !<!Operation> 
@@ -1594,11 +1794,24 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_26
-          - *ref_46
           - *ref_47
+          - *ref_48
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_11
             signatureParameters:
               - *ref_11
@@ -1614,7 +1827,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_35
+            schema: *ref_36
             language: !<!Languages> 
               default:
                 name: ''
@@ -1650,15 +1863,15 @@ operationGroups:
               itemName: values
               member: NextFragmentWithGrouping
               nextLinkName: odata.nextLink
-              nextLinkOperation: !<!Operation> &ref_51
+              nextLinkOperation: !<!Operation> &ref_52
                 apiVersions:
                   - !<!ApiVersion> 
                     version: 1.0.0
                 parameters:
                   - *ref_26
-                  - *ref_48
                   - *ref_49
-                  - !<!Parameter> &ref_50
+                  - *ref_50
+                  - !<!Parameter> &ref_51
                     schema: *ref_9
                     implementation: Method
                     required: true
@@ -1675,6 +1888,19 @@ operationGroups:
                 requests:
                   - !<!Request> 
                     parameters:
+                      - !<!Parameter> 
+                        schema: *ref_27
+                        implementation: Method
+                        origin: 'modelerfour:synthesized/accept'
+                        required: true
+                        language: !<!Languages> 
+                          default:
+                            name: Accept
+                            description: Accept header
+                            serializedName: Accept
+                        protocol: !<!Protocols> 
+                          http: !<!HttpParameter> 
+                            in: header
                       - *ref_12
                     signatureParameters:
                       - *ref_12
@@ -1688,10 +1914,10 @@ operationGroups:
                         method: get
                         uri: '{$host}'
                 signatureParameters:
-                  - *ref_50
+                  - *ref_51
                 responses:
                   - !<!SchemaResponse> 
-                    schema: *ref_35
+                    schema: *ref_36
                     language: !<!Languages> 
                       default:
                         name: ''
@@ -1727,7 +1953,7 @@ operationGroups:
                       itemName: values
                       member: NextFragmentWithGrouping
                       nextLinkName: odata.nextLink
-                      nextLinkOperation: *ref_51
+                      nextLinkOperation: *ref_52
                 protocol: !<!Protocols> {}
         protocol: !<!Protocols> {}
       - !<!Operation> 
@@ -1736,7 +1962,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_26
-          - !<!Parameter> &ref_54
+          - !<!Parameter> &ref_55
             schema: *ref_9
             implementation: Method
             language: !<!Languages> 
@@ -1747,11 +1973,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: header
-          - *ref_52
           - *ref_53
+          - *ref_54
         requests:
           - !<!Request> 
             parameters:
+              - !<!Parameter> 
+                schema: *ref_27
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
               - *ref_14
             signatureParameters:
               - *ref_14
@@ -1765,10 +2004,10 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_54
+          - *ref_55
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -1803,8 +2042,8 @@ operationGroups:
               itemName: values
               nextLinkName: nextLink
         protocol: !<!Protocols> {}
-      - *ref_45
-      - *ref_51
+      - *ref_46
+      - *ref_52
     language: !<!Languages> 
       default:
         name: Paging

--- a/modelerfour/test/scenarios/report/flattened.yaml
+++ b/modelerfour/test/scenarios/report/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: report
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -24,7 +24,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
@@ -41,7 +41,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -51,24 +51,35 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_7
+    - !<!DictionarySchema> &ref_8
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: paths·ifo91j·report·get·responses·200·content·application-json·schema
           description: Dictionary of <integer>
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_8
+    - !<!ObjectSchema> &ref_9
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -76,7 +87,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -95,7 +106,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -120,7 +131,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_4
-          - !<!Parameter> &ref_6
+          - !<!Parameter> &ref_7
             schema: *ref_5
             implementation: Method
             language: !<!Languages> 
@@ -133,6 +144,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -143,10 +169,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_6
+          - *ref_7
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -160,7 +186,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -183,7 +209,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_4
-          - !<!Parameter> &ref_9
+          - !<!Parameter> &ref_10
             schema: *ref_5
             implementation: Method
             language: !<!Languages> 
@@ -196,6 +222,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -206,10 +247,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_9
+          - *ref_10
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -223,7 +264,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/report/grouped.yaml
+++ b/modelerfour/test/scenarios/report/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: report
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -24,7 +24,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
@@ -41,7 +41,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -51,24 +51,35 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_7
+    - !<!DictionarySchema> &ref_8
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: paths·ifo91j·report·get·responses·200·content·application-json·schema
           description: Dictionary of <integer>
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_8
+    - !<!ObjectSchema> &ref_9
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -76,7 +87,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -95,7 +106,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -120,7 +131,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_4
-          - !<!Parameter> &ref_6
+          - !<!Parameter> &ref_7
             schema: *ref_5
             implementation: Method
             language: !<!Languages> 
@@ -133,6 +144,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -143,10 +169,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_6
+          - *ref_7
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -160,7 +186,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -183,7 +209,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_4
-          - !<!Parameter> &ref_9
+          - !<!Parameter> &ref_10
             schema: *ref_5
             implementation: Method
             language: !<!Languages> 
@@ -196,6 +222,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -206,10 +247,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_9
+          - *ref_10
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -223,7 +264,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/report/modeler.yaml
+++ b/modelerfour/test/scenarios/report/modeler.yaml
@@ -51,8 +51,19 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_3
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_6
+    - !<!DictionarySchema> &ref_7
       type: dictionary
       elementType: *ref_0
       language: !<!Languages> 
@@ -61,7 +72,7 @@ schemas: !<!Schemas>
           description: Dictionary of <integer>
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -94,7 +105,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_8
+  - !<!Parameter> &ref_9
     schema: *ref_3
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -119,7 +130,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_8
+          - *ref_9
           - !<!Parameter> &ref_5
             schema: *ref_4
             implementation: Method
@@ -133,6 +144,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -146,7 +172,7 @@ operationGroups:
           - *ref_5
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -160,7 +186,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -182,8 +208,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_8
-          - !<!Parameter> &ref_9
+          - *ref_9
+          - !<!Parameter> &ref_10
             schema: *ref_4
             implementation: Method
             language: !<!Languages> 
@@ -196,6 +222,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -206,10 +247,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_9
+          - *ref_10
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_6
+            schema: *ref_7
             language: !<!Languages> 
               default:
                 name: ''
@@ -223,7 +264,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/report/namer.yaml
+++ b/modelerfour/test/scenarios/report/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: report
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -15,7 +15,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_1
+    - !<!NumberSchema> &ref_2
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -24,7 +24,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
@@ -41,7 +41,7 @@ schemas: !<!Schemas>
           name: String
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -51,24 +51,35 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_6
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   dictionaries:
-    - !<!DictionarySchema> &ref_7
+    - !<!DictionarySchema> &ref_8
       type: dictionary
-      elementType: *ref_0
+      elementType: *ref_1
       language: !<!Languages> 
         default:
           name: DictionaryOfInteger
           description: Dictionary of <integer>
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_8
+    - !<!ObjectSchema> &ref_9
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -76,7 +87,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_2
+          schema: *ref_3
           serializedName: message
           language: !<!Languages> 
             default:
@@ -95,7 +106,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_4
-    schema: *ref_3
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -120,7 +131,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_4
-          - !<!Parameter> &ref_6
+          - !<!Parameter> &ref_7
             schema: *ref_5
             implementation: Method
             language: !<!Languages> 
@@ -133,6 +144,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -143,10 +169,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_6
+          - *ref_7
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -160,7 +186,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -183,7 +209,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_4
-          - !<!Parameter> &ref_9
+          - !<!Parameter> &ref_10
             schema: *ref_5
             implementation: Method
             language: !<!Languages> 
@@ -196,6 +222,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_6
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -206,10 +247,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_9
+          - *ref_10
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -223,7 +264,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/required-optional/flattened.yaml
+++ b/modelerfour/test/scenarios/required-optional/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: required-optional
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_13
+    - !<!NumberSchema> &ref_14
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -24,14 +24,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_9
+    - !<!StringSchema> &ref_10
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -39,16 +39,6 @@ schemas: !<!Schemas>
       language: !<!Languages> 
         default:
           name: string
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: Error-message
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_2
@@ -58,7 +48,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       language: !<!Languages> 
         default:
-          name: string-wrapper-value
+          name: Error-message
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_3
@@ -68,7 +58,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       language: !<!Languages> 
         default:
-          name: string-optional-wrapper-value
+          name: string-wrapper-value
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_4
@@ -78,10 +68,20 @@ schemas: !<!Schemas>
           version: 1.0.0
       language: !<!Languages> 
         default:
+          name: string-optional-wrapper-value
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_5
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
           name: product-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -91,7 +91,7 @@ schemas: !<!Schemas>
           name: post-content-schemaItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -101,7 +101,7 @@ schemas: !<!Schemas>
           name: array-wrapper-valueItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_8
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -111,7 +111,7 @@ schemas: !<!Schemas>
           name: array-optional-wrapper-valueItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_12
+    - !<!StringSchema> &ref_13
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -121,15 +121,26 @@ schemas: !<!Schemas>
           name: post-0-itemsItem
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_16
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_17
+    - !<!ObjectSchema> &ref_18
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -137,7 +148,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -154,14 +165,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_26
+    - !<!ObjectSchema> &ref_27
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_28
-          schema: *ref_0
+        - !<!Property> &ref_29
+          schema: *ref_1
           required: true
           serializedName: value
           language: !<!Languages> 
@@ -179,14 +190,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_30
+    - !<!ObjectSchema> &ref_31
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_32
-          schema: *ref_0
+        - !<!Property> &ref_33
+          schema: *ref_1
           serializedName: value
           language: !<!Languages> 
             default:
@@ -203,14 +214,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_38
+    - !<!ObjectSchema> &ref_39
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_40
-          schema: *ref_2
+        - !<!Property> &ref_41
+          schema: *ref_3
           required: true
           serializedName: value
           language: !<!Languages> 
@@ -228,14 +239,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_42
+    - !<!ObjectSchema> &ref_43
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_44
-          schema: *ref_3
+        - !<!Property> &ref_45
+          schema: *ref_4
           serializedName: value
           language: !<!Languages> 
             default:
@@ -252,14 +263,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_49
-          schema: *ref_0
+        - !<!Property> &ref_50
+          schema: *ref_1
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -267,8 +278,8 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_50
-          schema: *ref_4
+        - !<!Property> &ref_51
+          schema: *ref_5
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -286,14 +297,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_56
+    - !<!ObjectSchema> &ref_57
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_58
-          schema: *ref_5
+        - !<!Property> &ref_59
+          schema: *ref_6
           required: true
           serializedName: value
           language: !<!Languages> 
@@ -311,14 +322,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_60
+    - !<!ObjectSchema> &ref_61
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_62
-          schema: *ref_5
+        - !<!Property> &ref_63
+          schema: *ref_6
           serializedName: value
           language: !<!Languages> 
             default:
@@ -335,19 +346,19 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_68
+    - !<!ObjectSchema> &ref_69
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_70
-          schema: !<!ArraySchema> &ref_10
+        - !<!Property> &ref_71
+          schema: !<!ArraySchema> &ref_11
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            elementType: *ref_6
+            elementType: *ref_7
             language: !<!Languages> 
               default:
                 name: array-wrapper-value
@@ -370,19 +381,19 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_72
+    - !<!ObjectSchema> &ref_73
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_74
-          schema: !<!ArraySchema> &ref_11
+        - !<!Property> &ref_75
+          schema: !<!ArraySchema> &ref_12
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            elementType: *ref_7
+            elementType: *ref_8
             language: !<!Languages> 
               default:
                 name: array-optional-wrapper-value
@@ -405,18 +416,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_64
-      type: array
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      elementType: *ref_8
-      language: !<!Languages> 
-        default:
-          name: paths·1cfd2ux·reqopt-requied-array-parameter·post·requestbody·content·application-json·schema
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_66
+    - !<!ArraySchema> &ref_65
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -424,25 +424,36 @@ schemas: !<!Schemas>
       elementType: *ref_9
       language: !<!Languages> 
         default:
-          name: paths·1h5nnq2·reqopt-optional-array-header·post·parameters·0·schema
+          name: paths·1cfd2ux·reqopt-requied-array-parameter·post·requestbody·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - *ref_10
-    - *ref_11
-    - !<!ArraySchema> &ref_76
+    - !<!ArraySchema> &ref_67
       type: array
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_12
+      elementType: *ref_10
+      language: !<!Languages> 
+        default:
+          name: paths·1h5nnq2·reqopt-optional-array-header·post·parameters·0·schema
+          description: ''
+      protocol: !<!Protocols> {}
+    - *ref_11
+    - *ref_12
+    - !<!ArraySchema> &ref_77
+      type: array
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      elementType: *ref_13
       language: !<!Languages> 
         default:
           name: paths·9esllz·reqopt-requied-array-header·post·parameters·0·schema
           description: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_21
-    schema: *ref_9
+  - !<!Parameter> &ref_22
+    schema: *ref_10
     implementation: Client
     required: true
     extensions:
@@ -455,8 +466,8 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: path
-  - !<!Parameter> &ref_22
-    schema: *ref_9
+  - !<!Parameter> &ref_23
+    schema: *ref_10
     implementation: Client
     required: true
     extensions:
@@ -469,8 +480,8 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: query
-  - !<!Parameter> &ref_23
-    schema: *ref_13
+  - !<!Parameter> &ref_24
+    schema: *ref_14
     implementation: Client
     extensions:
       x-ms-priority: 2
@@ -483,7 +494,7 @@ globalParameters:
       http: !<!HttpParameter> 
         in: query
   - !<!Parameter> &ref_15
-    schema: *ref_14
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -508,8 +519,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_16
-            schema: *ref_9
+          - !<!Parameter> &ref_17
+            schema: *ref_10
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -522,6 +533,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -532,7 +558,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_16
+          - *ref_17
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -545,7 +571,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -568,8 +594,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_18
-            schema: *ref_9
+          - !<!Parameter> &ref_19
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -581,6 +607,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -591,7 +632,7 @@ operationGroups:
                 method: put
                 uri: '{$host}'
         signatureParameters:
-          - *ref_18
+          - *ref_19
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -604,7 +645,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -627,8 +668,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_19
-            schema: *ref_9
+          - !<!Parameter> &ref_20
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -640,6 +681,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -650,7 +706,7 @@ operationGroups:
                 method: put
                 uri: '{$host}'
         signatureParameters:
-          - *ref_19
+          - *ref_20
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -663,7 +719,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -689,8 +745,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_20
-                schema: *ref_9
+              - !<!Parameter> &ref_21
+                schema: *ref_10
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -701,8 +757,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_20
+              - *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -728,7 +797,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -751,9 +820,24 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - *ref_21
+          - *ref_22
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -776,7 +860,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -799,9 +883,24 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - *ref_22
+          - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -824,7 +923,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -847,9 +946,24 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - *ref_23
+          - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -872,7 +986,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -906,8 +1020,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_24
-                schema: *ref_13
+              - !<!Parameter> &ref_25
+                schema: *ref_14
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -918,8 +1032,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_24
+              - *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -945,7 +1072,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -971,8 +1098,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_25
-                schema: *ref_13
+              - !<!Parameter> &ref_26
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -983,8 +1110,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_25
+              - *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1010,7 +1150,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1036,8 +1176,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_27
-                schema: *ref_26
+              - !<!Parameter> &ref_28
+                schema: *ref_27
                 flattened: true
                 implementation: Method
                 required: true
@@ -1049,20 +1189,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_29
-                schema: *ref_0
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_27
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_30
+                schema: *ref_1
+                implementation: Method
+                originalParameter: *ref_28
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_28
+                targetProperty: *ref_29
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_29
+              - *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1088,7 +1241,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1114,8 +1267,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
-                schema: *ref_30
+              - !<!Parameter> &ref_32
+                schema: *ref_31
                 flattened: true
                 implementation: Method
                 required: false
@@ -1127,19 +1280,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_33
-                schema: *ref_0
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_31
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_34
+                schema: *ref_1
+                implementation: Method
+                originalParameter: *ref_32
                 pathToProperty: []
-                targetProperty: *ref_32
+                targetProperty: *ref_33
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1165,7 +1331,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1188,8 +1354,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_34
-            schema: *ref_13
+          - !<!Parameter> &ref_35
+            schema: *ref_14
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1202,6 +1368,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1212,7 +1393,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_34
+          - *ref_35
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1225,7 +1406,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1248,8 +1429,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_35
-            schema: *ref_13
+          - !<!Parameter> &ref_36
+            schema: *ref_14
             implementation: Method
             language: !<!Languages> 
               default:
@@ -1261,6 +1442,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1271,7 +1467,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_35
+          - *ref_36
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1284,7 +1480,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1310,8 +1506,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_9
+              - !<!Parameter> &ref_37
+                schema: *ref_10
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1322,8 +1518,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -1349,7 +1558,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1375,8 +1584,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_37
-                schema: *ref_9
+              - !<!Parameter> &ref_38
+                schema: *ref_10
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1387,8 +1596,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_37
+              - *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1414,7 +1636,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1440,8 +1662,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_39
-                schema: *ref_38
+              - !<!Parameter> &ref_40
+                schema: *ref_39
                 flattened: true
                 implementation: Method
                 required: true
@@ -1453,20 +1675,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_41
-                schema: *ref_2
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_39
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_42
+                schema: *ref_3
+                implementation: Method
+                originalParameter: *ref_40
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_40
+                targetProperty: *ref_41
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_41
+              - *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -1492,7 +1727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1518,8 +1753,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_43
-                schema: *ref_42
+              - !<!Parameter> &ref_44
+                schema: *ref_43
                 flattened: true
                 implementation: Method
                 required: false
@@ -1531,19 +1766,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_45
-                schema: *ref_3
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_43
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_46
+                schema: *ref_4
+                implementation: Method
+                originalParameter: *ref_44
                 pathToProperty: []
-                targetProperty: *ref_44
+                targetProperty: *ref_45
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -1569,7 +1817,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1592,8 +1840,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_46
-            schema: *ref_9
+          - !<!Parameter> &ref_47
+            schema: *ref_10
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1606,6 +1854,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1616,7 +1879,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_46
+          - *ref_47
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1629,7 +1892,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1652,8 +1915,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_47
-            schema: *ref_9
+          - !<!Parameter> &ref_48
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -1665,6 +1928,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1675,7 +1953,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_47
+          - *ref_48
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1688,7 +1966,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1714,8 +1992,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_48
-                schema: *ref_5
+              - !<!Parameter> &ref_49
+                schema: *ref_6
                 flattened: true
                 implementation: Method
                 required: true
@@ -1727,33 +2005,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_51
-                schema: *ref_0
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_48
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_52
+                schema: *ref_1
+                implementation: Method
+                originalParameter: *ref_49
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_49
+                targetProperty: *ref_50
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_52
-                schema: *ref_4
+              - !<!VirtualParameter> &ref_53
+                schema: *ref_5
                 implementation: Method
-                originalParameter: *ref_48
+                originalParameter: *ref_49
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_50
+                targetProperty: *ref_51
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_51
               - *ref_52
+              - *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -1779,7 +2070,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1805,8 +2096,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_53
-                schema: *ref_5
+              - !<!Parameter> &ref_54
+                schema: *ref_6
                 flattened: true
                 implementation: Method
                 required: false
@@ -1818,33 +2109,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_54
-                schema: *ref_0
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_53
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_55
+                schema: *ref_1
+                implementation: Method
+                originalParameter: *ref_54
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_49
+                targetProperty: *ref_50
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_55
-                schema: *ref_4
+              - !<!VirtualParameter> &ref_56
+                schema: *ref_5
                 implementation: Method
-                originalParameter: *ref_53
+                originalParameter: *ref_54
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_50
+                targetProperty: *ref_51
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_54
               - *ref_55
+              - *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -1870,7 +2174,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1896,8 +2200,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_57
-                schema: *ref_56
+              - !<!Parameter> &ref_58
+                schema: *ref_57
                 flattened: true
                 implementation: Method
                 required: true
@@ -1909,20 +2213,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_59
-                schema: *ref_5
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_57
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_60
+                schema: *ref_6
+                implementation: Method
+                originalParameter: *ref_58
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_58
+                targetProperty: *ref_59
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_59
+              - *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -1948,7 +2265,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1974,8 +2291,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_61
-                schema: *ref_60
+              - !<!Parameter> &ref_62
+                schema: *ref_61
                 flattened: true
                 implementation: Method
                 required: false
@@ -1987,19 +2304,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_63
-                schema: *ref_5
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_61
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_64
+                schema: *ref_6
+                implementation: Method
+                originalParameter: *ref_62
                 pathToProperty: []
-                targetProperty: *ref_62
+                targetProperty: *ref_63
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -2025,7 +2355,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2051,8 +2381,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_65
-                schema: *ref_64
+              - !<!Parameter> &ref_66
+                schema: *ref_65
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2063,8 +2393,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_65
+              - *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -2090,7 +2433,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2116,8 +2459,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_67
-                schema: *ref_66
+              - !<!Parameter> &ref_68
+                schema: *ref_67
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2128,8 +2471,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_67
+              - *ref_68
             language: !<!Languages> 
               default:
                 name: ''
@@ -2155,7 +2511,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2181,8 +2537,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_69
-                schema: *ref_68
+              - !<!Parameter> &ref_70
+                schema: *ref_69
                 flattened: true
                 implementation: Method
                 required: true
@@ -2194,20 +2550,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_71
-                schema: *ref_10
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_69
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_72
+                schema: *ref_11
+                implementation: Method
+                originalParameter: *ref_70
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_70
+                targetProperty: *ref_71
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_71
+              - *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2233,7 +2602,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2259,8 +2628,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_73
-                schema: *ref_72
+              - !<!Parameter> &ref_74
+                schema: *ref_73
                 flattened: true
                 implementation: Method
                 required: false
@@ -2272,19 +2641,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_75
-                schema: *ref_11
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_73
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_76
+                schema: *ref_12
+                implementation: Method
+                originalParameter: *ref_74
                 pathToProperty: []
-                targetProperty: *ref_74
+                targetProperty: *ref_75
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_75
+              - *ref_76
             language: !<!Languages> 
               default:
                 name: ''
@@ -2310,7 +2692,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2333,8 +2715,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_77
-            schema: *ref_76
+          - !<!Parameter> &ref_78
+            schema: *ref_77
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2348,6 +2730,21 @@ operationGroups:
                 style: simple
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2358,7 +2755,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_77
+          - *ref_78
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2371,7 +2768,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2394,8 +2791,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_78
-            schema: *ref_66
+          - !<!Parameter> &ref_79
+            schema: *ref_67
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2408,6 +2805,21 @@ operationGroups:
                 style: simple
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2418,7 +2830,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_78
+          - *ref_79
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2431,7 +2843,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/required-optional/grouped.yaml
+++ b/modelerfour/test/scenarios/required-optional/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: required-optional
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_13
+    - !<!NumberSchema> &ref_14
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -24,14 +24,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_9
+    - !<!StringSchema> &ref_10
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -39,16 +39,6 @@ schemas: !<!Schemas>
       language: !<!Languages> 
         default:
           name: string
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: Error-message
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_2
@@ -58,7 +48,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       language: !<!Languages> 
         default:
-          name: string-wrapper-value
+          name: Error-message
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_3
@@ -68,7 +58,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       language: !<!Languages> 
         default:
-          name: string-optional-wrapper-value
+          name: string-wrapper-value
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_4
@@ -78,10 +68,20 @@ schemas: !<!Schemas>
           version: 1.0.0
       language: !<!Languages> 
         default:
+          name: string-optional-wrapper-value
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_5
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
           name: product-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -91,7 +91,7 @@ schemas: !<!Schemas>
           name: post-content-schemaItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -101,7 +101,7 @@ schemas: !<!Schemas>
           name: array-wrapper-valueItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_8
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -111,7 +111,7 @@ schemas: !<!Schemas>
           name: array-optional-wrapper-valueItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_12
+    - !<!StringSchema> &ref_13
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -121,15 +121,26 @@ schemas: !<!Schemas>
           name: post-0-itemsItem
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_16
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_17
+    - !<!ObjectSchema> &ref_18
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -137,7 +148,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -154,14 +165,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_26
+    - !<!ObjectSchema> &ref_27
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_28
-          schema: *ref_0
+        - !<!Property> &ref_29
+          schema: *ref_1
           required: true
           serializedName: value
           language: !<!Languages> 
@@ -179,14 +190,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_30
+    - !<!ObjectSchema> &ref_31
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_32
-          schema: *ref_0
+        - !<!Property> &ref_33
+          schema: *ref_1
           serializedName: value
           language: !<!Languages> 
             default:
@@ -203,14 +214,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_38
+    - !<!ObjectSchema> &ref_39
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_40
-          schema: *ref_2
+        - !<!Property> &ref_41
+          schema: *ref_3
           required: true
           serializedName: value
           language: !<!Languages> 
@@ -228,14 +239,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_42
+    - !<!ObjectSchema> &ref_43
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_44
-          schema: *ref_3
+        - !<!Property> &ref_45
+          schema: *ref_4
           serializedName: value
           language: !<!Languages> 
             default:
@@ -252,14 +263,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_49
-          schema: *ref_0
+        - !<!Property> &ref_50
+          schema: *ref_1
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -267,8 +278,8 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_50
-          schema: *ref_4
+        - !<!Property> &ref_51
+          schema: *ref_5
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -286,14 +297,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_56
+    - !<!ObjectSchema> &ref_57
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_58
-          schema: *ref_5
+        - !<!Property> &ref_59
+          schema: *ref_6
           required: true
           serializedName: value
           language: !<!Languages> 
@@ -311,14 +322,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_60
+    - !<!ObjectSchema> &ref_61
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_62
-          schema: *ref_5
+        - !<!Property> &ref_63
+          schema: *ref_6
           serializedName: value
           language: !<!Languages> 
             default:
@@ -335,19 +346,19 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_68
+    - !<!ObjectSchema> &ref_69
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_70
-          schema: !<!ArraySchema> &ref_10
+        - !<!Property> &ref_71
+          schema: !<!ArraySchema> &ref_11
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            elementType: *ref_6
+            elementType: *ref_7
             language: !<!Languages> 
               default:
                 name: array-wrapper-value
@@ -370,19 +381,19 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_72
+    - !<!ObjectSchema> &ref_73
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_74
-          schema: !<!ArraySchema> &ref_11
+        - !<!Property> &ref_75
+          schema: !<!ArraySchema> &ref_12
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            elementType: *ref_7
+            elementType: *ref_8
             language: !<!Languages> 
               default:
                 name: array-optional-wrapper-value
@@ -405,18 +416,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_64
-      type: array
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      elementType: *ref_8
-      language: !<!Languages> 
-        default:
-          name: paths·1cfd2ux·reqopt-requied-array-parameter·post·requestbody·content·application-json·schema
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_66
+    - !<!ArraySchema> &ref_65
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -424,25 +424,36 @@ schemas: !<!Schemas>
       elementType: *ref_9
       language: !<!Languages> 
         default:
-          name: paths·1h5nnq2·reqopt-optional-array-header·post·parameters·0·schema
+          name: paths·1cfd2ux·reqopt-requied-array-parameter·post·requestbody·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - *ref_10
-    - *ref_11
-    - !<!ArraySchema> &ref_76
+    - !<!ArraySchema> &ref_67
       type: array
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_12
+      elementType: *ref_10
+      language: !<!Languages> 
+        default:
+          name: paths·1h5nnq2·reqopt-optional-array-header·post·parameters·0·schema
+          description: ''
+      protocol: !<!Protocols> {}
+    - *ref_11
+    - *ref_12
+    - !<!ArraySchema> &ref_77
+      type: array
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      elementType: *ref_13
       language: !<!Languages> 
         default:
           name: paths·9esllz·reqopt-requied-array-header·post·parameters·0·schema
           description: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_21
-    schema: *ref_9
+  - !<!Parameter> &ref_22
+    schema: *ref_10
     implementation: Client
     required: true
     extensions:
@@ -455,8 +466,8 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: path
-  - !<!Parameter> &ref_22
-    schema: *ref_9
+  - !<!Parameter> &ref_23
+    schema: *ref_10
     implementation: Client
     required: true
     extensions:
@@ -469,8 +480,8 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: query
-  - !<!Parameter> &ref_23
-    schema: *ref_13
+  - !<!Parameter> &ref_24
+    schema: *ref_14
     implementation: Client
     extensions:
       x-ms-priority: 2
@@ -483,7 +494,7 @@ globalParameters:
       http: !<!HttpParameter> 
         in: query
   - !<!Parameter> &ref_15
-    schema: *ref_14
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -508,8 +519,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_16
-            schema: *ref_9
+          - !<!Parameter> &ref_17
+            schema: *ref_10
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -522,6 +533,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -532,7 +558,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_16
+          - *ref_17
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -545,7 +571,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -568,8 +594,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_18
-            schema: *ref_9
+          - !<!Parameter> &ref_19
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -581,6 +607,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -591,7 +632,7 @@ operationGroups:
                 method: put
                 uri: '{$host}'
         signatureParameters:
-          - *ref_18
+          - *ref_19
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -604,7 +645,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -627,8 +668,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_19
-            schema: *ref_9
+          - !<!Parameter> &ref_20
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -640,6 +681,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -650,7 +706,7 @@ operationGroups:
                 method: put
                 uri: '{$host}'
         signatureParameters:
-          - *ref_19
+          - *ref_20
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -663,7 +719,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -689,8 +745,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_20
-                schema: *ref_9
+              - !<!Parameter> &ref_21
+                schema: *ref_10
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -701,8 +757,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_20
+              - *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -728,7 +797,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -751,9 +820,24 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - *ref_21
+          - *ref_22
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -776,7 +860,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -799,9 +883,24 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - *ref_22
+          - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -824,7 +923,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -847,9 +946,24 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - *ref_23
+          - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -872,7 +986,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -906,8 +1020,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_24
-                schema: *ref_13
+              - !<!Parameter> &ref_25
+                schema: *ref_14
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -918,8 +1032,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_24
+              - *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -945,7 +1072,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -971,8 +1098,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_25
-                schema: *ref_13
+              - !<!Parameter> &ref_26
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -983,8 +1110,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_25
+              - *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1010,7 +1150,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1036,8 +1176,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_27
-                schema: *ref_26
+              - !<!Parameter> &ref_28
+                schema: *ref_27
                 flattened: true
                 implementation: Method
                 required: true
@@ -1049,20 +1189,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_29
-                schema: *ref_0
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_27
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_30
+                schema: *ref_1
+                implementation: Method
+                originalParameter: *ref_28
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_28
+                targetProperty: *ref_29
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_29
+              - *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1088,7 +1241,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1114,8 +1267,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
-                schema: *ref_30
+              - !<!Parameter> &ref_32
+                schema: *ref_31
                 flattened: true
                 implementation: Method
                 required: false
@@ -1127,19 +1280,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_33
-                schema: *ref_0
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_31
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_34
+                schema: *ref_1
+                implementation: Method
+                originalParameter: *ref_32
                 pathToProperty: []
-                targetProperty: *ref_32
+                targetProperty: *ref_33
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1165,7 +1331,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1188,8 +1354,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_34
-            schema: *ref_13
+          - !<!Parameter> &ref_35
+            schema: *ref_14
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1202,6 +1368,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1212,7 +1393,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_34
+          - *ref_35
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1225,7 +1406,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1248,8 +1429,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_35
-            schema: *ref_13
+          - !<!Parameter> &ref_36
+            schema: *ref_14
             implementation: Method
             language: !<!Languages> 
               default:
@@ -1261,6 +1442,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1271,7 +1467,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_35
+          - *ref_36
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1284,7 +1480,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1310,8 +1506,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_9
+              - !<!Parameter> &ref_37
+                schema: *ref_10
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1322,8 +1518,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -1349,7 +1558,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1375,8 +1584,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_37
-                schema: *ref_9
+              - !<!Parameter> &ref_38
+                schema: *ref_10
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1387,8 +1596,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_37
+              - *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1414,7 +1636,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1440,8 +1662,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_39
-                schema: *ref_38
+              - !<!Parameter> &ref_40
+                schema: *ref_39
                 flattened: true
                 implementation: Method
                 required: true
@@ -1453,20 +1675,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_41
-                schema: *ref_2
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_39
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_42
+                schema: *ref_3
+                implementation: Method
+                originalParameter: *ref_40
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_40
+                targetProperty: *ref_41
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_41
+              - *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -1492,7 +1727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1518,8 +1753,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_43
-                schema: *ref_42
+              - !<!Parameter> &ref_44
+                schema: *ref_43
                 flattened: true
                 implementation: Method
                 required: false
@@ -1531,19 +1766,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_45
-                schema: *ref_3
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_43
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_46
+                schema: *ref_4
+                implementation: Method
+                originalParameter: *ref_44
                 pathToProperty: []
-                targetProperty: *ref_44
+                targetProperty: *ref_45
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -1569,7 +1817,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1592,8 +1840,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_46
-            schema: *ref_9
+          - !<!Parameter> &ref_47
+            schema: *ref_10
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1606,6 +1854,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1616,7 +1879,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_46
+          - *ref_47
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1629,7 +1892,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1652,8 +1915,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_47
-            schema: *ref_9
+          - !<!Parameter> &ref_48
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -1665,6 +1928,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1675,7 +1953,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_47
+          - *ref_48
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1688,7 +1966,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1714,8 +1992,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_48
-                schema: *ref_5
+              - !<!Parameter> &ref_49
+                schema: *ref_6
                 flattened: true
                 implementation: Method
                 required: true
@@ -1727,33 +2005,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_51
-                schema: *ref_0
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_48
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_52
+                schema: *ref_1
+                implementation: Method
+                originalParameter: *ref_49
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_49
+                targetProperty: *ref_50
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_52
-                schema: *ref_4
+              - !<!VirtualParameter> &ref_53
+                schema: *ref_5
                 implementation: Method
-                originalParameter: *ref_48
+                originalParameter: *ref_49
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_50
+                targetProperty: *ref_51
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_51
               - *ref_52
+              - *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -1779,7 +2070,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1805,8 +2096,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_53
-                schema: *ref_5
+              - !<!Parameter> &ref_54
+                schema: *ref_6
                 flattened: true
                 implementation: Method
                 required: false
@@ -1818,33 +2109,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_54
-                schema: *ref_0
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_53
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_55
+                schema: *ref_1
+                implementation: Method
+                originalParameter: *ref_54
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_49
+                targetProperty: *ref_50
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_55
-                schema: *ref_4
+              - !<!VirtualParameter> &ref_56
+                schema: *ref_5
                 implementation: Method
-                originalParameter: *ref_53
+                originalParameter: *ref_54
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_50
+                targetProperty: *ref_51
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_54
               - *ref_55
+              - *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -1870,7 +2174,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1896,8 +2200,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_57
-                schema: *ref_56
+              - !<!Parameter> &ref_58
+                schema: *ref_57
                 flattened: true
                 implementation: Method
                 required: true
@@ -1909,20 +2213,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_59
-                schema: *ref_5
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_57
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_60
+                schema: *ref_6
+                implementation: Method
+                originalParameter: *ref_58
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_58
+                targetProperty: *ref_59
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_59
+              - *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -1948,7 +2265,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1974,8 +2291,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_61
-                schema: *ref_60
+              - !<!Parameter> &ref_62
+                schema: *ref_61
                 flattened: true
                 implementation: Method
                 required: false
@@ -1987,19 +2304,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_63
-                schema: *ref_5
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_61
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_64
+                schema: *ref_6
+                implementation: Method
+                originalParameter: *ref_62
                 pathToProperty: []
-                targetProperty: *ref_62
+                targetProperty: *ref_63
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -2025,7 +2355,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2051,8 +2381,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_65
-                schema: *ref_64
+              - !<!Parameter> &ref_66
+                schema: *ref_65
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2063,8 +2393,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_65
+              - *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -2090,7 +2433,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2116,8 +2459,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_67
-                schema: *ref_66
+              - !<!Parameter> &ref_68
+                schema: *ref_67
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2128,8 +2471,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_67
+              - *ref_68
             language: !<!Languages> 
               default:
                 name: ''
@@ -2155,7 +2511,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2181,8 +2537,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_69
-                schema: *ref_68
+              - !<!Parameter> &ref_70
+                schema: *ref_69
                 flattened: true
                 implementation: Method
                 required: true
@@ -2194,20 +2550,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_71
-                schema: *ref_10
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_69
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_72
+                schema: *ref_11
+                implementation: Method
+                originalParameter: *ref_70
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_70
+                targetProperty: *ref_71
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_71
+              - *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2233,7 +2602,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2259,8 +2628,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_73
-                schema: *ref_72
+              - !<!Parameter> &ref_74
+                schema: *ref_73
                 flattened: true
                 implementation: Method
                 required: false
@@ -2272,19 +2641,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_75
-                schema: *ref_11
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_73
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_76
+                schema: *ref_12
+                implementation: Method
+                originalParameter: *ref_74
                 pathToProperty: []
-                targetProperty: *ref_74
+                targetProperty: *ref_75
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_75
+              - *ref_76
             language: !<!Languages> 
               default:
                 name: ''
@@ -2310,7 +2692,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2333,8 +2715,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_77
-            schema: *ref_76
+          - !<!Parameter> &ref_78
+            schema: *ref_77
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2348,6 +2730,21 @@ operationGroups:
                 style: simple
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2358,7 +2755,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_77
+          - *ref_78
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2371,7 +2768,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2394,8 +2791,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_78
-            schema: *ref_66
+          - !<!Parameter> &ref_79
+            schema: *ref_67
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2408,6 +2805,21 @@ operationGroups:
                 style: simple
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2418,7 +2830,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_78
+          - *ref_79
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2431,7 +2843,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/required-optional/modeler.yaml
+++ b/modelerfour/test/scenarios/required-optional/modeler.yaml
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_20
+    - !<!NumberSchema> &ref_21
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -24,14 +24,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_13
+    - !<!StringSchema> &ref_8
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_9
+    - !<!StringSchema> &ref_10
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -81,7 +81,7 @@ schemas: !<!Schemas>
           name: product-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -111,7 +111,7 @@ schemas: !<!Schemas>
           name: array-optional-wrapper-valueItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_12
+    - !<!StringSchema> &ref_13
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -121,8 +121,19 @@ schemas: !<!Schemas>
           name: post-0-itemsItem
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_15
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_8
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_15
+    - !<!ObjectSchema> &ref_16
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -154,7 +165,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_23
+    - !<!ObjectSchema> &ref_24
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -179,7 +190,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_25
+    - !<!ObjectSchema> &ref_26
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -203,7 +214,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_31
+    - !<!ObjectSchema> &ref_32
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -228,7 +239,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_33
+    - !<!ObjectSchema> &ref_34
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -286,7 +297,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_39
+    - !<!ObjectSchema> &ref_40
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -311,7 +322,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_41
+    - !<!ObjectSchema> &ref_42
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -335,14 +346,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_47
+    - !<!ObjectSchema> &ref_48
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: !<!ArraySchema> &ref_10
+          schema: !<!ArraySchema> &ref_11
             type: array
             apiVersions:
               - !<!ApiVersion> 
@@ -370,14 +381,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_49
+    - !<!ObjectSchema> &ref_50
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: !<!ArraySchema> &ref_11
+          schema: !<!ArraySchema> &ref_12
             type: array
             apiVersions:
               - !<!ApiVersion> 
@@ -405,18 +416,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_43
-      type: array
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      elementType: *ref_8
-      language: !<!Languages> 
-        default:
-          name: paths·1cfd2ux·reqopt-requied-array-parameter·post·requestbody·content·application-json·schema
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_45
+    - !<!ArraySchema> &ref_44
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -424,25 +424,36 @@ schemas: !<!Schemas>
       elementType: *ref_9
       language: !<!Languages> 
         default:
-          name: paths·1h5nnq2·reqopt-optional-array-header·post·parameters·0·schema
+          name: paths·1cfd2ux·reqopt-requied-array-parameter·post·requestbody·content·application-json·schema
           description: ''
       protocol: !<!Protocols> {}
-    - *ref_10
-    - *ref_11
-    - !<!ArraySchema> &ref_51
+    - !<!ArraySchema> &ref_46
       type: array
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_12
+      elementType: *ref_10
+      language: !<!Languages> 
+        default:
+          name: paths·1h5nnq2·reqopt-optional-array-header·post·parameters·0·schema
+          description: ''
+      protocol: !<!Protocols> {}
+    - *ref_11
+    - *ref_12
+    - !<!ArraySchema> &ref_52
+      type: array
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      elementType: *ref_13
       language: !<!Languages> 
         default:
           name: paths·9esllz·reqopt-requied-array-header·post·parameters·0·schema
           description: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_54
-    schema: *ref_9
+  - !<!Parameter> &ref_55
+    schema: *ref_10
     implementation: Client
     required: true
     extensions:
@@ -455,8 +466,8 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: path
-  - !<!Parameter> &ref_55
-    schema: *ref_9
+  - !<!Parameter> &ref_56
+    schema: *ref_10
     implementation: Client
     required: true
     extensions:
@@ -469,8 +480,8 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: query
-  - !<!Parameter> &ref_56
-    schema: *ref_20
+  - !<!Parameter> &ref_57
+    schema: *ref_21
     implementation: Client
     extensions:
       x-ms-priority: 2
@@ -482,8 +493,8 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: query
-  - !<!Parameter> &ref_16
-    schema: *ref_13
+  - !<!Parameter> &ref_17
+    schema: *ref_8
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -507,9 +518,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
           - !<!Parameter> &ref_14
-            schema: *ref_9
+            schema: *ref_10
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -522,6 +533,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -545,7 +571,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -567,9 +593,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
-          - !<!Parameter> &ref_17
-            schema: *ref_9
+          - *ref_17
+          - !<!Parameter> &ref_18
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -581,6 +607,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -591,7 +632,7 @@ operationGroups:
                 method: put
                 uri: '{$host}'
         signatureParameters:
-          - *ref_17
+          - *ref_18
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -604,7 +645,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -626,9 +667,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
-          - !<!Parameter> &ref_18
-            schema: *ref_9
+          - *ref_17
+          - !<!Parameter> &ref_19
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -640,6 +681,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -650,7 +706,7 @@ operationGroups:
                 method: put
                 uri: '{$host}'
         signatureParameters:
-          - *ref_18
+          - *ref_19
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -663,7 +719,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -685,12 +741,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_19
-                schema: *ref_9
+              - !<!Parameter> &ref_20
+                schema: *ref_10
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -701,8 +757,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_19
+              - *ref_20
             language: !<!Languages> 
               default:
                 name: ''
@@ -728,7 +797,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -750,10 +819,25 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
-          - *ref_54
+          - *ref_17
+          - *ref_55
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -776,7 +860,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -798,10 +882,25 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
-          - *ref_55
+          - *ref_17
+          - *ref_56
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -824,7 +923,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -846,10 +945,25 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
-          - *ref_56
+          - *ref_17
+          - *ref_57
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -872,7 +986,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -902,12 +1016,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_21
-                schema: *ref_20
+              - !<!Parameter> &ref_22
+                schema: *ref_21
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -918,8 +1032,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_21
+              - *ref_22
             language: !<!Languages> 
               default:
                 name: ''
@@ -945,7 +1072,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -967,12 +1094,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_22
-                schema: *ref_20
+              - !<!Parameter> &ref_23
+                schema: *ref_21
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -983,8 +1110,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_22
+              - *ref_23
             language: !<!Languages> 
               default:
                 name: ''
@@ -1010,7 +1150,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1032,12 +1172,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_24
-                schema: *ref_23
+              - !<!Parameter> &ref_25
+                schema: *ref_24
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1048,8 +1188,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_24
+              - *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -1075,7 +1228,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1097,12 +1250,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_26
-                schema: *ref_25
+              - !<!Parameter> &ref_27
+                schema: *ref_26
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1113,8 +1266,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_26
+              - *ref_27
             language: !<!Languages> 
               default:
                 name: ''
@@ -1140,7 +1306,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1162,9 +1328,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
-          - !<!Parameter> &ref_27
-            schema: *ref_20
+          - *ref_17
+          - !<!Parameter> &ref_28
+            schema: *ref_21
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1177,6 +1343,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1187,7 +1368,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_27
+          - *ref_28
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1200,7 +1381,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1222,9 +1403,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
-          - !<!Parameter> &ref_28
-            schema: *ref_20
+          - *ref_17
+          - !<!Parameter> &ref_29
+            schema: *ref_21
             implementation: Method
             language: !<!Languages> 
               default:
@@ -1236,6 +1417,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1246,7 +1442,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
+          - *ref_29
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1259,7 +1455,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1281,12 +1477,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_29
-                schema: *ref_9
+              - !<!Parameter> &ref_30
+                schema: *ref_10
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1297,8 +1493,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_29
+              - *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1324,7 +1533,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1346,12 +1555,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_30
-                schema: *ref_9
+              - !<!Parameter> &ref_31
+                schema: *ref_10
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1362,8 +1571,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_30
+              - *ref_31
             language: !<!Languages> 
               default:
                 name: ''
@@ -1389,7 +1611,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1411,12 +1633,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_32
-                schema: *ref_31
+              - !<!Parameter> &ref_33
+                schema: *ref_32
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1427,8 +1649,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_32
+              - *ref_33
             language: !<!Languages> 
               default:
                 name: ''
@@ -1454,7 +1689,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1476,12 +1711,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_34
-                schema: *ref_33
+              - !<!Parameter> &ref_35
+                schema: *ref_34
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1492,8 +1727,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_34
+              - *ref_35
             language: !<!Languages> 
               default:
                 name: ''
@@ -1519,7 +1767,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1541,9 +1789,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
-          - !<!Parameter> &ref_35
-            schema: *ref_9
+          - *ref_17
+          - !<!Parameter> &ref_36
+            schema: *ref_10
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1556,6 +1804,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1566,7 +1829,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_35
+          - *ref_36
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1579,7 +1842,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1601,9 +1864,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
-          - !<!Parameter> &ref_36
-            schema: *ref_9
+          - *ref_17
+          - !<!Parameter> &ref_37
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -1615,6 +1878,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1625,7 +1903,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_36
+          - *ref_37
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1638,7 +1916,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1660,11 +1938,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_37
+              - !<!Parameter> &ref_38
                 schema: *ref_5
                 implementation: Method
                 required: true
@@ -1676,8 +1954,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_37
+              - *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1703,7 +1994,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1725,11 +2016,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_38
+              - !<!Parameter> &ref_39
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -1741,8 +2032,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_38
+              - *ref_39
             language: !<!Languages> 
               default:
                 name: ''
@@ -1768,7 +2072,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1790,12 +2094,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_40
-                schema: *ref_39
+              - !<!Parameter> &ref_41
+                schema: *ref_40
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1806,8 +2110,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_40
+              - *ref_41
             language: !<!Languages> 
               default:
                 name: ''
@@ -1833,7 +2150,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1855,12 +2172,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_42
-                schema: *ref_41
+              - !<!Parameter> &ref_43
+                schema: *ref_42
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1871,8 +2188,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_42
+              - *ref_43
             language: !<!Languages> 
               default:
                 name: ''
@@ -1898,7 +2228,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1920,12 +2250,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_44
-                schema: *ref_43
+              - !<!Parameter> &ref_45
+                schema: *ref_44
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1936,8 +2266,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_44
+              - *ref_45
             language: !<!Languages> 
               default:
                 name: ''
@@ -1963,7 +2306,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -1985,12 +2328,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_46
-                schema: *ref_45
+              - !<!Parameter> &ref_47
+                schema: *ref_46
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2001,8 +2344,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_46
+              - *ref_47
             language: !<!Languages> 
               default:
                 name: ''
@@ -2028,7 +2384,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -2050,12 +2406,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_48
-                schema: *ref_47
+              - !<!Parameter> &ref_49
+                schema: *ref_48
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2066,8 +2422,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_48
+              - *ref_49
             language: !<!Languages> 
               default:
                 name: ''
@@ -2093,7 +2462,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -2115,12 +2484,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
+          - *ref_17
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_50
-                schema: *ref_49
+              - !<!Parameter> &ref_51
+                schema: *ref_50
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2131,8 +2500,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_50
+              - *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -2158,7 +2540,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -2180,9 +2562,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
-          - !<!Parameter> &ref_52
-            schema: *ref_51
+          - *ref_17
+          - !<!Parameter> &ref_53
+            schema: *ref_52
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2196,6 +2578,21 @@ operationGroups:
                 style: simple
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2206,7 +2603,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_52
+          - *ref_53
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2219,7 +2616,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''
@@ -2241,9 +2638,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_16
-          - !<!Parameter> &ref_53
-            schema: *ref_45
+          - *ref_17
+          - !<!Parameter> &ref_54
+            schema: *ref_46
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2256,6 +2653,21 @@ operationGroups:
                 style: simple
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_15
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2266,7 +2678,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_53
+          - *ref_54
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2279,7 +2691,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_15
+            schema: *ref_16
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/required-optional/namer.yaml
+++ b/modelerfour/test/scenarios/required-optional/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: required-optional
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -12,7 +12,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_13
+    - !<!NumberSchema> &ref_14
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -24,14 +24,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_9
+    - !<!StringSchema> &ref_10
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -39,16 +39,6 @@ schemas: !<!Schemas>
       language: !<!Languages> 
         default:
           name: String
-          description: ''
-      protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
-      type: string
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      language: !<!Languages> 
-        default:
-          name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_2
@@ -58,7 +48,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       language: !<!Languages> 
         default:
-          name: StringWrapperValue
+          name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_3
@@ -68,7 +58,7 @@ schemas: !<!Schemas>
           version: 1.0.0
       language: !<!Languages> 
         default:
-          name: StringOptionalWrapperValue
+          name: StringWrapperValue
           description: ''
       protocol: !<!Protocols> {}
     - !<!StringSchema> &ref_4
@@ -78,10 +68,20 @@ schemas: !<!Schemas>
           version: 1.0.0
       language: !<!Languages> 
         default:
+          name: StringOptionalWrapperValue
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_5
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
           name: ProductName
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -91,7 +91,7 @@ schemas: !<!Schemas>
           name: PostContentSchemaItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_6
+    - !<!StringSchema> &ref_7
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -101,7 +101,7 @@ schemas: !<!Schemas>
           name: ArrayWrapperValueItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_8
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -111,7 +111,7 @@ schemas: !<!Schemas>
           name: ArrayOptionalWrapperValueItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_12
+    - !<!StringSchema> &ref_13
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -121,15 +121,26 @@ schemas: !<!Schemas>
           name: Post0ItemsItem
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_16
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_17
+    - !<!ObjectSchema> &ref_18
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -137,7 +148,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -154,14 +165,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_26
+    - !<!ObjectSchema> &ref_27
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_28
-          schema: *ref_0
+        - !<!Property> &ref_29
+          schema: *ref_1
           required: true
           serializedName: value
           language: !<!Languages> 
@@ -179,14 +190,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_30
+    - !<!ObjectSchema> &ref_31
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_32
-          schema: *ref_0
+        - !<!Property> &ref_33
+          schema: *ref_1
           serializedName: value
           language: !<!Languages> 
             default:
@@ -203,14 +214,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_38
+    - !<!ObjectSchema> &ref_39
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_40
-          schema: *ref_2
+        - !<!Property> &ref_41
+          schema: *ref_3
           required: true
           serializedName: value
           language: !<!Languages> 
@@ -228,14 +239,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_42
+    - !<!ObjectSchema> &ref_43
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_44
-          schema: *ref_3
+        - !<!Property> &ref_45
+          schema: *ref_4
           serializedName: value
           language: !<!Languages> 
             default:
@@ -252,14 +263,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_5
+    - !<!ObjectSchema> &ref_6
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_49
-          schema: *ref_0
+        - !<!Property> &ref_50
+          schema: *ref_1
           required: true
           serializedName: id
           language: !<!Languages> 
@@ -267,8 +278,8 @@ schemas: !<!Schemas>
               name: id
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_50
-          schema: *ref_4
+        - !<!Property> &ref_51
+          schema: *ref_5
           required: false
           serializedName: name
           language: !<!Languages> 
@@ -286,14 +297,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_56
+    - !<!ObjectSchema> &ref_57
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_58
-          schema: *ref_5
+        - !<!Property> &ref_59
+          schema: *ref_6
           required: true
           serializedName: value
           language: !<!Languages> 
@@ -311,14 +322,14 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_60
+    - !<!ObjectSchema> &ref_61
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_62
-          schema: *ref_5
+        - !<!Property> &ref_63
+          schema: *ref_6
           serializedName: value
           language: !<!Languages> 
             default:
@@ -335,19 +346,19 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_68
+    - !<!ObjectSchema> &ref_69
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_70
-          schema: !<!ArraySchema> &ref_10
+        - !<!Property> &ref_71
+          schema: !<!ArraySchema> &ref_11
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            elementType: *ref_6
+            elementType: *ref_7
             language: !<!Languages> 
               default:
                 name: ArrayWrapperValue
@@ -370,19 +381,19 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_72
+    - !<!ObjectSchema> &ref_73
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_74
-          schema: !<!ArraySchema> &ref_11
+        - !<!Property> &ref_75
+          schema: !<!ArraySchema> &ref_12
             type: array
             apiVersions:
               - !<!ApiVersion> 
                 version: 1.0.0
-            elementType: *ref_7
+            elementType: *ref_8
             language: !<!Languages> 
               default:
                 name: ArrayOptionalWrapperValue
@@ -405,18 +416,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_64
-      type: array
-      apiVersions:
-        - !<!ApiVersion> 
-          version: 1.0.0
-      elementType: *ref_8
-      language: !<!Languages> 
-        default:
-          name: ArrayOfPostContentSchemaItem
-          description: Array of PostContentSchemaItem
-      protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_66
+    - !<!ArraySchema> &ref_65
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -424,25 +424,36 @@ schemas: !<!Schemas>
       elementType: *ref_9
       language: !<!Languages> 
         default:
-          name: ArrayOfString
-          description: Array of String
+          name: ArrayOfPostContentSchemaItem
+          description: Array of PostContentSchemaItem
       protocol: !<!Protocols> {}
-    - *ref_10
-    - *ref_11
-    - !<!ArraySchema> &ref_76
+    - !<!ArraySchema> &ref_67
       type: array
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_12
+      elementType: *ref_10
+      language: !<!Languages> 
+        default:
+          name: ArrayOfString
+          description: Array of String
+      protocol: !<!Protocols> {}
+    - *ref_11
+    - *ref_12
+    - !<!ArraySchema> &ref_77
+      type: array
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      elementType: *ref_13
       language: !<!Languages> 
         default:
           name: ArrayOfPost0ItemsItem
           description: Array of Post0ItemsItem
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_21
-    schema: *ref_9
+  - !<!Parameter> &ref_22
+    schema: *ref_10
     implementation: Client
     required: true
     extensions:
@@ -455,8 +466,8 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: path
-  - !<!Parameter> &ref_22
-    schema: *ref_9
+  - !<!Parameter> &ref_23
+    schema: *ref_10
     implementation: Client
     required: true
     extensions:
@@ -469,8 +480,8 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: query
-  - !<!Parameter> &ref_23
-    schema: *ref_13
+  - !<!Parameter> &ref_24
+    schema: *ref_14
     implementation: Client
     extensions:
       x-ms-priority: 2
@@ -483,7 +494,7 @@ globalParameters:
       http: !<!HttpParameter> 
         in: query
   - !<!Parameter> &ref_15
-    schema: *ref_14
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -508,8 +519,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_16
-            schema: *ref_9
+          - !<!Parameter> &ref_17
+            schema: *ref_10
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -522,6 +533,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -532,7 +558,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_16
+          - *ref_17
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -545,7 +571,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -568,8 +594,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_18
-            schema: *ref_9
+          - !<!Parameter> &ref_19
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -581,6 +607,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -591,7 +632,7 @@ operationGroups:
                 method: put
                 uri: '{$host}'
         signatureParameters:
-          - *ref_18
+          - *ref_19
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -604,7 +645,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -627,8 +668,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_19
-            schema: *ref_9
+          - !<!Parameter> &ref_20
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -640,6 +681,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -650,7 +706,7 @@ operationGroups:
                 method: put
                 uri: '{$host}'
         signatureParameters:
-          - *ref_19
+          - *ref_20
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -663,7 +719,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -689,8 +745,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_20
-                schema: *ref_9
+              - !<!Parameter> &ref_21
+                schema: *ref_10
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -701,8 +757,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_20
+              - *ref_21
             language: !<!Languages> 
               default:
                 name: ''
@@ -728,7 +797,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -751,9 +820,24 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - *ref_21
+          - *ref_22
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -776,7 +860,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -799,9 +883,24 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - *ref_22
+          - *ref_23
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -824,7 +923,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -847,9 +946,24 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - *ref_23
+          - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -872,7 +986,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -906,8 +1020,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_24
-                schema: *ref_13
+              - !<!Parameter> &ref_25
+                schema: *ref_14
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -918,8 +1032,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_24
+              - *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -945,7 +1072,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -971,8 +1098,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_25
-                schema: *ref_13
+              - !<!Parameter> &ref_26
+                schema: *ref_14
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -983,8 +1110,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_25
+              - *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -1010,7 +1150,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1036,8 +1176,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_27
-                schema: *ref_26
+              - !<!Parameter> &ref_28
+                schema: *ref_27
                 flattened: true
                 implementation: Method
                 required: true
@@ -1049,20 +1189,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_29
-                schema: *ref_0
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_27
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_30
+                schema: *ref_1
+                implementation: Method
+                originalParameter: *ref_28
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_28
+                targetProperty: *ref_29
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_29
+              - *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -1088,7 +1241,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1114,8 +1267,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
-                schema: *ref_30
+              - !<!Parameter> &ref_32
+                schema: *ref_31
                 flattened: true
                 implementation: Method
                 required: false
@@ -1127,19 +1280,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_33
-                schema: *ref_0
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_31
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_34
+                schema: *ref_1
+                implementation: Method
+                originalParameter: *ref_32
                 pathToProperty: []
-                targetProperty: *ref_32
+                targetProperty: *ref_33
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -1165,7 +1331,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1188,8 +1354,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_34
-            schema: *ref_13
+          - !<!Parameter> &ref_35
+            schema: *ref_14
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1202,6 +1368,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1212,7 +1393,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_34
+          - *ref_35
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1225,7 +1406,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1248,8 +1429,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_35
-            schema: *ref_13
+          - !<!Parameter> &ref_36
+            schema: *ref_14
             implementation: Method
             language: !<!Languages> 
               default:
@@ -1261,6 +1442,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1271,7 +1467,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_35
+          - *ref_36
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1284,7 +1480,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1310,8 +1506,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_36
-                schema: *ref_9
+              - !<!Parameter> &ref_37
+                schema: *ref_10
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1322,8 +1518,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_36
+              - *ref_37
             language: !<!Languages> 
               default:
                 name: ''
@@ -1349,7 +1558,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1375,8 +1584,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_37
-                schema: *ref_9
+              - !<!Parameter> &ref_38
+                schema: *ref_10
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -1387,8 +1596,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_37
+              - *ref_38
             language: !<!Languages> 
               default:
                 name: ''
@@ -1414,7 +1636,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1440,8 +1662,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_39
-                schema: *ref_38
+              - !<!Parameter> &ref_40
+                schema: *ref_39
                 flattened: true
                 implementation: Method
                 required: true
@@ -1453,20 +1675,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_41
-                schema: *ref_2
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_39
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_42
+                schema: *ref_3
+                implementation: Method
+                originalParameter: *ref_40
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_40
+                targetProperty: *ref_41
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_41
+              - *ref_42
             language: !<!Languages> 
               default:
                 name: ''
@@ -1492,7 +1727,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1518,8 +1753,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_43
-                schema: *ref_42
+              - !<!Parameter> &ref_44
+                schema: *ref_43
                 flattened: true
                 implementation: Method
                 required: false
@@ -1531,19 +1766,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_45
-                schema: *ref_3
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_43
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_46
+                schema: *ref_4
+                implementation: Method
+                originalParameter: *ref_44
                 pathToProperty: []
-                targetProperty: *ref_44
+                targetProperty: *ref_45
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_45
+              - *ref_46
             language: !<!Languages> 
               default:
                 name: ''
@@ -1569,7 +1817,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1592,8 +1840,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_46
-            schema: *ref_9
+          - !<!Parameter> &ref_47
+            schema: *ref_10
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1606,6 +1854,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1616,7 +1879,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_46
+          - *ref_47
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1629,7 +1892,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1652,8 +1915,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_47
-            schema: *ref_9
+          - !<!Parameter> &ref_48
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -1665,6 +1928,21 @@ operationGroups:
                 in: header
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1675,7 +1953,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_47
+          - *ref_48
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1688,7 +1966,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1714,8 +1992,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_48
-                schema: *ref_5
+              - !<!Parameter> &ref_49
+                schema: *ref_6
                 flattened: true
                 implementation: Method
                 required: true
@@ -1727,33 +2005,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_51
-                schema: *ref_0
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_48
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_52
+                schema: *ref_1
+                implementation: Method
+                originalParameter: *ref_49
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_49
+                targetProperty: *ref_50
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_52
-                schema: *ref_4
+              - !<!VirtualParameter> &ref_53
+                schema: *ref_5
                 implementation: Method
-                originalParameter: *ref_48
+                originalParameter: *ref_49
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_50
+                targetProperty: *ref_51
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_51
               - *ref_52
+              - *ref_53
             language: !<!Languages> 
               default:
                 name: ''
@@ -1779,7 +2070,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1805,8 +2096,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_53
-                schema: *ref_5
+              - !<!Parameter> &ref_54
+                schema: *ref_6
                 flattened: true
                 implementation: Method
                 required: false
@@ -1818,33 +2109,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_54
-                schema: *ref_0
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_53
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_55
+                schema: *ref_1
+                implementation: Method
+                originalParameter: *ref_54
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_49
+                targetProperty: *ref_50
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_55
-                schema: *ref_4
+              - !<!VirtualParameter> &ref_56
+                schema: *ref_5
                 implementation: Method
-                originalParameter: *ref_53
+                originalParameter: *ref_54
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_50
+                targetProperty: *ref_51
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_54
               - *ref_55
+              - *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -1870,7 +2174,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1896,8 +2200,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_57
-                schema: *ref_56
+              - !<!Parameter> &ref_58
+                schema: *ref_57
                 flattened: true
                 implementation: Method
                 required: true
@@ -1909,20 +2213,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_59
-                schema: *ref_5
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_57
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_60
+                schema: *ref_6
+                implementation: Method
+                originalParameter: *ref_58
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_58
+                targetProperty: *ref_59
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_59
+              - *ref_60
             language: !<!Languages> 
               default:
                 name: ''
@@ -1948,7 +2265,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -1974,8 +2291,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_61
-                schema: *ref_60
+              - !<!Parameter> &ref_62
+                schema: *ref_61
                 flattened: true
                 implementation: Method
                 required: false
@@ -1987,19 +2304,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_63
-                schema: *ref_5
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_61
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_64
+                schema: *ref_6
+                implementation: Method
+                originalParameter: *ref_62
                 pathToProperty: []
-                targetProperty: *ref_62
+                targetProperty: *ref_63
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -2025,7 +2355,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2051,8 +2381,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_65
-                schema: *ref_64
+              - !<!Parameter> &ref_66
+                schema: *ref_65
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2063,8 +2393,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_65
+              - *ref_66
             language: !<!Languages> 
               default:
                 name: ''
@@ -2090,7 +2433,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2116,8 +2459,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_67
-                schema: *ref_66
+              - !<!Parameter> &ref_68
+                schema: *ref_67
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -2128,8 +2471,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_67
+              - *ref_68
             language: !<!Languages> 
               default:
                 name: ''
@@ -2155,7 +2511,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2181,8 +2537,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_69
-                schema: *ref_68
+              - !<!Parameter> &ref_70
+                schema: *ref_69
                 flattened: true
                 implementation: Method
                 required: true
@@ -2194,20 +2550,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_71
-                schema: *ref_10
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_69
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_72
+                schema: *ref_11
+                implementation: Method
+                originalParameter: *ref_70
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_70
+                targetProperty: *ref_71
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_71
+              - *ref_72
             language: !<!Languages> 
               default:
                 name: ''
@@ -2233,7 +2602,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2259,8 +2628,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_73
-                schema: *ref_72
+              - !<!Parameter> &ref_74
+                schema: *ref_73
                 flattened: true
                 implementation: Method
                 required: false
@@ -2272,19 +2641,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_75
-                schema: *ref_11
+              - !<!Parameter> 
+                schema: *ref_16
                 implementation: Method
-                originalParameter: *ref_73
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_76
+                schema: *ref_12
+                implementation: Method
+                originalParameter: *ref_74
                 pathToProperty: []
-                targetProperty: *ref_74
+                targetProperty: *ref_75
                 language: !<!Languages> 
                   default:
                     name: value
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_75
+              - *ref_76
             language: !<!Languages> 
               default:
                 name: ''
@@ -2310,7 +2692,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2333,8 +2715,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_77
-            schema: *ref_76
+          - !<!Parameter> &ref_78
+            schema: *ref_77
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2348,6 +2730,21 @@ operationGroups:
                 style: simple
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2358,7 +2755,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_77
+          - *ref_78
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2371,7 +2768,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''
@@ -2394,8 +2791,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_15
-          - !<!Parameter> &ref_78
-            schema: *ref_66
+          - !<!Parameter> &ref_79
+            schema: *ref_67
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2408,6 +2805,21 @@ operationGroups:
                 style: simple
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_16
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2418,7 +2830,7 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_78
+          - *ref_79
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2431,7 +2843,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_17
+            schema: *ref_18
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/storage/flattened.yaml
+++ b/modelerfour/test/scenarios/storage/flattened.yaml
@@ -437,6 +437,16 @@ schemas: !<!Schemas>
           name: ApiVersion-2015-05-01-preview
           description: Api Version (2015-05-01-preview)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_50
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'application/json, text/json'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json, text/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_29
       type: dictionary
@@ -478,7 +488,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 2015-05-01-preview
       properties:
-        - !<!Property> &ref_51
+        - !<!Property> &ref_52
           schema: *ref_2
           required: true
           serializedName: name
@@ -487,7 +497,7 @@ schemas: !<!Schemas>
               name: name
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_52
+        - !<!Property> &ref_53
           schema: *ref_3
           required: false
           serializedName: type
@@ -506,7 +516,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_55
+    - !<!ObjectSchema> &ref_56
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -986,7 +996,7 @@ schemas: !<!Schemas>
     - *ref_31
     - *ref_22
     - *ref_24
-    - !<!ObjectSchema> &ref_68
+    - !<!ObjectSchema> &ref_69
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1018,7 +1028,7 @@ schemas: !<!Schemas>
           description: The access keys for the storage account.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_69
+    - !<!ObjectSchema> &ref_70
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1060,13 +1070,13 @@ schemas: !<!Schemas>
           description: The list storage accounts operation response.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_71
+    - !<!ObjectSchema> &ref_72
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
       properties:
-        - !<!Property> &ref_73
+        - !<!Property> &ref_74
           schema: *ref_34
           serializedName: keyName
           language: !<!Languages> 
@@ -1084,7 +1094,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_77
+    - !<!ObjectSchema> &ref_78
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1282,7 +1292,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_50
+              - !<!Parameter> &ref_51
                 schema: *ref_49
                 flattened: true
                 implementation: Method
@@ -1295,33 +1305,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_53
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_54
                 schema: *ref_2
                 implementation: Method
-                originalParameter: *ref_50
+                originalParameter: *ref_51
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_51
+                targetProperty: *ref_52
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_54
+              - !<!VirtualParameter> &ref_55
                 schema: *ref_3
                 implementation: Method
-                originalParameter: *ref_50
+                originalParameter: *ref_51
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_52
+                targetProperty: *ref_53
                 language: !<!Languages> 
                   default:
                     name: type
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_53
               - *ref_54
+              - *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -1338,7 +1361,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -1362,7 +1385,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_57
+          - !<!Parameter> &ref_58
             schema: *ref_1
             implementation: Method
             required: true
@@ -1374,7 +1397,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_58
+          - !<!Parameter> &ref_59
             schema: *ref_1
             implementation: Method
             required: true
@@ -1391,7 +1414,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_56
+              - !<!Parameter> &ref_57
                 schema: *ref_7
                 implementation: Method
                 required: true
@@ -1403,8 +1426,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_56
+              - *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -1419,8 +1455,8 @@ operationGroups:
                   - text/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_57
           - *ref_58
+          - *ref_59
         responses:
           - !<!SchemaResponse> 
             schema: *ref_23
@@ -1460,7 +1496,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_59
+          - !<!Parameter> &ref_60
             schema: *ref_1
             implementation: Method
             required: true
@@ -1472,7 +1508,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_60
+          - !<!Parameter> &ref_61
             schema: *ref_1
             implementation: Method
             required: true
@@ -1498,8 +1534,8 @@ operationGroups:
                 method: delete
                 uri: '{$host}'
         signatureParameters:
-          - *ref_59
           - *ref_60
+          - *ref_61
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1530,7 +1566,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_61
+          - !<!Parameter> &ref_62
             schema: *ref_1
             implementation: Method
             required: true
@@ -1542,7 +1578,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_62
+          - !<!Parameter> &ref_63
             schema: *ref_1
             implementation: Method
             required: true
@@ -1558,6 +1594,21 @@ operationGroups:
           - *ref_48
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1568,8 +1619,8 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_61
           - *ref_62
+          - *ref_63
         responses:
           - !<!SchemaResponse> 
             schema: *ref_23
@@ -1596,7 +1647,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_64
+          - !<!Parameter> &ref_65
             schema: *ref_1
             implementation: Method
             required: true
@@ -1608,7 +1659,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_65
+          - !<!Parameter> &ref_66
             schema: *ref_1
             implementation: Method
             required: true
@@ -1625,7 +1676,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_63
+              - !<!Parameter> &ref_64
                 schema: *ref_24
                 implementation: Method
                 required: true
@@ -1637,8 +1688,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -1653,8 +1717,8 @@ operationGroups:
                   - text/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_64
           - *ref_65
+          - *ref_66
         responses:
           - !<!SchemaResponse> 
             schema: *ref_23
@@ -1684,7 +1748,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_66
+          - !<!Parameter> &ref_67
             schema: *ref_1
             implementation: Method
             required: true
@@ -1696,7 +1760,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_67
+          - !<!Parameter> &ref_68
             schema: *ref_1
             implementation: Method
             required: true
@@ -1712,6 +1776,21 @@ operationGroups:
           - *ref_48
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1722,11 +1801,11 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_66
           - *ref_67
+          - *ref_68
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_68
+            schema: *ref_69
             language: !<!Languages> 
               default:
                 name: ''
@@ -1754,6 +1833,21 @@ operationGroups:
           - *ref_48
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1766,7 +1860,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_69
+            schema: *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -1795,7 +1889,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_70
+          - !<!Parameter> &ref_71
             schema: *ref_1
             implementation: Method
             required: true
@@ -1811,6 +1905,21 @@ operationGroups:
           - *ref_48
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1821,10 +1930,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_70
+          - *ref_71
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_69
+            schema: *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -1853,7 +1962,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_75
+          - !<!Parameter> &ref_76
             schema: *ref_1
             implementation: Method
             required: true
@@ -1865,7 +1974,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_76
+          - !<!Parameter> &ref_77
             schema: *ref_1
             implementation: Method
             required: true
@@ -1882,8 +1991,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_72
-                schema: *ref_71
+              - !<!Parameter> &ref_73
+                schema: *ref_72
                 flattened: true
                 implementation: Method
                 required: true
@@ -1895,19 +2004,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_74
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_75
                 schema: *ref_34
                 implementation: Method
-                originalParameter: *ref_72
+                originalParameter: *ref_73
                 pathToProperty: []
-                targetProperty: *ref_73
+                targetProperty: *ref_74
                 language: !<!Languages> 
                   default:
                     name: keyName
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_74
+              - *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -1922,11 +2044,11 @@ operationGroups:
                   - text/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_75
           - *ref_76
+          - *ref_77
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_68
+            schema: *ref_69
             language: !<!Languages> 
               default:
                 name: ''
@@ -1962,6 +2084,21 @@ operationGroups:
           - *ref_48
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1974,7 +2111,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_77
+            schema: *ref_78
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/storage/grouped.yaml
+++ b/modelerfour/test/scenarios/storage/grouped.yaml
@@ -437,6 +437,16 @@ schemas: !<!Schemas>
           name: ApiVersion-2015-05-01-preview
           description: Api Version (2015-05-01-preview)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_50
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'application/json, text/json'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json, text/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_29
       type: dictionary
@@ -478,7 +488,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 2015-05-01-preview
       properties:
-        - !<!Property> &ref_51
+        - !<!Property> &ref_52
           schema: *ref_2
           required: true
           serializedName: name
@@ -487,7 +497,7 @@ schemas: !<!Schemas>
               name: name
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_52
+        - !<!Property> &ref_53
           schema: *ref_3
           required: false
           serializedName: type
@@ -506,7 +516,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_55
+    - !<!ObjectSchema> &ref_56
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -986,7 +996,7 @@ schemas: !<!Schemas>
     - *ref_31
     - *ref_22
     - *ref_24
-    - !<!ObjectSchema> &ref_68
+    - !<!ObjectSchema> &ref_69
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1018,7 +1028,7 @@ schemas: !<!Schemas>
           description: The access keys for the storage account.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_69
+    - !<!ObjectSchema> &ref_70
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1060,13 +1070,13 @@ schemas: !<!Schemas>
           description: The list storage accounts operation response.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_71
+    - !<!ObjectSchema> &ref_72
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
       properties:
-        - !<!Property> &ref_73
+        - !<!Property> &ref_74
           schema: *ref_34
           serializedName: keyName
           language: !<!Languages> 
@@ -1084,7 +1094,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_77
+    - !<!ObjectSchema> &ref_78
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1282,7 +1292,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_50
+              - !<!Parameter> &ref_51
                 schema: *ref_49
                 flattened: true
                 implementation: Method
@@ -1295,33 +1305,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_53
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_54
                 schema: *ref_2
                 implementation: Method
-                originalParameter: *ref_50
+                originalParameter: *ref_51
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_51
+                targetProperty: *ref_52
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_54
+              - !<!VirtualParameter> &ref_55
                 schema: *ref_3
                 implementation: Method
-                originalParameter: *ref_50
+                originalParameter: *ref_51
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_52
+                targetProperty: *ref_53
                 language: !<!Languages> 
                   default:
                     name: type
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_53
               - *ref_54
+              - *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -1338,7 +1361,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -1362,7 +1385,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_57
+          - !<!Parameter> &ref_58
             schema: *ref_1
             implementation: Method
             required: true
@@ -1374,7 +1397,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_58
+          - !<!Parameter> &ref_59
             schema: *ref_1
             implementation: Method
             required: true
@@ -1391,7 +1414,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_56
+              - !<!Parameter> &ref_57
                 schema: *ref_7
                 implementation: Method
                 required: true
@@ -1403,8 +1426,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_56
+              - *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -1419,8 +1455,8 @@ operationGroups:
                   - text/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_57
           - *ref_58
+          - *ref_59
         responses:
           - !<!SchemaResponse> 
             schema: *ref_23
@@ -1460,7 +1496,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_59
+          - !<!Parameter> &ref_60
             schema: *ref_1
             implementation: Method
             required: true
@@ -1472,7 +1508,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_60
+          - !<!Parameter> &ref_61
             schema: *ref_1
             implementation: Method
             required: true
@@ -1498,8 +1534,8 @@ operationGroups:
                 method: delete
                 uri: '{$host}'
         signatureParameters:
-          - *ref_59
           - *ref_60
+          - *ref_61
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1530,7 +1566,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_61
+          - !<!Parameter> &ref_62
             schema: *ref_1
             implementation: Method
             required: true
@@ -1542,7 +1578,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_62
+          - !<!Parameter> &ref_63
             schema: *ref_1
             implementation: Method
             required: true
@@ -1558,6 +1594,21 @@ operationGroups:
           - *ref_48
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1568,8 +1619,8 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_61
           - *ref_62
+          - *ref_63
         responses:
           - !<!SchemaResponse> 
             schema: *ref_23
@@ -1596,7 +1647,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_64
+          - !<!Parameter> &ref_65
             schema: *ref_1
             implementation: Method
             required: true
@@ -1608,7 +1659,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_65
+          - !<!Parameter> &ref_66
             schema: *ref_1
             implementation: Method
             required: true
@@ -1625,7 +1676,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_63
+              - !<!Parameter> &ref_64
                 schema: *ref_24
                 implementation: Method
                 required: true
@@ -1637,8 +1688,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -1653,8 +1717,8 @@ operationGroups:
                   - text/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_64
           - *ref_65
+          - *ref_66
         responses:
           - !<!SchemaResponse> 
             schema: *ref_23
@@ -1684,7 +1748,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_66
+          - !<!Parameter> &ref_67
             schema: *ref_1
             implementation: Method
             required: true
@@ -1696,7 +1760,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_67
+          - !<!Parameter> &ref_68
             schema: *ref_1
             implementation: Method
             required: true
@@ -1712,6 +1776,21 @@ operationGroups:
           - *ref_48
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1722,11 +1801,11 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_66
           - *ref_67
+          - *ref_68
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_68
+            schema: *ref_69
             language: !<!Languages> 
               default:
                 name: ''
@@ -1754,6 +1833,21 @@ operationGroups:
           - *ref_48
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1766,7 +1860,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_69
+            schema: *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -1795,7 +1889,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_70
+          - !<!Parameter> &ref_71
             schema: *ref_1
             implementation: Method
             required: true
@@ -1811,6 +1905,21 @@ operationGroups:
           - *ref_48
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1821,10 +1930,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_70
+          - *ref_71
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_69
+            schema: *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -1853,7 +1962,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_75
+          - !<!Parameter> &ref_76
             schema: *ref_1
             implementation: Method
             required: true
@@ -1865,7 +1974,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_76
+          - !<!Parameter> &ref_77
             schema: *ref_1
             implementation: Method
             required: true
@@ -1882,8 +1991,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_72
-                schema: *ref_71
+              - !<!Parameter> &ref_73
+                schema: *ref_72
                 flattened: true
                 implementation: Method
                 required: true
@@ -1895,19 +2004,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_74
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_75
                 schema: *ref_34
                 implementation: Method
-                originalParameter: *ref_72
+                originalParameter: *ref_73
                 pathToProperty: []
-                targetProperty: *ref_73
+                targetProperty: *ref_74
                 language: !<!Languages> 
                   default:
                     name: keyName
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_74
+              - *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -1922,11 +2044,11 @@ operationGroups:
                   - text/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_75
           - *ref_76
+          - *ref_77
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_68
+            schema: *ref_69
             language: !<!Languages> 
               default:
                 name: ''
@@ -1962,6 +2084,21 @@ operationGroups:
           - *ref_48
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1974,7 +2111,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_77
+            schema: *ref_78
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/storage/modeler.yaml
+++ b/modelerfour/test/scenarios/storage/modeler.yaml
@@ -437,6 +437,16 @@ schemas: !<!Schemas>
           name: ApiVersion-2015-05-01-preview
           description: Api Version (2015-05-01-preview)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_50
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'application/json, text/json'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json, text/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_41
       type: dictionary
@@ -506,7 +516,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_51
+    - !<!ObjectSchema> &ref_52
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1025,7 +1035,7 @@ schemas: !<!Schemas>
     - *ref_20
     - *ref_22
     - *ref_27
-    - !<!ObjectSchema> &ref_67
+    - !<!ObjectSchema> &ref_68
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1057,7 +1067,7 @@ schemas: !<!Schemas>
           description: The access keys for the storage account.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_68
+    - !<!ObjectSchema> &ref_69
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1099,7 +1109,7 @@ schemas: !<!Schemas>
           description: The list storage accounts operation response.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_72
+    - !<!ObjectSchema> &ref_73
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1123,7 +1133,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_74
+    - !<!ObjectSchema> &ref_75
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1263,7 +1273,7 @@ schemas: !<!Schemas>
     - *ref_44
     - *ref_45
 globalParameters:
-  - !<!Parameter> &ref_54
+  - !<!Parameter> &ref_55
     schema: *ref_8
     implementation: Client
     required: true
@@ -1277,7 +1287,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: path
-  - !<!Parameter> &ref_52
+  - !<!Parameter> &ref_53
     schema: *ref_0
     clientDefaultValue: 'https://management.azure.com'
     implementation: Client
@@ -1293,7 +1303,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_53
+  - !<!Parameter> &ref_54
     schema: *ref_48
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -1315,13 +1325,13 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
         parameters:
-          - *ref_52
           - *ref_53
           - *ref_54
+          - *ref_55
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_50
+              - !<!Parameter> &ref_51
                 schema: *ref_49
                 implementation: Method
                 required: true
@@ -1333,8 +1343,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_50
+              - *ref_51
             language: !<!Languages> 
               default:
                 name: ''
@@ -1351,7 +1374,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_51
+            schema: *ref_52
             language: !<!Languages> 
               default:
                 name: ''
@@ -1374,8 +1397,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
         parameters:
-          - *ref_52
-          - !<!Parameter> &ref_55
+          - *ref_53
+          - !<!Parameter> &ref_56
             schema: *ref_8
             implementation: Method
             required: true
@@ -1387,7 +1410,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_56
+          - !<!Parameter> &ref_57
             schema: *ref_8
             implementation: Method
             required: true
@@ -1399,12 +1422,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_53
           - *ref_54
+          - *ref_55
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_57
+              - !<!Parameter> &ref_58
                 schema: *ref_9
                 implementation: Method
                 required: true
@@ -1416,8 +1439,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_57
+              - *ref_58
             language: !<!Languages> 
               default:
                 name: ''
@@ -1432,8 +1468,8 @@ operationGroups:
                   - text/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_55
           - *ref_56
+          - *ref_57
         responses:
           - !<!SchemaResponse> 
             schema: *ref_21
@@ -1472,8 +1508,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
         parameters:
-          - *ref_52
-          - !<!Parameter> &ref_58
+          - *ref_53
+          - !<!Parameter> &ref_59
             schema: *ref_8
             implementation: Method
             required: true
@@ -1485,7 +1521,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_59
+          - !<!Parameter> &ref_60
             schema: *ref_8
             implementation: Method
             required: true
@@ -1497,8 +1533,8 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_53
           - *ref_54
+          - *ref_55
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -1511,8 +1547,8 @@ operationGroups:
                 method: delete
                 uri: '{$host}'
         signatureParameters:
-          - *ref_58
           - *ref_59
+          - *ref_60
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1542,8 +1578,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
         parameters:
-          - *ref_52
-          - !<!Parameter> &ref_60
+          - *ref_53
+          - !<!Parameter> &ref_61
             schema: *ref_8
             implementation: Method
             required: true
@@ -1555,7 +1591,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_61
+          - !<!Parameter> &ref_62
             schema: *ref_8
             implementation: Method
             required: true
@@ -1567,10 +1603,25 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_53
           - *ref_54
+          - *ref_55
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1581,8 +1632,8 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_60
           - *ref_61
+          - *ref_62
         responses:
           - !<!SchemaResponse> 
             schema: *ref_21
@@ -1608,8 +1659,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
         parameters:
-          - *ref_52
-          - !<!Parameter> &ref_62
+          - *ref_53
+          - !<!Parameter> &ref_63
             schema: *ref_8
             implementation: Method
             required: true
@@ -1621,7 +1672,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_63
+          - !<!Parameter> &ref_64
             schema: *ref_8
             implementation: Method
             required: true
@@ -1633,12 +1684,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_53
           - *ref_54
+          - *ref_55
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_64
+              - !<!Parameter> &ref_65
                 schema: *ref_22
                 implementation: Method
                 required: true
@@ -1650,8 +1701,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_64
+              - *ref_65
             language: !<!Languages> 
               default:
                 name: ''
@@ -1666,8 +1730,8 @@ operationGroups:
                   - text/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_62
           - *ref_63
+          - *ref_64
         responses:
           - !<!SchemaResponse> 
             schema: *ref_21
@@ -1696,8 +1760,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
         parameters:
-          - *ref_52
-          - !<!Parameter> &ref_65
+          - *ref_53
+          - !<!Parameter> &ref_66
             schema: *ref_8
             implementation: Method
             required: true
@@ -1709,7 +1773,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_66
+          - !<!Parameter> &ref_67
             schema: *ref_8
             implementation: Method
             required: true
@@ -1721,10 +1785,25 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_53
           - *ref_54
+          - *ref_55
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1735,11 +1814,11 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_65
           - *ref_66
+          - *ref_67
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_67
+            schema: *ref_68
             language: !<!Languages> 
               default:
                 name: ''
@@ -1762,11 +1841,26 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
         parameters:
-          - *ref_52
           - *ref_53
           - *ref_54
+          - *ref_55
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1779,7 +1873,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_68
+            schema: *ref_69
             language: !<!Languages> 
               default:
                 name: ''
@@ -1807,8 +1901,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
         parameters:
-          - *ref_52
-          - !<!Parameter> &ref_69
+          - *ref_53
+          - !<!Parameter> &ref_70
             schema: *ref_8
             implementation: Method
             required: true
@@ -1820,10 +1914,25 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_53
           - *ref_54
+          - *ref_55
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1834,10 +1943,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_69
+          - *ref_70
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_68
+            schema: *ref_69
             language: !<!Languages> 
               default:
                 name: ''
@@ -1865,8 +1974,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
         parameters:
-          - *ref_52
-          - !<!Parameter> &ref_70
+          - *ref_53
+          - !<!Parameter> &ref_71
             schema: *ref_8
             implementation: Method
             required: true
@@ -1878,7 +1987,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_71
+          - !<!Parameter> &ref_72
             schema: *ref_8
             implementation: Method
             required: true
@@ -1890,13 +1999,13 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_53
           - *ref_54
+          - *ref_55
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_73
-                schema: *ref_72
+              - !<!Parameter> &ref_74
+                schema: *ref_73
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -1907,8 +2016,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_73
+              - *ref_74
             language: !<!Languages> 
               default:
                 name: ''
@@ -1923,11 +2045,11 @@ operationGroups:
                   - text/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_70
           - *ref_71
+          - *ref_72
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_67
+            schema: *ref_68
             language: !<!Languages> 
               default:
                 name: ''
@@ -1958,11 +2080,26 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2015-05-01-preview
         parameters:
-          - *ref_52
           - *ref_53
           - *ref_54
+          - *ref_55
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1975,7 +2112,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_74
+            schema: *ref_75
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/storage/namer.yaml
+++ b/modelerfour/test/scenarios/storage/namer.yaml
@@ -437,6 +437,16 @@ schemas: !<!Schemas>
           name: ApiVersion20150501Preview
           description: Api Version (2015-05-01-preview)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_50
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'application/json, text/json'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json, text/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_29
       type: dictionary
@@ -478,7 +488,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: 2015-05-01-preview
       properties:
-        - !<!Property> &ref_51
+        - !<!Property> &ref_52
           schema: *ref_2
           required: true
           serializedName: name
@@ -487,7 +497,7 @@ schemas: !<!Schemas>
               name: name
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_52
+        - !<!Property> &ref_53
           schema: *ref_3
           required: false
           serializedName: type
@@ -506,7 +516,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_55
+    - !<!ObjectSchema> &ref_56
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -986,7 +996,7 @@ schemas: !<!Schemas>
     - *ref_31
     - *ref_22
     - *ref_24
-    - !<!ObjectSchema> &ref_68
+    - !<!ObjectSchema> &ref_69
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1018,7 +1028,7 @@ schemas: !<!Schemas>
           description: The access keys for the storage account.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_69
+    - !<!ObjectSchema> &ref_70
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1060,13 +1070,13 @@ schemas: !<!Schemas>
           description: The list storage accounts operation response.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_71
+    - !<!ObjectSchema> &ref_72
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 2015-05-01-preview
       properties:
-        - !<!Property> &ref_73
+        - !<!Property> &ref_74
           schema: *ref_34
           serializedName: keyName
           language: !<!Languages> 
@@ -1084,7 +1094,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_77
+    - !<!ObjectSchema> &ref_78
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1282,7 +1292,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_50
+              - !<!Parameter> &ref_51
                 schema: *ref_49
                 flattened: true
                 implementation: Method
@@ -1295,33 +1305,46 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_53
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_54
                 schema: *ref_2
                 implementation: Method
-                originalParameter: *ref_50
+                originalParameter: *ref_51
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_51
+                targetProperty: *ref_52
                 language: !<!Languages> 
                   default:
                     name: name
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_54
+              - !<!VirtualParameter> &ref_55
                 schema: *ref_3
                 implementation: Method
-                originalParameter: *ref_50
+                originalParameter: *ref_51
                 pathToProperty: []
                 required: false
-                targetProperty: *ref_52
+                targetProperty: *ref_53
                 language: !<!Languages> 
                   default:
                     name: type
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_53
               - *ref_54
+              - *ref_55
             language: !<!Languages> 
               default:
                 name: ''
@@ -1338,7 +1361,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_55
+            schema: *ref_56
             language: !<!Languages> 
               default:
                 name: ''
@@ -1362,7 +1385,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_57
+          - !<!Parameter> &ref_58
             schema: *ref_1
             implementation: Method
             required: true
@@ -1374,7 +1397,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_58
+          - !<!Parameter> &ref_59
             schema: *ref_1
             implementation: Method
             required: true
@@ -1391,7 +1414,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_56
+              - !<!Parameter> &ref_57
                 schema: *ref_7
                 implementation: Method
                 required: true
@@ -1403,8 +1426,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_56
+              - *ref_57
             language: !<!Languages> 
               default:
                 name: ''
@@ -1419,8 +1455,8 @@ operationGroups:
                   - text/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_57
           - *ref_58
+          - *ref_59
         responses:
           - !<!SchemaResponse> 
             schema: *ref_23
@@ -1460,7 +1496,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_59
+          - !<!Parameter> &ref_60
             schema: *ref_1
             implementation: Method
             required: true
@@ -1472,7 +1508,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_60
+          - !<!Parameter> &ref_61
             schema: *ref_1
             implementation: Method
             required: true
@@ -1498,8 +1534,8 @@ operationGroups:
                 method: delete
                 uri: '{$host}'
         signatureParameters:
-          - *ref_59
           - *ref_60
+          - *ref_61
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1530,7 +1566,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_61
+          - !<!Parameter> &ref_62
             schema: *ref_1
             implementation: Method
             required: true
@@ -1542,7 +1578,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_62
+          - !<!Parameter> &ref_63
             schema: *ref_1
             implementation: Method
             required: true
@@ -1558,6 +1594,21 @@ operationGroups:
           - *ref_48
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1568,8 +1619,8 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_61
           - *ref_62
+          - *ref_63
         responses:
           - !<!SchemaResponse> 
             schema: *ref_23
@@ -1596,7 +1647,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_64
+          - !<!Parameter> &ref_65
             schema: *ref_1
             implementation: Method
             required: true
@@ -1608,7 +1659,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_65
+          - !<!Parameter> &ref_66
             schema: *ref_1
             implementation: Method
             required: true
@@ -1625,7 +1676,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_63
+              - !<!Parameter> &ref_64
                 schema: *ref_24
                 implementation: Method
                 required: true
@@ -1637,8 +1688,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_63
+              - *ref_64
             language: !<!Languages> 
               default:
                 name: ''
@@ -1653,8 +1717,8 @@ operationGroups:
                   - text/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_64
           - *ref_65
+          - *ref_66
         responses:
           - !<!SchemaResponse> 
             schema: *ref_23
@@ -1684,7 +1748,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_66
+          - !<!Parameter> &ref_67
             schema: *ref_1
             implementation: Method
             required: true
@@ -1696,7 +1760,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_67
+          - !<!Parameter> &ref_68
             schema: *ref_1
             implementation: Method
             required: true
@@ -1712,6 +1776,21 @@ operationGroups:
           - *ref_48
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1722,11 +1801,11 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_66
           - *ref_67
+          - *ref_68
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_68
+            schema: *ref_69
             language: !<!Languages> 
               default:
                 name: ''
@@ -1754,6 +1833,21 @@ operationGroups:
           - *ref_48
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1766,7 +1860,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_69
+            schema: *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -1795,7 +1889,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_70
+          - !<!Parameter> &ref_71
             schema: *ref_1
             implementation: Method
             required: true
@@ -1811,6 +1905,21 @@ operationGroups:
           - *ref_48
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1821,10 +1930,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_70
+          - *ref_71
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_69
+            schema: *ref_70
             language: !<!Languages> 
               default:
                 name: ''
@@ -1853,7 +1962,7 @@ operationGroups:
             version: 2015-05-01-preview
         parameters:
           - *ref_46
-          - !<!Parameter> &ref_75
+          - !<!Parameter> &ref_76
             schema: *ref_1
             implementation: Method
             required: true
@@ -1865,7 +1974,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_76
+          - !<!Parameter> &ref_77
             schema: *ref_1
             implementation: Method
             required: true
@@ -1882,8 +1991,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_72
-                schema: *ref_71
+              - !<!Parameter> &ref_73
+                schema: *ref_72
                 flattened: true
                 implementation: Method
                 required: true
@@ -1895,19 +2004,32 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_74
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_75
                 schema: *ref_34
                 implementation: Method
-                originalParameter: *ref_72
+                originalParameter: *ref_73
                 pathToProperty: []
-                targetProperty: *ref_73
+                targetProperty: *ref_74
                 language: !<!Languages> 
                   default:
                     name: keyName
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_74
+              - *ref_75
             language: !<!Languages> 
               default:
                 name: ''
@@ -1922,11 +2044,11 @@ operationGroups:
                   - text/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_75
           - *ref_76
+          - *ref_77
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_68
+            schema: *ref_69
             language: !<!Languages> 
               default:
                 name: ''
@@ -1962,6 +2084,21 @@ operationGroups:
           - *ref_48
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_50
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1974,7 +2111,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_77
+            schema: *ref_78
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/flattened.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/flattened.yaml
@@ -71,8 +71,18 @@ schemas: !<!Schemas>
           name: ApiVersion-2014-04-01-preview
           description: Api Version (2014-04-01-preview)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_10
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_11
+    - !<!ObjectSchema> &ref_12
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -104,7 +114,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_12
+    - !<!ObjectSchema> &ref_13
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -191,7 +201,7 @@ operationGroups:
         parameters:
           - *ref_7
           - *ref_8
-          - !<!Parameter> &ref_10
+          - !<!Parameter> &ref_11
             schema: *ref_5
             implementation: Method
             required: true
@@ -206,6 +216,21 @@ operationGroups:
           - *ref_9
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_10
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -216,10 +241,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_10
+          - *ref_11
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -233,7 +258,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/grouped.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/grouped.yaml
@@ -71,8 +71,18 @@ schemas: !<!Schemas>
           name: ApiVersion-2014-04-01-preview
           description: Api Version (2014-04-01-preview)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_10
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_11
+    - !<!ObjectSchema> &ref_12
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -104,7 +114,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_12
+    - !<!ObjectSchema> &ref_13
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -191,7 +201,7 @@ operationGroups:
         parameters:
           - *ref_7
           - *ref_8
-          - !<!Parameter> &ref_10
+          - !<!Parameter> &ref_11
             schema: *ref_5
             implementation: Method
             required: true
@@ -206,6 +216,21 @@ operationGroups:
           - *ref_9
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_10
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -216,10 +241,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_10
+          - *ref_11
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -233,7 +258,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/modeler.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/modeler.yaml
@@ -71,8 +71,18 @@ schemas: !<!Schemas>
           name: ApiVersion-2014-04-01-preview
           description: Api Version (2014-04-01-preview)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_8
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_8
+    - !<!ObjectSchema> &ref_9
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -104,7 +114,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_9
+    - !<!ObjectSchema> &ref_10
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -137,7 +147,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_10
+  - !<!Parameter> &ref_11
     schema: *ref_5
     implementation: Client
     required: true
@@ -151,7 +161,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: path
-  - !<!Parameter> &ref_11
+  - !<!Parameter> &ref_12
     schema: *ref_0
     clientDefaultValue: 'https://management.azure.com'
     implementation: Client
@@ -167,7 +177,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_12
+  - !<!Parameter> &ref_13
     schema: *ref_6
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -189,8 +199,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 2014-04-01-preview
         parameters:
+          - *ref_12
           - *ref_11
-          - *ref_10
           - !<!Parameter> &ref_7
             schema: *ref_5
             implementation: Method
@@ -203,9 +213,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_12
+          - *ref_13
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_8
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,7 +244,7 @@ operationGroups:
           - *ref_7
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -233,7 +258,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_9
+            schema: *ref_10
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/subscriptionId-apiVersion/namer.yaml
+++ b/modelerfour/test/scenarios/subscriptionId-apiVersion/namer.yaml
@@ -71,8 +71,18 @@ schemas: !<!Schemas>
           name: ApiVersion20140401Preview
           description: Api Version (2014-04-01-preview)
       protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_10
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_11
+    - !<!ObjectSchema> &ref_12
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -104,7 +114,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_12
+    - !<!ObjectSchema> &ref_13
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -191,7 +201,7 @@ operationGroups:
         parameters:
           - *ref_7
           - *ref_8
-          - !<!Parameter> &ref_10
+          - !<!Parameter> &ref_11
             schema: *ref_5
             implementation: Method
             required: true
@@ -206,6 +216,21 @@ operationGroups:
           - *ref_9
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_10
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -216,10 +241,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_10
+          - *ref_11
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_11
+            schema: *ref_12
             language: !<!Languages> 
               default:
                 name: ''
@@ -233,7 +258,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_12
+            schema: *ref_13
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/text-analytics/flattened.yaml
+++ b/modelerfour/test/scenarios/text-analytics/flattened.yaml
@@ -677,6 +677,17 @@ schemas: !<!Schemas>
           name: SentenceSentimentValue
           description: The predicted Sentiment for the sentence.
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_98
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'application/json, text/json'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json, text/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_21
       type: dictionary
@@ -693,7 +704,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: v3.0-preview.1
       properties:
-        - !<!Property> &ref_99
+        - !<!Property> &ref_100
           schema: !<!ArraySchema> &ref_75
             type: array
             apiVersions:
@@ -765,7 +776,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_5
-    - !<!ObjectSchema> &ref_103
+    - !<!ObjectSchema> &ref_104
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1214,7 +1225,7 @@ schemas: !<!Schemas>
     - *ref_24
     - *ref_23
     - *ref_34
-    - !<!ObjectSchema> &ref_112
+    - !<!ObjectSchema> &ref_113
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1471,7 +1482,7 @@ schemas: !<!Schemas>
     - *ref_46
     - *ref_47
     - *ref_48
-    - !<!ObjectSchema> &ref_117
+    - !<!ObjectSchema> &ref_118
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1596,13 +1607,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_52
-    - !<!ObjectSchema> &ref_118
+    - !<!ObjectSchema> &ref_119
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: v3.0-preview.1
       properties:
-        - !<!Property> &ref_120
+        - !<!Property> &ref_121
           schema: !<!ArraySchema> &ref_87
             type: array
             apiVersions:
@@ -1674,7 +1685,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_56
-    - !<!ObjectSchema> &ref_124
+    - !<!ObjectSchema> &ref_125
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1842,7 +1853,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_62
     - *ref_63
-    - !<!ObjectSchema> &ref_129
+    - !<!ObjectSchema> &ref_130
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2150,7 +2161,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_101
+          - !<!Parameter> &ref_102
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2161,7 +2172,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_102
+          - !<!Parameter> &ref_103
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2175,7 +2186,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_98
+              - !<!Parameter> &ref_99
                 schema: *ref_97
                 flattened: true
                 implementation: Method
@@ -2188,20 +2199,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_100
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_101
                 schema: *ref_75
                 implementation: Method
-                originalParameter: *ref_98
+                originalParameter: *ref_99
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_99
+                targetProperty: *ref_100
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: The set of documents to process as part of this batch.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_100
+              - *ref_101
             language: !<!Languages> 
               default:
                 name: ''
@@ -2216,11 +2240,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_101
           - *ref_102
+          - *ref_103
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_103
+            schema: *ref_104
             language: !<!Languages> 
               default:
                 name: ''
@@ -2319,7 +2343,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_106
+          - !<!Parameter> &ref_107
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2330,7 +2354,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_107
+          - !<!Parameter> &ref_108
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2344,7 +2368,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_104
+              - !<!Parameter> &ref_105
                 schema: *ref_97
                 flattened: true
                 implementation: Method
@@ -2357,20 +2381,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_105
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_106
                 schema: *ref_75
                 implementation: Method
-                originalParameter: *ref_104
+                originalParameter: *ref_105
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_99
+                targetProperty: *ref_100
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: The set of documents to process as part of this batch.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_105
+              - *ref_106
             language: !<!Languages> 
               default:
                 name: ''
@@ -2385,11 +2422,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_106
           - *ref_107
+          - *ref_108
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_103
+            schema: *ref_104
             language: !<!Languages> 
               default:
                 name: ''
@@ -2479,7 +2516,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_110
+          - !<!Parameter> &ref_111
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2490,7 +2527,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_111
+          - !<!Parameter> &ref_112
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2504,7 +2541,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_108
+              - !<!Parameter> &ref_109
                 schema: *ref_97
                 flattened: true
                 implementation: Method
@@ -2517,20 +2554,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_109
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_110
                 schema: *ref_75
                 implementation: Method
-                originalParameter: *ref_108
+                originalParameter: *ref_109
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_99
+                targetProperty: *ref_100
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: The set of documents to process as part of this batch.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_109
+              - *ref_110
             language: !<!Languages> 
               default:
                 name: ''
@@ -2545,11 +2595,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_110
           - *ref_111
+          - *ref_112
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_112
+            schema: *ref_113
             language: !<!Languages> 
               default:
                 name: ''
@@ -2649,7 +2699,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_115
+          - !<!Parameter> &ref_116
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2660,7 +2710,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_116
+          - !<!Parameter> &ref_117
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2674,7 +2724,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_113
+              - !<!Parameter> &ref_114
                 schema: *ref_97
                 flattened: true
                 implementation: Method
@@ -2687,20 +2737,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_114
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_115
                 schema: *ref_75
                 implementation: Method
-                originalParameter: *ref_113
+                originalParameter: *ref_114
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_99
+                targetProperty: *ref_100
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: The set of documents to process as part of this batch.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_114
+              - *ref_115
             language: !<!Languages> 
               default:
                 name: ''
@@ -2715,11 +2778,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_115
           - *ref_116
+          - *ref_117
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_117
+            schema: *ref_118
             language: !<!Languages> 
               default:
                 name: ''
@@ -2795,7 +2858,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_122
+          - !<!Parameter> &ref_123
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2806,7 +2869,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_123
+          - !<!Parameter> &ref_124
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2820,8 +2883,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_119
-                schema: *ref_118
+              - !<!Parameter> &ref_120
+                schema: *ref_119
                 flattened: true
                 implementation: Method
                 required: true
@@ -2833,20 +2896,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_121
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_122
                 schema: *ref_87
                 implementation: Method
-                originalParameter: *ref_119
+                originalParameter: *ref_120
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_120
+                targetProperty: *ref_121
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_121
+              - *ref_122
             language: !<!Languages> 
               default:
                 name: ''
@@ -2861,11 +2937,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_122
           - *ref_123
+          - *ref_124
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_124
+            schema: *ref_125
             language: !<!Languages> 
               default:
                 name: ''
@@ -2944,7 +3020,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_127
+          - !<!Parameter> &ref_128
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2955,7 +3031,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_128
+          - !<!Parameter> &ref_129
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2969,7 +3045,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_125
+              - !<!Parameter> &ref_126
                 schema: *ref_97
                 flattened: true
                 implementation: Method
@@ -2982,20 +3058,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_126
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_127
                 schema: *ref_75
                 implementation: Method
-                originalParameter: *ref_125
+                originalParameter: *ref_126
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_99
+                targetProperty: *ref_100
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: The set of documents to process as part of this batch.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_126
+              - *ref_127
             language: !<!Languages> 
               default:
                 name: ''
@@ -3010,11 +3099,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_127
           - *ref_128
+          - *ref_129
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_129
+            schema: *ref_130
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/text-analytics/grouped.yaml
+++ b/modelerfour/test/scenarios/text-analytics/grouped.yaml
@@ -677,6 +677,17 @@ schemas: !<!Schemas>
           name: SentenceSentimentValue
           description: The predicted Sentiment for the sentence.
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_98
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'application/json, text/json'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json, text/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_21
       type: dictionary
@@ -693,7 +704,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: v3.0-preview.1
       properties:
-        - !<!Property> &ref_99
+        - !<!Property> &ref_100
           schema: !<!ArraySchema> &ref_75
             type: array
             apiVersions:
@@ -765,7 +776,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_5
-    - !<!ObjectSchema> &ref_103
+    - !<!ObjectSchema> &ref_104
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1214,7 +1225,7 @@ schemas: !<!Schemas>
     - *ref_24
     - *ref_23
     - *ref_34
-    - !<!ObjectSchema> &ref_112
+    - !<!ObjectSchema> &ref_113
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1471,7 +1482,7 @@ schemas: !<!Schemas>
     - *ref_46
     - *ref_47
     - *ref_48
-    - !<!ObjectSchema> &ref_117
+    - !<!ObjectSchema> &ref_118
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1596,13 +1607,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_52
-    - !<!ObjectSchema> &ref_118
+    - !<!ObjectSchema> &ref_119
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: v3.0-preview.1
       properties:
-        - !<!Property> &ref_120
+        - !<!Property> &ref_121
           schema: !<!ArraySchema> &ref_87
             type: array
             apiVersions:
@@ -1674,7 +1685,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_56
-    - !<!ObjectSchema> &ref_124
+    - !<!ObjectSchema> &ref_125
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1842,7 +1853,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_62
     - *ref_63
-    - !<!ObjectSchema> &ref_129
+    - !<!ObjectSchema> &ref_130
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2150,7 +2161,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_101
+          - !<!Parameter> &ref_102
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2161,7 +2172,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_102
+          - !<!Parameter> &ref_103
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2175,7 +2186,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_98
+              - !<!Parameter> &ref_99
                 schema: *ref_97
                 flattened: true
                 implementation: Method
@@ -2188,20 +2199,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_100
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_101
                 schema: *ref_75
                 implementation: Method
-                originalParameter: *ref_98
+                originalParameter: *ref_99
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_99
+                targetProperty: *ref_100
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: The set of documents to process as part of this batch.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_100
+              - *ref_101
             language: !<!Languages> 
               default:
                 name: ''
@@ -2216,11 +2240,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_101
           - *ref_102
+          - *ref_103
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_103
+            schema: *ref_104
             language: !<!Languages> 
               default:
                 name: ''
@@ -2319,7 +2343,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_106
+          - !<!Parameter> &ref_107
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2330,7 +2354,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_107
+          - !<!Parameter> &ref_108
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2344,7 +2368,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_104
+              - !<!Parameter> &ref_105
                 schema: *ref_97
                 flattened: true
                 implementation: Method
@@ -2357,20 +2381,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_105
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_106
                 schema: *ref_75
                 implementation: Method
-                originalParameter: *ref_104
+                originalParameter: *ref_105
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_99
+                targetProperty: *ref_100
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: The set of documents to process as part of this batch.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_105
+              - *ref_106
             language: !<!Languages> 
               default:
                 name: ''
@@ -2385,11 +2422,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_106
           - *ref_107
+          - *ref_108
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_103
+            schema: *ref_104
             language: !<!Languages> 
               default:
                 name: ''
@@ -2479,7 +2516,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_110
+          - !<!Parameter> &ref_111
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2490,7 +2527,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_111
+          - !<!Parameter> &ref_112
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2504,7 +2541,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_108
+              - !<!Parameter> &ref_109
                 schema: *ref_97
                 flattened: true
                 implementation: Method
@@ -2517,20 +2554,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_109
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_110
                 schema: *ref_75
                 implementation: Method
-                originalParameter: *ref_108
+                originalParameter: *ref_109
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_99
+                targetProperty: *ref_100
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: The set of documents to process as part of this batch.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_109
+              - *ref_110
             language: !<!Languages> 
               default:
                 name: ''
@@ -2545,11 +2595,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_110
           - *ref_111
+          - *ref_112
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_112
+            schema: *ref_113
             language: !<!Languages> 
               default:
                 name: ''
@@ -2649,7 +2699,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_115
+          - !<!Parameter> &ref_116
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2660,7 +2710,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_116
+          - !<!Parameter> &ref_117
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2674,7 +2724,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_113
+              - !<!Parameter> &ref_114
                 schema: *ref_97
                 flattened: true
                 implementation: Method
@@ -2687,20 +2737,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_114
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_115
                 schema: *ref_75
                 implementation: Method
-                originalParameter: *ref_113
+                originalParameter: *ref_114
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_99
+                targetProperty: *ref_100
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: The set of documents to process as part of this batch.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_114
+              - *ref_115
             language: !<!Languages> 
               default:
                 name: ''
@@ -2715,11 +2778,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_115
           - *ref_116
+          - *ref_117
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_117
+            schema: *ref_118
             language: !<!Languages> 
               default:
                 name: ''
@@ -2795,7 +2858,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_122
+          - !<!Parameter> &ref_123
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2806,7 +2869,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_123
+          - !<!Parameter> &ref_124
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2820,8 +2883,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_119
-                schema: *ref_118
+              - !<!Parameter> &ref_120
+                schema: *ref_119
                 flattened: true
                 implementation: Method
                 required: true
@@ -2833,20 +2896,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_121
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_122
                 schema: *ref_87
                 implementation: Method
-                originalParameter: *ref_119
+                originalParameter: *ref_120
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_120
+                targetProperty: *ref_121
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_121
+              - *ref_122
             language: !<!Languages> 
               default:
                 name: ''
@@ -2861,11 +2937,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_122
           - *ref_123
+          - *ref_124
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_124
+            schema: *ref_125
             language: !<!Languages> 
               default:
                 name: ''
@@ -2944,7 +3020,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_127
+          - !<!Parameter> &ref_128
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2955,7 +3031,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_128
+          - !<!Parameter> &ref_129
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2969,7 +3045,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_125
+              - !<!Parameter> &ref_126
                 schema: *ref_97
                 flattened: true
                 implementation: Method
@@ -2982,20 +3058,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_126
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_127
                 schema: *ref_75
                 implementation: Method
-                originalParameter: *ref_125
+                originalParameter: *ref_126
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_99
+                targetProperty: *ref_100
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: The set of documents to process as part of this batch.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_126
+              - *ref_127
             language: !<!Languages> 
               default:
                 name: ''
@@ -3010,11 +3099,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_127
           - *ref_128
+          - *ref_129
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_129
+            schema: *ref_130
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/text-analytics/modeler.yaml
+++ b/modelerfour/test/scenarios/text-analytics/modeler.yaml
@@ -677,6 +677,17 @@ schemas: !<!Schemas>
           name: SentenceSentimentValue
           description: The predicted Sentiment for the sentence.
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_99
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'application/json, text/json'
+      valueType: *ref_9
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json, text/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_94
       type: dictionary
@@ -765,7 +776,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_3
-    - !<!ObjectSchema> &ref_100
+    - !<!ObjectSchema> &ref_101
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1214,7 +1225,7 @@ schemas: !<!Schemas>
     - *ref_16
     - *ref_15
     - *ref_22
-    - !<!ObjectSchema> &ref_108
+    - !<!ObjectSchema> &ref_109
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1471,7 +1482,7 @@ schemas: !<!Schemas>
     - *ref_31
     - *ref_32
     - *ref_33
-    - !<!ObjectSchema> &ref_112
+    - !<!ObjectSchema> &ref_113
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1596,7 +1607,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_37
-    - !<!ObjectSchema> &ref_115
+    - !<!ObjectSchema> &ref_116
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1674,7 +1685,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_41
-    - !<!ObjectSchema> &ref_117
+    - !<!ObjectSchema> &ref_118
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1842,7 +1853,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_46
     - *ref_47
-    - !<!ObjectSchema> &ref_121
+    - !<!ObjectSchema> &ref_122
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2121,7 +2132,7 @@ schemas: !<!Schemas>
     - *ref_73
     - *ref_74
 globalParameters:
-  - !<!Parameter> &ref_101
+  - !<!Parameter> &ref_102
     schema: *ref_9
     implementation: Client
     required: true
@@ -2149,7 +2160,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: v3.0-preview.1
         parameters:
-          - *ref_101
+          - *ref_102
           - !<!Parameter> &ref_96
             schema: *ref_13
             implementation: Method
@@ -2175,7 +2186,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_99
+              - !<!Parameter> &ref_100
                 schema: *ref_98
                 implementation: Method
                 required: true
@@ -2187,8 +2198,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_99
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_99
+              - *ref_100
             language: !<!Languages> 
               default:
                 name: ''
@@ -2207,7 +2231,7 @@ operationGroups:
           - *ref_97
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_100
+            schema: *ref_101
             language: !<!Languages> 
               default:
                 name: ''
@@ -2305,8 +2329,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: v3.0-preview.1
         parameters:
-          - *ref_101
-          - !<!Parameter> &ref_102
+          - *ref_102
+          - !<!Parameter> &ref_103
             schema: *ref_13
             implementation: Method
             language: !<!Languages> 
@@ -2317,7 +2341,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_103
+          - !<!Parameter> &ref_104
             schema: *ref_95
             implementation: Method
             language: !<!Languages> 
@@ -2331,7 +2355,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_104
+              - !<!Parameter> &ref_105
                 schema: *ref_98
                 implementation: Method
                 required: true
@@ -2343,8 +2367,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_99
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_104
+              - *ref_105
             language: !<!Languages> 
               default:
                 name: ''
@@ -2359,11 +2396,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_102
           - *ref_103
+          - *ref_104
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_100
+            schema: *ref_101
             language: !<!Languages> 
               default:
                 name: ''
@@ -2452,8 +2489,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: v3.0-preview.1
         parameters:
-          - *ref_101
-          - !<!Parameter> &ref_105
+          - *ref_102
+          - !<!Parameter> &ref_106
             schema: *ref_13
             implementation: Method
             language: !<!Languages> 
@@ -2464,7 +2501,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_106
+          - !<!Parameter> &ref_107
             schema: *ref_95
             implementation: Method
             language: !<!Languages> 
@@ -2478,7 +2515,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_107
+              - !<!Parameter> &ref_108
                 schema: *ref_98
                 implementation: Method
                 required: true
@@ -2490,8 +2527,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_99
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_107
+              - *ref_108
             language: !<!Languages> 
               default:
                 name: ''
@@ -2506,11 +2556,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_105
           - *ref_106
+          - *ref_107
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_108
+            schema: *ref_109
             language: !<!Languages> 
               default:
                 name: ''
@@ -2609,8 +2659,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: v3.0-preview.1
         parameters:
-          - *ref_101
-          - !<!Parameter> &ref_109
+          - *ref_102
+          - !<!Parameter> &ref_110
             schema: *ref_13
             implementation: Method
             language: !<!Languages> 
@@ -2621,7 +2671,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_110
+          - !<!Parameter> &ref_111
             schema: *ref_95
             implementation: Method
             language: !<!Languages> 
@@ -2635,7 +2685,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_111
+              - !<!Parameter> &ref_112
                 schema: *ref_98
                 implementation: Method
                 required: true
@@ -2647,8 +2697,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_99
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_111
+              - *ref_112
             language: !<!Languages> 
               default:
                 name: ''
@@ -2663,11 +2726,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_109
           - *ref_110
+          - *ref_111
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_112
+            schema: *ref_113
             language: !<!Languages> 
               default:
                 name: ''
@@ -2742,8 +2805,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: v3.0-preview.1
         parameters:
-          - *ref_101
-          - !<!Parameter> &ref_113
+          - *ref_102
+          - !<!Parameter> &ref_114
             schema: *ref_13
             implementation: Method
             language: !<!Languages> 
@@ -2754,7 +2817,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_114
+          - !<!Parameter> &ref_115
             schema: *ref_95
             implementation: Method
             language: !<!Languages> 
@@ -2768,8 +2831,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_116
-                schema: *ref_115
+              - !<!Parameter> &ref_117
+                schema: *ref_116
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2780,8 +2843,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_99
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_116
+              - *ref_117
             language: !<!Languages> 
               default:
                 name: ''
@@ -2796,11 +2872,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_113
           - *ref_114
+          - *ref_115
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_117
+            schema: *ref_118
             language: !<!Languages> 
               default:
                 name: ''
@@ -2878,8 +2954,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: v3.0-preview.1
         parameters:
-          - *ref_101
-          - !<!Parameter> &ref_118
+          - *ref_102
+          - !<!Parameter> &ref_119
             schema: *ref_13
             implementation: Method
             language: !<!Languages> 
@@ -2890,7 +2966,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_119
+          - !<!Parameter> &ref_120
             schema: *ref_95
             implementation: Method
             language: !<!Languages> 
@@ -2904,7 +2980,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_120
+              - !<!Parameter> &ref_121
                 schema: *ref_98
                 implementation: Method
                 required: true
@@ -2916,8 +2992,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_99
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_120
+              - *ref_121
             language: !<!Languages> 
               default:
                 name: ''
@@ -2932,11 +3021,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_118
           - *ref_119
+          - *ref_120
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_121
+            schema: *ref_122
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/text-analytics/namer.yaml
+++ b/modelerfour/test/scenarios/text-analytics/namer.yaml
@@ -677,6 +677,17 @@ schemas: !<!Schemas>
           name: SentenceSentimentValue
           description: The predicted Sentiment for the sentence.
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_98
+      type: constant
+      value: !<!ConstantValue> 
+        value: 'application/json, text/json'
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json, text/json'
+      protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_21
       type: dictionary
@@ -693,7 +704,7 @@ schemas: !<!Schemas>
         - !<!ApiVersion> 
           version: v3.0-preview.1
       properties:
-        - !<!Property> &ref_99
+        - !<!Property> &ref_100
           schema: !<!ArraySchema> &ref_75
             type: array
             apiVersions:
@@ -765,7 +776,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_5
-    - !<!ObjectSchema> &ref_103
+    - !<!ObjectSchema> &ref_104
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1214,7 +1225,7 @@ schemas: !<!Schemas>
     - *ref_24
     - *ref_23
     - *ref_34
-    - !<!ObjectSchema> &ref_112
+    - !<!ObjectSchema> &ref_113
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1471,7 +1482,7 @@ schemas: !<!Schemas>
     - *ref_46
     - *ref_47
     - *ref_48
-    - !<!ObjectSchema> &ref_117
+    - !<!ObjectSchema> &ref_118
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1596,13 +1607,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_52
-    - !<!ObjectSchema> &ref_118
+    - !<!ObjectSchema> &ref_119
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: v3.0-preview.1
       properties:
-        - !<!Property> &ref_120
+        - !<!Property> &ref_121
           schema: !<!ArraySchema> &ref_87
             type: array
             apiVersions:
@@ -1674,7 +1685,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_56
-    - !<!ObjectSchema> &ref_124
+    - !<!ObjectSchema> &ref_125
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1842,7 +1853,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_62
     - *ref_63
-    - !<!ObjectSchema> &ref_129
+    - !<!ObjectSchema> &ref_130
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2150,7 +2161,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_101
+          - !<!Parameter> &ref_102
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2161,7 +2172,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_102
+          - !<!Parameter> &ref_103
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2175,7 +2186,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_98
+              - !<!Parameter> &ref_99
                 schema: *ref_97
                 flattened: true
                 implementation: Method
@@ -2188,20 +2199,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_100
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_101
                 schema: *ref_75
                 implementation: Method
-                originalParameter: *ref_98
+                originalParameter: *ref_99
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_99
+                targetProperty: *ref_100
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: The set of documents to process as part of this batch.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_100
+              - *ref_101
             language: !<!Languages> 
               default:
                 name: ''
@@ -2216,11 +2240,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_101
           - *ref_102
+          - *ref_103
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_103
+            schema: *ref_104
             language: !<!Languages> 
               default:
                 name: ''
@@ -2319,7 +2343,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_106
+          - !<!Parameter> &ref_107
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2330,7 +2354,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_107
+          - !<!Parameter> &ref_108
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2344,7 +2368,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_104
+              - !<!Parameter> &ref_105
                 schema: *ref_97
                 flattened: true
                 implementation: Method
@@ -2357,20 +2381,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_105
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_106
                 schema: *ref_75
                 implementation: Method
-                originalParameter: *ref_104
+                originalParameter: *ref_105
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_99
+                targetProperty: *ref_100
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: The set of documents to process as part of this batch.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_105
+              - *ref_106
             language: !<!Languages> 
               default:
                 name: ''
@@ -2385,11 +2422,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_106
           - *ref_107
+          - *ref_108
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_103
+            schema: *ref_104
             language: !<!Languages> 
               default:
                 name: ''
@@ -2479,7 +2516,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_110
+          - !<!Parameter> &ref_111
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2490,7 +2527,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_111
+          - !<!Parameter> &ref_112
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2504,7 +2541,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_108
+              - !<!Parameter> &ref_109
                 schema: *ref_97
                 flattened: true
                 implementation: Method
@@ -2517,20 +2554,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_109
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_110
                 schema: *ref_75
                 implementation: Method
-                originalParameter: *ref_108
+                originalParameter: *ref_109
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_99
+                targetProperty: *ref_100
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: The set of documents to process as part of this batch.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_109
+              - *ref_110
             language: !<!Languages> 
               default:
                 name: ''
@@ -2545,11 +2595,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_110
           - *ref_111
+          - *ref_112
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_112
+            schema: *ref_113
             language: !<!Languages> 
               default:
                 name: ''
@@ -2649,7 +2699,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_115
+          - !<!Parameter> &ref_116
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2660,7 +2710,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_116
+          - !<!Parameter> &ref_117
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2674,7 +2724,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_113
+              - !<!Parameter> &ref_114
                 schema: *ref_97
                 flattened: true
                 implementation: Method
@@ -2687,20 +2737,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_114
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_115
                 schema: *ref_75
                 implementation: Method
-                originalParameter: *ref_113
+                originalParameter: *ref_114
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_99
+                targetProperty: *ref_100
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: The set of documents to process as part of this batch.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_114
+              - *ref_115
             language: !<!Languages> 
               default:
                 name: ''
@@ -2715,11 +2778,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_115
           - *ref_116
+          - *ref_117
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_117
+            schema: *ref_118
             language: !<!Languages> 
               default:
                 name: ''
@@ -2795,7 +2858,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_122
+          - !<!Parameter> &ref_123
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2806,7 +2869,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_123
+          - !<!Parameter> &ref_124
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2820,8 +2883,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_119
-                schema: *ref_118
+              - !<!Parameter> &ref_120
+                schema: *ref_119
                 flattened: true
                 implementation: Method
                 required: true
@@ -2833,20 +2896,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_121
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_122
                 schema: *ref_87
                 implementation: Method
-                originalParameter: *ref_119
+                originalParameter: *ref_120
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_120
+                targetProperty: *ref_121
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_121
+              - *ref_122
             language: !<!Languages> 
               default:
                 name: ''
@@ -2861,11 +2937,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_122
           - *ref_123
+          - *ref_124
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_124
+            schema: *ref_125
             language: !<!Languages> 
               default:
                 name: ''
@@ -2944,7 +3020,7 @@ operationGroups:
             version: v3.0-preview.1
         parameters:
           - *ref_95
-          - !<!Parameter> &ref_127
+          - !<!Parameter> &ref_128
             schema: *ref_1
             implementation: Method
             language: !<!Languages> 
@@ -2955,7 +3031,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - !<!Parameter> &ref_128
+          - !<!Parameter> &ref_129
             schema: *ref_96
             implementation: Method
             language: !<!Languages> 
@@ -2969,7 +3045,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_125
+              - !<!Parameter> &ref_126
                 schema: *ref_97
                 flattened: true
                 implementation: Method
@@ -2982,20 +3058,33 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_126
+              - !<!Parameter> 
+                schema: *ref_98
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_127
                 schema: *ref_75
                 implementation: Method
-                originalParameter: *ref_125
+                originalParameter: *ref_126
                 pathToProperty: []
                 required: true
-                targetProperty: *ref_99
+                targetProperty: *ref_100
                 language: !<!Languages> 
                   default:
                     name: documents
                     description: The set of documents to process as part of this batch.
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_126
+              - *ref_127
             language: !<!Languages> 
               default:
                 name: ''
@@ -3010,11 +3099,11 @@ operationGroups:
                   - text/json
                 uri: '{Endpoint}/text/analytics/v3.0-preview.1'
         signatureParameters:
-          - *ref_127
           - *ref_128
+          - *ref_129
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_129
+            schema: *ref_130
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/flattened.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: url-multi-collectionFormat
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_4
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: get-0-itemsItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -40,7 +40,7 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -50,15 +50,26 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_7
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_8
+    - !<!ObjectSchema> &ref_9
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -66,7 +77,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -89,18 +100,18 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_2
+      elementType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·clhwmo·queries-array-multi-string-null·get·parameters·0·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_9
+    - !<!ArraySchema> &ref_10
       type: array
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_3
+      elementType: *ref_4
       language: !<!Languages> 
         default:
           name: paths·1bxsii3·queries-array-multi-string-empty·get·parameters·0·schema
@@ -108,7 +119,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_5
-    schema: *ref_4
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -133,7 +144,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_7
+          - !<!Parameter> &ref_8
             schema: *ref_6
             implementation: Method
             language: !<!Languages> 
@@ -148,6 +159,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -158,7 +184,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_7
+          - *ref_8
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -171,7 +197,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,8 +220,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_10
-            schema: *ref_9
+          - !<!Parameter> &ref_11
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -209,6 +235,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,7 +260,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_10
+          - *ref_11
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -232,7 +273,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -255,8 +296,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_11
-            schema: *ref_9
+          - !<!Parameter> &ref_12
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -270,6 +311,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -280,7 +336,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_11
+          - *ref_12
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -293,7 +349,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/grouped.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: url-multi-collectionFormat
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_4
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: string
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: get-0-itemsItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -40,7 +40,7 @@ schemas: !<!Schemas>
           name: Error-message
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -50,15 +50,26 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_7
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_8
+    - !<!ObjectSchema> &ref_9
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -66,7 +77,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -89,18 +100,18 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_2
+      elementType: *ref_3
       language: !<!Languages> 
         default:
           name: paths·clhwmo·queries-array-multi-string-null·get·parameters·0·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_9
+    - !<!ArraySchema> &ref_10
       type: array
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_3
+      elementType: *ref_4
       language: !<!Languages> 
         default:
           name: paths·1bxsii3·queries-array-multi-string-empty·get·parameters·0·schema
@@ -108,7 +119,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_5
-    schema: *ref_4
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -133,7 +144,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_7
+          - !<!Parameter> &ref_8
             schema: *ref_6
             implementation: Method
             language: !<!Languages> 
@@ -148,6 +159,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -158,7 +184,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_7
+          - *ref_8
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -171,7 +197,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,8 +220,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_10
-            schema: *ref_9
+          - !<!Parameter> &ref_11
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -209,6 +235,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,7 +260,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_10
+          - *ref_11
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -232,7 +273,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -255,8 +296,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_11
-            schema: *ref_9
+          - !<!Parameter> &ref_12
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -270,6 +311,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -280,7 +336,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_11
+          - *ref_12
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -293,7 +349,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/modeler.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/modeler.yaml
@@ -50,8 +50,19 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_7
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_4
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_7
+    - !<!ObjectSchema> &ref_8
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -95,7 +106,7 @@ schemas: !<!Schemas>
           name: paths·clhwmo·queries-array-multi-string-null·get·parameters·0·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_9
+    - !<!ArraySchema> &ref_10
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -107,7 +118,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_8
+  - !<!Parameter> &ref_9
     schema: *ref_4
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -132,7 +143,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_8
+          - *ref_9
           - !<!Parameter> &ref_6
             schema: *ref_5
             implementation: Method
@@ -148,6 +159,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -171,7 +197,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -193,9 +219,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_8
-          - !<!Parameter> &ref_10
-            schema: *ref_9
+          - *ref_9
+          - !<!Parameter> &ref_11
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -209,6 +235,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,7 +260,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_10
+          - *ref_11
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -232,7 +273,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''
@@ -254,9 +295,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_8
-          - !<!Parameter> &ref_11
-            schema: *ref_9
+          - *ref_9
+          - !<!Parameter> &ref_12
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -270,6 +311,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -280,7 +336,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_11
+          - *ref_12
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -293,7 +349,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_7
+            schema: *ref_8
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/url-multi-collectionFormat/namer.yaml
+++ b/modelerfour/test/scenarios/url-multi-collectionFormat/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: url-multi-collectionFormat
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_0
+    - !<!NumberSchema> &ref_1
       type: integer
       precision: 32
       language: !<!Languages> 
@@ -13,14 +13,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_4
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
           name: String
           description: simple string
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_2
+    - !<!StringSchema> &ref_3
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -30,7 +30,7 @@ schemas: !<!Schemas>
           name: Get0ItemsItem
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -40,7 +40,7 @@ schemas: !<!Schemas>
           name: ErrorMessage
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -50,15 +50,26 @@ schemas: !<!Schemas>
           name: String
           description: ''
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_7
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_8
+    - !<!ObjectSchema> &ref_9
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_0
+          schema: *ref_1
           serializedName: status
           language: !<!Languages> 
             default:
@@ -66,7 +77,7 @@ schemas: !<!Schemas>
               description: ''
           protocol: !<!Protocols> {}
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: message
           language: !<!Languages> 
             default:
@@ -89,18 +100,18 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_2
+      elementType: *ref_3
       language: !<!Languages> 
         default:
           name: ArrayOfGet0ItemsItem
           description: Array of Get0ItemsItem
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_9
+    - !<!ArraySchema> &ref_10
       type: array
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      elementType: *ref_3
+      elementType: *ref_4
       language: !<!Languages> 
         default:
           name: ArrayOfString
@@ -108,7 +119,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
 globalParameters:
   - !<!Parameter> &ref_5
-    schema: *ref_4
+    schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -133,7 +144,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_7
+          - !<!Parameter> &ref_8
             schema: *ref_6
             implementation: Method
             language: !<!Languages> 
@@ -148,6 +159,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -158,7 +184,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_7
+          - *ref_8
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -171,7 +197,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -194,8 +220,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_10
-            schema: *ref_9
+          - !<!Parameter> &ref_11
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -209,6 +235,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -219,7 +260,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_10
+          - *ref_11
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -232,7 +273,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''
@@ -255,8 +296,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_5
-          - !<!Parameter> &ref_11
-            schema: *ref_9
+          - !<!Parameter> &ref_12
+            schema: *ref_10
             implementation: Method
             language: !<!Languages> 
               default:
@@ -270,6 +311,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_7
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -280,7 +336,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_11
+          - *ref_12
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -293,7 +349,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_8
+            schema: *ref_9
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/url/flattened.yaml
+++ b/modelerfour/test/scenarios/url/flattened.yaml
@@ -11,7 +11,7 @@ schemas: !<!Schemas>
           name: bool
           description: simple boolean
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_48
+    - !<!BooleanSchema> &ref_49
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -54,7 +54,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_50
+    - !<!NumberSchema> &ref_51
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -65,7 +65,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_52
+    - !<!NumberSchema> &ref_53
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -76,7 +76,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_54
+    - !<!NumberSchema> &ref_55
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -87,7 +87,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_56
+    - !<!NumberSchema> &ref_57
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -137,7 +137,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_29
+    - !<!SealedChoiceSchema> &ref_30
       choices:
         - !<!ChoiceValue> 
           value: red color
@@ -178,7 +178,17 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_15
+    - !<!ConstantSchema> &ref_14
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_16
       type: constant
       value: !<!ConstantValue> 
         value: false
@@ -188,7 +198,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_16
+    - !<!ConstantSchema> &ref_17
       type: constant
       value: !<!ConstantValue> 
         value: 1000000
@@ -198,7 +208,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_17
+    - !<!ConstantSchema> &ref_18
       type: constant
       value: !<!ConstantValue> 
         value: -1000000
@@ -208,7 +218,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_18
+    - !<!ConstantSchema> &ref_19
       type: constant
       value: !<!ConstantValue> 
         value: 10000000000
@@ -218,7 +228,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_19
+    - !<!ConstantSchema> &ref_20
       type: constant
       value: !<!ConstantValue> 
         value: -10000000000
@@ -228,7 +238,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_20
+    - !<!ConstantSchema> &ref_21
       type: constant
       value: !<!ConstantValue> 
         value: 103400000000000000000
@@ -238,7 +248,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_21
+    - !<!ConstantSchema> &ref_22
       type: constant
       value: !<!ConstantValue> 
         value: -1.034e-20
@@ -248,7 +258,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_22
+    - !<!ConstantSchema> &ref_23
       type: constant
       value: !<!ConstantValue> 
         value: 9999999.999
@@ -258,7 +268,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_23
+    - !<!ConstantSchema> &ref_24
       type: constant
       value: !<!ConstantValue> 
         value: -9999999.999
@@ -268,7 +278,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_24
+    - !<!ConstantSchema> &ref_25
       type: constant
       value: !<!ConstantValue> 
         value: 啊齄丂狛狜隣郎隣兀﨩
@@ -278,7 +288,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_25
+    - !<!ConstantSchema> &ref_26
       type: constant
       value: !<!ConstantValue> 
         value: 'begin!*''();:@ &=+$,/?#[]end'
@@ -288,7 +298,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_26
+    - !<!ConstantSchema> &ref_27
       type: constant
       value: !<!ConstantValue> 
         value: 'begin!*''();:@&=+$,end'
@@ -298,7 +308,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_27
+    - !<!ConstantSchema> &ref_28
       type: constant
       value: !<!ConstantValue> 
         value: ''
@@ -308,7 +318,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_34
+    - !<!ConstantSchema> &ref_35
       type: constant
       value: !<!ConstantValue> 
         value: ''
@@ -325,7 +335,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_36
+    - !<!ConstantSchema> &ref_37
       type: constant
       value: !<!ConstantValue> 
         value: '2012-01-01'
@@ -341,7 +351,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_39
+    - !<!ConstantSchema> &ref_40
       type: constant
       value: !<!ConstantValue> 
         value: '2012-01-01T01:01:01Z'
@@ -359,7 +369,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_32
+    - !<!ByteArraySchema> &ref_33
       type: byte-array
       format: byte
       apiVersions:
@@ -371,7 +381,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
     - *ref_6
-    - !<!ByteArraySchema> &ref_42
+    - !<!ByteArraySchema> &ref_43
       type: byte-array
       format: base64url
       apiVersions:
@@ -384,7 +394,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
   dateTimes:
     - *ref_7
-    - !<!DateTimeSchema> &ref_40
+    - !<!DateTimeSchema> &ref_41
       type: date-time
       format: date-time
       apiVersions:
@@ -397,7 +407,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
   dates:
     - *ref_8
-    - !<!DateSchema> &ref_37
+    - !<!DateSchema> &ref_38
       type: date
       apiVersions:
         - !<!ApiVersion> 
@@ -408,7 +418,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   unixtimes:
-    - !<!UnixTimeSchema> &ref_46
+    - !<!UnixTimeSchema> &ref_47
       type: unixtime
       apiVersions:
         - !<!ApiVersion> 
@@ -419,7 +429,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_14
+    - !<!ObjectSchema> &ref_15
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -452,7 +462,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_44
+    - !<!ArraySchema> &ref_45
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -463,7 +473,7 @@ schemas: !<!Schemas>
           name: paths·15pc9hp·paths-array-arraypath1-2cbegin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend-2c-2c-arraypath·get·parameters·0·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_65
+    - !<!ArraySchema> &ref_66
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -475,7 +485,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_72
+  - !<!Parameter> &ref_73
     schema: *ref_11
     implementation: Client
     required: true
@@ -489,7 +499,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: path
-  - !<!Parameter> &ref_73
+  - !<!Parameter> &ref_74
     schema: *ref_11
     implementation: Client
     extensions:
@@ -542,6 +552,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -564,7 +589,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -588,7 +613,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_15
+            schema: *ref_16
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -601,6 +626,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -623,7 +663,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -647,7 +687,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_16
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -660,6 +700,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -682,7 +737,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -706,7 +761,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_17
+            schema: *ref_18
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -719,6 +774,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -741,7 +811,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -765,7 +835,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_18
+            schema: *ref_19
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -778,6 +848,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -800,7 +885,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -824,7 +909,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_19
+            schema: *ref_20
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -837,6 +922,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -859,7 +959,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -883,7 +983,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_20
+            schema: *ref_21
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -896,6 +996,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -918,7 +1033,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -942,7 +1057,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_21
+            schema: *ref_22
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -955,6 +1070,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -977,7 +1107,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1001,7 +1131,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_22
+            schema: *ref_23
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1014,6 +1144,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1036,7 +1181,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1060,7 +1205,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_23
+            schema: *ref_24
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1073,6 +1218,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1095,7 +1255,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1119,7 +1279,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_24
+            schema: *ref_25
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1132,6 +1292,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1154,7 +1329,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1178,7 +1353,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_25
+            schema: *ref_26
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1191,6 +1366,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1213,7 +1403,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1237,7 +1427,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_26
+            schema: *ref_27
             implementation: Method
             required: true
             extensions:
@@ -1252,6 +1442,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1274,7 +1479,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1299,7 +1504,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_27
+            schema: *ref_28
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1312,6 +1517,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1334,7 +1554,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1357,7 +1577,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_11
             implementation: Method
             required: true
@@ -1371,6 +1591,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1381,7 +1616,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
+          - *ref_29
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1394,7 +1629,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1417,8 +1652,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_30
-            schema: *ref_29
+          - !<!Parameter> &ref_31
+            schema: *ref_30
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1431,6 +1666,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1441,7 +1691,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_30
+          - *ref_31
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1454,7 +1704,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1477,8 +1727,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_31
-            schema: *ref_29
+          - !<!Parameter> &ref_32
+            schema: *ref_30
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1491,6 +1741,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1501,7 +1766,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_31
+          - *ref_32
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1514,7 +1779,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1537,8 +1802,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_33
-            schema: *ref_32
+          - !<!Parameter> &ref_34
+            schema: *ref_33
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1551,6 +1816,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1561,7 +1841,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_33
+          - *ref_34
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1574,7 +1854,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1598,7 +1878,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_34
+            schema: *ref_35
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1611,6 +1891,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1633,7 +1928,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1656,8 +1951,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_35
-            schema: *ref_32
+          - !<!Parameter> &ref_36
+            schema: *ref_33
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1670,6 +1965,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1680,7 +1990,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_35
+          - *ref_36
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1693,7 +2003,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1717,7 +2027,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_36
+            schema: *ref_37
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1730,6 +2040,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1752,7 +2077,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1775,8 +2100,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_38
-            schema: *ref_37
+          - !<!Parameter> &ref_39
+            schema: *ref_38
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1789,6 +2114,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1799,7 +2139,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_38
+          - *ref_39
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1812,7 +2152,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1836,7 +2176,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_39
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1849,6 +2189,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1871,7 +2226,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1894,8 +2249,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_41
-            schema: *ref_40
+          - !<!Parameter> &ref_42
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1908,6 +2263,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1918,7 +2288,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_41
+          - *ref_42
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1931,7 +2301,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1954,8 +2324,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_43
-            schema: *ref_42
+          - !<!Parameter> &ref_44
+            schema: *ref_43
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1968,6 +2338,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1978,7 +2363,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_43
+          - *ref_44
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1991,7 +2376,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2014,8 +2399,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_45
-            schema: *ref_44
+          - !<!Parameter> &ref_46
+            schema: *ref_45
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2029,6 +2414,21 @@ operationGroups:
                 style: simple
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2039,7 +2439,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_45
+          - *ref_46
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2052,7 +2452,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2075,8 +2475,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_47
-            schema: *ref_46
+          - !<!Parameter> &ref_48
+            schema: *ref_47
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2089,6 +2489,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2099,7 +2514,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_47
+          - *ref_48
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2112,7 +2527,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2157,6 +2572,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2179,7 +2609,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2203,7 +2633,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_15
+            schema: *ref_16
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2216,6 +2646,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2238,7 +2683,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2261,8 +2706,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_49
-            schema: *ref_48
+          - !<!Parameter> &ref_50
+            schema: *ref_49
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2274,6 +2719,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2284,7 +2744,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_49
+          - *ref_50
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2297,7 +2757,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2321,7 +2781,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_16
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2334,6 +2794,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2356,7 +2831,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2380,7 +2855,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_17
+            schema: *ref_18
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2393,6 +2868,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2415,7 +2905,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2438,8 +2928,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_51
-            schema: *ref_50
+          - !<!Parameter> &ref_52
+            schema: *ref_51
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2451,6 +2941,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2461,7 +2966,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_51
+          - *ref_52
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2474,7 +2979,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2498,7 +3003,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_18
+            schema: *ref_19
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2511,6 +3016,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2533,7 +3053,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2557,7 +3077,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_19
+            schema: *ref_20
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2570,6 +3090,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2592,7 +3127,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2615,8 +3150,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_53
-            schema: *ref_52
+          - !<!Parameter> &ref_54
+            schema: *ref_53
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2628,6 +3163,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2638,7 +3188,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_53
+          - *ref_54
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2651,7 +3201,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2675,7 +3225,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_20
+            schema: *ref_21
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2688,6 +3238,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2710,7 +3275,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2734,7 +3299,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_21
+            schema: *ref_22
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2747,6 +3312,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2769,7 +3349,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2792,8 +3372,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_55
-            schema: *ref_54
+          - !<!Parameter> &ref_56
+            schema: *ref_55
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2805,6 +3385,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2815,7 +3410,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_55
+          - *ref_56
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2828,7 +3423,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2852,7 +3447,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_22
+            schema: *ref_23
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2865,6 +3460,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2887,7 +3497,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2911,7 +3521,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_23
+            schema: *ref_24
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2924,6 +3534,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2946,7 +3571,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2969,8 +3594,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_57
-            schema: *ref_56
+          - !<!Parameter> &ref_58
+            schema: *ref_57
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2982,6 +3607,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2992,7 +3632,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_57
+          - *ref_58
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3005,7 +3645,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3029,7 +3669,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_24
+            schema: *ref_25
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3042,6 +3682,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3064,7 +3719,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3088,7 +3743,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_25
+            schema: *ref_26
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3101,6 +3756,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3123,7 +3793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3147,7 +3817,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_27
+            schema: *ref_28
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3160,6 +3830,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3182,7 +3867,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3205,7 +3890,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_58
+          - !<!Parameter> &ref_59
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -3218,6 +3903,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3228,7 +3928,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_58
+          - *ref_59
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3241,7 +3941,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3264,8 +3964,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_59
-            schema: *ref_29
+          - !<!Parameter> &ref_60
+            schema: *ref_30
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3277,6 +3977,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3287,7 +4002,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_59
+          - *ref_60
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3300,7 +4015,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3323,8 +4038,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_60
-            schema: *ref_29
+          - !<!Parameter> &ref_61
+            schema: *ref_30
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3336,6 +4051,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3346,7 +4076,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_60
+          - *ref_61
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3359,7 +4089,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3382,8 +4112,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_61
-            schema: *ref_32
+          - !<!Parameter> &ref_62
+            schema: *ref_33
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3395,6 +4125,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3405,7 +4150,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_61
+          - *ref_62
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3418,7 +4163,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3442,7 +4187,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_34
+            schema: *ref_35
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3455,6 +4200,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3477,7 +4237,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3500,8 +4260,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_62
-            schema: *ref_32
+          - !<!Parameter> &ref_63
+            schema: *ref_33
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3513,6 +4273,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3523,7 +4298,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_62
+          - *ref_63
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3536,7 +4311,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3560,7 +4335,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_36
+            schema: *ref_37
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3573,6 +4348,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3595,7 +4385,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3618,8 +4408,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_63
-            schema: *ref_37
+          - !<!Parameter> &ref_64
+            schema: *ref_38
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3631,6 +4421,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3641,7 +4446,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_63
+          - *ref_64
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3654,7 +4459,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3678,7 +4483,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_39
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3691,6 +4496,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3713,7 +4533,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3736,8 +4556,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_64
-            schema: *ref_40
+          - !<!Parameter> &ref_65
+            schema: *ref_41
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3749,6 +4569,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3759,7 +4594,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_64
+          - *ref_65
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3772,7 +4607,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3795,8 +4630,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_66
-            schema: *ref_65
+          - !<!Parameter> &ref_67
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3809,6 +4644,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3819,7 +4669,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_66
+          - *ref_67
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3832,7 +4682,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3855,8 +4705,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_67
-            schema: *ref_65
+          - !<!Parameter> &ref_68
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3869,6 +4719,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3879,7 +4744,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_67
+          - *ref_68
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3892,7 +4757,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3915,8 +4780,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_68
-            schema: *ref_65
+          - !<!Parameter> &ref_69
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3929,6 +4794,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3939,7 +4819,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_68
+          - *ref_69
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3952,7 +4832,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3975,8 +4855,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_69
-            schema: *ref_65
+          - !<!Parameter> &ref_70
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3989,6 +4869,21 @@ operationGroups:
                 style: spaceDelimited
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3999,7 +4894,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_69
+          - *ref_70
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4012,7 +4907,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4035,8 +4930,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_70
-            schema: *ref_65
+          - !<!Parameter> &ref_71
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4049,6 +4944,21 @@ operationGroups:
                 style: tabDelimited
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4059,7 +4969,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_70
+          - *ref_71
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4072,7 +4982,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4095,8 +5005,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_71
-            schema: *ref_65
+          - !<!Parameter> &ref_72
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4109,6 +5019,21 @@ operationGroups:
                 style: pipeDelimited
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4119,7 +5044,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_71
+          - *ref_72
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4132,7 +5057,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4163,7 +5088,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_74
+          - !<!Parameter> &ref_75
             schema: *ref_11
             implementation: Method
             required: true
@@ -4175,7 +5100,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_75
+          - !<!Parameter> &ref_76
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4186,9 +5111,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_72
           - *ref_73
-          - !<!Parameter> &ref_76
+          - *ref_74
+          - !<!Parameter> &ref_77
             schema: *ref_11
             implementation: Method
             required: true
@@ -4200,7 +5125,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_77
+          - !<!Parameter> &ref_78
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4213,6 +5138,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4223,10 +5163,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_74
           - *ref_75
           - *ref_76
           - *ref_77
+          - *ref_78
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4239,7 +5179,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4264,7 +5204,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_78
+          - !<!Parameter> &ref_79
             schema: *ref_11
             implementation: Method
             required: true
@@ -4276,7 +5216,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_79
+          - !<!Parameter> &ref_80
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4287,9 +5227,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_72
           - *ref_73
-          - !<!Parameter> &ref_80
+          - *ref_74
+          - !<!Parameter> &ref_81
             schema: *ref_11
             implementation: Method
             required: true
@@ -4301,7 +5241,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_81
+          - !<!Parameter> &ref_82
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4314,6 +5254,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4324,10 +5279,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_78
           - *ref_79
           - *ref_80
           - *ref_81
+          - *ref_82
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4340,7 +5295,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4363,7 +5318,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_82
+          - !<!Parameter> &ref_83
             schema: *ref_11
             implementation: Method
             required: true
@@ -4375,7 +5330,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_83
+          - !<!Parameter> &ref_84
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4386,9 +5341,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_72
           - *ref_73
-          - !<!Parameter> &ref_84
+          - *ref_74
+          - !<!Parameter> &ref_85
             schema: *ref_11
             implementation: Method
             required: true
@@ -4400,7 +5355,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_85
+          - !<!Parameter> &ref_86
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4413,6 +5368,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4423,10 +5393,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_82
           - *ref_83
           - *ref_84
           - *ref_85
+          - *ref_86
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4439,7 +5409,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4462,7 +5432,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_86
+          - !<!Parameter> &ref_87
             schema: *ref_11
             implementation: Method
             required: true
@@ -4474,7 +5444,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_87
+          - !<!Parameter> &ref_88
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4485,9 +5455,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_72
           - *ref_73
-          - !<!Parameter> &ref_88
+          - *ref_74
+          - !<!Parameter> &ref_89
             schema: *ref_11
             implementation: Method
             required: true
@@ -4499,7 +5469,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_89
+          - !<!Parameter> &ref_90
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4512,6 +5482,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4522,10 +5507,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_86
           - *ref_87
           - *ref_88
           - *ref_89
+          - *ref_90
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4538,7 +5523,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/url/grouped.yaml
+++ b/modelerfour/test/scenarios/url/grouped.yaml
@@ -11,7 +11,7 @@ schemas: !<!Schemas>
           name: bool
           description: simple boolean
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_48
+    - !<!BooleanSchema> &ref_49
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -54,7 +54,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_50
+    - !<!NumberSchema> &ref_51
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -65,7 +65,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_52
+    - !<!NumberSchema> &ref_53
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -76,7 +76,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_54
+    - !<!NumberSchema> &ref_55
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -87,7 +87,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_56
+    - !<!NumberSchema> &ref_57
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -137,7 +137,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_29
+    - !<!SealedChoiceSchema> &ref_30
       choices:
         - !<!ChoiceValue> 
           value: red color
@@ -178,7 +178,17 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_15
+    - !<!ConstantSchema> &ref_14
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_16
       type: constant
       value: !<!ConstantValue> 
         value: false
@@ -188,7 +198,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_16
+    - !<!ConstantSchema> &ref_17
       type: constant
       value: !<!ConstantValue> 
         value: 1000000
@@ -198,7 +208,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_17
+    - !<!ConstantSchema> &ref_18
       type: constant
       value: !<!ConstantValue> 
         value: -1000000
@@ -208,7 +218,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_18
+    - !<!ConstantSchema> &ref_19
       type: constant
       value: !<!ConstantValue> 
         value: 10000000000
@@ -218,7 +228,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_19
+    - !<!ConstantSchema> &ref_20
       type: constant
       value: !<!ConstantValue> 
         value: -10000000000
@@ -228,7 +238,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_20
+    - !<!ConstantSchema> &ref_21
       type: constant
       value: !<!ConstantValue> 
         value: 103400000000000000000
@@ -238,7 +248,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_21
+    - !<!ConstantSchema> &ref_22
       type: constant
       value: !<!ConstantValue> 
         value: -1.034e-20
@@ -248,7 +258,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_22
+    - !<!ConstantSchema> &ref_23
       type: constant
       value: !<!ConstantValue> 
         value: 9999999.999
@@ -258,7 +268,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_23
+    - !<!ConstantSchema> &ref_24
       type: constant
       value: !<!ConstantValue> 
         value: -9999999.999
@@ -268,7 +278,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_24
+    - !<!ConstantSchema> &ref_25
       type: constant
       value: !<!ConstantValue> 
         value: 啊齄丂狛狜隣郎隣兀﨩
@@ -278,7 +288,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_25
+    - !<!ConstantSchema> &ref_26
       type: constant
       value: !<!ConstantValue> 
         value: 'begin!*''();:@ &=+$,/?#[]end'
@@ -288,7 +298,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_26
+    - !<!ConstantSchema> &ref_27
       type: constant
       value: !<!ConstantValue> 
         value: 'begin!*''();:@&=+$,end'
@@ -298,7 +308,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_27
+    - !<!ConstantSchema> &ref_28
       type: constant
       value: !<!ConstantValue> 
         value: ''
@@ -308,7 +318,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_34
+    - !<!ConstantSchema> &ref_35
       type: constant
       value: !<!ConstantValue> 
         value: ''
@@ -325,7 +335,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_36
+    - !<!ConstantSchema> &ref_37
       type: constant
       value: !<!ConstantValue> 
         value: '2012-01-01'
@@ -341,7 +351,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_39
+    - !<!ConstantSchema> &ref_40
       type: constant
       value: !<!ConstantValue> 
         value: '2012-01-01T01:01:01Z'
@@ -359,7 +369,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_32
+    - !<!ByteArraySchema> &ref_33
       type: byte-array
       format: byte
       apiVersions:
@@ -371,7 +381,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
     - *ref_6
-    - !<!ByteArraySchema> &ref_42
+    - !<!ByteArraySchema> &ref_43
       type: byte-array
       format: base64url
       apiVersions:
@@ -384,7 +394,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
   dateTimes:
     - *ref_7
-    - !<!DateTimeSchema> &ref_40
+    - !<!DateTimeSchema> &ref_41
       type: date-time
       format: date-time
       apiVersions:
@@ -397,7 +407,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
   dates:
     - *ref_8
-    - !<!DateSchema> &ref_37
+    - !<!DateSchema> &ref_38
       type: date
       apiVersions:
         - !<!ApiVersion> 
@@ -408,7 +418,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   unixtimes:
-    - !<!UnixTimeSchema> &ref_46
+    - !<!UnixTimeSchema> &ref_47
       type: unixtime
       apiVersions:
         - !<!ApiVersion> 
@@ -419,7 +429,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_14
+    - !<!ObjectSchema> &ref_15
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -452,7 +462,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_44
+    - !<!ArraySchema> &ref_45
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -463,7 +473,7 @@ schemas: !<!Schemas>
           name: paths·15pc9hp·paths-array-arraypath1-2cbegin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend-2c-2c-arraypath·get·parameters·0·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_65
+    - !<!ArraySchema> &ref_66
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -475,7 +485,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_72
+  - !<!Parameter> &ref_73
     schema: *ref_11
     implementation: Client
     required: true
@@ -489,7 +499,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: path
-  - !<!Parameter> &ref_73
+  - !<!Parameter> &ref_74
     schema: *ref_11
     implementation: Client
     extensions:
@@ -542,6 +552,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -564,7 +589,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -588,7 +613,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_15
+            schema: *ref_16
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -601,6 +626,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -623,7 +663,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -647,7 +687,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_16
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -660,6 +700,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -682,7 +737,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -706,7 +761,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_17
+            schema: *ref_18
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -719,6 +774,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -741,7 +811,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -765,7 +835,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_18
+            schema: *ref_19
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -778,6 +848,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -800,7 +885,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -824,7 +909,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_19
+            schema: *ref_20
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -837,6 +922,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -859,7 +959,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -883,7 +983,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_20
+            schema: *ref_21
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -896,6 +996,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -918,7 +1033,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -942,7 +1057,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_21
+            schema: *ref_22
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -955,6 +1070,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -977,7 +1107,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1001,7 +1131,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_22
+            schema: *ref_23
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1014,6 +1144,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1036,7 +1181,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1060,7 +1205,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_23
+            schema: *ref_24
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1073,6 +1218,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1095,7 +1255,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1119,7 +1279,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_24
+            schema: *ref_25
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1132,6 +1292,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1154,7 +1329,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1178,7 +1353,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_25
+            schema: *ref_26
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1191,6 +1366,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1213,7 +1403,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1237,7 +1427,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_26
+            schema: *ref_27
             implementation: Method
             required: true
             extensions:
@@ -1252,6 +1442,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1274,7 +1479,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1299,7 +1504,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_27
+            schema: *ref_28
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1312,6 +1517,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1334,7 +1554,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1357,7 +1577,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_11
             implementation: Method
             required: true
@@ -1371,6 +1591,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1381,7 +1616,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
+          - *ref_29
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1394,7 +1629,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1417,8 +1652,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_30
-            schema: *ref_29
+          - !<!Parameter> &ref_31
+            schema: *ref_30
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1431,6 +1666,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1441,7 +1691,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_30
+          - *ref_31
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1454,7 +1704,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1477,8 +1727,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_31
-            schema: *ref_29
+          - !<!Parameter> &ref_32
+            schema: *ref_30
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1491,6 +1741,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1501,7 +1766,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_31
+          - *ref_32
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1514,7 +1779,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1537,8 +1802,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_33
-            schema: *ref_32
+          - !<!Parameter> &ref_34
+            schema: *ref_33
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1551,6 +1816,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1561,7 +1841,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_33
+          - *ref_34
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1574,7 +1854,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1598,7 +1878,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_34
+            schema: *ref_35
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1611,6 +1891,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1633,7 +1928,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1656,8 +1951,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_35
-            schema: *ref_32
+          - !<!Parameter> &ref_36
+            schema: *ref_33
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1670,6 +1965,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1680,7 +1990,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_35
+          - *ref_36
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1693,7 +2003,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1717,7 +2027,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_36
+            schema: *ref_37
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1730,6 +2040,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1752,7 +2077,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1775,8 +2100,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_38
-            schema: *ref_37
+          - !<!Parameter> &ref_39
+            schema: *ref_38
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1789,6 +2114,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1799,7 +2139,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_38
+          - *ref_39
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1812,7 +2152,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1836,7 +2176,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_39
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1849,6 +2189,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1871,7 +2226,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1894,8 +2249,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_41
-            schema: *ref_40
+          - !<!Parameter> &ref_42
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1908,6 +2263,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1918,7 +2288,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_41
+          - *ref_42
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1931,7 +2301,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1954,8 +2324,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_43
-            schema: *ref_42
+          - !<!Parameter> &ref_44
+            schema: *ref_43
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1968,6 +2338,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1978,7 +2363,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_43
+          - *ref_44
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1991,7 +2376,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2014,8 +2399,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_45
-            schema: *ref_44
+          - !<!Parameter> &ref_46
+            schema: *ref_45
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2029,6 +2414,21 @@ operationGroups:
                 style: simple
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2039,7 +2439,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_45
+          - *ref_46
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2052,7 +2452,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2075,8 +2475,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_47
-            schema: *ref_46
+          - !<!Parameter> &ref_48
+            schema: *ref_47
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2089,6 +2489,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2099,7 +2514,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_47
+          - *ref_48
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2112,7 +2527,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2157,6 +2572,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2179,7 +2609,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2203,7 +2633,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_15
+            schema: *ref_16
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2216,6 +2646,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2238,7 +2683,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2261,8 +2706,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_49
-            schema: *ref_48
+          - !<!Parameter> &ref_50
+            schema: *ref_49
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2274,6 +2719,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2284,7 +2744,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_49
+          - *ref_50
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2297,7 +2757,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2321,7 +2781,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_16
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2334,6 +2794,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2356,7 +2831,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2380,7 +2855,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_17
+            schema: *ref_18
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2393,6 +2868,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2415,7 +2905,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2438,8 +2928,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_51
-            schema: *ref_50
+          - !<!Parameter> &ref_52
+            schema: *ref_51
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2451,6 +2941,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2461,7 +2966,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_51
+          - *ref_52
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2474,7 +2979,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2498,7 +3003,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_18
+            schema: *ref_19
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2511,6 +3016,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2533,7 +3053,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2557,7 +3077,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_19
+            schema: *ref_20
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2570,6 +3090,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2592,7 +3127,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2615,8 +3150,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_53
-            schema: *ref_52
+          - !<!Parameter> &ref_54
+            schema: *ref_53
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2628,6 +3163,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2638,7 +3188,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_53
+          - *ref_54
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2651,7 +3201,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2675,7 +3225,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_20
+            schema: *ref_21
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2688,6 +3238,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2710,7 +3275,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2734,7 +3299,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_21
+            schema: *ref_22
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2747,6 +3312,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2769,7 +3349,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2792,8 +3372,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_55
-            schema: *ref_54
+          - !<!Parameter> &ref_56
+            schema: *ref_55
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2805,6 +3385,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2815,7 +3410,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_55
+          - *ref_56
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2828,7 +3423,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2852,7 +3447,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_22
+            schema: *ref_23
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2865,6 +3460,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2887,7 +3497,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2911,7 +3521,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_23
+            schema: *ref_24
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2924,6 +3534,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2946,7 +3571,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2969,8 +3594,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_57
-            schema: *ref_56
+          - !<!Parameter> &ref_58
+            schema: *ref_57
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2982,6 +3607,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2992,7 +3632,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_57
+          - *ref_58
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3005,7 +3645,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3029,7 +3669,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_24
+            schema: *ref_25
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3042,6 +3682,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3064,7 +3719,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3088,7 +3743,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_25
+            schema: *ref_26
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3101,6 +3756,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3123,7 +3793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3147,7 +3817,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_27
+            schema: *ref_28
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3160,6 +3830,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3182,7 +3867,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3205,7 +3890,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_58
+          - !<!Parameter> &ref_59
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -3218,6 +3903,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3228,7 +3928,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_58
+          - *ref_59
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3241,7 +3941,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3264,8 +3964,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_59
-            schema: *ref_29
+          - !<!Parameter> &ref_60
+            schema: *ref_30
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3277,6 +3977,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3287,7 +4002,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_59
+          - *ref_60
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3300,7 +4015,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3323,8 +4038,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_60
-            schema: *ref_29
+          - !<!Parameter> &ref_61
+            schema: *ref_30
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3336,6 +4051,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3346,7 +4076,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_60
+          - *ref_61
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3359,7 +4089,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3382,8 +4112,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_61
-            schema: *ref_32
+          - !<!Parameter> &ref_62
+            schema: *ref_33
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3395,6 +4125,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3405,7 +4150,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_61
+          - *ref_62
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3418,7 +4163,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3442,7 +4187,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_34
+            schema: *ref_35
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3455,6 +4200,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3477,7 +4237,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3500,8 +4260,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_62
-            schema: *ref_32
+          - !<!Parameter> &ref_63
+            schema: *ref_33
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3513,6 +4273,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3523,7 +4298,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_62
+          - *ref_63
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3536,7 +4311,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3560,7 +4335,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_36
+            schema: *ref_37
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3573,6 +4348,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3595,7 +4385,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3618,8 +4408,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_63
-            schema: *ref_37
+          - !<!Parameter> &ref_64
+            schema: *ref_38
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3631,6 +4421,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3641,7 +4446,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_63
+          - *ref_64
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3654,7 +4459,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3678,7 +4483,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_39
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3691,6 +4496,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3713,7 +4533,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3736,8 +4556,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_64
-            schema: *ref_40
+          - !<!Parameter> &ref_65
+            schema: *ref_41
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3749,6 +4569,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3759,7 +4594,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_64
+          - *ref_65
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3772,7 +4607,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3795,8 +4630,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_66
-            schema: *ref_65
+          - !<!Parameter> &ref_67
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3809,6 +4644,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3819,7 +4669,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_66
+          - *ref_67
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3832,7 +4682,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3855,8 +4705,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_67
-            schema: *ref_65
+          - !<!Parameter> &ref_68
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3869,6 +4719,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3879,7 +4744,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_67
+          - *ref_68
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3892,7 +4757,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3915,8 +4780,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_68
-            schema: *ref_65
+          - !<!Parameter> &ref_69
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3929,6 +4794,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3939,7 +4819,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_68
+          - *ref_69
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3952,7 +4832,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3975,8 +4855,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_69
-            schema: *ref_65
+          - !<!Parameter> &ref_70
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3989,6 +4869,21 @@ operationGroups:
                 style: spaceDelimited
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3999,7 +4894,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_69
+          - *ref_70
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4012,7 +4907,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4035,8 +4930,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_70
-            schema: *ref_65
+          - !<!Parameter> &ref_71
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4049,6 +4944,21 @@ operationGroups:
                 style: tabDelimited
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4059,7 +4969,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_70
+          - *ref_71
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4072,7 +4982,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4095,8 +5005,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_71
-            schema: *ref_65
+          - !<!Parameter> &ref_72
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4109,6 +5019,21 @@ operationGroups:
                 style: pipeDelimited
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4119,7 +5044,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_71
+          - *ref_72
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4132,7 +5057,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4163,7 +5088,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_74
+          - !<!Parameter> &ref_75
             schema: *ref_11
             implementation: Method
             required: true
@@ -4175,7 +5100,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_75
+          - !<!Parameter> &ref_76
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4186,9 +5111,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_72
           - *ref_73
-          - !<!Parameter> &ref_76
+          - *ref_74
+          - !<!Parameter> &ref_77
             schema: *ref_11
             implementation: Method
             required: true
@@ -4200,7 +5125,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_77
+          - !<!Parameter> &ref_78
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4213,6 +5138,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4223,10 +5163,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_74
           - *ref_75
           - *ref_76
           - *ref_77
+          - *ref_78
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4239,7 +5179,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4264,7 +5204,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_78
+          - !<!Parameter> &ref_79
             schema: *ref_11
             implementation: Method
             required: true
@@ -4276,7 +5216,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_79
+          - !<!Parameter> &ref_80
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4287,9 +5227,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_72
           - *ref_73
-          - !<!Parameter> &ref_80
+          - *ref_74
+          - !<!Parameter> &ref_81
             schema: *ref_11
             implementation: Method
             required: true
@@ -4301,7 +5241,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_81
+          - !<!Parameter> &ref_82
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4314,6 +5254,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4324,10 +5279,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_78
           - *ref_79
           - *ref_80
           - *ref_81
+          - *ref_82
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4340,7 +5295,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4363,7 +5318,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_82
+          - !<!Parameter> &ref_83
             schema: *ref_11
             implementation: Method
             required: true
@@ -4375,7 +5330,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_83
+          - !<!Parameter> &ref_84
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4386,9 +5341,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_72
           - *ref_73
-          - !<!Parameter> &ref_84
+          - *ref_74
+          - !<!Parameter> &ref_85
             schema: *ref_11
             implementation: Method
             required: true
@@ -4400,7 +5355,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_85
+          - !<!Parameter> &ref_86
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4413,6 +5368,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4423,10 +5393,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_82
           - *ref_83
           - *ref_84
           - *ref_85
+          - *ref_86
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4439,7 +5409,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4462,7 +5432,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_86
+          - !<!Parameter> &ref_87
             schema: *ref_11
             implementation: Method
             required: true
@@ -4474,7 +5444,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_87
+          - !<!Parameter> &ref_88
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4485,9 +5455,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_72
           - *ref_73
-          - !<!Parameter> &ref_88
+          - *ref_74
+          - !<!Parameter> &ref_89
             schema: *ref_11
             implementation: Method
             required: true
@@ -4499,7 +5469,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_89
+          - !<!Parameter> &ref_90
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4512,6 +5482,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4522,10 +5507,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_86
           - *ref_87
           - *ref_88
           - *ref_89
+          - *ref_90
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4538,7 +5523,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/url/modeler.yaml
+++ b/modelerfour/test/scenarios/url/modeler.yaml
@@ -11,7 +11,7 @@ schemas: !<!Schemas>
           name: bool
           description: simple boolean
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_48
+    - !<!BooleanSchema> &ref_49
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -22,39 +22,39 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   numbers:
-    - !<!NumberSchema> &ref_1
-      type: integer
-      precision: 32
-      language: !<!Languages> 
-        default:
-          name: integer
-          description: ''
-      protocol: !<!Protocols> {}
     - !<!NumberSchema> &ref_2
       type: integer
-      precision: 64
+      precision: 32
       language: !<!Languages> 
         default:
           name: integer
           description: ''
       protocol: !<!Protocols> {}
     - !<!NumberSchema> &ref_3
-      type: number
-      precision: 32
+      type: integer
+      precision: 64
       language: !<!Languages> 
         default:
-          name: number
+          name: integer
           description: ''
       protocol: !<!Protocols> {}
     - !<!NumberSchema> &ref_4
       type: number
+      precision: 32
+      language: !<!Languages> 
+        default:
+          name: number
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!NumberSchema> &ref_5
+      type: number
       precision: 64
       language: !<!Languages> 
         default:
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_50
+    - !<!NumberSchema> &ref_51
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -65,7 +65,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_52
+    - !<!NumberSchema> &ref_53
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -76,7 +76,7 @@ schemas: !<!Schemas>
           name: integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_54
+    - !<!NumberSchema> &ref_55
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -87,7 +87,7 @@ schemas: !<!Schemas>
           name: number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_56
+    - !<!NumberSchema> &ref_57
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -99,7 +99,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_5
+    - !<!StringSchema> &ref_1
       type: string
       language: !<!Languages> 
         default:
@@ -137,7 +137,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_29
+    - !<!SealedChoiceSchema> &ref_30
       choices:
         - !<!ChoiceValue> 
           value: red color
@@ -161,7 +161,7 @@ schemas: !<!Schemas>
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
-      choiceType: *ref_5
+      choiceType: *ref_1
       language: !<!Languages> 
         default:
           name: UriColor
@@ -178,7 +178,17 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_15
+    - !<!ConstantSchema> &ref_13
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_16
       type: constant
       value: !<!ConstantValue> 
         value: false
@@ -188,21 +198,11 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_16
-      type: constant
-      value: !<!ConstantValue> 
-        value: 1000000
-      valueType: *ref_1
-      language: !<!Languages> 
-        default:
-          name: ''
-          description: ''
-      protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_17
       type: constant
       value: !<!ConstantValue> 
-        value: -1000000
-      valueType: *ref_1
+        value: 1000000
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: ''
@@ -211,7 +211,7 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_18
       type: constant
       value: !<!ConstantValue> 
-        value: 10000000000
+        value: -1000000
       valueType: *ref_2
       language: !<!Languages> 
         default:
@@ -221,8 +221,8 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_19
       type: constant
       value: !<!ConstantValue> 
-        value: -10000000000
-      valueType: *ref_2
+        value: 10000000000
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: ''
@@ -231,7 +231,7 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_20
       type: constant
       value: !<!ConstantValue> 
-        value: 103400000000000000000
+        value: -10000000000
       valueType: *ref_3
       language: !<!Languages> 
         default:
@@ -241,8 +241,8 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_21
       type: constant
       value: !<!ConstantValue> 
-        value: -1.034e-20
-      valueType: *ref_3
+        value: 103400000000000000000
+      valueType: *ref_4
       language: !<!Languages> 
         default:
           name: ''
@@ -251,7 +251,7 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_22
       type: constant
       value: !<!ConstantValue> 
-        value: 9999999.999
+        value: -1.034e-20
       valueType: *ref_4
       language: !<!Languages> 
         default:
@@ -261,8 +261,8 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_23
       type: constant
       value: !<!ConstantValue> 
-        value: -9999999.999
-      valueType: *ref_4
+        value: 9999999.999
+      valueType: *ref_5
       language: !<!Languages> 
         default:
           name: ''
@@ -271,7 +271,7 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_24
       type: constant
       value: !<!ConstantValue> 
-        value: 啊齄丂狛狜隣郎隣兀﨩
+        value: -9999999.999
       valueType: *ref_5
       language: !<!Languages> 
         default:
@@ -281,8 +281,8 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_25
       type: constant
       value: !<!ConstantValue> 
-        value: 'begin!*''();:@ &=+$,/?#[]end'
-      valueType: *ref_5
+        value: 啊齄丂狛狜隣郎隣兀﨩
+      valueType: *ref_1
       language: !<!Languages> 
         default:
           name: ''
@@ -291,8 +291,8 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_26
       type: constant
       value: !<!ConstantValue> 
-        value: 'begin!*''();:@&=+$,end'
-      valueType: *ref_5
+        value: 'begin!*''();:@ &=+$,/?#[]end'
+      valueType: *ref_1
       language: !<!Languages> 
         default:
           name: ''
@@ -301,14 +301,24 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_27
       type: constant
       value: !<!ConstantValue> 
-        value: ''
-      valueType: *ref_5
+        value: 'begin!*''();:@&=+$,end'
+      valueType: *ref_1
       language: !<!Languages> 
         default:
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_34
+    - !<!ConstantSchema> &ref_28
+      type: constant
+      value: !<!ConstantValue> 
+        value: ''
+      valueType: *ref_1
+      language: !<!Languages> 
+        default:
+          name: ''
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_35
       type: constant
       value: !<!ConstantValue> 
         value: ''
@@ -325,7 +335,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_36
+    - !<!ConstantSchema> &ref_37
       type: constant
       value: !<!ConstantValue> 
         value: '2012-01-01'
@@ -341,7 +351,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_39
+    - !<!ConstantSchema> &ref_40
       type: constant
       value: !<!ConstantValue> 
         value: '2012-01-01T01:01:01Z'
@@ -359,7 +369,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_32
+    - !<!ByteArraySchema> &ref_33
       type: byte-array
       format: byte
       apiVersions:
@@ -371,7 +381,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
     - *ref_7
-    - !<!ByteArraySchema> &ref_42
+    - !<!ByteArraySchema> &ref_43
       type: byte-array
       format: base64url
       apiVersions:
@@ -384,7 +394,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
   dateTimes:
     - *ref_9
-    - !<!DateTimeSchema> &ref_40
+    - !<!DateTimeSchema> &ref_41
       type: date-time
       format: date-time
       apiVersions:
@@ -397,7 +407,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
   dates:
     - *ref_8
-    - !<!DateSchema> &ref_37
+    - !<!DateSchema> &ref_38
       type: date
       apiVersions:
         - !<!ApiVersion> 
@@ -408,7 +418,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   unixtimes:
-    - !<!UnixTimeSchema> &ref_46
+    - !<!UnixTimeSchema> &ref_47
       type: unixtime
       apiVersions:
         - !<!ApiVersion> 
@@ -419,14 +429,14 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_13
+    - !<!ObjectSchema> &ref_14
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
         - !<!Property> 
-          schema: *ref_1
+          schema: *ref_2
           serializedName: status
           language: !<!Languages> 
             default:
@@ -452,7 +462,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_44
+    - !<!ArraySchema> &ref_45
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -463,7 +473,7 @@ schemas: !<!Schemas>
           name: paths·15pc9hp·paths-array-arraypath1-2cbegin-21-2a-27-28-29-3b-3a-40-20-26-3d-2b-24-2c-2f-3f-23-5b-5dend-2c-2c-arraypath·get·parameters·0·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_65
+    - !<!ArraySchema> &ref_66
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -475,7 +485,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_76
+  - !<!Parameter> &ref_77
     schema: *ref_11
     implementation: Client
     required: true
@@ -489,7 +499,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: path
-  - !<!Parameter> &ref_77
+  - !<!Parameter> &ref_78
     schema: *ref_11
     implementation: Client
     extensions:
@@ -502,8 +512,8 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: query
-  - !<!Parameter> &ref_14
-    schema: *ref_5
+  - !<!Parameter> &ref_15
+    schema: *ref_1
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -527,7 +537,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
             schema: *ref_12
             implementation: Method
@@ -542,6 +552,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -564,7 +589,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -586,9 +611,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_15
+            schema: *ref_16
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -601,6 +626,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -623,7 +663,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -645,9 +685,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_16
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -660,6 +700,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -682,7 +737,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -704,9 +759,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_17
+            schema: *ref_18
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -719,6 +774,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -741,7 +811,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -763,9 +833,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_18
+            schema: *ref_19
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -778,6 +848,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -800,7 +885,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -822,9 +907,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_19
+            schema: *ref_20
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -837,6 +922,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -859,7 +959,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -881,9 +981,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_20
+            schema: *ref_21
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -896,6 +996,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -918,7 +1033,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -940,9 +1055,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_21
+            schema: *ref_22
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -955,6 +1070,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -977,7 +1107,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -999,9 +1129,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_22
+            schema: *ref_23
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1014,6 +1144,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1036,7 +1181,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1058,9 +1203,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_23
+            schema: *ref_24
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1073,6 +1218,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1095,7 +1255,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1117,9 +1277,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_24
+            schema: *ref_25
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1132,6 +1292,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1154,7 +1329,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1176,9 +1351,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_25
+            schema: *ref_26
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1191,6 +1366,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1213,7 +1403,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1235,9 +1425,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_26
+            schema: *ref_27
             implementation: Method
             required: true
             extensions:
@@ -1252,6 +1442,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1274,7 +1479,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1297,9 +1502,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_27
+            schema: *ref_28
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1312,6 +1517,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1334,7 +1554,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1356,8 +1576,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_28
+          - *ref_15
+          - !<!Parameter> &ref_29
             schema: *ref_11
             implementation: Method
             required: true
@@ -1371,6 +1591,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1381,7 +1616,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
+          - *ref_29
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1394,7 +1629,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1416,9 +1651,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_30
-            schema: *ref_29
+          - *ref_15
+          - !<!Parameter> &ref_31
+            schema: *ref_30
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1431,6 +1666,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1441,7 +1691,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_30
+          - *ref_31
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1454,7 +1704,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1476,9 +1726,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_31
-            schema: *ref_29
+          - *ref_15
+          - !<!Parameter> &ref_32
+            schema: *ref_30
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1491,6 +1741,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1501,7 +1766,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_31
+          - *ref_32
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1514,7 +1779,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1536,9 +1801,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_33
-            schema: *ref_32
+          - *ref_15
+          - !<!Parameter> &ref_34
+            schema: *ref_33
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1551,6 +1816,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1561,7 +1841,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_33
+          - *ref_34
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1574,7 +1854,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1596,9 +1876,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_34
+            schema: *ref_35
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1611,6 +1891,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1633,7 +1928,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1655,9 +1950,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_35
-            schema: *ref_32
+          - *ref_15
+          - !<!Parameter> &ref_36
+            schema: *ref_33
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1670,6 +1965,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1680,7 +1990,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_35
+          - *ref_36
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1693,7 +2003,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1715,9 +2025,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_36
+            schema: *ref_37
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1730,6 +2040,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1752,7 +2077,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1774,9 +2099,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_38
-            schema: *ref_37
+          - *ref_15
+          - !<!Parameter> &ref_39
+            schema: *ref_38
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1789,6 +2114,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1799,7 +2139,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_38
+          - *ref_39
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1812,7 +2152,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1834,9 +2174,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_39
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1849,6 +2189,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1871,7 +2226,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1893,9 +2248,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_41
-            schema: *ref_40
+          - *ref_15
+          - !<!Parameter> &ref_42
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1908,6 +2263,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1918,7 +2288,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_41
+          - *ref_42
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1931,7 +2301,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -1953,9 +2323,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_43
-            schema: *ref_42
+          - *ref_15
+          - !<!Parameter> &ref_44
+            schema: *ref_43
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1968,6 +2338,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1978,7 +2363,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_43
+          - *ref_44
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1991,7 +2376,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2013,9 +2398,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_45
-            schema: *ref_44
+          - *ref_15
+          - !<!Parameter> &ref_46
+            schema: *ref_45
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2029,6 +2414,21 @@ operationGroups:
                 style: simple
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2039,7 +2439,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_45
+          - *ref_46
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2052,7 +2452,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2074,9 +2474,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_47
-            schema: *ref_46
+          - *ref_15
+          - !<!Parameter> &ref_48
+            schema: *ref_47
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2089,6 +2489,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2099,7 +2514,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_47
+          - *ref_48
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2112,7 +2527,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2142,7 +2557,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
             schema: *ref_12
             implementation: Method
@@ -2157,6 +2572,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2179,7 +2609,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2201,9 +2631,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_15
+            schema: *ref_16
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2216,6 +2646,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2238,7 +2683,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2260,9 +2705,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_49
-            schema: *ref_48
+          - *ref_15
+          - !<!Parameter> &ref_50
+            schema: *ref_49
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2274,6 +2719,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2284,7 +2744,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_49
+          - *ref_50
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2297,7 +2757,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2319,9 +2779,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_16
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2334,6 +2794,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2356,7 +2831,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2378,9 +2853,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_17
+            schema: *ref_18
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2393,6 +2868,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2415,7 +2905,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2437,9 +2927,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_51
-            schema: *ref_50
+          - *ref_15
+          - !<!Parameter> &ref_52
+            schema: *ref_51
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2451,6 +2941,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2461,7 +2966,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_51
+          - *ref_52
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2474,7 +2979,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2496,9 +3001,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_18
+            schema: *ref_19
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2511,6 +3016,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2533,7 +3053,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2555,9 +3075,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_19
+            schema: *ref_20
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2570,6 +3090,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2592,7 +3127,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2614,9 +3149,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_53
-            schema: *ref_52
+          - *ref_15
+          - !<!Parameter> &ref_54
+            schema: *ref_53
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2628,6 +3163,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2638,7 +3188,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_53
+          - *ref_54
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2651,7 +3201,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2673,9 +3223,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_20
+            schema: *ref_21
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2688,6 +3238,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2710,7 +3275,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2732,9 +3297,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_21
+            schema: *ref_22
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2747,6 +3312,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2769,7 +3349,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2791,9 +3371,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_55
-            schema: *ref_54
+          - *ref_15
+          - !<!Parameter> &ref_56
+            schema: *ref_55
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2805,6 +3385,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2815,7 +3410,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_55
+          - *ref_56
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2828,7 +3423,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2850,9 +3445,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_22
+            schema: *ref_23
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2865,6 +3460,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2887,7 +3497,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2909,9 +3519,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_23
+            schema: *ref_24
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2924,6 +3534,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2946,7 +3571,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -2968,9 +3593,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_57
-            schema: *ref_56
+          - *ref_15
+          - !<!Parameter> &ref_58
+            schema: *ref_57
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2982,6 +3607,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2992,7 +3632,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_57
+          - *ref_58
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3005,7 +3645,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3027,9 +3667,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_24
+            schema: *ref_25
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3042,6 +3682,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3064,7 +3719,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3086,9 +3741,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_25
+            schema: *ref_26
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3101,6 +3756,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3123,7 +3793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3145,9 +3815,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_27
+            schema: *ref_28
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3160,6 +3830,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3182,7 +3867,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3204,8 +3889,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_58
+          - *ref_15
+          - !<!Parameter> &ref_59
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -3218,6 +3903,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3228,7 +3928,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_58
+          - *ref_59
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3241,7 +3941,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3263,9 +3963,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_59
-            schema: *ref_29
+          - *ref_15
+          - !<!Parameter> &ref_60
+            schema: *ref_30
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3277,6 +3977,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3287,7 +4002,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_59
+          - *ref_60
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3300,7 +4015,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3322,9 +4037,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_60
-            schema: *ref_29
+          - *ref_15
+          - !<!Parameter> &ref_61
+            schema: *ref_30
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3336,6 +4051,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3346,7 +4076,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_60
+          - *ref_61
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3359,7 +4089,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3381,9 +4111,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_61
-            schema: *ref_32
+          - *ref_15
+          - !<!Parameter> &ref_62
+            schema: *ref_33
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3395,6 +4125,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3405,7 +4150,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_61
+          - *ref_62
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3418,7 +4163,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3440,9 +4185,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_34
+            schema: *ref_35
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3455,6 +4200,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3477,7 +4237,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3499,9 +4259,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_62
-            schema: *ref_32
+          - *ref_15
+          - !<!Parameter> &ref_63
+            schema: *ref_33
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3513,6 +4273,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3523,7 +4298,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_62
+          - *ref_63
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3536,7 +4311,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3558,9 +4333,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_36
+            schema: *ref_37
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3573,6 +4348,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3595,7 +4385,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3617,9 +4407,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_63
-            schema: *ref_37
+          - *ref_15
+          - !<!Parameter> &ref_64
+            schema: *ref_38
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3631,6 +4421,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3641,7 +4446,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_63
+          - *ref_64
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3654,7 +4459,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3676,9 +4481,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
+          - *ref_15
           - !<!Parameter> 
-            schema: *ref_39
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3691,6 +4496,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3713,7 +4533,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3735,9 +4555,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_64
-            schema: *ref_40
+          - *ref_15
+          - !<!Parameter> &ref_65
+            schema: *ref_41
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3749,6 +4569,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3759,7 +4594,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_64
+          - *ref_65
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3772,7 +4607,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3794,9 +4629,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_66
-            schema: *ref_65
+          - *ref_15
+          - !<!Parameter> &ref_67
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3809,6 +4644,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3819,7 +4669,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_66
+          - *ref_67
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3832,7 +4682,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3854,9 +4704,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_67
-            schema: *ref_65
+          - *ref_15
+          - !<!Parameter> &ref_68
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3869,6 +4719,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3879,7 +4744,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_67
+          - *ref_68
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3892,7 +4757,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3914,9 +4779,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_68
-            schema: *ref_65
+          - *ref_15
+          - !<!Parameter> &ref_69
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3929,6 +4794,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3939,7 +4819,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_68
+          - *ref_69
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3952,7 +4832,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -3974,9 +4854,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_69
-            schema: *ref_65
+          - *ref_15
+          - !<!Parameter> &ref_70
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3989,6 +4869,21 @@ operationGroups:
                 style: spaceDelimited
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3999,7 +4894,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_69
+          - *ref_70
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4012,7 +4907,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -4034,9 +4929,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_70
-            schema: *ref_65
+          - *ref_15
+          - !<!Parameter> &ref_71
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4049,6 +4944,21 @@ operationGroups:
                 style: tabDelimited
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4059,7 +4969,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_70
+          - *ref_71
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4072,7 +4982,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -4094,9 +5004,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_71
-            schema: *ref_65
+          - *ref_15
+          - !<!Parameter> &ref_72
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4109,6 +5019,21 @@ operationGroups:
                 style: pipeDelimited
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4119,7 +5044,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_71
+          - *ref_72
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4132,7 +5057,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -4162,8 +5087,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_72
+          - *ref_15
+          - !<!Parameter> &ref_73
             schema: *ref_11
             implementation: Method
             required: true
@@ -4175,7 +5100,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_73
+          - !<!Parameter> &ref_74
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4186,9 +5111,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_76
           - *ref_77
-          - !<!Parameter> &ref_74
+          - *ref_78
+          - !<!Parameter> &ref_75
             schema: *ref_11
             implementation: Method
             required: true
@@ -4200,7 +5125,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_75
+          - !<!Parameter> &ref_76
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4213,6 +5138,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4223,10 +5163,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_72
           - *ref_73
           - *ref_74
           - *ref_75
+          - *ref_76
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4239,7 +5179,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -4263,8 +5203,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_78
+          - *ref_15
+          - !<!Parameter> &ref_79
             schema: *ref_11
             implementation: Method
             required: true
@@ -4276,7 +5216,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_79
+          - !<!Parameter> &ref_80
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4287,9 +5227,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_76
           - *ref_77
-          - !<!Parameter> &ref_80
+          - *ref_78
+          - !<!Parameter> &ref_81
             schema: *ref_11
             implementation: Method
             required: true
@@ -4301,7 +5241,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_81
+          - !<!Parameter> &ref_82
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4314,6 +5254,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4324,10 +5279,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_78
           - *ref_79
           - *ref_80
           - *ref_81
+          - *ref_82
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4340,7 +5295,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -4362,8 +5317,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_82
+          - *ref_15
+          - !<!Parameter> &ref_83
             schema: *ref_11
             implementation: Method
             required: true
@@ -4375,7 +5330,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_83
+          - !<!Parameter> &ref_84
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4386,9 +5341,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_76
           - *ref_77
-          - !<!Parameter> &ref_84
+          - *ref_78
+          - !<!Parameter> &ref_85
             schema: *ref_11
             implementation: Method
             required: true
@@ -4400,7 +5355,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_85
+          - !<!Parameter> &ref_86
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4413,6 +5368,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4423,10 +5393,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_82
           - *ref_83
           - *ref_84
           - *ref_85
+          - *ref_86
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4439,7 +5409,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''
@@ -4461,8 +5431,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_14
-          - !<!Parameter> &ref_86
+          - *ref_15
+          - !<!Parameter> &ref_87
             schema: *ref_11
             implementation: Method
             required: true
@@ -4474,7 +5444,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_87
+          - !<!Parameter> &ref_88
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4485,9 +5455,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_76
           - *ref_77
-          - !<!Parameter> &ref_88
+          - *ref_78
+          - !<!Parameter> &ref_89
             schema: *ref_11
             implementation: Method
             required: true
@@ -4499,7 +5469,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_89
+          - !<!Parameter> &ref_90
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4512,6 +5482,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_13
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4522,10 +5507,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_86
           - *ref_87
           - *ref_88
           - *ref_89
+          - *ref_90
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4538,7 +5523,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_13
+            schema: *ref_14
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/url/namer.yaml
+++ b/modelerfour/test/scenarios/url/namer.yaml
@@ -11,7 +11,7 @@ schemas: !<!Schemas>
           name: Bool
           description: simple boolean
       protocol: !<!Protocols> {}
-    - !<!BooleanSchema> &ref_48
+    - !<!BooleanSchema> &ref_49
       type: boolean
       apiVersions:
         - !<!ApiVersion> 
@@ -54,7 +54,7 @@ schemas: !<!Schemas>
           name: Number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_50
+    - !<!NumberSchema> &ref_51
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -65,7 +65,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_52
+    - !<!NumberSchema> &ref_53
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -76,7 +76,7 @@ schemas: !<!Schemas>
           name: Integer
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_54
+    - !<!NumberSchema> &ref_55
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -87,7 +87,7 @@ schemas: !<!Schemas>
           name: Number
           description: ''
       protocol: !<!Protocols> {}
-    - !<!NumberSchema> &ref_56
+    - !<!NumberSchema> &ref_57
       type: number
       apiVersions:
         - !<!ApiVersion> 
@@ -137,7 +137,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   sealedChoices:
-    - !<!SealedChoiceSchema> &ref_29
+    - !<!SealedChoiceSchema> &ref_30
       choices:
         - !<!ChoiceValue> 
           value: red color
@@ -178,21 +178,21 @@ schemas: !<!Schemas>
           name: Constant1
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_15
+    - !<!ConstantSchema> &ref_14
       type: constant
       value: !<!ConstantValue> 
-        value: false
-      valueType: *ref_1
+        value: application/json
+      valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant2
-          description: ''
+          name: Accept
+          description: 'Accept: application/json'
       protocol: !<!Protocols> {}
     - !<!ConstantSchema> &ref_16
       type: constant
       value: !<!ConstantValue> 
-        value: 1000000
-      valueType: *ref_2
+        value: false
+      valueType: *ref_1
       language: !<!Languages> 
         default:
           name: Constant3
@@ -201,7 +201,7 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_17
       type: constant
       value: !<!ConstantValue> 
-        value: -1000000
+        value: 1000000
       valueType: *ref_2
       language: !<!Languages> 
         default:
@@ -211,8 +211,8 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_18
       type: constant
       value: !<!ConstantValue> 
-        value: 10000000000
-      valueType: *ref_3
+        value: -1000000
+      valueType: *ref_2
       language: !<!Languages> 
         default:
           name: Constant5
@@ -221,7 +221,7 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_19
       type: constant
       value: !<!ConstantValue> 
-        value: -10000000000
+        value: 10000000000
       valueType: *ref_3
       language: !<!Languages> 
         default:
@@ -231,8 +231,8 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_20
       type: constant
       value: !<!ConstantValue> 
-        value: 103400000000000000000
-      valueType: *ref_4
+        value: -10000000000
+      valueType: *ref_3
       language: !<!Languages> 
         default:
           name: Constant7
@@ -241,7 +241,7 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_21
       type: constant
       value: !<!ConstantValue> 
-        value: -1.034e-20
+        value: 103400000000000000000
       valueType: *ref_4
       language: !<!Languages> 
         default:
@@ -251,8 +251,8 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_22
       type: constant
       value: !<!ConstantValue> 
-        value: 9999999.999
-      valueType: *ref_5
+        value: -1.034e-20
+      valueType: *ref_4
       language: !<!Languages> 
         default:
           name: Constant9
@@ -261,7 +261,7 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_23
       type: constant
       value: !<!ConstantValue> 
-        value: -9999999.999
+        value: 9999999.999
       valueType: *ref_5
       language: !<!Languages> 
         default:
@@ -271,8 +271,8 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_24
       type: constant
       value: !<!ConstantValue> 
-        value: 啊齄丂狛狜隣郎隣兀﨩
-      valueType: *ref_0
+        value: -9999999.999
+      valueType: *ref_5
       language: !<!Languages> 
         default:
           name: Constant11
@@ -281,7 +281,7 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_25
       type: constant
       value: !<!ConstantValue> 
-        value: 'begin!*''();:@ &=+$,/?#[]end'
+        value: 啊齄丂狛狜隣郎隣兀﨩
       valueType: *ref_0
       language: !<!Languages> 
         default:
@@ -291,7 +291,7 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_26
       type: constant
       value: !<!ConstantValue> 
-        value: 'begin!*''();:@&=+$,end'
+        value: 'begin!*''();:@ &=+$,/?#[]end'
       valueType: *ref_0
       language: !<!Languages> 
         default:
@@ -301,14 +301,24 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_27
       type: constant
       value: !<!ConstantValue> 
-        value: ''
+        value: 'begin!*''();:@&=+$,end'
       valueType: *ref_0
       language: !<!Languages> 
         default:
           name: Constant14
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_34
+    - !<!ConstantSchema> &ref_28
+      type: constant
+      value: !<!ConstantValue> 
+        value: ''
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Constant15
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_35
       type: constant
       value: !<!ConstantValue> 
         value: ''
@@ -322,10 +332,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       language: !<!Languages> 
         default:
-          name: Constant15
+          name: Constant16
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_36
+    - !<!ConstantSchema> &ref_37
       type: constant
       value: !<!ConstantValue> 
         value: '2012-01-01'
@@ -338,10 +348,10 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       language: !<!Languages> 
         default:
-          name: Constant16
+          name: Constant17
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_39
+    - !<!ConstantSchema> &ref_40
       type: constant
       value: !<!ConstantValue> 
         value: '2012-01-01T01:01:01Z'
@@ -355,11 +365,11 @@ schemas: !<!Schemas>
         protocol: !<!Protocols> {}
       language: !<!Languages> 
         default:
-          name: Constant17
+          name: Constant18
           description: ''
       protocol: !<!Protocols> {}
   byteArrays:
-    - !<!ByteArraySchema> &ref_32
+    - !<!ByteArraySchema> &ref_33
       type: byte-array
       format: byte
       apiVersions:
@@ -371,7 +381,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
     - *ref_6
-    - !<!ByteArraySchema> &ref_42
+    - !<!ByteArraySchema> &ref_43
       type: byte-array
       format: base64url
       apiVersions:
@@ -384,7 +394,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
   dateTimes:
     - *ref_7
-    - !<!DateTimeSchema> &ref_40
+    - !<!DateTimeSchema> &ref_41
       type: date-time
       format: date-time
       apiVersions:
@@ -397,7 +407,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
   dates:
     - *ref_8
-    - !<!DateSchema> &ref_37
+    - !<!DateSchema> &ref_38
       type: date
       apiVersions:
         - !<!ApiVersion> 
@@ -408,7 +418,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   unixtimes:
-    - !<!UnixTimeSchema> &ref_46
+    - !<!UnixTimeSchema> &ref_47
       type: unixtime
       apiVersions:
         - !<!ApiVersion> 
@@ -419,7 +429,7 @@ schemas: !<!Schemas>
           description: 'date in seconds since 1970-01-01T00:00:00Z.'
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_14
+    - !<!ObjectSchema> &ref_15
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -452,7 +462,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
   arrays:
-    - !<!ArraySchema> &ref_44
+    - !<!ArraySchema> &ref_45
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -463,7 +473,7 @@ schemas: !<!Schemas>
           name: ArrayOfGet0ItemsItem
           description: Array of Get0ItemsItem
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_65
+    - !<!ArraySchema> &ref_66
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -475,7 +485,7 @@ schemas: !<!Schemas>
           description: Array of String
       protocol: !<!Protocols> {}
 globalParameters:
-  - !<!Parameter> &ref_72
+  - !<!Parameter> &ref_73
     schema: *ref_11
     implementation: Client
     required: true
@@ -489,7 +499,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: path
-  - !<!Parameter> &ref_73
+  - !<!Parameter> &ref_74
     schema: *ref_11
     implementation: Client
     extensions:
@@ -542,6 +552,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -564,7 +589,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -588,7 +613,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_15
+            schema: *ref_16
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -601,6 +626,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -623,7 +663,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -647,7 +687,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_16
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -660,6 +700,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -682,7 +737,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -706,7 +761,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_17
+            schema: *ref_18
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -719,6 +774,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -741,7 +811,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -765,7 +835,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_18
+            schema: *ref_19
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -778,6 +848,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -800,7 +885,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -824,7 +909,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_19
+            schema: *ref_20
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -837,6 +922,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -859,7 +959,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -883,7 +983,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_20
+            schema: *ref_21
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -896,6 +996,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -918,7 +1033,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -942,7 +1057,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_21
+            schema: *ref_22
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -955,6 +1070,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -977,7 +1107,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1001,7 +1131,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_22
+            schema: *ref_23
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1014,6 +1144,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1036,7 +1181,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1060,7 +1205,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_23
+            schema: *ref_24
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1073,6 +1218,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1095,7 +1255,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1119,7 +1279,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_24
+            schema: *ref_25
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1132,6 +1292,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1154,7 +1329,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1178,7 +1353,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_25
+            schema: *ref_26
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1191,6 +1366,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1213,7 +1403,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1237,7 +1427,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_26
+            schema: *ref_27
             implementation: Method
             required: true
             extensions:
@@ -1252,6 +1442,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1274,7 +1479,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1299,7 +1504,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_27
+            schema: *ref_28
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1312,6 +1517,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1334,7 +1554,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1357,7 +1577,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_11
             implementation: Method
             required: true
@@ -1371,6 +1591,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1381,7 +1616,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
+          - *ref_29
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1394,7 +1629,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1417,8 +1652,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_30
-            schema: *ref_29
+          - !<!Parameter> &ref_31
+            schema: *ref_30
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1431,6 +1666,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1441,7 +1691,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_30
+          - *ref_31
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1454,7 +1704,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1477,8 +1727,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_31
-            schema: *ref_29
+          - !<!Parameter> &ref_32
+            schema: *ref_30
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1491,6 +1741,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1501,7 +1766,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_31
+          - *ref_32
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1514,7 +1779,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1537,8 +1802,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_33
-            schema: *ref_32
+          - !<!Parameter> &ref_34
+            schema: *ref_33
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1551,6 +1816,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1561,7 +1841,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_33
+          - *ref_34
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1574,7 +1854,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1598,7 +1878,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_34
+            schema: *ref_35
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1611,6 +1891,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1633,7 +1928,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1656,8 +1951,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_35
-            schema: *ref_32
+          - !<!Parameter> &ref_36
+            schema: *ref_33
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1670,6 +1965,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1680,7 +1990,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_35
+          - *ref_36
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1693,7 +2003,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1717,7 +2027,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_36
+            schema: *ref_37
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1730,6 +2040,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1752,7 +2077,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1775,8 +2100,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_38
-            schema: *ref_37
+          - !<!Parameter> &ref_39
+            schema: *ref_38
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1789,6 +2114,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1799,7 +2139,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_38
+          - *ref_39
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1812,7 +2152,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1836,7 +2176,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_39
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1849,6 +2189,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1871,7 +2226,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1894,8 +2249,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_41
-            schema: *ref_40
+          - !<!Parameter> &ref_42
+            schema: *ref_41
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1908,6 +2263,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1918,7 +2288,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_41
+          - *ref_42
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1931,7 +2301,7 @@ operationGroups:
                   - '400'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -1954,8 +2324,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_43
-            schema: *ref_42
+          - !<!Parameter> &ref_44
+            schema: *ref_43
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -1968,6 +2338,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -1978,7 +2363,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_43
+          - *ref_44
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -1991,7 +2376,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2014,8 +2399,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_45
-            schema: *ref_44
+          - !<!Parameter> &ref_46
+            schema: *ref_45
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2029,6 +2414,21 @@ operationGroups:
                 style: simple
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2039,7 +2439,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_45
+          - *ref_46
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2052,7 +2452,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2075,8 +2475,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_47
-            schema: *ref_46
+          - !<!Parameter> &ref_48
+            schema: *ref_47
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2089,6 +2489,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2099,7 +2514,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_47
+          - *ref_48
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2112,7 +2527,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2157,6 +2572,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2179,7 +2609,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2203,7 +2633,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_15
+            schema: *ref_16
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2216,6 +2646,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2238,7 +2683,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2261,8 +2706,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_49
-            schema: *ref_48
+          - !<!Parameter> &ref_50
+            schema: *ref_49
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2274,6 +2719,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2284,7 +2744,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_49
+          - *ref_50
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2297,7 +2757,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2321,7 +2781,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_16
+            schema: *ref_17
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2334,6 +2794,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2356,7 +2831,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2380,7 +2855,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_17
+            schema: *ref_18
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2393,6 +2868,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2415,7 +2905,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2438,8 +2928,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_51
-            schema: *ref_50
+          - !<!Parameter> &ref_52
+            schema: *ref_51
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2451,6 +2941,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2461,7 +2966,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_51
+          - *ref_52
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2474,7 +2979,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2498,7 +3003,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_18
+            schema: *ref_19
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2511,6 +3016,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2533,7 +3053,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2557,7 +3077,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_19
+            schema: *ref_20
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2570,6 +3090,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2592,7 +3127,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2615,8 +3150,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_53
-            schema: *ref_52
+          - !<!Parameter> &ref_54
+            schema: *ref_53
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2628,6 +3163,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2638,7 +3188,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_53
+          - *ref_54
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2651,7 +3201,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2675,7 +3225,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_20
+            schema: *ref_21
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2688,6 +3238,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2710,7 +3275,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2734,7 +3299,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_21
+            schema: *ref_22
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2747,6 +3312,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2769,7 +3349,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2792,8 +3372,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_55
-            schema: *ref_54
+          - !<!Parameter> &ref_56
+            schema: *ref_55
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2805,6 +3385,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2815,7 +3410,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_55
+          - *ref_56
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -2828,7 +3423,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2852,7 +3447,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_22
+            schema: *ref_23
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2865,6 +3460,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2887,7 +3497,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2911,7 +3521,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_23
+            schema: *ref_24
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -2924,6 +3534,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2946,7 +3571,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -2969,8 +3594,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_57
-            schema: *ref_56
+          - !<!Parameter> &ref_58
+            schema: *ref_57
             implementation: Method
             language: !<!Languages> 
               default:
@@ -2982,6 +3607,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2992,7 +3632,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_57
+          - *ref_58
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3005,7 +3645,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3029,7 +3669,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_24
+            schema: *ref_25
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3042,6 +3682,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3064,7 +3719,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3088,7 +3743,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_25
+            schema: *ref_26
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3101,6 +3756,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3123,7 +3793,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3147,7 +3817,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_27
+            schema: *ref_28
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3160,6 +3830,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3182,7 +3867,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3205,7 +3890,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_58
+          - !<!Parameter> &ref_59
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -3218,6 +3903,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3228,7 +3928,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_58
+          - *ref_59
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3241,7 +3941,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3264,8 +3964,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_59
-            schema: *ref_29
+          - !<!Parameter> &ref_60
+            schema: *ref_30
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3277,6 +3977,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3287,7 +4002,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_59
+          - *ref_60
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3300,7 +4015,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3323,8 +4038,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_60
-            schema: *ref_29
+          - !<!Parameter> &ref_61
+            schema: *ref_30
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3336,6 +4051,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3346,7 +4076,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_60
+          - *ref_61
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3359,7 +4089,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3382,8 +4112,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_61
-            schema: *ref_32
+          - !<!Parameter> &ref_62
+            schema: *ref_33
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3395,6 +4125,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3405,7 +4150,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_61
+          - *ref_62
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3418,7 +4163,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3442,7 +4187,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_34
+            schema: *ref_35
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3455,6 +4200,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3477,7 +4237,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3500,8 +4260,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_62
-            schema: *ref_32
+          - !<!Parameter> &ref_63
+            schema: *ref_33
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3513,6 +4273,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3523,7 +4298,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_62
+          - *ref_63
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3536,7 +4311,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3560,7 +4335,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_36
+            schema: *ref_37
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3573,6 +4348,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3595,7 +4385,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3618,8 +4408,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_63
-            schema: *ref_37
+          - !<!Parameter> &ref_64
+            schema: *ref_38
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3631,6 +4421,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3641,7 +4446,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_63
+          - *ref_64
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3654,7 +4459,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3678,7 +4483,7 @@ operationGroups:
         parameters:
           - *ref_12
           - !<!Parameter> 
-            schema: *ref_39
+            schema: *ref_40
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3691,6 +4496,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3713,7 +4533,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3736,8 +4556,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_64
-            schema: *ref_40
+          - !<!Parameter> &ref_65
+            schema: *ref_41
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3749,6 +4569,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3759,7 +4594,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_64
+          - *ref_65
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3772,7 +4607,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3795,8 +4630,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_66
-            schema: *ref_65
+          - !<!Parameter> &ref_67
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3809,6 +4644,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3819,7 +4669,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_66
+          - *ref_67
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3832,7 +4682,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3855,8 +4705,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_67
-            schema: *ref_65
+          - !<!Parameter> &ref_68
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3869,6 +4719,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3879,7 +4744,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_67
+          - *ref_68
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3892,7 +4757,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3915,8 +4780,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_68
-            schema: *ref_65
+          - !<!Parameter> &ref_69
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3929,6 +4794,21 @@ operationGroups:
                 style: form
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3939,7 +4819,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_68
+          - *ref_69
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -3952,7 +4832,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -3975,8 +4855,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_69
-            schema: *ref_65
+          - !<!Parameter> &ref_70
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -3989,6 +4869,21 @@ operationGroups:
                 style: spaceDelimited
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3999,7 +4894,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_69
+          - *ref_70
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4012,7 +4907,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4035,8 +4930,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_70
-            schema: *ref_65
+          - !<!Parameter> &ref_71
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4049,6 +4944,21 @@ operationGroups:
                 style: tabDelimited
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4059,7 +4969,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_70
+          - *ref_71
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4072,7 +4982,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4095,8 +5005,8 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_71
-            schema: *ref_65
+          - !<!Parameter> &ref_72
+            schema: *ref_66
             implementation: Method
             language: !<!Languages> 
               default:
@@ -4109,6 +5019,21 @@ operationGroups:
                 style: pipeDelimited
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4119,7 +5044,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_71
+          - *ref_72
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4132,7 +5057,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4163,7 +5088,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_74
+          - !<!Parameter> &ref_75
             schema: *ref_11
             implementation: Method
             required: true
@@ -4175,7 +5100,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_75
+          - !<!Parameter> &ref_76
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4186,9 +5111,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_72
           - *ref_73
-          - !<!Parameter> &ref_76
+          - *ref_74
+          - !<!Parameter> &ref_77
             schema: *ref_11
             implementation: Method
             required: true
@@ -4200,7 +5125,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_77
+          - !<!Parameter> &ref_78
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4213,6 +5138,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4223,10 +5163,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_74
           - *ref_75
           - *ref_76
           - *ref_77
+          - *ref_78
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4239,7 +5179,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4264,7 +5204,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_78
+          - !<!Parameter> &ref_79
             schema: *ref_11
             implementation: Method
             required: true
@@ -4276,7 +5216,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_79
+          - !<!Parameter> &ref_80
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4287,9 +5227,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_72
           - *ref_73
-          - !<!Parameter> &ref_80
+          - *ref_74
+          - !<!Parameter> &ref_81
             schema: *ref_11
             implementation: Method
             required: true
@@ -4301,7 +5241,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_81
+          - !<!Parameter> &ref_82
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4314,6 +5254,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4324,10 +5279,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_78
           - *ref_79
           - *ref_80
           - *ref_81
+          - *ref_82
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4340,7 +5295,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4363,7 +5318,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_82
+          - !<!Parameter> &ref_83
             schema: *ref_11
             implementation: Method
             required: true
@@ -4375,7 +5330,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_83
+          - !<!Parameter> &ref_84
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4386,9 +5341,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_72
           - *ref_73
-          - !<!Parameter> &ref_84
+          - *ref_74
+          - !<!Parameter> &ref_85
             schema: *ref_11
             implementation: Method
             required: true
@@ -4400,7 +5355,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_85
+          - !<!Parameter> &ref_86
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4413,6 +5368,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4423,10 +5393,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_82
           - *ref_83
           - *ref_84
           - *ref_85
+          - *ref_86
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4439,7 +5409,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''
@@ -4462,7 +5432,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_12
-          - !<!Parameter> &ref_86
+          - !<!Parameter> &ref_87
             schema: *ref_11
             implementation: Method
             required: true
@@ -4474,7 +5444,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_87
+          - !<!Parameter> &ref_88
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4485,9 +5455,9 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: query
-          - *ref_72
           - *ref_73
-          - !<!Parameter> &ref_88
+          - *ref_74
+          - !<!Parameter> &ref_89
             schema: *ref_11
             implementation: Method
             required: true
@@ -4499,7 +5469,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_89
+          - !<!Parameter> &ref_90
             schema: *ref_11
             implementation: Method
             language: !<!Languages> 
@@ -4512,6 +5482,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_14
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4522,10 +5507,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_86
           - *ref_87
           - *ref_88
           - *ref_89
+          - *ref_90
         responses:
           - !<!Response> 
             language: !<!Languages> 
@@ -4538,7 +5523,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_14
+            schema: *ref_15
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/validation/flattened.yaml
+++ b/modelerfour/test/scenarios/validation/flattened.yaml
@@ -223,7 +223,17 @@ schemas: !<!Schemas>
           name: EnumConst
           description: Constant string as Enum
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_32
+    - !<!ConstantSchema> &ref_25
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_33
       type: constant
       value: !<!ConstantValue> 
         value: constant
@@ -234,7 +244,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_27
+    - !<!ObjectSchema> &ref_28
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -405,7 +415,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_12
     - *ref_13
-    - !<!ObjectSchema> &ref_28
+    - !<!ObjectSchema> &ref_29
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -502,7 +512,7 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_25
+          - !<!Parameter> &ref_26
             schema: *ref_22
             implementation: Method
             required: true
@@ -514,7 +524,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_26
+          - !<!Parameter> &ref_27
             schema: *ref_23
             implementation: Method
             required: true
@@ -529,6 +539,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -539,11 +564,11 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_25
           - *ref_26
+          - *ref_27
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -557,7 +582,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -582,7 +607,7 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_30
+          - !<!Parameter> &ref_31
             schema: *ref_22
             implementation: Method
             required: true
@@ -594,7 +619,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_31
+          - !<!Parameter> &ref_32
             schema: *ref_23
             implementation: Method
             required: true
@@ -610,8 +635,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_29
-                schema: *ref_27
+              - !<!Parameter> &ref_30
+                schema: *ref_28
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -622,8 +647,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_29
+              - *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -637,11 +675,11 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_30
           - *ref_31
+          - *ref_32
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -655,7 +693,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -680,7 +718,7 @@ operationGroups:
         parameters:
           - *ref_20
           - !<!Parameter> 
-            schema: *ref_32
+            schema: *ref_33
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -725,7 +763,7 @@ operationGroups:
         parameters:
           - *ref_20
           - !<!Parameter> 
-            schema: *ref_32
+            schema: *ref_33
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -739,8 +777,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
-                schema: *ref_27
+              - !<!Parameter> &ref_34
+                schema: *ref_28
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -751,8 +789,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -768,7 +819,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/validation/grouped.yaml
+++ b/modelerfour/test/scenarios/validation/grouped.yaml
@@ -223,7 +223,17 @@ schemas: !<!Schemas>
           name: EnumConst
           description: Constant string as Enum
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_32
+    - !<!ConstantSchema> &ref_25
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_33
       type: constant
       value: !<!ConstantValue> 
         value: constant
@@ -234,7 +244,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_27
+    - !<!ObjectSchema> &ref_28
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -405,7 +415,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_12
     - *ref_13
-    - !<!ObjectSchema> &ref_28
+    - !<!ObjectSchema> &ref_29
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -502,7 +512,7 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_25
+          - !<!Parameter> &ref_26
             schema: *ref_22
             implementation: Method
             required: true
@@ -514,7 +524,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_26
+          - !<!Parameter> &ref_27
             schema: *ref_23
             implementation: Method
             required: true
@@ -529,6 +539,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -539,11 +564,11 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_25
           - *ref_26
+          - *ref_27
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -557,7 +582,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -582,7 +607,7 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_30
+          - !<!Parameter> &ref_31
             schema: *ref_22
             implementation: Method
             required: true
@@ -594,7 +619,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_31
+          - !<!Parameter> &ref_32
             schema: *ref_23
             implementation: Method
             required: true
@@ -610,8 +635,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_29
-                schema: *ref_27
+              - !<!Parameter> &ref_30
+                schema: *ref_28
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -622,8 +647,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_29
+              - *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -637,11 +675,11 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_30
           - *ref_31
+          - *ref_32
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -655,7 +693,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -680,7 +718,7 @@ operationGroups:
         parameters:
           - *ref_20
           - !<!Parameter> 
-            schema: *ref_32
+            schema: *ref_33
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -725,7 +763,7 @@ operationGroups:
         parameters:
           - *ref_20
           - !<!Parameter> 
-            schema: *ref_32
+            schema: *ref_33
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -739,8 +777,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
-                schema: *ref_27
+              - !<!Parameter> &ref_34
+                schema: *ref_28
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -751,8 +789,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -768,7 +819,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/validation/modeler.yaml
+++ b/modelerfour/test/scenarios/validation/modeler.yaml
@@ -223,7 +223,17 @@ schemas: !<!Schemas>
           name: EnumConst
           description: Constant string as Enum
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_32
+    - !<!ConstantSchema> &ref_24
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_33
       type: constant
       value: !<!ConstantValue> 
         value: constant
@@ -234,7 +244,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_24
+    - !<!ObjectSchema> &ref_25
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -405,7 +415,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_12
     - *ref_13
-    - !<!ObjectSchema> &ref_25
+    - !<!ObjectSchema> &ref_26
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -448,7 +458,7 @@ schemas: !<!Schemas>
   arrays:
     - *ref_17
 globalParameters:
-  - !<!Parameter> &ref_27
+  - !<!Parameter> &ref_28
     schema: *ref_18
     implementation: Client
     required: true
@@ -462,7 +472,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: path
-  - !<!Parameter> &ref_26
+  - !<!Parameter> &ref_27
     schema: *ref_0
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -478,7 +488,7 @@ globalParameters:
     protocol: !<!Protocols> 
       http: !<!HttpParameter> 
         in: uri
-  - !<!Parameter> &ref_28
+  - !<!Parameter> &ref_29
     schema: *ref_21
     implementation: Client
     origin: 'modelerfour:synthesized/api-version'
@@ -500,8 +510,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_26
           - *ref_27
+          - *ref_28
           - !<!Parameter> &ref_22
             schema: *ref_19
             implementation: Method
@@ -526,9 +536,24 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -543,7 +568,7 @@ operationGroups:
           - *ref_23
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -557,7 +582,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -580,9 +605,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_26
           - *ref_27
-          - !<!Parameter> &ref_29
+          - *ref_28
+          - !<!Parameter> &ref_30
             schema: *ref_19
             implementation: Method
             required: true
@@ -594,7 +619,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_30
+          - !<!Parameter> &ref_31
             schema: *ref_20
             implementation: Method
             required: true
@@ -606,12 +631,12 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - *ref_28
+          - *ref_29
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_31
-                schema: *ref_24
+              - !<!Parameter> &ref_32
+                schema: *ref_25
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -622,8 +647,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_31
+              - *ref_32
             language: !<!Languages> 
               default:
                 name: ''
@@ -637,11 +675,11 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_29
           - *ref_30
+          - *ref_31
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''
@@ -655,7 +693,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_25
+            schema: *ref_26
             language: !<!Languages> 
               default:
                 name: ''
@@ -678,9 +716,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_26
+          - *ref_27
           - !<!Parameter> 
-            schema: *ref_32
+            schema: *ref_33
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -723,9 +761,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_26
+          - *ref_27
           - !<!Parameter> 
-            schema: *ref_32
+            schema: *ref_33
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -739,8 +777,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
-                schema: *ref_24
+              - !<!Parameter> &ref_34
+                schema: *ref_25
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -751,8 +789,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_24
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -768,7 +819,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_24
+            schema: *ref_25
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/validation/namer.yaml
+++ b/modelerfour/test/scenarios/validation/namer.yaml
@@ -223,18 +223,28 @@ schemas: !<!Schemas>
           name: EnumConst
           description: Constant string as Enum
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_32
+    - !<!ConstantSchema> &ref_25
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_33
       type: constant
       value: !<!ConstantValue> 
         value: constant
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant7
+          name: Constant8
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_27
+    - !<!ObjectSchema> &ref_28
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -405,7 +415,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_12
     - *ref_13
-    - !<!ObjectSchema> &ref_28
+    - !<!ObjectSchema> &ref_29
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -502,7 +512,7 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_25
+          - !<!Parameter> &ref_26
             schema: *ref_22
             implementation: Method
             required: true
@@ -514,7 +524,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_26
+          - !<!Parameter> &ref_27
             schema: *ref_23
             implementation: Method
             required: true
@@ -529,6 +539,21 @@ operationGroups:
           - *ref_24
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -539,11 +564,11 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_25
           - *ref_26
+          - *ref_27
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -557,7 +582,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -582,7 +607,7 @@ operationGroups:
         parameters:
           - *ref_20
           - *ref_21
-          - !<!Parameter> &ref_30
+          - !<!Parameter> &ref_31
             schema: *ref_22
             implementation: Method
             required: true
@@ -594,7 +619,7 @@ operationGroups:
             protocol: !<!Protocols> 
               http: !<!HttpParameter> 
                 in: path
-          - !<!Parameter> &ref_31
+          - !<!Parameter> &ref_32
             schema: *ref_23
             implementation: Method
             required: true
@@ -610,8 +635,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_29
-                schema: *ref_27
+              - !<!Parameter> &ref_30
+                schema: *ref_28
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -622,8 +647,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_29
+              - *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -637,11 +675,11 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_30
           - *ref_31
+          - *ref_32
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''
@@ -655,7 +693,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_28
+            schema: *ref_29
             language: !<!Languages> 
               default:
                 name: ''
@@ -680,7 +718,7 @@ operationGroups:
         parameters:
           - *ref_20
           - !<!Parameter> 
-            schema: *ref_32
+            schema: *ref_33
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -725,7 +763,7 @@ operationGroups:
         parameters:
           - *ref_20
           - !<!Parameter> 
-            schema: *ref_32
+            schema: *ref_33
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -739,8 +777,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_33
-                schema: *ref_27
+              - !<!Parameter> &ref_34
+                schema: *ref_28
                 implementation: Method
                 required: false
                 language: !<!Languages> 
@@ -751,8 +789,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
+              - !<!Parameter> 
+                schema: *ref_25
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_33
+              - *ref_34
             language: !<!Languages> 
               default:
                 name: ''
@@ -768,7 +819,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/xml-service/flattened.yaml
+++ b/modelerfour/test/scenarios/xml-service/flattened.yaml
@@ -971,7 +971,17 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_137
+    - !<!ConstantSchema> &ref_106
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/xml
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/xml'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_138
       type: constant
       value: !<!ConstantValue> 
         value: list
@@ -981,7 +991,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_139
+    - !<!ConstantSchema> &ref_140
       type: constant
       value: !<!ConstantValue> 
         value: properties
@@ -991,7 +1001,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_140
+    - !<!ConstantSchema> &ref_141
       type: constant
       value: !<!ConstantValue> 
         value: service
@@ -1001,7 +1011,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_143
+    - !<!ConstantSchema> &ref_144
       type: constant
       value: !<!ConstantValue> 
         value: acl
@@ -1011,7 +1021,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_144
+    - !<!ConstantSchema> &ref_145
       type: constant
       value: !<!ConstantValue> 
         value: container
@@ -1020,6 +1030,16 @@ schemas: !<!Schemas>
         default:
           name: ''
           description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_153
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
       protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_32
@@ -1115,13 +1135,13 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_106
+    - !<!ObjectSchema> &ref_107
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_108
+        - !<!Property> &ref_109
           schema: !<!ObjectSchema> &ref_4
             type: object
             apiVersions:
@@ -1153,7 +1173,7 @@ schemas: !<!Schemas>
               name: RefToModel
               description: XML will use RefToModel
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_109
+        - !<!Property> &ref_110
           schema: *ref_3
           serializedName: Something
           language: !<!Languages> 
@@ -1173,13 +1193,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_4
-    - !<!ObjectSchema> &ref_112
+    - !<!ObjectSchema> &ref_113
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_114
+        - !<!Property> &ref_115
           schema: !<!ObjectSchema> &ref_7
             type: object
             apiVersions:
@@ -1217,7 +1237,7 @@ schemas: !<!Schemas>
               name: RefToModel
               description: XML will use XMLComplexTypeWithMeta
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_115
+        - !<!Property> &ref_116
           schema: *ref_6
           serializedName: Something
           language: !<!Languages> 
@@ -1237,7 +1257,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_7
-    - !<!ObjectSchema> &ref_118
+    - !<!ObjectSchema> &ref_119
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1359,7 +1379,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_14
-    - !<!ObjectSchema> &ref_119
+    - !<!ObjectSchema> &ref_120
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1391,13 +1411,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_121
+    - !<!ObjectSchema> &ref_122
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_123
+        - !<!Property> &ref_124
           schema: !<!ArraySchema> &ref_97
             type: array
             apiVersions:
@@ -1420,7 +1440,7 @@ schemas: !<!Schemas>
               name: GoodApples
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_124
+        - !<!Property> &ref_125
           schema: !<!ArraySchema> &ref_98
             type: array
             apiVersions:
@@ -1501,7 +1521,7 @@ schemas: !<!Schemas>
           description: A banana.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_138
+    - !<!ObjectSchema> &ref_139
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1705,7 +1725,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_34
     - *ref_35
-    - !<!ObjectSchema> &ref_141
+    - !<!ObjectSchema> &ref_142
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2092,7 +2112,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_59
-    - !<!ObjectSchema> &ref_147
+    - !<!ObjectSchema> &ref_148
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2598,13 +2618,13 @@ schemas: !<!Schemas>
     - *ref_92
     - *ref_93
     - *ref_94
-    - !<!ObjectSchema> &ref_148
+    - !<!ObjectSchema> &ref_149
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_150
+        - !<!Property> &ref_151
           schema: *ref_15
           serializedName: id
           language: !<!Languages> 
@@ -2622,7 +2642,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_152
+    - !<!ObjectSchema> &ref_154
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2651,7 +2671,7 @@ schemas: !<!Schemas>
     - *ref_96
     - *ref_97
     - *ref_98
-    - !<!ArraySchema> &ref_131
+    - !<!ArraySchema> &ref_132
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -2668,7 +2688,7 @@ schemas: !<!Schemas>
           name: paths·6kxc7q·xml-root_list·get·responses·200·content·application-xml·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_132
+    - !<!ArraySchema> &ref_133
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -2687,7 +2707,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_100
     - *ref_101
-    - !<!ArraySchema> &ref_145
+    - !<!ArraySchema> &ref_146
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -2735,6 +2755,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2747,7 +2782,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_106
+            schema: *ref_107
             language: !<!Languages> 
               default:
                 name: ''
@@ -2773,8 +2808,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_107
-                schema: *ref_106
+              - !<!Parameter> &ref_108
+                schema: *ref_107
                 flattened: true
                 implementation: Method
                 required: true
@@ -2786,31 +2821,31 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - !<!VirtualParameter> &ref_110
+              - !<!VirtualParameter> &ref_111
                 schema: *ref_4
                 implementation: Method
-                originalParameter: *ref_107
+                originalParameter: *ref_108
                 pathToProperty: []
-                targetProperty: *ref_108
+                targetProperty: *ref_109
                 language: !<!Languages> 
                   default:
                     name: RefToModel
                     description: XML will use RefToModel
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_111
+              - !<!VirtualParameter> &ref_112
                 schema: *ref_3
                 implementation: Method
-                originalParameter: *ref_107
+                originalParameter: *ref_108
                 pathToProperty: []
-                targetProperty: *ref_109
+                targetProperty: *ref_110
                 language: !<!Languages> 
                   default:
                     name: Something
                     description: Something else (just to avoid flattening)
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_110
               - *ref_111
+              - *ref_112
             language: !<!Languages> 
               default:
                 name: ''
@@ -2847,6 +2882,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2859,7 +2909,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_112
+            schema: *ref_113
             language: !<!Languages> 
               default:
                 name: ''
@@ -2885,8 +2935,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_113
-                schema: *ref_112
+              - !<!Parameter> &ref_114
+                schema: *ref_113
                 flattened: true
                 implementation: Method
                 required: true
@@ -2898,31 +2948,31 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - !<!VirtualParameter> &ref_116
+              - !<!VirtualParameter> &ref_117
                 schema: *ref_7
                 implementation: Method
-                originalParameter: *ref_113
+                originalParameter: *ref_114
                 pathToProperty: []
-                targetProperty: *ref_114
+                targetProperty: *ref_115
                 language: !<!Languages> 
                   default:
                     name: RefToModel
                     description: XML will use XMLComplexTypeWithMeta
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_117
+              - !<!VirtualParameter> &ref_118
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_113
+                originalParameter: *ref_114
                 pathToProperty: []
-                targetProperty: *ref_115
+                targetProperty: *ref_116
                 language: !<!Languages> 
                   default:
                     name: Something
                     description: Something else (just to avoid flattening)
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_116
               - *ref_117
+              - *ref_118
             language: !<!Languages> 
               default:
                 name: ''
@@ -2959,6 +3009,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2971,7 +3036,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_118
+            schema: *ref_119
             language: !<!Languages> 
               default:
                 name: ''
@@ -2985,7 +3050,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_119
+            schema: *ref_120
             language: !<!Languages> 
               default:
                 name: ''
@@ -3011,8 +3076,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_120
-                schema: *ref_118
+              - !<!Parameter> &ref_121
+                schema: *ref_119
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3023,8 +3088,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_120
+              - *ref_121
             language: !<!Languages> 
               default:
                 name: ''
@@ -3050,7 +3128,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_119
+            schema: *ref_120
             language: !<!Languages> 
               default:
                 name: ''
@@ -3075,6 +3153,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3087,7 +3180,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_121
+            schema: *ref_122
             language: !<!Languages> 
               default:
                 name: ''
@@ -3113,8 +3206,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_122
-                schema: *ref_121
+              - !<!Parameter> &ref_123
+                schema: *ref_122
                 flattened: true
                 implementation: Method
                 required: true
@@ -3126,31 +3219,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - !<!VirtualParameter> &ref_125
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_126
                 schema: *ref_97
                 implementation: Method
-                originalParameter: *ref_122
+                originalParameter: *ref_123
                 pathToProperty: []
-                targetProperty: *ref_123
+                targetProperty: *ref_124
                 language: !<!Languages> 
                   default:
                     name: GoodApples
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_126
+              - !<!VirtualParameter> &ref_127
                 schema: *ref_98
                 implementation: Method
-                originalParameter: *ref_122
+                originalParameter: *ref_123
                 pathToProperty: []
-                targetProperty: *ref_124
+                targetProperty: *ref_125
                 language: !<!Languages> 
                   default:
                     name: BadApples
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_125
               - *ref_126
+              - *ref_127
             language: !<!Languages> 
               default:
                 name: ''
@@ -3176,7 +3282,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_119
+            schema: *ref_120
             language: !<!Languages> 
               default:
                 name: ''
@@ -3242,6 +3348,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3254,7 +3375,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_118
+            schema: *ref_119
             language: !<!Languages> 
               default:
                 name: ''
@@ -3280,8 +3401,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_127
-                schema: *ref_118
+              - !<!Parameter> &ref_128
+                schema: *ref_119
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3293,7 +3414,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_127
+              - *ref_128
             language: !<!Languages> 
               default:
                 name: ''
@@ -3330,6 +3451,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3342,7 +3478,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_121
+            schema: *ref_122
             language: !<!Languages> 
               default:
                 name: ''
@@ -3368,8 +3504,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_128
-                schema: *ref_121
+              - !<!Parameter> &ref_129
+                schema: *ref_122
                 flattened: true
                 implementation: Method
                 required: true
@@ -3381,31 +3517,31 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - !<!VirtualParameter> &ref_129
+              - !<!VirtualParameter> &ref_130
                 schema: *ref_97
                 implementation: Method
-                originalParameter: *ref_128
+                originalParameter: *ref_129
                 pathToProperty: []
-                targetProperty: *ref_123
+                targetProperty: *ref_124
                 language: !<!Languages> 
                   default:
                     name: GoodApples
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_130
+              - !<!VirtualParameter> &ref_131
                 schema: *ref_98
                 implementation: Method
-                originalParameter: *ref_128
+                originalParameter: *ref_129
                 pathToProperty: []
-                targetProperty: *ref_124
+                targetProperty: *ref_125
                 language: !<!Languages> 
                   default:
                     name: BadApples
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_129
               - *ref_130
+              - *ref_131
             language: !<!Languages> 
               default:
                 name: ''
@@ -3442,6 +3578,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3454,7 +3605,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_131
+            schema: *ref_132
             language: !<!Languages> 
               default:
                 name: ''
@@ -3480,8 +3631,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_133
-                schema: *ref_132
+              - !<!Parameter> &ref_134
+                schema: *ref_133
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3493,7 +3644,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_133
+              - *ref_134
             language: !<!Languages> 
               default:
                 name: ''
@@ -3530,6 +3681,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3542,7 +3708,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_131
+            schema: *ref_132
             language: !<!Languages> 
               default:
                 name: ''
@@ -3568,8 +3734,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_134
-                schema: *ref_132
+              - !<!Parameter> &ref_135
+                schema: *ref_133
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3581,7 +3747,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_134
+              - *ref_135
             language: !<!Languages> 
               default:
                 name: ''
@@ -3618,6 +3784,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3630,7 +3811,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_131
+            schema: *ref_132
             language: !<!Languages> 
               default:
                 name: ''
@@ -3656,8 +3837,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_135
-                schema: *ref_132
+              - !<!Parameter> &ref_136
+                schema: *ref_133
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3669,7 +3850,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_135
+              - *ref_136
             language: !<!Languages> 
               default:
                 name: ''
@@ -3706,6 +3887,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3744,7 +3940,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_136
+              - !<!Parameter> &ref_137
                 schema: *ref_99
                 implementation: Method
                 required: true
@@ -3757,7 +3953,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_136
+              - *ref_137
             language: !<!Languages> 
               default:
                 name: ''
@@ -3793,7 +3989,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_137
+            schema: *ref_138
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3806,6 +4002,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3818,7 +4029,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_138
+            schema: *ref_139
             language: !<!Languages> 
               default:
                 name: ''
@@ -3842,7 +4053,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_139
+            schema: *ref_140
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3854,7 +4065,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_140
+            schema: *ref_141
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3867,6 +4078,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3879,7 +4105,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_141
+            schema: *ref_142
             language: !<!Languages> 
               default:
                 name: ''
@@ -3903,7 +4129,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_139
+            schema: *ref_140
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3915,7 +4141,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_140
+            schema: *ref_141
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3929,8 +4155,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_142
-                schema: *ref_141
+              - !<!Parameter> &ref_143
+                schema: *ref_142
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3942,7 +4168,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_142
+              - *ref_143
             language: !<!Languages> 
               default:
                 name: ''
@@ -3978,7 +4204,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_143
+            schema: *ref_144
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3990,7 +4216,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_144
+            schema: *ref_145
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4003,6 +4229,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4015,7 +4256,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -4039,7 +4280,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_143
+            schema: *ref_144
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4051,7 +4292,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_144
+            schema: *ref_145
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4065,8 +4306,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_146
-                schema: *ref_145
+              - !<!Parameter> &ref_147
+                schema: *ref_146
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -4078,7 +4319,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_146
+              - *ref_147
             language: !<!Languages> 
               default:
                 name: ''
@@ -4114,7 +4355,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_137
+            schema: *ref_138
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4126,7 +4367,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_144
+            schema: *ref_145
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4139,6 +4380,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4151,7 +4407,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -4177,8 +4433,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_149
-                schema: *ref_148
+              - !<!Parameter> &ref_150
+                schema: *ref_149
                 flattened: true
                 implementation: Method
                 required: true
@@ -4190,19 +4446,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_151
+              - !<!VirtualParameter> &ref_152
                 schema: *ref_15
                 implementation: Method
-                originalParameter: *ref_149
+                originalParameter: *ref_150
                 pathToProperty: []
-                targetProperty: *ref_150
+                targetProperty: *ref_151
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_151
+              - *ref_152
             language: !<!Languages> 
               default:
                 name: ''
@@ -4239,6 +4495,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_153
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4251,7 +4522,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_152
+            schema: *ref_154
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/xml-service/grouped.yaml
+++ b/modelerfour/test/scenarios/xml-service/grouped.yaml
@@ -971,7 +971,17 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_137
+    - !<!ConstantSchema> &ref_106
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/xml
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/xml'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_138
       type: constant
       value: !<!ConstantValue> 
         value: list
@@ -981,7 +991,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_139
+    - !<!ConstantSchema> &ref_140
       type: constant
       value: !<!ConstantValue> 
         value: properties
@@ -991,7 +1001,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_140
+    - !<!ConstantSchema> &ref_141
       type: constant
       value: !<!ConstantValue> 
         value: service
@@ -1001,7 +1011,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_143
+    - !<!ConstantSchema> &ref_144
       type: constant
       value: !<!ConstantValue> 
         value: acl
@@ -1011,7 +1021,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_144
+    - !<!ConstantSchema> &ref_145
       type: constant
       value: !<!ConstantValue> 
         value: container
@@ -1020,6 +1030,16 @@ schemas: !<!Schemas>
         default:
           name: ''
           description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_153
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
       protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_32
@@ -1115,13 +1135,13 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_106
+    - !<!ObjectSchema> &ref_107
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_108
+        - !<!Property> &ref_109
           schema: !<!ObjectSchema> &ref_4
             type: object
             apiVersions:
@@ -1153,7 +1173,7 @@ schemas: !<!Schemas>
               name: RefToModel
               description: XML will use RefToModel
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_109
+        - !<!Property> &ref_110
           schema: *ref_3
           serializedName: Something
           language: !<!Languages> 
@@ -1173,13 +1193,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_4
-    - !<!ObjectSchema> &ref_112
+    - !<!ObjectSchema> &ref_113
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_114
+        - !<!Property> &ref_115
           schema: !<!ObjectSchema> &ref_7
             type: object
             apiVersions:
@@ -1217,7 +1237,7 @@ schemas: !<!Schemas>
               name: RefToModel
               description: XML will use XMLComplexTypeWithMeta
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_115
+        - !<!Property> &ref_116
           schema: *ref_6
           serializedName: Something
           language: !<!Languages> 
@@ -1237,7 +1257,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_7
-    - !<!ObjectSchema> &ref_118
+    - !<!ObjectSchema> &ref_119
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1359,7 +1379,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_14
-    - !<!ObjectSchema> &ref_119
+    - !<!ObjectSchema> &ref_120
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1391,13 +1411,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_121
+    - !<!ObjectSchema> &ref_122
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_123
+        - !<!Property> &ref_124
           schema: !<!ArraySchema> &ref_97
             type: array
             apiVersions:
@@ -1420,7 +1440,7 @@ schemas: !<!Schemas>
               name: GoodApples
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_124
+        - !<!Property> &ref_125
           schema: !<!ArraySchema> &ref_98
             type: array
             apiVersions:
@@ -1501,7 +1521,7 @@ schemas: !<!Schemas>
           description: A banana.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_138
+    - !<!ObjectSchema> &ref_139
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1705,7 +1725,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_34
     - *ref_35
-    - !<!ObjectSchema> &ref_141
+    - !<!ObjectSchema> &ref_142
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2092,7 +2112,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_59
-    - !<!ObjectSchema> &ref_147
+    - !<!ObjectSchema> &ref_148
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2598,13 +2618,13 @@ schemas: !<!Schemas>
     - *ref_92
     - *ref_93
     - *ref_94
-    - !<!ObjectSchema> &ref_148
+    - !<!ObjectSchema> &ref_149
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_150
+        - !<!Property> &ref_151
           schema: *ref_15
           serializedName: id
           language: !<!Languages> 
@@ -2622,7 +2642,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_152
+    - !<!ObjectSchema> &ref_154
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2651,7 +2671,7 @@ schemas: !<!Schemas>
     - *ref_96
     - *ref_97
     - *ref_98
-    - !<!ArraySchema> &ref_131
+    - !<!ArraySchema> &ref_132
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -2668,7 +2688,7 @@ schemas: !<!Schemas>
           name: paths·6kxc7q·xml-root_list·get·responses·200·content·application-xml·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_132
+    - !<!ArraySchema> &ref_133
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -2687,7 +2707,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_100
     - *ref_101
-    - !<!ArraySchema> &ref_145
+    - !<!ArraySchema> &ref_146
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -2735,6 +2755,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2747,7 +2782,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_106
+            schema: *ref_107
             language: !<!Languages> 
               default:
                 name: ''
@@ -2773,8 +2808,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_107
-                schema: *ref_106
+              - !<!Parameter> &ref_108
+                schema: *ref_107
                 flattened: true
                 implementation: Method
                 required: true
@@ -2786,31 +2821,31 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - !<!VirtualParameter> &ref_110
+              - !<!VirtualParameter> &ref_111
                 schema: *ref_4
                 implementation: Method
-                originalParameter: *ref_107
+                originalParameter: *ref_108
                 pathToProperty: []
-                targetProperty: *ref_108
+                targetProperty: *ref_109
                 language: !<!Languages> 
                   default:
                     name: RefToModel
                     description: XML will use RefToModel
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_111
+              - !<!VirtualParameter> &ref_112
                 schema: *ref_3
                 implementation: Method
-                originalParameter: *ref_107
+                originalParameter: *ref_108
                 pathToProperty: []
-                targetProperty: *ref_109
+                targetProperty: *ref_110
                 language: !<!Languages> 
                   default:
                     name: Something
                     description: Something else (just to avoid flattening)
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_110
               - *ref_111
+              - *ref_112
             language: !<!Languages> 
               default:
                 name: ''
@@ -2847,6 +2882,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2859,7 +2909,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_112
+            schema: *ref_113
             language: !<!Languages> 
               default:
                 name: ''
@@ -2885,8 +2935,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_113
-                schema: *ref_112
+              - !<!Parameter> &ref_114
+                schema: *ref_113
                 flattened: true
                 implementation: Method
                 required: true
@@ -2898,31 +2948,31 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - !<!VirtualParameter> &ref_116
+              - !<!VirtualParameter> &ref_117
                 schema: *ref_7
                 implementation: Method
-                originalParameter: *ref_113
+                originalParameter: *ref_114
                 pathToProperty: []
-                targetProperty: *ref_114
+                targetProperty: *ref_115
                 language: !<!Languages> 
                   default:
                     name: RefToModel
                     description: XML will use XMLComplexTypeWithMeta
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_117
+              - !<!VirtualParameter> &ref_118
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_113
+                originalParameter: *ref_114
                 pathToProperty: []
-                targetProperty: *ref_115
+                targetProperty: *ref_116
                 language: !<!Languages> 
                   default:
                     name: Something
                     description: Something else (just to avoid flattening)
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_116
               - *ref_117
+              - *ref_118
             language: !<!Languages> 
               default:
                 name: ''
@@ -2959,6 +3009,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2971,7 +3036,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_118
+            schema: *ref_119
             language: !<!Languages> 
               default:
                 name: ''
@@ -2985,7 +3050,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_119
+            schema: *ref_120
             language: !<!Languages> 
               default:
                 name: ''
@@ -3011,8 +3076,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_120
-                schema: *ref_118
+              - !<!Parameter> &ref_121
+                schema: *ref_119
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3023,8 +3088,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_120
+              - *ref_121
             language: !<!Languages> 
               default:
                 name: ''
@@ -3050,7 +3128,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_119
+            schema: *ref_120
             language: !<!Languages> 
               default:
                 name: ''
@@ -3075,6 +3153,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3087,7 +3180,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_121
+            schema: *ref_122
             language: !<!Languages> 
               default:
                 name: ''
@@ -3113,8 +3206,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_122
-                schema: *ref_121
+              - !<!Parameter> &ref_123
+                schema: *ref_122
                 flattened: true
                 implementation: Method
                 required: true
@@ -3126,31 +3219,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - !<!VirtualParameter> &ref_125
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_126
                 schema: *ref_97
                 implementation: Method
-                originalParameter: *ref_122
+                originalParameter: *ref_123
                 pathToProperty: []
-                targetProperty: *ref_123
+                targetProperty: *ref_124
                 language: !<!Languages> 
                   default:
                     name: GoodApples
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_126
+              - !<!VirtualParameter> &ref_127
                 schema: *ref_98
                 implementation: Method
-                originalParameter: *ref_122
+                originalParameter: *ref_123
                 pathToProperty: []
-                targetProperty: *ref_124
+                targetProperty: *ref_125
                 language: !<!Languages> 
                   default:
                     name: BadApples
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_125
               - *ref_126
+              - *ref_127
             language: !<!Languages> 
               default:
                 name: ''
@@ -3176,7 +3282,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_119
+            schema: *ref_120
             language: !<!Languages> 
               default:
                 name: ''
@@ -3242,6 +3348,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3254,7 +3375,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_118
+            schema: *ref_119
             language: !<!Languages> 
               default:
                 name: ''
@@ -3280,8 +3401,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_127
-                schema: *ref_118
+              - !<!Parameter> &ref_128
+                schema: *ref_119
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3293,7 +3414,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_127
+              - *ref_128
             language: !<!Languages> 
               default:
                 name: ''
@@ -3330,6 +3451,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3342,7 +3478,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_121
+            schema: *ref_122
             language: !<!Languages> 
               default:
                 name: ''
@@ -3368,8 +3504,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_128
-                schema: *ref_121
+              - !<!Parameter> &ref_129
+                schema: *ref_122
                 flattened: true
                 implementation: Method
                 required: true
@@ -3381,31 +3517,31 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - !<!VirtualParameter> &ref_129
+              - !<!VirtualParameter> &ref_130
                 schema: *ref_97
                 implementation: Method
-                originalParameter: *ref_128
+                originalParameter: *ref_129
                 pathToProperty: []
-                targetProperty: *ref_123
+                targetProperty: *ref_124
                 language: !<!Languages> 
                   default:
                     name: GoodApples
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_130
+              - !<!VirtualParameter> &ref_131
                 schema: *ref_98
                 implementation: Method
-                originalParameter: *ref_128
+                originalParameter: *ref_129
                 pathToProperty: []
-                targetProperty: *ref_124
+                targetProperty: *ref_125
                 language: !<!Languages> 
                   default:
                     name: BadApples
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_129
               - *ref_130
+              - *ref_131
             language: !<!Languages> 
               default:
                 name: ''
@@ -3442,6 +3578,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3454,7 +3605,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_131
+            schema: *ref_132
             language: !<!Languages> 
               default:
                 name: ''
@@ -3480,8 +3631,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_133
-                schema: *ref_132
+              - !<!Parameter> &ref_134
+                schema: *ref_133
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3493,7 +3644,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_133
+              - *ref_134
             language: !<!Languages> 
               default:
                 name: ''
@@ -3530,6 +3681,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3542,7 +3708,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_131
+            schema: *ref_132
             language: !<!Languages> 
               default:
                 name: ''
@@ -3568,8 +3734,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_134
-                schema: *ref_132
+              - !<!Parameter> &ref_135
+                schema: *ref_133
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3581,7 +3747,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_134
+              - *ref_135
             language: !<!Languages> 
               default:
                 name: ''
@@ -3618,6 +3784,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3630,7 +3811,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_131
+            schema: *ref_132
             language: !<!Languages> 
               default:
                 name: ''
@@ -3656,8 +3837,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_135
-                schema: *ref_132
+              - !<!Parameter> &ref_136
+                schema: *ref_133
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3669,7 +3850,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_135
+              - *ref_136
             language: !<!Languages> 
               default:
                 name: ''
@@ -3706,6 +3887,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3744,7 +3940,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_136
+              - !<!Parameter> &ref_137
                 schema: *ref_99
                 implementation: Method
                 required: true
@@ -3757,7 +3953,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_136
+              - *ref_137
             language: !<!Languages> 
               default:
                 name: ''
@@ -3793,7 +3989,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_137
+            schema: *ref_138
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3806,6 +4002,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3818,7 +4029,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_138
+            schema: *ref_139
             language: !<!Languages> 
               default:
                 name: ''
@@ -3842,7 +4053,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_139
+            schema: *ref_140
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3854,7 +4065,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_140
+            schema: *ref_141
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3867,6 +4078,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3879,7 +4105,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_141
+            schema: *ref_142
             language: !<!Languages> 
               default:
                 name: ''
@@ -3903,7 +4129,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_139
+            schema: *ref_140
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3915,7 +4141,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_140
+            schema: *ref_141
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3929,8 +4155,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_142
-                schema: *ref_141
+              - !<!Parameter> &ref_143
+                schema: *ref_142
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3942,7 +4168,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_142
+              - *ref_143
             language: !<!Languages> 
               default:
                 name: ''
@@ -3978,7 +4204,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_143
+            schema: *ref_144
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3990,7 +4216,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_144
+            schema: *ref_145
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4003,6 +4229,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4015,7 +4256,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -4039,7 +4280,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_143
+            schema: *ref_144
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4051,7 +4292,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_144
+            schema: *ref_145
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4065,8 +4306,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_146
-                schema: *ref_145
+              - !<!Parameter> &ref_147
+                schema: *ref_146
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -4078,7 +4319,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_146
+              - *ref_147
             language: !<!Languages> 
               default:
                 name: ''
@@ -4114,7 +4355,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_137
+            schema: *ref_138
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4126,7 +4367,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_144
+            schema: *ref_145
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4139,6 +4380,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4151,7 +4407,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -4177,8 +4433,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_149
-                schema: *ref_148
+              - !<!Parameter> &ref_150
+                schema: *ref_149
                 flattened: true
                 implementation: Method
                 required: true
@@ -4190,19 +4446,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_151
+              - !<!VirtualParameter> &ref_152
                 schema: *ref_15
                 implementation: Method
-                originalParameter: *ref_149
+                originalParameter: *ref_150
                 pathToProperty: []
-                targetProperty: *ref_150
+                targetProperty: *ref_151
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_151
+              - *ref_152
             language: !<!Languages> 
               default:
                 name: ''
@@ -4239,6 +4495,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_153
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4251,7 +4522,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_152
+            schema: *ref_154
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/xml-service/modeler.yaml
+++ b/modelerfour/test/scenarios/xml-service/modeler.yaml
@@ -971,7 +971,17 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_123
+    - !<!ConstantSchema> &ref_105
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/xml
+      valueType: *ref_24
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/xml'
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_124
       type: constant
       value: !<!ConstantValue> 
         value: list
@@ -981,7 +991,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_125
+    - !<!ConstantSchema> &ref_126
       type: constant
       value: !<!ConstantValue> 
         value: properties
@@ -991,7 +1001,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_126
+    - !<!ConstantSchema> &ref_127
       type: constant
       value: !<!ConstantValue> 
         value: service
@@ -1001,7 +1011,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_129
+    - !<!ConstantSchema> &ref_130
       type: constant
       value: !<!ConstantValue> 
         value: acl
@@ -1011,7 +1021,7 @@ schemas: !<!Schemas>
           name: ''
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_130
+    - !<!ConstantSchema> &ref_131
       type: constant
       value: !<!ConstantValue> 
         value: container
@@ -1020,6 +1030,16 @@ schemas: !<!Schemas>
         default:
           name: ''
           description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_137
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_24
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
       protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_67
@@ -1115,7 +1135,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_105
+    - !<!ObjectSchema> &ref_106
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1173,7 +1193,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_2
-    - !<!ObjectSchema> &ref_108
+    - !<!ObjectSchema> &ref_109
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1237,7 +1257,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_5
-    - !<!ObjectSchema> &ref_110
+    - !<!ObjectSchema> &ref_111
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1359,7 +1379,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_12
-    - !<!ObjectSchema> &ref_111
+    - !<!ObjectSchema> &ref_112
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1391,7 +1411,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_113
+    - !<!ObjectSchema> &ref_114
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1501,7 +1521,7 @@ schemas: !<!Schemas>
           description: A banana.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_124
+    - !<!ObjectSchema> &ref_125
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1705,7 +1725,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_27
     - *ref_28
-    - !<!ObjectSchema> &ref_127
+    - !<!ObjectSchema> &ref_128
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2092,7 +2112,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_42
-    - !<!ObjectSchema> &ref_133
+    - !<!ObjectSchema> &ref_134
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2598,7 +2618,7 @@ schemas: !<!Schemas>
     - *ref_70
     - *ref_71
     - *ref_72
-    - !<!ObjectSchema> &ref_134
+    - !<!ObjectSchema> &ref_135
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2622,7 +2642,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_136
+    - !<!ObjectSchema> &ref_138
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2651,7 +2671,7 @@ schemas: !<!Schemas>
     - *ref_74
     - *ref_75
     - *ref_76
-    - !<!ArraySchema> &ref_117
+    - !<!ArraySchema> &ref_118
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -2668,7 +2688,7 @@ schemas: !<!Schemas>
           name: paths·6kxc7q·xml-root_list·get·responses·200·content·application-xml·schema
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_118
+    - !<!ArraySchema> &ref_119
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -2687,7 +2707,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_78
     - *ref_79
-    - !<!ArraySchema> &ref_131
+    - !<!ArraySchema> &ref_132
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -2707,7 +2727,7 @@ schemas: !<!Schemas>
     - *ref_81
     - *ref_82
 globalParameters:
-  - !<!Parameter> &ref_106
+  - !<!Parameter> &ref_107
     schema: *ref_24
     clientDefaultValue: 'http://localhost:3000'
     implementation: Client
@@ -2732,9 +2752,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_105
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2747,7 +2782,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_105
+            schema: *ref_106
             language: !<!Languages> 
               default:
                 name: ''
@@ -2769,12 +2804,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_107
-                schema: *ref_105
+              - !<!Parameter> &ref_108
+                schema: *ref_106
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2786,7 +2821,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_107
+              - *ref_108
             language: !<!Languages> 
               default:
                 name: ''
@@ -2820,9 +2855,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_105
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2835,7 +2885,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_108
+            schema: *ref_109
             language: !<!Languages> 
               default:
                 name: ''
@@ -2857,12 +2907,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_109
-                schema: *ref_108
+              - !<!Parameter> &ref_110
+                schema: *ref_109
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2874,7 +2924,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_109
+              - *ref_110
             language: !<!Languages> 
               default:
                 name: ''
@@ -2908,9 +2958,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_105
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2923,7 +2988,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_110
+            schema: *ref_111
             language: !<!Languages> 
               default:
                 name: ''
@@ -2937,7 +3002,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_111
+            schema: *ref_112
             language: !<!Languages> 
               default:
                 name: ''
@@ -2959,12 +3024,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_112
-                schema: *ref_110
+              - !<!Parameter> &ref_113
+                schema: *ref_111
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -2975,8 +3040,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_105
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_112
+              - *ref_113
             language: !<!Languages> 
               default:
                 name: ''
@@ -3002,7 +3080,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_111
+            schema: *ref_112
             language: !<!Languages> 
               default:
                 name: ''
@@ -3024,9 +3102,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_105
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3039,7 +3132,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_113
+            schema: *ref_114
             language: !<!Languages> 
               default:
                 name: ''
@@ -3061,12 +3154,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_114
-                schema: *ref_113
+              - !<!Parameter> &ref_115
+                schema: *ref_114
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3077,8 +3170,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_105
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_114
+              - *ref_115
             language: !<!Languages> 
               default:
                 name: ''
@@ -3104,7 +3210,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_111
+            schema: *ref_112
             language: !<!Languages> 
               default:
                 name: ''
@@ -3126,7 +3232,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
             language: !<!Languages> 
@@ -3167,9 +3273,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_105
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3182,7 +3303,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_110
+            schema: *ref_111
             language: !<!Languages> 
               default:
                 name: ''
@@ -3204,12 +3325,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_115
-                schema: *ref_110
+              - !<!Parameter> &ref_116
+                schema: *ref_111
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3221,7 +3342,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_115
+              - *ref_116
             language: !<!Languages> 
               default:
                 name: ''
@@ -3255,9 +3376,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_105
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3270,7 +3406,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_113
+            schema: *ref_114
             language: !<!Languages> 
               default:
                 name: ''
@@ -3292,12 +3428,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_116
-                schema: *ref_113
+              - !<!Parameter> &ref_117
+                schema: *ref_114
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3309,7 +3445,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_116
+              - *ref_117
             language: !<!Languages> 
               default:
                 name: ''
@@ -3343,9 +3479,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_105
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3358,7 +3509,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_117
+            schema: *ref_118
             language: !<!Languages> 
               default:
                 name: ''
@@ -3380,12 +3531,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_119
-                schema: *ref_118
+              - !<!Parameter> &ref_120
+                schema: *ref_119
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3397,7 +3548,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_119
+              - *ref_120
             language: !<!Languages> 
               default:
                 name: ''
@@ -3431,9 +3582,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_105
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3446,7 +3612,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_117
+            schema: *ref_118
             language: !<!Languages> 
               default:
                 name: ''
@@ -3468,12 +3634,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_120
-                schema: *ref_118
+              - !<!Parameter> &ref_121
+                schema: *ref_119
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3485,7 +3651,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_120
+              - *ref_121
             language: !<!Languages> 
               default:
                 name: ''
@@ -3519,9 +3685,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_105
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3534,7 +3715,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_117
+            schema: *ref_118
             language: !<!Languages> 
               default:
                 name: ''
@@ -3556,12 +3737,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_121
-                schema: *ref_118
+              - !<!Parameter> &ref_122
+                schema: *ref_119
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3573,7 +3754,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_121
+              - *ref_122
             language: !<!Languages> 
               default:
                 name: ''
@@ -3607,9 +3788,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_105
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3644,11 +3840,11 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_122
+              - !<!Parameter> &ref_123
                 schema: *ref_77
                 implementation: Method
                 required: true
@@ -3661,7 +3857,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_122
+              - *ref_123
             language: !<!Languages> 
               default:
                 name: ''
@@ -3695,9 +3891,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
           - !<!Parameter> 
-            schema: *ref_123
+            schema: *ref_124
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3710,6 +3906,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_105
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3722,7 +3933,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_124
+            schema: *ref_125
             language: !<!Languages> 
               default:
                 name: ''
@@ -3744,9 +3955,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
           - !<!Parameter> 
-            schema: *ref_125
+            schema: *ref_126
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3758,7 +3969,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_126
+            schema: *ref_127
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3771,6 +3982,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_105
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3783,7 +4009,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_127
+            schema: *ref_128
             language: !<!Languages> 
               default:
                 name: ''
@@ -3805,9 +4031,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
           - !<!Parameter> 
-            schema: *ref_125
+            schema: *ref_126
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3819,7 +4045,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_126
+            schema: *ref_127
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3833,8 +4059,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_128
-                schema: *ref_127
+              - !<!Parameter> &ref_129
+                schema: *ref_128
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3846,7 +4072,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_128
+              - *ref_129
             language: !<!Languages> 
               default:
                 name: ''
@@ -3880,9 +4106,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
           - !<!Parameter> 
-            schema: *ref_129
+            schema: *ref_130
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3894,7 +4120,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_130
+            schema: *ref_131
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3907,6 +4133,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_105
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3919,7 +4160,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_131
+            schema: *ref_132
             language: !<!Languages> 
               default:
                 name: ''
@@ -3941,9 +4182,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
           - !<!Parameter> 
-            schema: *ref_129
+            schema: *ref_130
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3955,7 +4196,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_130
+            schema: *ref_131
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3969,8 +4210,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_132
-                schema: *ref_131
+              - !<!Parameter> &ref_133
+                schema: *ref_132
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3982,7 +4223,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_132
+              - *ref_133
             language: !<!Languages> 
               default:
                 name: ''
@@ -4016,9 +4257,9 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
           - !<!Parameter> 
-            schema: *ref_123
+            schema: *ref_124
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4030,7 +4271,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_130
+            schema: *ref_131
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4043,6 +4284,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_105
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4055,7 +4311,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_133
+            schema: *ref_134
             language: !<!Languages> 
               default:
                 name: ''
@@ -4077,12 +4333,12 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_135
-                schema: *ref_134
+              - !<!Parameter> &ref_136
+                schema: *ref_135
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -4094,7 +4350,7 @@ operationGroups:
                     in: body
                     style: json
             signatureParameters:
-              - *ref_135
+              - *ref_136
             language: !<!Languages> 
               default:
                 name: ''
@@ -4128,9 +4384,24 @@ operationGroups:
           - !<!ApiVersion> 
             version: 1.0.0
         parameters:
-          - *ref_106
+          - *ref_107
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_137
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4143,7 +4414,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_136
+            schema: *ref_138
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/xml-service/namer.yaml
+++ b/modelerfour/test/scenarios/xml-service/namer.yaml
@@ -971,20 +971,20 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   constants:
-    - !<!ConstantSchema> &ref_137
+    - !<!ConstantSchema> &ref_106
       type: constant
       value: !<!ConstantValue> 
-        value: list
+        value: application/xml
       valueType: *ref_0
       language: !<!Languages> 
         default:
-          name: Constant8
-          description: ''
+          name: Accept
+          description: 'Accept: application/xml'
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_139
+    - !<!ConstantSchema> &ref_138
       type: constant
       value: !<!ConstantValue> 
-        value: properties
+        value: list
       valueType: *ref_0
       language: !<!Languages> 
         default:
@@ -994,17 +994,17 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_140
       type: constant
       value: !<!ConstantValue> 
-        value: service
+        value: properties
       valueType: *ref_0
       language: !<!Languages> 
         default:
           name: Constant10
           description: ''
       protocol: !<!Protocols> {}
-    - !<!ConstantSchema> &ref_143
+    - !<!ConstantSchema> &ref_141
       type: constant
       value: !<!ConstantValue> 
-        value: acl
+        value: service
       valueType: *ref_0
       language: !<!Languages> 
         default:
@@ -1014,12 +1014,32 @@ schemas: !<!Schemas>
     - !<!ConstantSchema> &ref_144
       type: constant
       value: !<!ConstantValue> 
-        value: container
+        value: acl
       valueType: *ref_0
       language: !<!Languages> 
         default:
           name: Constant12
           description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_145
+      type: constant
+      value: !<!ConstantValue> 
+        value: container
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Constant13
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!ConstantSchema> &ref_153
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
       protocol: !<!Protocols> {}
   dictionaries:
     - !<!DictionarySchema> &ref_32
@@ -1115,13 +1135,13 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_106
+    - !<!ObjectSchema> &ref_107
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_108
+        - !<!Property> &ref_109
           schema: !<!ObjectSchema> &ref_4
             type: object
             apiVersions:
@@ -1153,7 +1173,7 @@ schemas: !<!Schemas>
               name: refToModel
               description: XML will use RefToModel
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_109
+        - !<!Property> &ref_110
           schema: *ref_3
           serializedName: Something
           language: !<!Languages> 
@@ -1173,13 +1193,13 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_4
-    - !<!ObjectSchema> &ref_112
+    - !<!ObjectSchema> &ref_113
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_114
+        - !<!Property> &ref_115
           schema: !<!ObjectSchema> &ref_7
             type: object
             apiVersions:
@@ -1217,7 +1237,7 @@ schemas: !<!Schemas>
               name: refToModel
               description: XML will use XMLComplexTypeWithMeta
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_115
+        - !<!Property> &ref_116
           schema: *ref_6
           serializedName: Something
           language: !<!Languages> 
@@ -1237,7 +1257,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_7
-    - !<!ObjectSchema> &ref_118
+    - !<!ObjectSchema> &ref_119
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1359,7 +1379,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_14
-    - !<!ObjectSchema> &ref_119
+    - !<!ObjectSchema> &ref_120
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1391,13 +1411,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_121
+    - !<!ObjectSchema> &ref_122
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_123
+        - !<!Property> &ref_124
           schema: !<!ArraySchema> &ref_97
             type: array
             apiVersions:
@@ -1420,7 +1440,7 @@ schemas: !<!Schemas>
               name: goodApples
               description: ''
           protocol: !<!Protocols> {}
-        - !<!Property> &ref_124
+        - !<!Property> &ref_125
           schema: !<!ArraySchema> &ref_98
             type: array
             apiVersions:
@@ -1501,7 +1521,7 @@ schemas: !<!Schemas>
           description: A banana.
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_138
+    - !<!ObjectSchema> &ref_139
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -1705,7 +1725,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_34
     - *ref_35
-    - !<!ObjectSchema> &ref_141
+    - !<!ObjectSchema> &ref_142
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2092,7 +2112,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_59
-    - !<!ObjectSchema> &ref_147
+    - !<!ObjectSchema> &ref_148
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2598,13 +2618,13 @@ schemas: !<!Schemas>
     - *ref_92
     - *ref_93
     - *ref_94
-    - !<!ObjectSchema> &ref_148
+    - !<!ObjectSchema> &ref_149
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 1.0.0
       properties:
-        - !<!Property> &ref_150
+        - !<!Property> &ref_151
           schema: *ref_15
           serializedName: id
           language: !<!Languages> 
@@ -2622,7 +2642,7 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_152
+    - !<!ObjectSchema> &ref_154
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -2651,7 +2671,7 @@ schemas: !<!Schemas>
     - *ref_96
     - *ref_97
     - *ref_98
-    - !<!ArraySchema> &ref_131
+    - !<!ArraySchema> &ref_132
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -2668,7 +2688,7 @@ schemas: !<!Schemas>
           name: ArrayOfBanana
           description: Array of Banana
       protocol: !<!Protocols> {}
-    - !<!ArraySchema> &ref_132
+    - !<!ArraySchema> &ref_133
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -2687,7 +2707,7 @@ schemas: !<!Schemas>
       protocol: !<!Protocols> {}
     - *ref_100
     - *ref_101
-    - !<!ArraySchema> &ref_145
+    - !<!ArraySchema> &ref_146
       type: array
       apiVersions:
         - !<!ApiVersion> 
@@ -2735,6 +2755,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2747,7 +2782,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_106
+            schema: *ref_107
             language: !<!Languages> 
               default:
                 name: ''
@@ -2773,8 +2808,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_107
-                schema: *ref_106
+              - !<!Parameter> &ref_108
+                schema: *ref_107
                 flattened: true
                 implementation: Method
                 required: true
@@ -2786,31 +2821,31 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - !<!VirtualParameter> &ref_110
+              - !<!VirtualParameter> &ref_111
                 schema: *ref_4
                 implementation: Method
-                originalParameter: *ref_107
+                originalParameter: *ref_108
                 pathToProperty: []
-                targetProperty: *ref_108
+                targetProperty: *ref_109
                 language: !<!Languages> 
                   default:
                     name: refToModel
                     description: XML will use RefToModel
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_111
+              - !<!VirtualParameter> &ref_112
                 schema: *ref_3
                 implementation: Method
-                originalParameter: *ref_107
+                originalParameter: *ref_108
                 pathToProperty: []
-                targetProperty: *ref_109
+                targetProperty: *ref_110
                 language: !<!Languages> 
                   default:
                     name: something
                     description: Something else (just to avoid flattening)
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_110
               - *ref_111
+              - *ref_112
             language: !<!Languages> 
               default:
                 name: ''
@@ -2847,6 +2882,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2859,7 +2909,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_112
+            schema: *ref_113
             language: !<!Languages> 
               default:
                 name: ''
@@ -2885,8 +2935,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_113
-                schema: *ref_112
+              - !<!Parameter> &ref_114
+                schema: *ref_113
                 flattened: true
                 implementation: Method
                 required: true
@@ -2898,31 +2948,31 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - !<!VirtualParameter> &ref_116
+              - !<!VirtualParameter> &ref_117
                 schema: *ref_7
                 implementation: Method
-                originalParameter: *ref_113
+                originalParameter: *ref_114
                 pathToProperty: []
-                targetProperty: *ref_114
+                targetProperty: *ref_115
                 language: !<!Languages> 
                   default:
                     name: refToModel
                     description: XML will use XMLComplexTypeWithMeta
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_117
+              - !<!VirtualParameter> &ref_118
                 schema: *ref_6
                 implementation: Method
-                originalParameter: *ref_113
+                originalParameter: *ref_114
                 pathToProperty: []
-                targetProperty: *ref_115
+                targetProperty: *ref_116
                 language: !<!Languages> 
                   default:
                     name: something
                     description: Something else (just to avoid flattening)
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_116
               - *ref_117
+              - *ref_118
             language: !<!Languages> 
               default:
                 name: ''
@@ -2959,6 +3009,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -2971,7 +3036,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_118
+            schema: *ref_119
             language: !<!Languages> 
               default:
                 name: ''
@@ -2985,7 +3050,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_119
+            schema: *ref_120
             language: !<!Languages> 
               default:
                 name: ''
@@ -3011,8 +3076,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_120
-                schema: *ref_118
+              - !<!Parameter> &ref_121
+                schema: *ref_119
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3023,8 +3088,21 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
             signatureParameters:
-              - *ref_120
+              - *ref_121
             language: !<!Languages> 
               default:
                 name: ''
@@ -3050,7 +3128,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_119
+            schema: *ref_120
             language: !<!Languages> 
               default:
                 name: ''
@@ -3075,6 +3153,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3087,7 +3180,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_121
+            schema: *ref_122
             language: !<!Languages> 
               default:
                 name: ''
@@ -3113,8 +3206,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_122
-                schema: *ref_121
+              - !<!Parameter> &ref_123
+                schema: *ref_122
                 flattened: true
                 implementation: Method
                 required: true
@@ -3126,31 +3219,44 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - !<!VirtualParameter> &ref_125
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+              - !<!VirtualParameter> &ref_126
                 schema: *ref_97
                 implementation: Method
-                originalParameter: *ref_122
+                originalParameter: *ref_123
                 pathToProperty: []
-                targetProperty: *ref_123
+                targetProperty: *ref_124
                 language: !<!Languages> 
                   default:
                     name: goodApples
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_126
+              - !<!VirtualParameter> &ref_127
                 schema: *ref_98
                 implementation: Method
-                originalParameter: *ref_122
+                originalParameter: *ref_123
                 pathToProperty: []
-                targetProperty: *ref_124
+                targetProperty: *ref_125
                 language: !<!Languages> 
                   default:
                     name: badApples
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_125
               - *ref_126
+              - *ref_127
             language: !<!Languages> 
               default:
                 name: ''
@@ -3176,7 +3282,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_119
+            schema: *ref_120
             language: !<!Languages> 
               default:
                 name: ''
@@ -3242,6 +3348,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3254,7 +3375,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_118
+            schema: *ref_119
             language: !<!Languages> 
               default:
                 name: ''
@@ -3280,8 +3401,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_127
-                schema: *ref_118
+              - !<!Parameter> &ref_128
+                schema: *ref_119
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3293,7 +3414,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_127
+              - *ref_128
             language: !<!Languages> 
               default:
                 name: ''
@@ -3330,6 +3451,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3342,7 +3478,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_121
+            schema: *ref_122
             language: !<!Languages> 
               default:
                 name: ''
@@ -3368,8 +3504,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_128
-                schema: *ref_121
+              - !<!Parameter> &ref_129
+                schema: *ref_122
                 flattened: true
                 implementation: Method
                 required: true
@@ -3381,31 +3517,31 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: xml
-              - !<!VirtualParameter> &ref_129
+              - !<!VirtualParameter> &ref_130
                 schema: *ref_97
                 implementation: Method
-                originalParameter: *ref_128
+                originalParameter: *ref_129
                 pathToProperty: []
-                targetProperty: *ref_123
+                targetProperty: *ref_124
                 language: !<!Languages> 
                   default:
                     name: goodApples
                     description: ''
                 protocol: !<!Protocols> {}
-              - !<!VirtualParameter> &ref_130
+              - !<!VirtualParameter> &ref_131
                 schema: *ref_98
                 implementation: Method
-                originalParameter: *ref_128
+                originalParameter: *ref_129
                 pathToProperty: []
-                targetProperty: *ref_124
+                targetProperty: *ref_125
                 language: !<!Languages> 
                   default:
                     name: badApples
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_129
               - *ref_130
+              - *ref_131
             language: !<!Languages> 
               default:
                 name: ''
@@ -3442,6 +3578,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3454,7 +3605,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_131
+            schema: *ref_132
             language: !<!Languages> 
               default:
                 name: ''
@@ -3480,8 +3631,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_133
-                schema: *ref_132
+              - !<!Parameter> &ref_134
+                schema: *ref_133
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3493,7 +3644,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_133
+              - *ref_134
             language: !<!Languages> 
               default:
                 name: ''
@@ -3530,6 +3681,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3542,7 +3708,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_131
+            schema: *ref_132
             language: !<!Languages> 
               default:
                 name: ''
@@ -3568,8 +3734,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_134
-                schema: *ref_132
+              - !<!Parameter> &ref_135
+                schema: *ref_133
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3581,7 +3747,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_134
+              - *ref_135
             language: !<!Languages> 
               default:
                 name: ''
@@ -3618,6 +3784,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3630,7 +3811,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_131
+            schema: *ref_132
             language: !<!Languages> 
               default:
                 name: ''
@@ -3656,8 +3837,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_135
-                schema: *ref_132
+              - !<!Parameter> &ref_136
+                schema: *ref_133
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3669,7 +3850,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_135
+              - *ref_136
             language: !<!Languages> 
               default:
                 name: ''
@@ -3706,6 +3887,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3744,7 +3940,7 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_136
+              - !<!Parameter> &ref_137
                 schema: *ref_99
                 implementation: Method
                 required: true
@@ -3757,7 +3953,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_136
+              - *ref_137
             language: !<!Languages> 
               default:
                 name: ''
@@ -3793,7 +3989,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_137
+            schema: *ref_138
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3806,6 +4002,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3818,7 +4029,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_138
+            schema: *ref_139
             language: !<!Languages> 
               default:
                 name: ''
@@ -3842,7 +4053,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_139
+            schema: *ref_140
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3854,7 +4065,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_140
+            schema: *ref_141
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3867,6 +4078,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -3879,7 +4105,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_141
+            schema: *ref_142
             language: !<!Languages> 
               default:
                 name: ''
@@ -3903,7 +4129,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_139
+            schema: *ref_140
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3915,7 +4141,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_140
+            schema: *ref_141
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3929,8 +4155,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_142
-                schema: *ref_141
+              - !<!Parameter> &ref_143
+                schema: *ref_142
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -3942,7 +4168,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_142
+              - *ref_143
             language: !<!Languages> 
               default:
                 name: ''
@@ -3978,7 +4204,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_143
+            schema: *ref_144
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -3990,7 +4216,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_144
+            schema: *ref_145
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4003,6 +4229,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4015,7 +4256,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_145
+            schema: *ref_146
             language: !<!Languages> 
               default:
                 name: ''
@@ -4039,7 +4280,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_143
+            schema: *ref_144
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4051,7 +4292,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_144
+            schema: *ref_145
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4065,8 +4306,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_146
-                schema: *ref_145
+              - !<!Parameter> &ref_147
+                schema: *ref_146
                 implementation: Method
                 required: true
                 language: !<!Languages> 
@@ -4078,7 +4319,7 @@ operationGroups:
                     in: body
                     style: xml
             signatureParameters:
-              - *ref_146
+              - *ref_147
             language: !<!Languages> 
               default:
                 name: ''
@@ -4114,7 +4355,7 @@ operationGroups:
         parameters:
           - *ref_105
           - !<!Parameter> 
-            schema: *ref_137
+            schema: *ref_138
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4126,7 +4367,7 @@ operationGroups:
               http: !<!HttpParameter> 
                 in: query
           - !<!Parameter> 
-            schema: *ref_144
+            schema: *ref_145
             implementation: Method
             required: true
             language: !<!Languages> 
@@ -4139,6 +4380,21 @@ operationGroups:
                 in: query
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_106
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4151,7 +4407,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_147
+            schema: *ref_148
             language: !<!Languages> 
               default:
                 name: ''
@@ -4177,8 +4433,8 @@ operationGroups:
         requests:
           - !<!Request> 
             parameters:
-              - !<!Parameter> &ref_149
-                schema: *ref_148
+              - !<!Parameter> &ref_150
+                schema: *ref_149
                 flattened: true
                 implementation: Method
                 required: true
@@ -4190,19 +4446,19 @@ operationGroups:
                   http: !<!HttpParameter> 
                     in: body
                     style: json
-              - !<!VirtualParameter> &ref_151
+              - !<!VirtualParameter> &ref_152
                 schema: *ref_15
                 implementation: Method
-                originalParameter: *ref_149
+                originalParameter: *ref_150
                 pathToProperty: []
-                targetProperty: *ref_150
+                targetProperty: *ref_151
                 language: !<!Languages> 
                   default:
                     name: id
                     description: ''
                 protocol: !<!Protocols> {}
             signatureParameters:
-              - *ref_151
+              - *ref_152
             language: !<!Languages> 
               default:
                 name: ''
@@ -4239,6 +4495,21 @@ operationGroups:
           - *ref_105
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_153
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -4251,7 +4522,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_152
+            schema: *ref_154
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/xms-error-responses/flattened.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/flattened.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: xms-error-responses
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_27
+    - !<!NumberSchema> &ref_28
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -16,7 +16,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_23
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
@@ -33,7 +33,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -43,7 +43,7 @@ schemas: !<!Schemas>
           name: Pet-name
           description: Gets the Pet by id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -53,7 +53,7 @@ schemas: !<!Schemas>
           name: Animal-aniType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_12
+    - !<!StringSchema> &ref_13
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -63,7 +63,7 @@ schemas: !<!Schemas>
           name: NotFoundErrorBase-reason
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -73,7 +73,7 @@ schemas: !<!Schemas>
           name: NotFoundErrorBase-whatNotFound
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -83,7 +83,7 @@ schemas: !<!Schemas>
           name: BaseError-someBaseProp
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_15
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -93,7 +93,7 @@ schemas: !<!Schemas>
           name: PetAction-actionResponse
           description: action feedback
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_19
+    - !<!StringSchema> &ref_20
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -103,7 +103,7 @@ schemas: !<!Schemas>
           name: PetActionError-errorType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_22
+    - !<!StringSchema> &ref_23
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -113,7 +113,7 @@ schemas: !<!Schemas>
           name: PetActionError-errorMessage
           description: the error message
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_9
+    - !<!StringSchema> &ref_10
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -123,7 +123,7 @@ schemas: !<!Schemas>
           name: LinkNotFound-whatSubAddress
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_8
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -133,7 +133,7 @@ schemas: !<!Schemas>
           name: AnimalNotFound-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_20
+    - !<!StringSchema> &ref_21
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -143,7 +143,7 @@ schemas: !<!Schemas>
           name: PetSadError-reason
           description: why is the pet sad
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_17
+    - !<!StringSchema> &ref_18
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -153,27 +153,38 @@ schemas: !<!Schemas>
           name: PetHungryOrThirstyError-hungryOrThirsty
           description: is the pet hungry or thirsty or both
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_26
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_0
+    - !<!ObjectSchema> &ref_1
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
       parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_2
+          - !<!ObjectSchema> &ref_3
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 0.0.0
             children: !<!Relations> 
               all:
-                - *ref_0
+                - *ref_1
               immediate:
-                - *ref_0
+                - *ref_1
             properties:
               - !<!Property> 
-                schema: *ref_1
+                schema: *ref_2
                 serializedName: aniType
                 language: !<!Languages> 
                   default:
@@ -191,10 +202,10 @@ schemas: !<!Schemas>
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_2
+          - *ref_3
       properties:
         - !<!Property> 
-          schema: *ref_3
+          schema: *ref_4
           readOnly: true
           serializedName: name
           language: !<!Languages> 
@@ -212,15 +223,15 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_2
-    - !<!ObjectSchema> &ref_4
+    - *ref_3
+    - !<!ObjectSchema> &ref_5
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
       children: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_5
+          - !<!ObjectSchema> &ref_6
             type: object
             apiVersions:
               - !<!ApiVersion> 
@@ -228,17 +239,17 @@ schemas: !<!Schemas>
             discriminatorValue: InvalidResourceLink
             parents: !<!Relations> 
               all:
-                - *ref_4
-                - !<!ObjectSchema> &ref_6
+                - *ref_5
+                - !<!ObjectSchema> &ref_7
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: 0.0.0
                   children: !<!Relations> 
                     all:
-                      - *ref_4
                       - *ref_5
-                      - !<!ObjectSchema> &ref_10
+                      - *ref_6
+                      - !<!ObjectSchema> &ref_11
                         type: object
                         apiVersions:
                           - !<!ApiVersion> 
@@ -246,13 +257,13 @@ schemas: !<!Schemas>
                         discriminatorValue: AnimalNotFound
                         parents: !<!Relations> 
                           all:
-                            - *ref_4
-                            - *ref_6
+                            - *ref_5
+                            - *ref_7
                           immediate:
-                            - *ref_4
+                            - *ref_5
                         properties:
                           - !<!Property> 
-                            schema: *ref_7
+                            schema: *ref_8
                             serializedName: name
                             language: !<!Languages> 
                               default:
@@ -270,10 +281,10 @@ schemas: !<!Schemas>
                             namespace: ''
                         protocol: !<!Protocols> {}
                     immediate:
-                      - *ref_4
+                      - *ref_5
                   properties:
                     - !<!Property> 
-                      schema: *ref_8
+                      schema: *ref_9
                       serializedName: someBaseProp
                       language: !<!Languages> 
                         default:
@@ -291,10 +302,10 @@ schemas: !<!Schemas>
                       namespace: ''
                   protocol: !<!Protocols> {}
               immediate:
-                - *ref_4
+                - *ref_5
             properties:
               - !<!Property> 
-                schema: *ref_9
+                schema: *ref_10
                 serializedName: whatSubAddress
                 language: !<!Languages> 
                   default:
@@ -313,19 +324,19 @@ schemas: !<!Schemas>
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - *ref_10
+          - *ref_11
         immediate:
-          - *ref_5
-          - *ref_10
+          - *ref_6
+          - *ref_11
       discriminator: !<!Discriminator> 
         all:
-          AnimalNotFound: *ref_10
-          InvalidResourceLink: *ref_5
+          AnimalNotFound: *ref_11
+          InvalidResourceLink: *ref_6
         immediate:
-          AnimalNotFound: *ref_10
-          InvalidResourceLink: *ref_5
-        property: !<!Property> &ref_13
-          schema: *ref_11
+          AnimalNotFound: *ref_11
+          InvalidResourceLink: *ref_6
+        property: !<!Property> &ref_14
+          schema: *ref_12
           isDiscriminator: true
           required: true
           serializedName: whatNotFound
@@ -337,12 +348,12 @@ schemas: !<!Schemas>
       discriminatorValue: NotFoundErrorBase
       parents: !<!Relations> 
         all:
-          - *ref_6
+          - *ref_7
         immediate:
-          - *ref_6
+          - *ref_7
       properties:
         - !<!Property> 
-          schema: *ref_12
+          schema: *ref_13
           required: false
           serializedName: reason
           language: !<!Languages> 
@@ -350,7 +361,7 @@ schemas: !<!Schemas>
               name: reason
               description: ''
           protocol: !<!Protocols> {}
-        - *ref_13
+        - *ref_14
       serializationFormats:
         - json
       usage:
@@ -361,15 +372,15 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_6
-    - !<!ObjectSchema> &ref_29
+    - *ref_7
+    - !<!ObjectSchema> &ref_30
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
       properties:
         - !<!Property> 
-          schema: *ref_14
+          schema: *ref_15
           serializedName: actionResponse
           language: !<!Languages> 
             default:
@@ -386,21 +397,21 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_16
+    - !<!ObjectSchema> &ref_17
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
       children: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_15
+          - !<!ObjectSchema> &ref_16
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 0.0.0
             children: !<!Relations> 
               all:
-                - !<!ObjectSchema> &ref_18
+                - !<!ObjectSchema> &ref_19
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
@@ -408,13 +419,13 @@ schemas: !<!Schemas>
                   discriminatorValue: PetHungryOrThirstyError
                   parents: !<!Relations> 
                     all:
-                      - *ref_15
                       - *ref_16
+                      - *ref_17
                     immediate:
-                      - *ref_15
+                      - *ref_16
                   properties:
                     - !<!Property> 
-                      schema: *ref_17
+                      schema: *ref_18
                       serializedName: hungryOrThirsty
                       language: !<!Languages> 
                         default:
@@ -432,14 +443,14 @@ schemas: !<!Schemas>
                       namespace: ''
                   protocol: !<!Protocols> {}
               immediate:
-                - *ref_18
+                - *ref_19
             discriminator: !<!Discriminator> 
               all:
-                PetHungryOrThirstyError: *ref_18
+                PetHungryOrThirstyError: *ref_19
               immediate:
-                PetHungryOrThirstyError: *ref_18
-              property: !<!Property> &ref_21
-                schema: *ref_19
+                PetHungryOrThirstyError: *ref_19
+              property: !<!Property> &ref_22
+                schema: *ref_20
                 isDiscriminator: true
                 required: true
                 serializedName: errorType
@@ -451,12 +462,12 @@ schemas: !<!Schemas>
             discriminatorValue: PetSadError
             parents: !<!Relations> 
               all:
-                - *ref_16
+                - *ref_17
               immediate:
-                - *ref_16
+                - *ref_17
             properties:
               - !<!Property> 
-                schema: *ref_20
+                schema: *ref_21
                 serializedName: reason
                 language: !<!Languages> 
                   default:
@@ -473,20 +484,20 @@ schemas: !<!Schemas>
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - *ref_18
+          - *ref_19
         immediate:
-          - *ref_15
+          - *ref_16
       discriminator: !<!Discriminator> 
         all:
-          PetHungryOrThirstyError: *ref_18
-          PetSadError: *ref_15
+          PetHungryOrThirstyError: *ref_19
+          PetSadError: *ref_16
         immediate:
-          PetSadError: *ref_15
-        property: *ref_21
+          PetSadError: *ref_16
+        property: *ref_22
       properties:
-        - *ref_21
+        - *ref_22
         - !<!Property> 
-          schema: *ref_22
+          schema: *ref_23
           required: false
           serializedName: errorMessage
           language: !<!Languages> 
@@ -504,13 +515,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_5
-    - *ref_10
-    - *ref_15
-    - *ref_18
+    - *ref_6
+    - *ref_11
+    - *ref_16
+    - *ref_19
 globalParameters:
   - !<!Parameter> &ref_24
-    schema: *ref_23
+    schema: *ref_0
     clientDefaultValue: 'http://localhost'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -535,7 +546,7 @@ operationGroups:
             version: 0.0.0
         parameters:
           - *ref_24
-          - !<!Parameter> &ref_26
+          - !<!Parameter> &ref_27
             schema: *ref_25
             implementation: Method
             required: true
@@ -549,6 +560,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -559,10 +585,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_26
+          - *ref_27
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -600,7 +626,7 @@ operationGroups:
                 statusCodes:
                   - '400'
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             extensions:
               x-ms-error-response: true
             language: !<!Languages> 
@@ -615,7 +641,7 @@ operationGroups:
                 statusCodes:
                   - '404'
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             extensions:
               x-ms-error-response: true
             language: !<!Languages> 
@@ -649,7 +675,7 @@ operationGroups:
             version: 0.0.0
         parameters:
           - *ref_24
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_25
             implementation: Method
             required: true
@@ -663,6 +689,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -673,10 +714,10 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
+          - *ref_29
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -690,7 +731,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_16
+            schema: *ref_17
             extensions:
               x-ms-error-response: true
             language: !<!Languages> 
@@ -705,7 +746,7 @@ operationGroups:
                 statusCodes:
                   - '500'
           - !<!SchemaResponse> 
-            schema: *ref_16
+            schema: *ref_17
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/xms-error-responses/grouped.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/grouped.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: xms-error-responses
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_27
+    - !<!NumberSchema> &ref_28
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -16,7 +16,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_23
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
@@ -33,7 +33,7 @@ schemas: !<!Schemas>
           name: string
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -43,7 +43,7 @@ schemas: !<!Schemas>
           name: Pet-name
           description: Gets the Pet by id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -53,7 +53,7 @@ schemas: !<!Schemas>
           name: Animal-aniType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_12
+    - !<!StringSchema> &ref_13
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -63,7 +63,7 @@ schemas: !<!Schemas>
           name: NotFoundErrorBase-reason
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -73,7 +73,7 @@ schemas: !<!Schemas>
           name: NotFoundErrorBase-whatNotFound
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -83,7 +83,7 @@ schemas: !<!Schemas>
           name: BaseError-someBaseProp
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_15
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -93,7 +93,7 @@ schemas: !<!Schemas>
           name: PetAction-actionResponse
           description: action feedback
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_19
+    - !<!StringSchema> &ref_20
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -103,7 +103,7 @@ schemas: !<!Schemas>
           name: PetActionError-errorType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_22
+    - !<!StringSchema> &ref_23
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -113,7 +113,7 @@ schemas: !<!Schemas>
           name: PetActionError-errorMessage
           description: the error message
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_9
+    - !<!StringSchema> &ref_10
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -123,7 +123,7 @@ schemas: !<!Schemas>
           name: LinkNotFound-whatSubAddress
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_8
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -133,7 +133,7 @@ schemas: !<!Schemas>
           name: AnimalNotFound-name
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_20
+    - !<!StringSchema> &ref_21
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -143,7 +143,7 @@ schemas: !<!Schemas>
           name: PetSadError-reason
           description: why is the pet sad
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_17
+    - !<!StringSchema> &ref_18
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -153,27 +153,38 @@ schemas: !<!Schemas>
           name: PetHungryOrThirstyError-hungryOrThirsty
           description: is the pet hungry or thirsty or both
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_26
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_0
+    - !<!ObjectSchema> &ref_1
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
       parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_2
+          - !<!ObjectSchema> &ref_3
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 0.0.0
             children: !<!Relations> 
               all:
-                - *ref_0
+                - *ref_1
               immediate:
-                - *ref_0
+                - *ref_1
             properties:
               - !<!Property> 
-                schema: *ref_1
+                schema: *ref_2
                 serializedName: aniType
                 language: !<!Languages> 
                   default:
@@ -191,10 +202,10 @@ schemas: !<!Schemas>
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_2
+          - *ref_3
       properties:
         - !<!Property> 
-          schema: *ref_3
+          schema: *ref_4
           readOnly: true
           serializedName: name
           language: !<!Languages> 
@@ -212,15 +223,15 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_2
-    - !<!ObjectSchema> &ref_4
+    - *ref_3
+    - !<!ObjectSchema> &ref_5
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
       children: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_5
+          - !<!ObjectSchema> &ref_6
             type: object
             apiVersions:
               - !<!ApiVersion> 
@@ -228,17 +239,17 @@ schemas: !<!Schemas>
             discriminatorValue: InvalidResourceLink
             parents: !<!Relations> 
               all:
-                - *ref_4
-                - !<!ObjectSchema> &ref_6
+                - *ref_5
+                - !<!ObjectSchema> &ref_7
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: 0.0.0
                   children: !<!Relations> 
                     all:
-                      - *ref_4
                       - *ref_5
-                      - !<!ObjectSchema> &ref_10
+                      - *ref_6
+                      - !<!ObjectSchema> &ref_11
                         type: object
                         apiVersions:
                           - !<!ApiVersion> 
@@ -246,13 +257,13 @@ schemas: !<!Schemas>
                         discriminatorValue: AnimalNotFound
                         parents: !<!Relations> 
                           all:
-                            - *ref_4
-                            - *ref_6
+                            - *ref_5
+                            - *ref_7
                           immediate:
-                            - *ref_4
+                            - *ref_5
                         properties:
                           - !<!Property> 
-                            schema: *ref_7
+                            schema: *ref_8
                             serializedName: name
                             language: !<!Languages> 
                               default:
@@ -270,10 +281,10 @@ schemas: !<!Schemas>
                             namespace: ''
                         protocol: !<!Protocols> {}
                     immediate:
-                      - *ref_4
+                      - *ref_5
                   properties:
                     - !<!Property> 
-                      schema: *ref_8
+                      schema: *ref_9
                       serializedName: someBaseProp
                       language: !<!Languages> 
                         default:
@@ -291,10 +302,10 @@ schemas: !<!Schemas>
                       namespace: ''
                   protocol: !<!Protocols> {}
               immediate:
-                - *ref_4
+                - *ref_5
             properties:
               - !<!Property> 
-                schema: *ref_9
+                schema: *ref_10
                 serializedName: whatSubAddress
                 language: !<!Languages> 
                   default:
@@ -313,19 +324,19 @@ schemas: !<!Schemas>
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - *ref_10
+          - *ref_11
         immediate:
-          - *ref_5
-          - *ref_10
+          - *ref_6
+          - *ref_11
       discriminator: !<!Discriminator> 
         all:
-          AnimalNotFound: *ref_10
-          InvalidResourceLink: *ref_5
+          AnimalNotFound: *ref_11
+          InvalidResourceLink: *ref_6
         immediate:
-          AnimalNotFound: *ref_10
-          InvalidResourceLink: *ref_5
-        property: !<!Property> &ref_13
-          schema: *ref_11
+          AnimalNotFound: *ref_11
+          InvalidResourceLink: *ref_6
+        property: !<!Property> &ref_14
+          schema: *ref_12
           isDiscriminator: true
           required: true
           serializedName: whatNotFound
@@ -337,12 +348,12 @@ schemas: !<!Schemas>
       discriminatorValue: NotFoundErrorBase
       parents: !<!Relations> 
         all:
-          - *ref_6
+          - *ref_7
         immediate:
-          - *ref_6
+          - *ref_7
       properties:
         - !<!Property> 
-          schema: *ref_12
+          schema: *ref_13
           required: false
           serializedName: reason
           language: !<!Languages> 
@@ -350,7 +361,7 @@ schemas: !<!Schemas>
               name: reason
               description: ''
           protocol: !<!Protocols> {}
-        - *ref_13
+        - *ref_14
       serializationFormats:
         - json
       usage:
@@ -361,15 +372,15 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_6
-    - !<!ObjectSchema> &ref_29
+    - *ref_7
+    - !<!ObjectSchema> &ref_30
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
       properties:
         - !<!Property> 
-          schema: *ref_14
+          schema: *ref_15
           serializedName: actionResponse
           language: !<!Languages> 
             default:
@@ -386,21 +397,21 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_16
+    - !<!ObjectSchema> &ref_17
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
       children: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_15
+          - !<!ObjectSchema> &ref_16
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 0.0.0
             children: !<!Relations> 
               all:
-                - !<!ObjectSchema> &ref_18
+                - !<!ObjectSchema> &ref_19
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
@@ -408,13 +419,13 @@ schemas: !<!Schemas>
                   discriminatorValue: PetHungryOrThirstyError
                   parents: !<!Relations> 
                     all:
-                      - *ref_15
                       - *ref_16
+                      - *ref_17
                     immediate:
-                      - *ref_15
+                      - *ref_16
                   properties:
                     - !<!Property> 
-                      schema: *ref_17
+                      schema: *ref_18
                       serializedName: hungryOrThirsty
                       language: !<!Languages> 
                         default:
@@ -432,14 +443,14 @@ schemas: !<!Schemas>
                       namespace: ''
                   protocol: !<!Protocols> {}
               immediate:
-                - *ref_18
+                - *ref_19
             discriminator: !<!Discriminator> 
               all:
-                PetHungryOrThirstyError: *ref_18
+                PetHungryOrThirstyError: *ref_19
               immediate:
-                PetHungryOrThirstyError: *ref_18
-              property: !<!Property> &ref_21
-                schema: *ref_19
+                PetHungryOrThirstyError: *ref_19
+              property: !<!Property> &ref_22
+                schema: *ref_20
                 isDiscriminator: true
                 required: true
                 serializedName: errorType
@@ -451,12 +462,12 @@ schemas: !<!Schemas>
             discriminatorValue: PetSadError
             parents: !<!Relations> 
               all:
-                - *ref_16
+                - *ref_17
               immediate:
-                - *ref_16
+                - *ref_17
             properties:
               - !<!Property> 
-                schema: *ref_20
+                schema: *ref_21
                 serializedName: reason
                 language: !<!Languages> 
                   default:
@@ -473,20 +484,20 @@ schemas: !<!Schemas>
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - *ref_18
+          - *ref_19
         immediate:
-          - *ref_15
+          - *ref_16
       discriminator: !<!Discriminator> 
         all:
-          PetHungryOrThirstyError: *ref_18
-          PetSadError: *ref_15
+          PetHungryOrThirstyError: *ref_19
+          PetSadError: *ref_16
         immediate:
-          PetSadError: *ref_15
-        property: *ref_21
+          PetSadError: *ref_16
+        property: *ref_22
       properties:
-        - *ref_21
+        - *ref_22
         - !<!Property> 
-          schema: *ref_22
+          schema: *ref_23
           required: false
           serializedName: errorMessage
           language: !<!Languages> 
@@ -504,13 +515,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_5
-    - *ref_10
-    - *ref_15
-    - *ref_18
+    - *ref_6
+    - *ref_11
+    - *ref_16
+    - *ref_19
 globalParameters:
   - !<!Parameter> &ref_24
-    schema: *ref_23
+    schema: *ref_0
     clientDefaultValue: 'http://localhost'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -535,7 +546,7 @@ operationGroups:
             version: 0.0.0
         parameters:
           - *ref_24
-          - !<!Parameter> &ref_26
+          - !<!Parameter> &ref_27
             schema: *ref_25
             implementation: Method
             required: true
@@ -549,6 +560,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -559,10 +585,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_26
+          - *ref_27
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -600,7 +626,7 @@ operationGroups:
                 statusCodes:
                   - '400'
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             extensions:
               x-ms-error-response: true
             language: !<!Languages> 
@@ -615,7 +641,7 @@ operationGroups:
                 statusCodes:
                   - '404'
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             extensions:
               x-ms-error-response: true
             language: !<!Languages> 
@@ -649,7 +675,7 @@ operationGroups:
             version: 0.0.0
         parameters:
           - *ref_24
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_25
             implementation: Method
             required: true
@@ -663,6 +689,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -673,10 +714,10 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
+          - *ref_29
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -690,7 +731,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_16
+            schema: *ref_17
             extensions:
               x-ms-error-response: true
             language: !<!Languages> 
@@ -705,7 +746,7 @@ operationGroups:
                 statusCodes:
                   - '500'
           - !<!SchemaResponse> 
-            schema: *ref_16
+            schema: *ref_17
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/xms-error-responses/modeler.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/modeler.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: xms-error-responses
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_26
+    - !<!NumberSchema> &ref_27
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -152,6 +152,17 @@ schemas: !<!Schemas>
         default:
           name: PetHungryOrThirstyError-hungryOrThirsty
           description: is the pet hungry or thirsty or both
+      protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_26
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_23
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
       protocol: !<!Protocols> {}
   objects:
     - !<!ObjectSchema> &ref_2
@@ -362,7 +373,7 @@ schemas: !<!Schemas>
           namespace: ''
       protocol: !<!Protocols> {}
     - *ref_12
-    - !<!ObjectSchema> &ref_29
+    - !<!ObjectSchema> &ref_30
       type: object
       apiVersions:
         - !<!ApiVersion> 
@@ -509,7 +520,7 @@ schemas: !<!Schemas>
     - *ref_21
     - *ref_22
 globalParameters:
-  - !<!Parameter> &ref_27
+  - !<!Parameter> &ref_28
     schema: *ref_23
     clientDefaultValue: 'http://localhost'
     implementation: Client
@@ -534,7 +545,7 @@ operationGroups:
           - !<!ApiVersion> 
             version: 0.0.0
         parameters:
-          - *ref_27
+          - *ref_28
           - !<!Parameter> &ref_25
             schema: *ref_24
             implementation: Method
@@ -549,6 +560,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -615,7 +641,7 @@ operationGroups:
                 statusCodes:
                   - '404'
           - !<!SchemaResponse> 
-            schema: *ref_26
+            schema: *ref_27
             extensions:
               x-ms-error-response: true
             language: !<!Languages> 
@@ -648,8 +674,8 @@ operationGroups:
           - !<!ApiVersion> 
             version: 0.0.0
         parameters:
-          - *ref_27
-          - !<!Parameter> &ref_28
+          - *ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_24
             implementation: Method
             required: true
@@ -663,6 +689,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -673,10 +714,10 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
+          - *ref_29
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''

--- a/modelerfour/test/scenarios/xms-error-responses/namer.yaml
+++ b/modelerfour/test/scenarios/xms-error-responses/namer.yaml
@@ -4,7 +4,7 @@ info: !<!Info>
   title: xms-error-responses
 schemas: !<!Schemas> 
   numbers:
-    - !<!NumberSchema> &ref_27
+    - !<!NumberSchema> &ref_28
       type: integer
       apiVersions:
         - !<!ApiVersion> 
@@ -16,7 +16,7 @@ schemas: !<!Schemas>
           description: ''
       protocol: !<!Protocols> {}
   strings:
-    - !<!StringSchema> &ref_23
+    - !<!StringSchema> &ref_0
       type: string
       language: !<!Languages> 
         default:
@@ -33,7 +33,7 @@ schemas: !<!Schemas>
           name: String
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_3
+    - !<!StringSchema> &ref_4
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -43,7 +43,7 @@ schemas: !<!Schemas>
           name: PetName
           description: Gets the Pet by id.
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_1
+    - !<!StringSchema> &ref_2
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -53,7 +53,7 @@ schemas: !<!Schemas>
           name: AnimalAniType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_12
+    - !<!StringSchema> &ref_13
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -63,7 +63,7 @@ schemas: !<!Schemas>
           name: NotFoundErrorBaseReason
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_11
+    - !<!StringSchema> &ref_12
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -73,7 +73,7 @@ schemas: !<!Schemas>
           name: NotFoundErrorBaseWhatNotFound
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_8
+    - !<!StringSchema> &ref_9
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -83,7 +83,7 @@ schemas: !<!Schemas>
           name: BaseErrorSomeBaseProp
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_14
+    - !<!StringSchema> &ref_15
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -93,7 +93,7 @@ schemas: !<!Schemas>
           name: PetActionResponse
           description: action feedback
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_19
+    - !<!StringSchema> &ref_20
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -103,7 +103,7 @@ schemas: !<!Schemas>
           name: PetActionErrorType
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_22
+    - !<!StringSchema> &ref_23
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -113,7 +113,7 @@ schemas: !<!Schemas>
           name: PetActionErrorMessage
           description: the error message
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_9
+    - !<!StringSchema> &ref_10
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -123,7 +123,7 @@ schemas: !<!Schemas>
           name: LinkNotFoundWhatSubAddress
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_7
+    - !<!StringSchema> &ref_8
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -133,7 +133,7 @@ schemas: !<!Schemas>
           name: AnimalNotFoundName
           description: ''
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_20
+    - !<!StringSchema> &ref_21
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -143,7 +143,7 @@ schemas: !<!Schemas>
           name: PetSadErrorReason
           description: why is the pet sad
       protocol: !<!Protocols> {}
-    - !<!StringSchema> &ref_17
+    - !<!StringSchema> &ref_18
       type: string
       apiVersions:
         - !<!ApiVersion> 
@@ -153,27 +153,38 @@ schemas: !<!Schemas>
           name: PetHungryOrThirstyErrorHungryOrThirsty
           description: is the pet hungry or thirsty or both
       protocol: !<!Protocols> {}
+  constants:
+    - !<!ConstantSchema> &ref_26
+      type: constant
+      value: !<!ConstantValue> 
+        value: application/json
+      valueType: *ref_0
+      language: !<!Languages> 
+        default:
+          name: Accept
+          description: 'Accept: application/json'
+      protocol: !<!Protocols> {}
   objects:
-    - !<!ObjectSchema> &ref_0
+    - !<!ObjectSchema> &ref_1
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
       parents: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_2
+          - !<!ObjectSchema> &ref_3
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 0.0.0
             children: !<!Relations> 
               all:
-                - *ref_0
+                - *ref_1
               immediate:
-                - *ref_0
+                - *ref_1
             properties:
               - !<!Property> 
-                schema: *ref_1
+                schema: *ref_2
                 serializedName: aniType
                 language: !<!Languages> 
                   default:
@@ -191,10 +202,10 @@ schemas: !<!Schemas>
                 namespace: ''
             protocol: !<!Protocols> {}
         immediate:
-          - *ref_2
+          - *ref_3
       properties:
         - !<!Property> 
-          schema: *ref_3
+          schema: *ref_4
           readOnly: true
           serializedName: name
           language: !<!Languages> 
@@ -212,15 +223,15 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_2
-    - !<!ObjectSchema> &ref_4
+    - *ref_3
+    - !<!ObjectSchema> &ref_5
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
       children: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_5
+          - !<!ObjectSchema> &ref_6
             type: object
             apiVersions:
               - !<!ApiVersion> 
@@ -228,17 +239,17 @@ schemas: !<!Schemas>
             discriminatorValue: InvalidResourceLink
             parents: !<!Relations> 
               all:
-                - *ref_4
-                - !<!ObjectSchema> &ref_6
+                - *ref_5
+                - !<!ObjectSchema> &ref_7
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
                       version: 0.0.0
                   children: !<!Relations> 
                     all:
-                      - *ref_4
                       - *ref_5
-                      - !<!ObjectSchema> &ref_10
+                      - *ref_6
+                      - !<!ObjectSchema> &ref_11
                         type: object
                         apiVersions:
                           - !<!ApiVersion> 
@@ -246,13 +257,13 @@ schemas: !<!Schemas>
                         discriminatorValue: AnimalNotFound
                         parents: !<!Relations> 
                           all:
-                            - *ref_4
-                            - *ref_6
+                            - *ref_5
+                            - *ref_7
                           immediate:
-                            - *ref_4
+                            - *ref_5
                         properties:
                           - !<!Property> 
-                            schema: *ref_7
+                            schema: *ref_8
                             serializedName: name
                             language: !<!Languages> 
                               default:
@@ -270,10 +281,10 @@ schemas: !<!Schemas>
                             namespace: ''
                         protocol: !<!Protocols> {}
                     immediate:
-                      - *ref_4
+                      - *ref_5
                   properties:
                     - !<!Property> 
-                      schema: *ref_8
+                      schema: *ref_9
                       serializedName: someBaseProp
                       language: !<!Languages> 
                         default:
@@ -291,10 +302,10 @@ schemas: !<!Schemas>
                       namespace: ''
                   protocol: !<!Protocols> {}
               immediate:
-                - *ref_4
+                - *ref_5
             properties:
               - !<!Property> 
-                schema: *ref_9
+                schema: *ref_10
                 serializedName: whatSubAddress
                 language: !<!Languages> 
                   default:
@@ -313,19 +324,19 @@ schemas: !<!Schemas>
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - *ref_10
+          - *ref_11
         immediate:
-          - *ref_5
-          - *ref_10
+          - *ref_6
+          - *ref_11
       discriminator: !<!Discriminator> 
         all:
-          AnimalNotFound: *ref_10
-          InvalidResourceLink: *ref_5
+          AnimalNotFound: *ref_11
+          InvalidResourceLink: *ref_6
         immediate:
-          AnimalNotFound: *ref_10
-          InvalidResourceLink: *ref_5
-        property: !<!Property> &ref_13
-          schema: *ref_11
+          AnimalNotFound: *ref_11
+          InvalidResourceLink: *ref_6
+        property: !<!Property> &ref_14
+          schema: *ref_12
           isDiscriminator: true
           required: true
           serializedName: whatNotFound
@@ -337,12 +348,12 @@ schemas: !<!Schemas>
       discriminatorValue: NotFoundErrorBase
       parents: !<!Relations> 
         all:
-          - *ref_6
+          - *ref_7
         immediate:
-          - *ref_6
+          - *ref_7
       properties:
         - !<!Property> 
-          schema: *ref_12
+          schema: *ref_13
           required: false
           serializedName: reason
           language: !<!Languages> 
@@ -350,7 +361,7 @@ schemas: !<!Schemas>
               name: reason
               description: ''
           protocol: !<!Protocols> {}
-        - *ref_13
+        - *ref_14
       serializationFormats:
         - json
       usage:
@@ -361,15 +372,15 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_6
-    - !<!ObjectSchema> &ref_29
+    - *ref_7
+    - !<!ObjectSchema> &ref_30
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
       properties:
         - !<!Property> 
-          schema: *ref_14
+          schema: *ref_15
           serializedName: actionResponse
           language: !<!Languages> 
             default:
@@ -386,21 +397,21 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - !<!ObjectSchema> &ref_16
+    - !<!ObjectSchema> &ref_17
       type: object
       apiVersions:
         - !<!ApiVersion> 
           version: 0.0.0
       children: !<!Relations> 
         all:
-          - !<!ObjectSchema> &ref_15
+          - !<!ObjectSchema> &ref_16
             type: object
             apiVersions:
               - !<!ApiVersion> 
                 version: 0.0.0
             children: !<!Relations> 
               all:
-                - !<!ObjectSchema> &ref_18
+                - !<!ObjectSchema> &ref_19
                   type: object
                   apiVersions:
                     - !<!ApiVersion> 
@@ -408,13 +419,13 @@ schemas: !<!Schemas>
                   discriminatorValue: PetHungryOrThirstyError
                   parents: !<!Relations> 
                     all:
-                      - *ref_15
                       - *ref_16
+                      - *ref_17
                     immediate:
-                      - *ref_15
+                      - *ref_16
                   properties:
                     - !<!Property> 
-                      schema: *ref_17
+                      schema: *ref_18
                       serializedName: hungryOrThirsty
                       language: !<!Languages> 
                         default:
@@ -432,14 +443,14 @@ schemas: !<!Schemas>
                       namespace: ''
                   protocol: !<!Protocols> {}
               immediate:
-                - *ref_18
+                - *ref_19
             discriminator: !<!Discriminator> 
               all:
-                PetHungryOrThirstyError: *ref_18
+                PetHungryOrThirstyError: *ref_19
               immediate:
-                PetHungryOrThirstyError: *ref_18
-              property: !<!Property> &ref_21
-                schema: *ref_19
+                PetHungryOrThirstyError: *ref_19
+              property: !<!Property> &ref_22
+                schema: *ref_20
                 isDiscriminator: true
                 required: true
                 serializedName: errorType
@@ -451,12 +462,12 @@ schemas: !<!Schemas>
             discriminatorValue: PetSadError
             parents: !<!Relations> 
               all:
-                - *ref_16
+                - *ref_17
               immediate:
-                - *ref_16
+                - *ref_17
             properties:
               - !<!Property> 
-                schema: *ref_20
+                schema: *ref_21
                 serializedName: reason
                 language: !<!Languages> 
                   default:
@@ -473,20 +484,20 @@ schemas: !<!Schemas>
                 description: ''
                 namespace: ''
             protocol: !<!Protocols> {}
-          - *ref_18
+          - *ref_19
         immediate:
-          - *ref_15
+          - *ref_16
       discriminator: !<!Discriminator> 
         all:
-          PetHungryOrThirstyError: *ref_18
-          PetSadError: *ref_15
+          PetHungryOrThirstyError: *ref_19
+          PetSadError: *ref_16
         immediate:
-          PetSadError: *ref_15
-        property: *ref_21
+          PetSadError: *ref_16
+        property: *ref_22
       properties:
-        - *ref_21
+        - *ref_22
         - !<!Property> 
-          schema: *ref_22
+          schema: *ref_23
           required: false
           serializedName: errorMessage
           language: !<!Languages> 
@@ -504,13 +515,13 @@ schemas: !<!Schemas>
           description: ''
           namespace: ''
       protocol: !<!Protocols> {}
-    - *ref_5
-    - *ref_10
-    - *ref_15
-    - *ref_18
+    - *ref_6
+    - *ref_11
+    - *ref_16
+    - *ref_19
 globalParameters:
   - !<!Parameter> &ref_24
-    schema: *ref_23
+    schema: *ref_0
     clientDefaultValue: 'http://localhost'
     implementation: Client
     origin: 'modelerfour:synthesized/host'
@@ -535,7 +546,7 @@ operationGroups:
             version: 0.0.0
         parameters:
           - *ref_24
-          - !<!Parameter> &ref_26
+          - !<!Parameter> &ref_27
             schema: *ref_25
             implementation: Method
             required: true
@@ -549,6 +560,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -559,10 +585,10 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_26
+          - *ref_27
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_0
+            schema: *ref_1
             language: !<!Languages> 
               default:
                 name: ''
@@ -600,7 +626,7 @@ operationGroups:
                 statusCodes:
                   - '400'
           - !<!SchemaResponse> 
-            schema: *ref_4
+            schema: *ref_5
             extensions:
               x-ms-error-response: true
             language: !<!Languages> 
@@ -615,7 +641,7 @@ operationGroups:
                 statusCodes:
                   - '404'
           - !<!SchemaResponse> 
-            schema: *ref_27
+            schema: *ref_28
             extensions:
               x-ms-error-response: true
             language: !<!Languages> 
@@ -649,7 +675,7 @@ operationGroups:
             version: 0.0.0
         parameters:
           - *ref_24
-          - !<!Parameter> &ref_28
+          - !<!Parameter> &ref_29
             schema: *ref_25
             implementation: Method
             required: true
@@ -663,6 +689,21 @@ operationGroups:
                 in: path
         requests:
           - !<!Request> 
+            parameters:
+              - !<!Parameter> 
+                schema: *ref_26
+                implementation: Method
+                origin: 'modelerfour:synthesized/accept'
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: Accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: header
+            signatureParameters: []
             language: !<!Languages> 
               default:
                 name: ''
@@ -673,10 +714,10 @@ operationGroups:
                 method: post
                 uri: '{$host}'
         signatureParameters:
-          - *ref_28
+          - *ref_29
         responses:
           - !<!SchemaResponse> 
-            schema: *ref_29
+            schema: *ref_30
             language: !<!Languages> 
               default:
                 name: ''
@@ -690,7 +731,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !<!SchemaResponse> 
-            schema: *ref_16
+            schema: *ref_17
             extensions:
               x-ms-error-response: true
             language: !<!Languages> 
@@ -705,7 +746,7 @@ operationGroups:
                 statusCodes:
                   - '500'
           - !<!SchemaResponse> 
-            schema: *ref_16
+            schema: *ref_17
             language: !<!Languages> 
               default:
                 name: ''


### PR DESCRIPTION
This change addresses #324 which requests that modelerfour synthesize an `Accept` header based on the expected response media types.  This is intended to ensure that services which expect an `Accept` header receive one in a consistent way from SDK clients generated in all languages.  The logic adds a new `Accept` parameter to every request with a `ConstantSchema` containing a comma-delimited list string of all the possible response media types for that operation.